### PR TITLE
Fix initial actions XML parsing and TaxReturn postfix syntax

### DIFF
--- a/go/pkg/dtrules/loader/dt.go
+++ b/go/pkg/dtrules/loader/dt.go
@@ -103,15 +103,15 @@ type DTContextDetail struct {
 
 // DTInitialActions represents the initial actions section
 type DTInitialActions struct {
-	Actions []DTInitialAction `xml:"initial_action_details"`
+	Actions []DTInitialAction `xml:"initial_action"`
 }
 
 // DTInitialAction represents a single initial action
 type DTInitialAction struct {
-	Number      int    `xml:"initial_action_number"`
-	Comment     string `xml:"initial_action_comment"`
-	Description string `xml:"initial_action_description"`
-	Postfix     string `xml:"initial_action_postfix"`
+	Number      int    `xml:"action_number"`
+	Comment     string `xml:"action_comment"`
+	Description string `xml:"action_description"`
+	Postfix     string `xml:"action_postfix"`
 }
 
 // DTConditions represents the conditions section

--- a/go/pkg/dtrules/sampleprojects_test.go
+++ b/go/pkg/dtrules/sampleprojects_test.go
@@ -87,6 +87,34 @@ var sampleProjects = []SampleProject{
 			// Will be discovered when DT loading is fixed
 		},
 	},
+	{
+		Name:       "TaxReturn",
+		EDDFile:    "TaxReturn_edd.xml",
+		DTFile:     "TaxReturn_dt.xml",
+		MapFile:    "TaxReturn_map.xml",
+		EntryTable: "Compute_Tax_Return",
+		ExpectedTables: []string{
+			"Compute_Tax_Return",
+			"Calculate_Gross_Income",
+			"Process_W2_Income",
+			"Process_Self_Employment",
+			"Calculate_Vehicle_Deduction",
+			"Process_Rental_Income",
+			"Calculate_AGI_Adjustments",
+			"Calculate_Deductions",
+			"Calculate_Standard_Deduction",
+			"Calculate_Itemized_Deductions",
+			"Calculate_SALT_Deduction",
+			"Calculate_Mortgage_Interest",
+			"Calculate_Charitable_Deduction",
+			"Calculate_Taxable_Income",
+			"Calculate_Tax_Liability",
+			"Apply_Tax_Brackets",
+			"Calculate_Credits",
+			"Calculate_Child_Tax_Credit",
+			"Calculate_Final_Balance",
+		},
+	},
 }
 
 // findSampleProjectsDir locates the sampleprojects directory

--- a/sampleprojects/TaxReturn/DTRules.xml
+++ b/sampleprojects/TaxReturn/DTRules.xml
@@ -1,0 +1,18 @@
+<DTRules>
+
+  <compileralias name="EL">com.dtrules.compiler.el.EL</compileralias>
+  <compiler>EL</compiler>
+
+  <RuleSet name="TaxReturn" source="file">
+     <RuleSetFilePath>/xml</RuleSetFilePath>
+     <WorkingDirectory>/temp</WorkingDirectory>
+
+     <DTExcelFolder>/DecisionTables/</DTExcelFolder>
+     <EDDExcelFolder>/edd/</EDDExcelFolder>
+
+     <Entities        name="TaxReturn_edd.xml" />
+     <Decisiontables  name="TaxReturn_dt.xml"  />
+     <Map             name="TaxReturn_map.xml" />
+  </RuleSet>
+
+</DTRules>

--- a/sampleprojects/TaxReturn/pom.xml
+++ b/sampleprojects/TaxReturn/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+	license agreements. See the NOTICE file distributed with this work for additional
+	information regarding copyright ownership. The ASF licenses this file to
+	You under the Apache License, Version 2.0 (the "License"); you may not use
+	this file except in compliance with the License. You may obtain a copy of
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+	by applicable law or agreed to in writing, software distributed under the
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+	OF ANY KIND, either express or implied. See the License for the specific
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.dtrules</groupId>
+		<artifactId>sampleprojects</artifactId>
+		<version>5.0-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>TaxReturn</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>DTRules :: TaxReturn</name>
+	<description>Income Tax Calculation System with IRS Document Traceability</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.dtrules</groupId>
+			<artifactId>dtrules-engine</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.dtrules</groupId>
+			<artifactId>compilerutil</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.dtrules</groupId>
+			<artifactId>el</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/sampleprojects/TaxReturn/testfiles/TestScenarios/TestCase_Family_2025.xml
+++ b/sampleprojects/TaxReturn/testfiles/TestScenarios/TestCase_Family_2025.xml
@@ -1,0 +1,194 @@
+<job>
+   <copyright>
+      Copyright 2025 DTRules.com
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+   </copyright>
+
+   <!-- Tax Return Configuration -->
+   <id>1</id>
+   <tax_year>2025</tax_year>
+   <filing_status>MFJ</filing_status>
+   <state>TX</state>
+   <city>Austin</city>
+
+   <!-- Taxpayers -->
+   <taxpayers>
+      <!-- Mom (Sarah) - Real Estate Agent, Self-Employed -->
+      <taxpayer id="1">
+         <id>1</id>
+         <name>Sarah</name>
+         <ssn>123-45-6789</ssn>
+         <date_of_birth>5/15/1980</date_of_birth>
+         <occupation>Real Estate Agent</occupation>
+         <is_self_employed>true</is_self_employed>
+         <is_primary>true</is_primary>
+         <w2_wages>0</w2_wages>
+         <w2_withholding>0</w2_withholding>
+         <se_gross_income>145000</se_gross_income>
+         <estimated_payments>20000</estimated_payments>
+      </taxpayer>
+
+      <!-- Dad (Michael) - Engineer, W-2 Employee -->
+      <taxpayer id="2">
+         <id>2</id>
+         <name>Michael</name>
+         <ssn>234-56-7890</ssn>
+         <date_of_birth>8/22/1978</date_of_birth>
+         <occupation>Engineer</occupation>
+         <is_self_employed>false</is_self_employed>
+         <is_primary>false</is_primary>
+         <w2_wages>125000</w2_wages>
+         <w2_withholding>28000</w2_withholding>
+         <se_gross_income>0</se_gross_income>
+         <estimated_payments>0</estimated_payments>
+      </taxpayer>
+   </taxpayers>
+
+   <!-- Dependents (4 children) -->
+   <dependents>
+      <!-- Child 1 - Age 17, Private School Senior -->
+      <dependent id="1">
+         <id>1</id>
+         <name>Emma</name>
+         <ssn>345-67-8901</ssn>
+         <date_of_birth>3/10/2008</date_of_birth>
+         <age>17</age>
+         <relationship>child</relationship>
+         <months_lived_with>12</months_lived_with>
+         <is_student>true</is_student>
+         <school_type>private</school_type>
+         <tuition_paid>15000</tuition_paid>
+         <has_ssn>true</has_ssn>
+      </dependent>
+
+      <!-- Child 2 - Age 15, Private School -->
+      <dependent id="2">
+         <id>2</id>
+         <name>Ethan</name>
+         <ssn>456-78-9012</ssn>
+         <date_of_birth>7/25/2010</date_of_birth>
+         <age>15</age>
+         <relationship>child</relationship>
+         <months_lived_with>12</months_lived_with>
+         <is_student>true</is_student>
+         <school_type>private</school_type>
+         <tuition_paid>14000</tuition_paid>
+         <has_ssn>true</has_ssn>
+      </dependent>
+
+      <!-- Child 3 - Age 12, Private School -->
+      <dependent id="3">
+         <id>3</id>
+         <name>Olivia</name>
+         <ssn>567-89-0123</ssn>
+         <date_of_birth>11/5/2013</date_of_birth>
+         <age>12</age>
+         <relationship>child</relationship>
+         <months_lived_with>12</months_lived_with>
+         <is_student>true</is_student>
+         <school_type>private</school_type>
+         <tuition_paid>12000</tuition_paid>
+         <has_ssn>true</has_ssn>
+      </dependent>
+
+      <!-- Child 4 - Age 7, Private School -->
+      <dependent id="4">
+         <id>4</id>
+         <name>Liam</name>
+         <ssn>678-90-1234</ssn>
+         <date_of_birth>4/18/2018</date_of_birth>
+         <age>7</age>
+         <relationship>child</relationship>
+         <months_lived_with>12</months_lived_with>
+         <is_student>true</is_student>
+         <school_type>private</school_type>
+         <tuition_paid>10000</tuition_paid>
+         <has_ssn>true</has_ssn>
+      </dependent>
+   </dependents>
+
+   <!-- Properties -->
+   <properties>
+      <!-- Primary Residence in Austin -->
+      <property id="1">
+         <id>1</id>
+         <type>primary_residence</type>
+         <address>123 Oak Street, Austin, TX 78701</address>
+         <purchase_date>6/1/2018</purchase_date>
+         <purchase_price>450000</purchase_price>
+         <current_fmv>650000</current_fmv>
+         <mortgage_balance>320000</mortgage_balance>
+         <mortgage_origination_date>6/1/2018</mortgage_origination_date>
+         <mortgage_interest>18000</mortgage_interest>
+         <property_taxes>8500</property_taxes>
+         <rental_income>0</rental_income>
+         <rental_expenses>0</rental_expenses>
+         <depreciation>0</depreciation>
+      </property>
+
+      <!-- Rental Property -->
+      <property id="2">
+         <id>2</id>
+         <type>rental</type>
+         <address>456 Elm Avenue, Austin, TX 78702</address>
+         <purchase_date>3/15/2020</purchase_date>
+         <purchase_price>280000</purchase_price>
+         <current_fmv>350000</current_fmv>
+         <mortgage_balance>200000</mortgage_balance>
+         <mortgage_origination_date>3/15/2020</mortgage_origination_date>
+         <mortgage_interest>9600</mortgage_interest>
+         <property_taxes>4200</property_taxes>
+         <rental_income>36000</rental_income>
+         <rental_advertising>300</rental_advertising>
+         <rental_insurance>2400</rental_insurance>
+         <rental_repairs>3500</rental_repairs>
+         <rental_utilities>0</rental_utilities>
+         <rental_management>3600</rental_management>
+         <depreciation>8200</depreciation>
+      </property>
+   </properties>
+
+   <!-- Vehicles (Mom's business vehicle) -->
+   <vehicles>
+      <vehicle id="1">
+         <id>1</id>
+         <taxpayer_id>1</taxpayer_id>
+         <description>2022 Toyota Highlander</description>
+         <purchase_date>1/15/2022</purchase_date>
+         <purchase_price>42000</purchase_price>
+         <total_miles>30000</total_miles>
+         <business_miles>24000</business_miles>
+         <method>standard_mileage</method>
+         <actual_expenses>0</actual_expenses>
+         <vehicle_depreciation>0</vehicle_depreciation>
+      </vehicle>
+   </vehicles>
+
+   <!-- Deductions (for itemizing) -->
+   <deductions>
+      <!-- Charitable contributions -->
+      <deduction id="1">
+         <id>1</id>
+         <category>charity</category>
+         <description>Church donations</description>
+         <amount>5000</amount>
+      </deduction>
+      <deduction id="2">
+         <id>2</id>
+         <category>charity</category>
+         <description>Local food bank</description>
+         <amount>1500</amount>
+      </deduction>
+   </deductions>
+</job>

--- a/sampleprojects/TaxReturn/xml/TaxReturn_dt.xml
+++ b/sampleprojects/TaxReturn/xml/TaxReturn_dt.xml
@@ -1,0 +1,1756 @@
+<decision_tables>
+
+<!-- ====================================================================== -->
+<!-- TABLE 1: Compute_Tax_Return - Entry Point                             -->
+<!-- IRS Reference: Form 1040, Publication 17                               -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Compute_Tax_Return</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS>Entry point for tax return calculation. Orchestrates the complete tax calculation process following the structure of Form 1040. Determines filing status and executes calculation tables in proper order per IRS Form 1040 instructions.</COMMENTS>
+<TABLE_NUMBER>1000</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions>
+<initial_action>
+<action_description>Initialize result entity and determine state income tax status</action_description>
+<action_postfix>
+/result createentity entitypush
+result job.results swap addto
+no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
+"Tax Return Calculation Started for Tax Year " job.tax_year cvs strconcat " - Filing Status: " strconcat job.filing_status strconcat job.audit_trail swap addto
+</action_postfix>
+</initial_action>
+</initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Married Filing Jointly</condition_comment>
+<condition_description>job.filing_status equals MFJ</condition_description>
+<condition_postfix>
+job.filing_status MFJ streq
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+</condition_details>
+<condition_details>
+<condition_number>2</condition_number>
+<condition_comment>Single filer</condition_comment>
+<condition_description>job.filing_status equals Single</condition_description>
+<condition_postfix>
+job.filing_status SINGLE streq
+</condition_postfix>
+<condition_column column_number="2" column_value="Y"></condition_column>
+</condition_details>
+<condition_details>
+<condition_number>3</condition_number>
+<condition_comment>Head of Household</condition_comment>
+<condition_description>job.filing_status equals HOH</condition_description>
+<condition_postfix>
+job.filing_status HOH streq
+</condition_postfix>
+<condition_column column_number="3" column_value="Y"></condition_column>
+</condition_details>
+<condition_details>
+<condition_number>4</condition_number>
+<condition_comment>Default case</condition_comment>
+<condition_description>otherwise</condition_description>
+<condition_postfix>
+otherwise
+</condition_postfix>
+<condition_column column_number="4" column_value="*"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Log filing status per Form 1040 Line 1</action_comment>
+<action_description>Log filing status determination</action_description>
+<action_postfix>
+"Filing as Married Filing Jointly per Form 1040 Line 1, Publication 17 Chapter 2, IRC Section 1(a)" job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Log Single filing status</action_comment>
+<action_description>Log Single filing status</action_description>
+<action_postfix>
+"Filing as Single per Form 1040 Line 1, Publication 17 Chapter 2, IRC Section 1(c)" job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>3</action_number>
+<action_comment>Log HOH filing status</action_comment>
+<action_description>Log Head of Household filing status</action_description>
+<action_postfix>
+"Filing as Head of Household per Form 1040 Line 1, Publication 17 Chapter 2, IRC Section 1(b)" job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="3" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>4</action_number>
+<action_comment>Log MFS or QSS status</action_comment>
+<action_description>Log other filing status</action_description>
+<action_postfix>
+"Filing as " job.filing_status strconcat " per Form 1040 Line 1, Publication 17 Chapter 2" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="4" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>5</action_number>
+<action_comment>Calculate gross income (Form 1040 Lines 1-9)</action_comment>
+<action_description>Calculate_Gross_Income</action_description>
+<action_postfix>
+Calculate_Gross_Income
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+<action_column column_number="3" column_value="X"></action_column>
+<action_column column_number="4" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>6</action_number>
+<action_comment>Calculate deductions (Form 1040 Line 12)</action_comment>
+<action_description>Calculate_Deductions</action_description>
+<action_postfix>
+Calculate_Deductions
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+<action_column column_number="3" column_value="X"></action_column>
+<action_column column_number="4" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>7</action_number>
+<action_comment>Calculate taxable income (Form 1040 Line 15)</action_comment>
+<action_description>Calculate_Taxable_Income</action_description>
+<action_postfix>
+Calculate_Taxable_Income
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+<action_column column_number="3" column_value="X"></action_column>
+<action_column column_number="4" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>8</action_number>
+<action_comment>Calculate tax liability (Form 1040 Lines 16-24)</action_comment>
+<action_description>Calculate_Tax_Liability</action_description>
+<action_postfix>
+Calculate_Tax_Liability
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+<action_column column_number="3" column_value="X"></action_column>
+<action_column column_number="4" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>9</action_number>
+<action_comment>Calculate credits (Form 1040 Lines 19-21)</action_comment>
+<action_description>Calculate_Credits</action_description>
+<action_postfix>
+Calculate_Credits
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+<action_column column_number="3" column_value="X"></action_column>
+<action_column column_number="4" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>10</action_number>
+<action_comment>Calculate final balance (Form 1040 Lines 33-37)</action_comment>
+<action_description>Calculate_Final_Balance</action_description>
+<action_postfix>
+Calculate_Final_Balance
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+<action_column column_number="3" column_value="X"></action_column>
+<action_column column_number="4" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+<policy_statement column="1">
+<policy_description>Processing tax return for Married Filing Jointly</policy_description>
+<policy_statement_postfix>"Processing tax return for Married Filing Jointly per Form 1040, IRC Section 1(a)"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="2">
+<policy_description>Processing tax return for Single filer</policy_description>
+<policy_statement_postfix>"Processing tax return for Single filer per Form 1040, IRC Section 1(c)"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="3">
+<policy_description>Processing tax return for Head of Household</policy_description>
+<policy_statement_postfix>"Processing tax return for Head of Household per Form 1040, IRC Section 1(b)"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="4">
+<policy_description>Processing tax return</policy_description>
+<policy_statement_postfix>"Processing tax return per Form 1040"</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 2: Calculate_Gross_Income                                       -->
+<!-- IRS Reference: Form 1040 Lines 1-9, Schedule C, Schedule E            -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Calculate_Gross_Income</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS>Calculates total gross income from all sources including W-2 wages, self-employment income (Schedule C), rental income (Schedule E), and other income sources. References Form 1040 Lines 1-9.</COMMENTS>
+<TABLE_NUMBER>2000</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions>
+<initial_action>
+<action_description>Initialize income totals</action_description>
+<action_postfix>
+0.0 /result.total_w2_wages xdef
+0.0 /result.total_se_income xdef
+0.0 /result.total_rental_income xdef
+0.0 /result.total_other_income xdef
+"INCOME CALCULATION (Form 1040 Lines 1-9)" job.audit_trail swap addto
+</action_postfix>
+</initial_action>
+</initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Always execute</condition_comment>
+<condition_description>perform when called</condition_description>
+<condition_postfix>
+perform when called
+</condition_postfix>
+<condition_column column_number="1" column_value="*"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Process W-2 income for all taxpayers</action_comment>
+<action_description>Process_W2_Income</action_description>
+<action_postfix>
+Process_W2_Income
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Process self-employment income (Schedule C)</action_comment>
+<action_description>Process_Self_Employment</action_description>
+<action_postfix>
+Process_Self_Employment
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>3</action_number>
+<action_comment>Process rental income (Schedule E)</action_comment>
+<action_description>Process_Rental_Income</action_description>
+<action_postfix>
+Process_Rental_Income
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>4</action_number>
+<action_comment>Calculate AGI adjustments (Schedule 1 Part II)</action_comment>
+<action_description>Calculate_AGI_Adjustments</action_description>
+<action_postfix>
+Calculate_AGI_Adjustments
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>5</action_number>
+<action_comment>Calculate total gross income</action_comment>
+<action_description>Sum all income sources for gross income (Form 1040 Line 9)</action_description>
+<action_postfix>
+result.total_w2_wages result.total_se_income f+ result.total_rental_income f+ result.total_other_income f+ /result.gross_income xdef
+"Line 9 - Total Income: $" result.gross_income cvs strconcat " per Form 1040 Line 9" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>6</action_number>
+<action_comment>Calculate AGI</action_comment>
+<action_description>Calculate AGI (Form 1040 Line 11)</action_description>
+<action_postfix>
+result.gross_income result.total_adjustments f- /result.agi xdef
+"Line 11 - Adjusted Gross Income (AGI): $" result.agi cvs strconcat " per Form 1040 Line 11" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 2a: Process_W2_Income                                           -->
+<!-- IRS Reference: Form 1040 Line 1a, Form W-2, IRC Section 61(a)(1)      -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Process_W2_Income</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS>Processes W-2 wage income for all taxpayers. Records wages per Form 1040 Line 1a, IRC Section 61(a)(1). Also tracks withholding for payment calculation.</COMMENTS>
+<TABLE_NUMBER>2100</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>Process each taxpayer</context_comment>
+<context_description>for all taxpayers</context_description>
+<context_postfix>
+job.taxpayers dup forall pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Taxpayer has W-2 wages</condition_comment>
+<condition_description>taxpayer.w2_wages greater than 0</condition_description>
+<condition_postfix>
+taxpayer.w2_wages 0 >
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Add W-2 wages to total</action_comment>
+<action_description>Add taxpayer W-2 wages to result.total_w2_wages</action_description>
+<action_postfix>
+taxpayer.w2_wages result.total_w2_wages f+ /result.total_w2_wages xdef
+"  W-2 Wages for " taxpayer.name strconcat ": $" strconcat taxpayer.w2_wages cvs strconcat " (Form W-2, IRC 61(a)(1))" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Track withholding for payments</action_comment>
+<action_description>Add withholding to total payments</action_description>
+<action_postfix>
+taxpayer.w2_withholding result.total_payments f+ /result.total_payments xdef
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+<policy_statement column="1">
+<policy_description>W-2 wages recorded per Form 1040 Line 1a, Form W-2, IRC Section 61(a)(1)</policy_description>
+<policy_statement_postfix>"W-2 wages recorded per Form 1040 Line 1a, Form W-2, IRC Section 61(a)(1)"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="2">
+<policy_description>No W-2 wages for this taxpayer</policy_description>
+<policy_statement_postfix>"No W-2 wages for this taxpayer"</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 2b: Process_Self_Employment                                     -->
+<!-- IRS Reference: Schedule C, Schedule SE, Publication 334, IRC 162      -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Process_Self_Employment</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS>Processes self-employment income per Schedule C, calculates vehicle deductions per Publication 463, and computes SE tax per Schedule SE and IRC Section 1401. Supports standard mileage and actual expense methods for vehicle deductions.</COMMENTS>
+<TABLE_NUMBER>2200</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>Process each self-employed taxpayer</context_comment>
+<context_description>for all taxpayers whose is_self_employed equals true</context_description>
+<context_postfix>
+{ dup is_self_employed true beq if } job.taxpayers forall pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Has self-employment income</condition_comment>
+<condition_description>taxpayer.se_gross_income greater than 0</condition_description>
+<condition_postfix>
+taxpayer.se_gross_income 0 >
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="Y"></condition_column>
+<condition_column column_number="3" column_value="N"></condition_column>
+</condition_details>
+<condition_details>
+<condition_number>2</condition_number>
+<condition_comment>Net SE income meets threshold for SE tax</condition_comment>
+<condition_description>SE net profit greater than or equal to se_threshold</condition_description>
+<condition_postfix>
+taxpayer.se_net_profit se_threshold >=
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Log gross receipts</action_comment>
+<action_description>Record gross receipts per Schedule C Line 1</action_description>
+<action_postfix>
+"SCHEDULE C - " taxpayer.name strconcat " (" strconcat taxpayer.occupation strconcat ")" strconcat job.audit_trail swap addto
+"  Gross Receipts: $" taxpayer.se_gross_income cvs strconcat " (Schedule C Line 1, IRC 61)" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Calculate vehicle deduction</action_comment>
+<action_description>Calculate_Vehicle_Deduction for this taxpayer</action_description>
+<action_postfix>
+Calculate_Vehicle_Deduction
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>3</action_number>
+<action_comment>Calculate net profit</action_comment>
+<action_description>Calculate Schedule C net profit (Line 31)</action_description>
+<action_postfix>
+taxpayer.se_gross_income taxpayer.se_expenses f- /taxpayer.se_net_profit xdef
+"  Net Profit: $" taxpayer.se_net_profit cvs strconcat " (Schedule C Line 31)" strconcat job.audit_trail swap addto
+taxpayer.se_net_profit result.total_se_income f+ /result.total_se_income xdef
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>4</action_number>
+<action_comment>Calculate SE tax</action_comment>
+<action_description>Calculate self-employment tax per Schedule SE, IRC 1401</action_description>
+<action_postfix>
+taxpayer.se_net_profit se_income_multiplier f* se_tax_rate f* /taxpayer.se_tax xdef
+taxpayer.se_tax se_deduction_rate f* /taxpayer.se_tax_deduction xdef
+"SCHEDULE SE - Self-Employment Tax" job.audit_trail swap addto
+"  Net SE Earnings x 92.35%: $" taxpayer.se_net_profit se_income_multiplier f* cvs strconcat " (IRC 1402(a)(12))" strconcat job.audit_trail swap addto
+"  SE Tax (15.3%): $" taxpayer.se_tax cvs strconcat " (IRC 1401(a) SS 12.4% + IRC 1401(b) Medicare 2.9%)" strconcat job.audit_trail swap addto
+"  Deductible Portion (50%): $" taxpayer.se_tax_deduction cvs strconcat " (IRC 164(f), Schedule 1 Line 15)" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>5</action_number>
+<action_comment>No SE tax required - below threshold</action_comment>
+<action_description>Log no SE tax required</action_description>
+<action_postfix>
+"  SE Tax: Not required - net SE income below $400 threshold (IRC 1402(b)(2))" job.audit_trail swap addto
+0 /taxpayer.se_tax xdef
+0 /taxpayer.se_tax_deduction xdef
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+<policy_statement column="1">
+<policy_description>Self-employment income and SE tax calculated per Schedule C, Schedule SE, IRC 162, 1401</policy_description>
+<policy_statement_postfix>"Self-employment income and SE tax calculated per Schedule C, Schedule SE, IRC 162, 1401"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="2">
+<policy_description>Self-employment income calculated, SE tax not required (below $400 threshold)</policy_description>
+<policy_statement_postfix>"Self-employment income calculated, SE tax not required per IRC 1402(b)(2)"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="3">
+<policy_description>No self-employment income</policy_description>
+<policy_statement_postfix>"No self-employment income for this taxpayer"</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 2b1: Calculate_Vehicle_Deduction                                -->
+<!-- IRS Reference: Publication 463 Chapter 4, IRC 162, 274(d)             -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Calculate_Vehicle_Deduction</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS>Calculates vehicle expense deduction using either standard mileage rate or actual expenses method per Publication 463 Chapter 4, IRC Section 162 and 274(d). Standard mileage rate for 2025 estimated at $0.70 per mile.</COMMENTS>
+<TABLE_NUMBER>2210</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>Process vehicles for current taxpayer</context_comment>
+<context_description>for all vehicles where taxpayer_id matches current taxpayer</context_description>
+<context_postfix>
+{ dup taxpayer_id taxpayer.id == if } job.vehicles forall pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Has business miles</condition_comment>
+<condition_description>vehicle.business_miles greater than 0</condition_description>
+<condition_postfix>
+vehicle.business_miles 0 >
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="Y"></condition_column>
+<condition_column column_number="3" column_value="N"></condition_column>
+</condition_details>
+<condition_details>
+<condition_number>2</condition_number>
+<condition_comment>Using standard mileage method</condition_comment>
+<condition_description>vehicle.method equals standard_mileage</condition_description>
+<condition_postfix>
+vehicle.method "standard_mileage" streq
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Calculate business use percentage</action_comment>
+<action_description>Calculate business use percentage</action_description>
+<action_postfix>
+business_miles cvr total_miles cvr fdiv /business_use_percentage xdef
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Calculate standard mileage deduction</action_comment>
+<action_description>Calculate standard mileage deduction per Pub 463</action_description>
+<action_postfix>
+vehicle.business_miles cvr mileage_rate f* /vehicle.standard_mileage_deduction xdef
+vehicle.standard_mileage_deduction /vehicle.vehicle_deduction xdef
+vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
+"  Vehicle Expense (" vehicle.description strconcat "): $" strconcat vehicle.vehicle_deduction cvs strconcat job.audit_trail swap addto
+"    Method: Standard Mileage Rate @ $" mileage_rate cvs strconcat "/mile x " strconcat vehicle.business_miles cvs strconcat " business miles" strconcat job.audit_trail swap addto
+"    (Publication 463 Chapter 4, IRS Notice 2025-XX)" job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>3</action_number>
+<action_comment>Calculate actual expense deduction</action_comment>
+<action_description>Calculate actual expense deduction per Pub 463</action_description>
+<action_postfix>
+vehicle.actual_expenses vehicle.vehicle_depreciation f+ vehicle.business_use_percentage f* /vehicle.vehicle_deduction xdef
+vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
+"  Vehicle Expense (" vehicle.description strconcat "): $" strconcat vehicle.vehicle_deduction cvs strconcat job.audit_trail swap addto
+"    Method: Actual Expenses x " vehicle.business_use_percentage 100 f* cvs strconcat "% business use" strconcat job.audit_trail swap addto
+"    (Publication 463 Chapter 4, IRC 274)" job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+<policy_statement column="1">
+<policy_description>Standard mileage deduction calculated per Publication 463 Chapter 4</policy_description>
+<policy_statement_postfix>"Standard mileage deduction calculated per Publication 463 Chapter 4, IRS Notice 2025-XX"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="2">
+<policy_description>Actual expense deduction calculated per Publication 463 Chapter 4, IRC 274</policy_description>
+<policy_statement_postfix>"Actual expense deduction calculated per Publication 463 Chapter 4, IRC 274"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="3">
+<policy_description>No vehicle expenses claimed</policy_description>
+<policy_statement_postfix>"No vehicle expenses claimed for this vehicle"</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 2c: Process_Rental_Income                                       -->
+<!-- IRS Reference: Schedule E Part I, Publication 527, IRC 61(a)(5)       -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Process_Rental_Income</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS>Processes rental property income and expenses per Schedule E Part I, Publication 527, IRC Section 61(a)(5). Calculates depreciation, mortgage interest, property taxes, and other rental expenses.</COMMENTS>
+<TABLE_NUMBER>2300</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>Process each rental property</context_comment>
+<context_description>for all properties where type equals rental</context_description>
+<context_postfix>
+{ dup type "rental" streq if } job.properties forall pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Has rental income</condition_comment>
+<condition_description>property.rental_income greater than 0</condition_description>
+<condition_postfix>
+property.rental_income 0 >
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="Y"></condition_column>
+<condition_column column_number="3" column_value="N"></condition_column>
+</condition_details>
+<condition_details>
+<condition_number>2</condition_number>
+<condition_comment>Net rental income is positive</condition_comment>
+<condition_description>rental net income greater than 0</condition_description>
+<condition_postfix>
+property.rental_net_income 0 >
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Log rental property header</action_comment>
+<action_description>Log Schedule E header</action_description>
+<action_postfix>
+"SCHEDULE E Part I - Rental Property: " property.address strconcat job.audit_trail swap addto
+"  Rental Income: $" property.rental_income cvs strconcat " (Schedule E Line 3, IRC 61(a)(5))" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Calculate total rental expenses</action_comment>
+<action_description>Sum rental expenses</action_description>
+<action_postfix>
+property.rental_advertising property.rental_insurance f+ property.mortgage_interest f+ property.property_taxes f+ property.rental_repairs f+ property.rental_utilities f+ property.rental_management f+ property.depreciation f+ /property.rental_expenses xdef
+"  Expenses:" job.audit_trail swap addto
+"    Advertising: $" property.rental_advertising cvs strconcat " (Line 5)" strconcat job.audit_trail swap addto
+"    Insurance: $" property.rental_insurance cvs strconcat " (Line 9)" strconcat job.audit_trail swap addto
+"    Mortgage Interest: $" property.mortgage_interest cvs strconcat " (Line 12, Form 1098)" strconcat job.audit_trail swap addto
+"    Property Taxes: $" property.property_taxes cvs strconcat " (Line 16, IRC 164(a)(1))" strconcat job.audit_trail swap addto
+"    Repairs: $" property.rental_repairs cvs strconcat " (Line 14)" strconcat job.audit_trail swap addto
+"    Utilities: $" property.rental_utilities cvs strconcat " (Line 17)" strconcat job.audit_trail swap addto
+"    Depreciation: $" property.depreciation cvs strconcat " (Line 18, Publication 946, IRC 167/168)" strconcat job.audit_trail swap addto
+"    Total Expenses: $" property.rental_expenses cvs strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>3</action_number>
+<action_comment>Calculate net rental income</action_comment>
+<action_description>Calculate net rental income (Schedule E Line 21)</action_description>
+<action_postfix>
+property.rental_income property.rental_expenses f- /property.rental_net_income xdef
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>4</action_number>
+<action_comment>Add net rental income to total</action_comment>
+<action_description>Add net rental income to result</action_description>
+<action_postfix>
+"  Net Rental Income: $" property.rental_net_income cvs strconcat " (Schedule E Line 21)" strconcat job.audit_trail swap addto
+property.rental_net_income result.total_rental_income f+ /result.total_rental_income xdef
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>5</action_number>
+<action_comment>Handle rental loss</action_comment>
+<action_description>Log rental loss with passive activity note</action_description>
+<action_postfix>
+"  Net Rental Loss: $" property.rental_net_income cvs strconcat " (Schedule E Line 21)" strconcat job.audit_trail swap addto
+"  Note: Rental loss may be subject to passive activity limitations per Form 8582, IRC 469" job.audit_trail swap addto
+property.rental_net_income result.total_rental_income f+ /result.total_rental_income xdef
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+<policy_statement column="1">
+<policy_description>Rental income calculated per Schedule E Part I, Publication 527, IRC 61(a)(5)</policy_description>
+<policy_statement_postfix>"Rental income calculated per Schedule E Part I, Publication 527, IRC 61(a)(5)"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="2">
+<policy_description>Rental loss subject to passive activity rules per Form 8582, IRC 469</policy_description>
+<policy_statement_postfix>"Rental loss subject to passive activity limitations per Form 8582, IRC 469"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="3">
+<policy_description>Property is not a rental property</policy_description>
+<policy_statement_postfix>"Property is not a rental property - Schedule E not required"</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 2d: Calculate_AGI_Adjustments                                   -->
+<!-- IRS Reference: Schedule 1 Part II, IRC 62                             -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Calculate_AGI_Adjustments</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS>Calculates above-the-line deductions (adjustments to income) per Schedule 1 Part II, IRC Section 62. Includes SE tax deduction, health insurance for self-employed, and other adjustments.</COMMENTS>
+<TABLE_NUMBER>2400</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>Process each taxpayer for adjustments</context_comment>
+<context_description>for all taxpayers</context_description>
+<context_postfix>
+job.taxpayers dup forall pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions>
+<initial_action>
+<action_description>Initialize adjustments</action_description>
+<action_postfix>
+0.0 /result.total_adjustments xdef
+"ADJUSTMENTS TO INCOME (Schedule 1 Part II)" job.audit_trail swap addto
+</action_postfix>
+</initial_action>
+</initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Has SE tax to deduct</condition_comment>
+<condition_description>taxpayer.se_tax_deduction greater than 0</condition_description>
+<condition_postfix>
+taxpayer.se_tax_deduction 0 >
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Add SE tax deduction to adjustments</action_comment>
+<action_description>Add deductible portion of SE tax per IRC 164(f)</action_description>
+<action_postfix>
+taxpayer.se_tax_deduction result.total_adjustments f+ /result.total_adjustments xdef
+"  Line 15 - SE Tax Deduction for " taxpayer.name strconcat ": $" strconcat taxpayer.se_tax_deduction cvs strconcat " (IRC 164(f))" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Log total adjustments</action_comment>
+<action_description>Log total adjustments</action_description>
+<action_postfix>
+"  Line 26 - Total Adjustments: $" result.total_adjustments cvs strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 3: Calculate_Deductions                                         -->
+<!-- IRS Reference: Form 1040 Line 12, Schedule A, IRC 63                  -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Calculate_Deductions</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS>Determines whether to use standard or itemized deduction per Form 1040 Line 12, Schedule A, IRC Section 63. Calculates itemized deductions including SALT (with $10,000 cap per TCJA), mortgage interest, and charitable contributions.</COMMENTS>
+<TABLE_NUMBER>3000</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions>
+<initial_action>
+<action_description>Calculate standard deduction and itemized deductions</action_description>
+<action_postfix>
+"DEDUCTIONS (Form 1040 Line 12)" job.audit_trail swap addto
+Calculate_Standard_Deduction
+Calculate_Itemized_Deductions
+</action_postfix>
+</initial_action>
+</initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Itemized deductions exceed standard deduction</condition_comment>
+<condition_description>result.total_itemized greater than result.standard_deduction</condition_description>
+<condition_postfix>
+result.total_itemized result.standard_deduction >
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Use itemized deductions</action_comment>
+<action_description>Use itemized deductions (Schedule A)</action_description>
+<action_postfix>
+result.total_itemized /result.total_deduction xdef
+"itemized" /result.deduction_used xdef
+"Using ITEMIZED DEDUCTION: $" result.total_deduction cvs strconcat " (Schedule A total exceeds standard deduction)" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Use standard deduction</action_comment>
+<action_description>Use standard deduction per IRC 63(c)</action_description>
+<action_postfix>
+result.standard_deduction /result.total_deduction xdef
+"standard" /result.deduction_used xdef
+"Using STANDARD DEDUCTION: $" result.total_deduction cvs strconcat " (exceeds itemized total of $" strconcat result.total_itemized cvs strconcat ")" strconcat job.audit_trail swap addto
+"(Per IRC 63(c), " job.filing_status strconcat " filing status)" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+<policy_statement column="1">
+<policy_description>Itemized deduction claimed per Schedule A</policy_description>
+<policy_statement_postfix>"Itemized deduction claimed per Schedule A - exceeds standard deduction"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="2">
+<policy_description>Standard deduction claimed per IRC 63(c)</policy_description>
+<policy_statement_postfix>"Standard deduction claimed per IRC 63(c) - higher than itemized total"</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 3a: Calculate_Standard_Deduction                                -->
+<!-- IRS Reference: IRC 63(c), Publication 17 Chapter 20                   -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Calculate_Standard_Deduction</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS>Determines standard deduction amount based on filing status per IRC Section 63(c), Publication 17 Chapter 20. Amounts for 2025 are estimated.</COMMENTS>
+<TABLE_NUMBER>3100</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Married Filing Jointly or Qualifying Surviving Spouse</condition_comment>
+<condition_description>filing_status equals MFJ or QSS</condition_description>
+<condition_postfix>
+job.filing_status MFJ streq job.filing_status QSS streq or
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+</condition_details>
+<condition_details>
+<condition_number>2</condition_number>
+<condition_comment>Head of Household</condition_comment>
+<condition_description>filing_status equals HOH</condition_description>
+<condition_postfix>
+job.filing_status HOH streq
+</condition_postfix>
+<condition_column column_number="2" column_value="Y"></condition_column>
+</condition_details>
+<condition_details>
+<condition_number>3</condition_number>
+<condition_comment>Single or MFS</condition_comment>
+<condition_description>otherwise</condition_description>
+<condition_postfix>
+otherwise
+</condition_postfix>
+<condition_column column_number="3" column_value="*"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>MFJ/QSS standard deduction</action_comment>
+<action_description>Set MFJ standard deduction</action_description>
+<action_postfix>
+standard_deduction_mfj /result.standard_deduction xdef
+"Standard Deduction (MFJ): $" result.standard_deduction cvs strconcat " per IRC 63(c)(2)(A)" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>HOH standard deduction</action_comment>
+<action_description>Set HOH standard deduction</action_description>
+<action_postfix>
+standard_deduction_hoh /result.standard_deduction xdef
+"Standard Deduction (HOH): $" result.standard_deduction cvs strconcat " per IRC 63(c)(2)(B)" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>3</action_number>
+<action_comment>Single/MFS standard deduction</action_comment>
+<action_description>Set Single standard deduction</action_description>
+<action_postfix>
+standard_deduction_single /result.standard_deduction xdef
+"Standard Deduction (Single/MFS): $" result.standard_deduction cvs strconcat " per IRC 63(c)(2)(C)" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="3" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+<policy_statement column="1">
+<policy_description>Standard deduction for MFJ/QSS per IRC 63(c)(2)(A)</policy_description>
+<policy_statement_postfix>"Standard deduction for MFJ/QSS per IRC 63(c)(2)(A)"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="2">
+<policy_description>Standard deduction for HOH per IRC 63(c)(2)(B)</policy_description>
+<policy_statement_postfix>"Standard deduction for HOH per IRC 63(c)(2)(B)"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="3">
+<policy_description>Standard deduction for Single/MFS per IRC 63(c)(2)(C)</policy_description>
+<policy_statement_postfix>"Standard deduction for Single/MFS per IRC 63(c)(2)(C)"</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 3b: Calculate_Itemized_Deductions                               -->
+<!-- IRS Reference: Schedule A, IRC 164, 163, 170                          -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Calculate_Itemized_Deductions</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS>Calculates total itemized deductions per Schedule A including SALT (capped at $10,000 per IRC 164(b)(6)(B) as amended by TCJA Section 11042), mortgage interest, and charitable contributions.</COMMENTS>
+<TABLE_NUMBER>3200</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions>
+<initial_action>
+<action_description>Initialize itemized deduction tracking</action_description>
+<action_postfix>
+0.0 /result.total_itemized xdef
+"SCHEDULE A - Itemized Deductions" job.audit_trail swap addto
+</action_postfix>
+</initial_action>
+</initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Always calculate itemized for comparison</condition_comment>
+<condition_description>perform when called</condition_description>
+<condition_postfix>
+perform when called
+</condition_postfix>
+<condition_column column_number="1" column_value="*"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Calculate SALT deduction</action_comment>
+<action_description>Calculate_SALT_Deduction</action_description>
+<action_postfix>
+Calculate_SALT_Deduction
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Calculate mortgage interest deduction</action_comment>
+<action_description>Calculate_Mortgage_Interest</action_description>
+<action_postfix>
+Calculate_Mortgage_Interest
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>3</action_number>
+<action_comment>Calculate charitable contributions</action_comment>
+<action_description>Calculate_Charitable_Deduction</action_description>
+<action_postfix>
+Calculate_Charitable_Deduction
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>4</action_number>
+<action_comment>Log total itemized</action_comment>
+<action_description>Log total itemized deductions</action_description>
+<action_postfix>
+"  Total Itemized Deductions: $" result.total_itemized cvs strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 3b1: Calculate_SALT_Deduction                                   -->
+<!-- IRS Reference: Schedule A Lines 5a-5d, IRC 164, TCJA Section 11042    -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Calculate_SALT_Deduction</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS>Calculates State and Local Tax (SALT) deduction including state income tax, real estate taxes, and personal property taxes. SALT is capped at $10,000 per IRC Section 164(b)(6)(B) as amended by TCJA Section 11042. Texas has no state income tax.</COMMENTS>
+<TABLE_NUMBER>3210</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>Calculate property taxes from primary residence</context_comment>
+<context_description>local double property_tax_total = sum of property_taxes from primary residence properties</context_description>
+<context_postfix>
+0.0 { { property_taxes f+ } { pop } dup type "primary_residence" streq ifelse } job.properties forall cve allocate execute deallocate pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>State has income tax</condition_comment>
+<condition_description>job.has_state_income_tax equals true</condition_description>
+<condition_postfix>
+job.has_state_income_tax true beq
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+<condition_details>
+<condition_number>2</condition_number>
+<condition_comment>Total SALT exceeds cap</condition_comment>
+<condition_description>total SALT greater than salt_cap</condition_description>
+<condition_postfix>
+0 local@ salt_cap >
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="Y"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Apply SALT cap with state income tax</action_comment>
+<action_description>Apply $10,000 SALT cap</action_description>
+<action_postfix>
+"  State and Local Taxes (SALT):" job.audit_trail swap addto
+"    State Income Tax: (applicable)" job.audit_trail swap addto
+"    Real Estate Taxes: $" 0 local@ cvs strconcat " (Line 5b, IRC 164(a)(1))" strconcat job.audit_trail swap addto
+"    Total SALT LIMITED TO $" salt_cap cvs strconcat " per IRC 164(b)(6)(B), TCJA Section 11042" strconcat job.audit_trail swap addto
+salt_cap result.total_itemized f+ /result.total_itemized xdef
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Texas - no state income tax, apply cap if needed</action_comment>
+<action_description>Process SALT for no-income-tax state</action_description>
+<action_postfix>
+"  State and Local Taxes (SALT) - " job.state strconcat " (No State Income Tax):" strconcat job.audit_trail swap addto
+"    Real Estate Taxes: $" 0 local@ cvs strconcat " (Line 5b, IRC 164(a)(1))" strconcat job.audit_trail swap addto
+"    Total SALT LIMITED TO $" salt_cap cvs strconcat " per IRC 164(b)(6)(B), TCJA Section 11042" strconcat job.audit_trail swap addto
+salt_cap result.total_itemized f+ /result.total_itemized xdef
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+<policy_statement column="1">
+<policy_description>SALT deduction limited to $10,000 per IRC 164(b)(6)(B), TCJA Section 11042</policy_description>
+<policy_statement_postfix>"SALT deduction limited to $10,000 per IRC 164(b)(6)(B) as amended by TCJA Section 11042"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="2">
+<policy_description>Property taxes only (no state income tax); limited per IRC 164(b)(6)(B)</policy_description>
+<policy_statement_postfix>"Property taxes only (no state income tax in " job.state cvs strconcat "); limited per IRC 164(b)(6)(B)" strconcat</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 3b2: Calculate_Mortgage_Interest                                -->
+<!-- IRS Reference: Schedule A Lines 8a-8e, Publication 936, IRC 163(h)    -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Calculate_Mortgage_Interest</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS>Calculates mortgage interest deduction for qualified residences per Schedule A Lines 8a-8e, Publication 936, IRC Section 163(h). Applies $750,000 debt limit for post-12/15/2017 mortgages per TCJA Section 11043.</COMMENTS>
+<TABLE_NUMBER>3220</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>Process primary residence properties</context_comment>
+<context_description>for all properties where type equals primary_residence</context_description>
+<context_postfix>
+{ dup type "primary_residence" streq if } job.properties forall pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Has mortgage interest</condition_comment>
+<condition_description>property.mortgage_interest greater than 0</condition_description>
+<condition_postfix>
+property.mortgage_interest 0 >
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="Y"></condition_column>
+<condition_column column_number="3" column_value="N"></condition_column>
+</condition_details>
+<condition_details>
+<condition_number>2</condition_number>
+<condition_comment>Mortgage balance within limit</condition_comment>
+<condition_description>mortgage_balance less than or equal to mortgage_limit_post_tcja</condition_description>
+<condition_postfix>
+property.mortgage_balance mortgage_limit_post_tcja &lt;=
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Full mortgage interest deduction</action_comment>
+<action_description>Allow full mortgage interest deduction</action_description>
+<action_postfix>
+property.mortgage_interest /property.mortgage_interest_deductible xdef
+property.mortgage_interest_deductible result.total_itemized f+ /result.total_itemized xdef
+"  Mortgage Interest (Primary Residence):" job.audit_trail swap addto
+"    Form 1098 Interest: $" property.mortgage_interest cvs strconcat job.audit_trail swap addto
+"    Acquisition Debt: $" property.mortgage_balance cvs strconcat " (under $750,000 limit)" strconcat job.audit_trail swap addto
+"    Full deduction of $" property.mortgage_interest_deductible cvs strconcat " allowed per Schedule A Line 8a, IRC 163(h)(3)" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Limited mortgage interest deduction</action_comment>
+<action_description>Prorate mortgage interest for debt over limit</action_description>
+<action_postfix>
+property.mortgage_interest mortgage_limit_post_tcja * property.mortgage_balance / /property.mortgage_interest_deductible xdef
+property.mortgage_interest_deductible result.total_itemized f+ /result.total_itemized xdef
+"  Mortgage Interest (Primary Residence):" job.audit_trail swap addto
+"    Form 1098 Interest: $" property.mortgage_interest cvs strconcat job.audit_trail swap addto
+"    Acquisition Debt: $" property.mortgage_balance cvs strconcat " EXCEEDS $750,000 limit" strconcat job.audit_trail swap addto
+"    Deduction LIMITED to $" property.mortgage_interest_deductible cvs strconcat " per Publication 936 Worksheet, IRC 163(h)(3)(F)(i)(I)" strconcat job.audit_trail swap addto
+"    Calculation: ($750,000 / $" property.mortgage_balance cvs strconcat ") x $" strconcat property.mortgage_interest cvs strconcat " = $" strconcat property.mortgage_interest_deductible cvs strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+<policy_statement column="1">
+<policy_description>Full mortgage interest deduction allowed per IRC 163(h)(3)</policy_description>
+<policy_statement_postfix>"Full mortgage interest deduction allowed per IRC 163(h)(3), Publication 936"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="2">
+<policy_description>Mortgage interest limited due to debt exceeding $750,000 per IRC 163(h)(3)(F)(i)(I)</policy_description>
+<policy_statement_postfix>"Mortgage interest limited due to debt exceeding $750,000 per IRC 163(h)(3)(F)(i)(I), TCJA Section 11043"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="3">
+<policy_description>No mortgage interest to deduct</policy_description>
+<policy_statement_postfix>"No mortgage interest to deduct for this property"</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 3b3: Calculate_Charitable_Deduction                             -->
+<!-- IRS Reference: Schedule A Lines 11-14, Publication 526, IRC 170       -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Calculate_Charitable_Deduction</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS>Calculates charitable contribution deduction per Schedule A Lines 11-14, Publication 526, IRC Section 170. Sums all charity-category deductions.</COMMENTS>
+<TABLE_NUMBER>3230</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>Process charitable deductions</context_comment>
+<context_description>for all deductions where category equals charity</context_description>
+<context_postfix>
+{ dup category "charity" streq if } job.deductions forall pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Has charitable contribution</condition_comment>
+<condition_description>deduction.amount greater than 0</condition_description>
+<condition_postfix>
+deduction.amount 0 >
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Add charitable contribution</action_comment>
+<action_description>Add charitable deduction per IRC 170</action_description>
+<action_postfix>
+deduction.amount /deduction.allowed_amount xdef
+deduction.allowed_amount result.total_itemized f+ /result.total_itemized xdef
+"  Charitable Contribution: $" deduction.amount cvs strconcat " - " strconcat deduction.description strconcat " (Schedule A Line 11, IRC 170)" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+<policy_statement column="1">
+<policy_description>Charitable contribution allowed per IRC 170, Publication 526</policy_description>
+<policy_statement_postfix>"Charitable contribution allowed per IRC 170, Publication 526"</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 4: Calculate_Taxable_Income                                     -->
+<!-- IRS Reference: Form 1040 Line 15, IRC 63                              -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Calculate_Taxable_Income</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS>Calculates taxable income per Form 1040 Line 15, IRC Section 63. Subtracts deductions and QBI deduction from AGI.</COMMENTS>
+<TABLE_NUMBER>4000</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Has self-employment income for QBI</condition_comment>
+<condition_description>result.total_se_income greater than 0</condition_description>
+<condition_postfix>
+result.total_se_income 0 >
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Calculate QBI deduction</action_comment>
+<action_description>Calculate QBI deduction per IRC 199A (20% of qualified business income)</action_description>
+<action_postfix>
+result.total_se_income qbi_rate f* /result.qbi_deduction xdef
+"TAXABLE INCOME CALCULATION" job.audit_trail swap addto
+"  Line 13 - QBI Deduction (20% of SE income): $" result.qbi_deduction cvs strconcat " (IRC 199A, Form 8995)" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>No QBI deduction</action_comment>
+<action_description>Set QBI deduction to zero</action_description>
+<action_postfix>
+0.0 /result.qbi_deduction xdef
+"TAXABLE INCOME CALCULATION" job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>3</action_number>
+<action_comment>Calculate taxable income</action_comment>
+<action_description>Calculate taxable income (AGI - deductions - QBI)</action_description>
+<action_postfix>
+result.agi result.total_deduction f- result.qbi_deduction f- /result.taxable_income xdef
+{ 0.0 /result.taxable_income xdef } result.taxable_income 0 &lt; if
+"  Line 15 - Taxable Income: $" result.taxable_income cvs strconcat " per Form 1040 Line 15" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+<policy_statement column="1">
+<policy_description>Taxable income calculated with QBI deduction per IRC 199A</policy_description>
+<policy_statement_postfix>"Taxable income calculated with QBI deduction per IRC 199A"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="2">
+<policy_description>Taxable income calculated per Form 1040 Line 15</policy_description>
+<policy_statement_postfix>"Taxable income calculated per Form 1040 Line 15"</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 5: Calculate_Tax_Liability                                      -->
+<!-- IRS Reference: Form 1040 Lines 16-24, IRC 1                           -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Calculate_Tax_Liability</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS>Calculates total tax liability including regular tax (using tax brackets per IRC Section 1) and self-employment tax (Schedule SE, IRC Section 1401). Form 1040 Lines 16-24.</COMMENTS>
+<TABLE_NUMBER>5000</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions>
+<initial_action>
+<action_description>Initialize tax calculation</action_description>
+<action_postfix>
+"TAX CALCULATION (Form 1040 Lines 16-24)" job.audit_trail swap addto
+</action_postfix>
+</initial_action>
+</initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Always calculate</condition_comment>
+<condition_description>perform when called</condition_description>
+<condition_postfix>
+perform when called
+</condition_postfix>
+<condition_column column_number="1" column_value="*"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Calculate regular tax using brackets</action_comment>
+<action_description>Apply_Tax_Brackets</action_description>
+<action_postfix>
+Apply_Tax_Brackets
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Add SE tax from all taxpayers</action_comment>
+<action_description>Sum SE tax from all taxpayers</action_description>
+<action_postfix>
+0.0 { se_tax + } job.taxpayers forall /result.se_tax xdef
+"  SE Tax (Schedule SE): $" result.se_tax cvs strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>3</action_number>
+<action_comment>Calculate total tax before credits</action_comment>
+<action_description>Sum regular tax and SE tax</action_description>
+<action_postfix>
+result.regular_tax result.se_tax f+ /result.total_tax_before_credits xdef
+"  Total Tax Before Credits: $" result.total_tax_before_credits cvs strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 5a: Apply_Tax_Brackets                                          -->
+<!-- IRS Reference: Form 1040 Line 16, IRC 1(a)-(d)                        -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Apply_Tax_Brackets</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS>Applies marginal tax brackets to calculate regular tax per Form 1040 Line 16, IRC Section 1. Uses 2025 estimated bracket amounts for MFJ, Single, and other filing statuses.</COMMENTS>
+<TABLE_NUMBER>5100</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Married Filing Jointly</condition_comment>
+<condition_description>filing_status equals MFJ or QSS</condition_description>
+<condition_postfix>
+job.filing_status MFJ streq job.filing_status QSS streq or
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+</condition_details>
+<condition_details>
+<condition_number>2</condition_number>
+<condition_comment>Single or other</condition_comment>
+<condition_description>otherwise</condition_description>
+<condition_postfix>
+otherwise
+</condition_postfix>
+<condition_column column_number="2" column_value="*"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Calculate MFJ tax</action_comment>
+<action_description>Apply MFJ tax brackets per IRC 1(a)</action_description>
+<action_postfix>
+result.taxable_income allocate
+0.0 allocate
+{ 0 local@ bracket_1_rate f* 1 local! }
+{
+  bracket_1_mfj bracket_1_rate f* 1 local!
+  { 0 local@ bracket_1_mfj f- bracket_2_rate f* 1 local@ f+ 1 local! }
+  {
+    bracket_2_mfj bracket_1_mfj f- bracket_2_rate f* 1 local@ f+ 1 local!
+    { 0 local@ bracket_2_mfj f- bracket_3_rate f* 1 local@ f+ 1 local! }
+    {
+      bracket_3_mfj bracket_2_mfj f- bracket_3_rate f* 1 local@ f+ 1 local!
+      { 0 local@ bracket_3_mfj f- bracket_4_rate f* 1 local@ f+ 1 local! }
+      { bracket_4_mfj bracket_3_mfj f- bracket_4_rate f* 1 local@ f+ 1 local!
+        0 local@ bracket_4_mfj f- bracket_5_rate f* 1 local@ f+ 1 local! }
+      0 local@ bracket_4_mfj &lt;= ifelse
+    }
+    0 local@ bracket_3_mfj &lt;= ifelse
+  }
+  0 local@ bracket_2_mfj &lt;= ifelse
+}
+0 local@ bracket_1_mfj &lt;= ifelse
+1 local@ /result.regular_tax xdef
+deallocate pop deallocate pop
+"  Line 16 - Regular Tax (MFJ brackets): $" result.regular_tax cvs strconcat " per IRC 1(a)" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Calculate Single tax</action_comment>
+<action_description>Apply Single tax brackets per IRC 1(c)</action_description>
+<action_postfix>
+result.taxable_income allocate
+0.0 allocate
+{ 0 local@ bracket_1_rate f* 1 local! }
+{
+  bracket_1_single bracket_1_rate f* 1 local!
+  { 0 local@ bracket_1_single f- bracket_2_rate f* 1 local@ f+ 1 local! }
+  {
+    bracket_2_single bracket_1_single f- bracket_2_rate f* 1 local@ f+ 1 local!
+    { 0 local@ bracket_2_single f- bracket_3_rate f* 1 local@ f+ 1 local! }
+    {
+      bracket_3_single bracket_2_single f- bracket_3_rate f* 1 local@ f+ 1 local!
+      { 0 local@ bracket_3_single f- bracket_4_rate f* 1 local@ f+ 1 local! }
+      { bracket_4_single bracket_3_single f- bracket_4_rate f* 1 local@ f+ 1 local!
+        0 local@ bracket_4_single f- bracket_5_rate f* 1 local@ f+ 1 local! }
+      0 local@ bracket_4_single &lt;= ifelse
+    }
+    0 local@ bracket_3_single &lt;= ifelse
+  }
+  0 local@ bracket_2_single &lt;= ifelse
+}
+0 local@ bracket_1_single &lt;= ifelse
+1 local@ /result.regular_tax xdef
+deallocate pop deallocate pop
+"  Line 16 - Regular Tax (Single brackets): $" result.regular_tax cvs strconcat " per IRC 1(c)" strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+<policy_statement column="1">
+<policy_description>Tax calculated using MFJ brackets per IRC 1(a), Form 1040 Line 16</policy_description>
+<policy_statement_postfix>"Tax calculated using MFJ brackets per IRC 1(a), Form 1040 Line 16"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="2">
+<policy_description>Tax calculated using Single brackets per IRC 1(c), Form 1040 Line 16</policy_description>
+<policy_statement_postfix>"Tax calculated using Single brackets per IRC 1(c), Form 1040 Line 16"</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 6: Calculate_Credits                                            -->
+<!-- IRS Reference: Form 1040 Lines 19-21, Schedule 8812                   -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Calculate_Credits</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS>Calculates tax credits including Child Tax Credit (CTC), Other Dependent Credit (ODC), and Additional Child Tax Credit (ACTC) per Form 1040 Lines 19-21, Schedule 8812, IRC Section 24.</COMMENTS>
+<TABLE_NUMBER>6000</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions>
+<initial_action>
+<action_description>Initialize credit totals</action_description>
+<action_postfix>
+0.0 /result.total_ctc xdef
+0.0 /result.total_odc xdef
+0.0 /result.total_actc xdef
+0.0 /result.total_credits xdef
+"CREDITS (Form 1040 Lines 19-21)" job.audit_trail swap addto
+</action_postfix>
+</initial_action>
+</initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Always process credits</condition_comment>
+<condition_description>perform when called</condition_description>
+<condition_postfix>
+perform when called
+</condition_postfix>
+<condition_column column_number="1" column_value="*"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Calculate child tax credits for all dependents</action_comment>
+<action_description>Calculate_Child_Tax_Credit</action_description>
+<action_postfix>
+Calculate_Child_Tax_Credit
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Sum total credits</action_comment>
+<action_description>Calculate total credits</action_description>
+<action_postfix>
+result.total_ctc result.total_odc f+ /result.total_credits xdef
+"  Total Child Tax Credit: $" result.total_ctc cvs strconcat " (Schedule 8812)" strconcat job.audit_trail swap addto
+"  Total Other Dependent Credit: $" result.total_odc cvs strconcat " (Schedule 8812)" strconcat job.audit_trail swap addto
+"  Total Credits: $" result.total_credits cvs strconcat job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 6a: Calculate_Child_Tax_Credit                                  -->
+<!-- IRS Reference: Schedule 8812, Publication 972, IRC 24                 -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Calculate_Child_Tax_Credit</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS>Calculates Child Tax Credit (CTC) and Other Dependent Credit (ODC) per Schedule 8812, Publication 972, IRC Section 24. CTC requires child under 17 with SSN. ODC is $500 for dependents who dont qualify for CTC.</COMMENTS>
+<TABLE_NUMBER>6100</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>Process each dependent</context_comment>
+<context_description>for all dependents</context_description>
+<context_postfix>
+job.dependents dup forall pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Is a qualifying child (relationship)</condition_comment>
+<condition_description>dependent.relationship equals child</condition_description>
+<condition_postfix>
+dependent.relationship "child" streq
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="Y"></condition_column>
+<condition_column column_number="3" column_value="N"></condition_column>
+</condition_details>
+<condition_details>
+<condition_number>2</condition_number>
+<condition_comment>Under age 17 at end of year</condition_comment>
+<condition_description>dependent.age less than ctc_age_limit</condition_description>
+<condition_postfix>
+dependent.age ctc_age_limit &lt;
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+<condition_details>
+<condition_number>3</condition_number>
+<condition_comment>Has valid SSN</condition_comment>
+<condition_description>dependent.has_ssn equals true</condition_description>
+<condition_postfix>
+dependent.has_ssn true beq
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="Y"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Award Child Tax Credit</action_comment>
+<action_description>Award $2,000 CTC per IRC 24(a)</action_description>
+<action_postfix>
+true /dependent.qualifies_for_ctc xdef
+ctc_amount /dependent.ctc_amount xdef
+dependent.ctc_amount result.total_ctc f+ /result.total_ctc xdef
+"  Child Tax Credit for " dependent.name strconcat " (age " strconcat dependent.age cvs strconcat "): $" strconcat dependent.ctc_amount cvs strconcat job.audit_trail swap addto
+"    Qualifying child under age 17 per IRC 24(c)(1), Schedule 8812 Line 4" job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Award Other Dependent Credit (age 17)</action_comment>
+<action_description>Award $500 ODC for dependent age 17+ per IRC 24(h)(4)</action_description>
+<action_postfix>
+true /dependent.qualifies_for_odc xdef
+odc_amount /dependent.odc_amount xdef
+dependent.odc_amount result.total_odc f+ /result.total_odc xdef
+"  Other Dependent Credit for " dependent.name strconcat " (age " strconcat dependent.age cvs strconcat "): $" strconcat dependent.odc_amount cvs strconcat job.audit_trail swap addto
+"    Does not meet under-17 requirement for CTC per IRC 24(c)(1)" job.audit_trail swap addto
+"    $500 ODC allowed per IRC 24(h)(4), Schedule 8812 Part II-A" job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>3</action_number>
+<action_comment>Non-child dependent gets ODC</action_comment>
+<action_description>Award $500 ODC for non-child dependent</action_description>
+<action_postfix>
+true /dependent.qualifies_for_odc xdef
+odc_amount /dependent.odc_amount xdef
+dependent.odc_amount result.total_odc f+ /result.total_odc xdef
+"  Other Dependent Credit for " dependent.name strconcat " (" strconcat dependent.relationship strconcat "): $" strconcat dependent.odc_amount cvs strconcat job.audit_trail swap addto
+"    Not a qualifying child - $500 ODC per IRC 24(h)(4)" job.audit_trail swap addto
+</action_postfix>
+<action_column column_number="3" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+<policy_statement column="1">
+<policy_description>Child Tax Credit awarded per IRC 24(a), Schedule 8812</policy_description>
+<policy_statement_postfix>"Child Tax Credit of $2,000 awarded per IRC 24(a), qualifying child under age 17"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="2">
+<policy_description>Other Dependent Credit for child age 17+ per IRC 24(h)(4)</policy_description>
+<policy_statement_postfix>"Other Dependent Credit of $500 per IRC 24(h)(4) - dependent age 17, does not qualify for CTC"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="3">
+<policy_description>Other Dependent Credit for non-child dependent per IRC 24(h)(4)</policy_description>
+<policy_statement_postfix>"Other Dependent Credit of $500 per IRC 24(h)(4) - non-child dependent"</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- ====================================================================== -->
+<!-- TABLE 7: Calculate_Final_Balance                                      -->
+<!-- IRS Reference: Form 1040 Lines 33-37                                  -->
+<!-- ====================================================================== -->
+<decision_table>
+<table_name>Calculate_Final_Balance</table_name>
+<xls_file>TaxReturn_dt.xls</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS>Calculates final tax balance - total tax minus credits and payments to determine refund or amount owed per Form 1040 Lines 33-37.</COMMENTS>
+<TABLE_NUMBER>7000</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions>
+<initial_action>
+<action_description>Calculate total tax after credits</action_description>
+<action_postfix>
+"FINAL CALCULATION (Form 1040 Lines 33-37)" job.audit_trail swap addto
+result.total_tax_before_credits result.total_credits f- /result.total_tax xdef
+{ 0.0 /result.total_tax xdef } result.total_tax 0 &lt; if
+"  Line 24 - Total Tax: $" result.total_tax cvs strconcat job.audit_trail swap addto
+"  Line 33 - Total Payments: $" result.total_payments cvs strconcat job.audit_trail swap addto
+</action_postfix>
+</initial_action>
+</initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Payments exceed tax (refund)</condition_comment>
+<condition_description>result.total_payments greater than result.total_tax</condition_description>
+<condition_postfix>
+result.total_payments result.total_tax >
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Calculate refund</action_comment>
+<action_description>Calculate refund amount (Line 34)</action_description>
+<action_postfix>
+result.total_payments result.total_tax f- /result.refund_or_owed xdef
+"  Line 34 - REFUND: $" result.refund_or_owed cvs strconcat job.audit_trail swap addto
+"Form 1098" result.form_references swap addto
+"Form W-2" result.form_references swap addto
+"Schedule C" result.form_references swap addto
+"Schedule E" result.form_references swap addto
+"Schedule SE" result.form_references swap addto
+"Schedule 8812" result.form_references swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Calculate amount owed</action_comment>
+<action_description>Calculate amount owed (Line 37)</action_description>
+<action_postfix>
+result.total_tax result.total_payments f- fnegate /result.refund_or_owed xdef
+"  Line 37 - AMOUNT OWED: $" result.total_tax result.total_payments f- cvs strconcat job.audit_trail swap addto
+"Form 1098" result.form_references swap addto
+"Form W-2" result.form_references swap addto
+"Schedule C" result.form_references swap addto
+"Schedule E" result.form_references swap addto
+"Schedule SE" result.form_references swap addto
+"Schedule 8812" result.form_references swap addto
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+<policy_statement column="1">
+<policy_description>Taxpayer due refund per Form 1040 Line 34</policy_description>
+<policy_statement_postfix>"Taxpayer due refund per Form 1040 Line 34"</policy_statement_postfix>
+</policy_statement>
+<policy_statement column="2">
+<policy_description>Taxpayer owes additional tax per Form 1040 Line 37</policy_description>
+<policy_statement_postfix>"Taxpayer owes additional tax per Form 1040 Line 37"</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+</decision_tables>

--- a/sampleprojects/TaxReturn/xml/TaxReturn_edd.xml
+++ b/sampleprojects/TaxReturn/xml/TaxReturn_edd.xml
@@ -1,0 +1,308 @@
+<entity_data_dictionary version='2' xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+
+	<!-- ================================================================== -->
+	<!-- JOB - Root processing entity containing tax year and filing info  -->
+	<!-- ================================================================== -->
+	<entity name='job' access='rw' comment='Root entity for tax return processing'>
+		<field name='job' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='mapping*key' type='string' subtype='' access='r' input='' default_value='' comment='Mapping Key'></field>
+		<field name='id' type='integer' subtype='' access='r' input='main' default_value='' comment='Job ID'></field>
+		<field name='tax_year' type='integer' subtype='' access='r' input='main' default_value='2025' comment='Tax year being processed'></field>
+		<field name='filing_status' type='string' subtype='' access='r' input='main' default_value='MFJ' comment='Filing status: MFJ, MFS, Single, HOH, QSS'></field>
+		<field name='state' type='string' subtype='' access='r' input='main' default_value='TX' comment='State of residence'></field>
+		<field name='city' type='string' subtype='' access='r' input='main' default_value='' comment='City of residence'></field>
+		<field name='has_state_income_tax' type='boolean' subtype='' access='rw' input='' default_value='false' comment='Whether state has income tax (computed)'></field>
+		<field name='taxpayers' type='array' subtype='taxpayer' access='r' input='' default_value='' comment='Taxpayers on this return'></field>
+		<field name='dependents' type='array' subtype='dependent' access='r' input='' default_value='' comment='Dependents on this return'></field>
+		<field name='properties' type='array' subtype='property' access='r' input='' default_value='' comment='Properties owned'></field>
+		<field name='vehicles' type='array' subtype='vehicle' access='r' input='' default_value='' comment='Vehicles used for business'></field>
+		<field name='deductions' type='array' subtype='deduction' access='r' input='' default_value='' comment='Itemized deductions'></field>
+		<field name='credits' type='array' subtype='credit' access='r' input='' default_value='' comment='Tax credits'></field>
+		<field name='results' type='array' subtype='result' access='r' input='' default_value='' comment='Results of tax calculation'></field>
+		<field name='audit_trail' type='array' subtype='' access='rw' input='' default_value='' comment='Detailed trace of every decision'></field>
+	</entity>
+
+	<!-- ================================================================== -->
+	<!-- TAXPAYER - Individual taxpayer information                        -->
+	<!-- ================================================================== -->
+	<entity name='taxpayer' access='rw' comment='Individual taxpayer'>
+		<field name='taxpayer' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='mapping*key' type='string' subtype='' access='r' input='' default_value='' comment='Mapping Key'></field>
+		<field name='id' type='integer' subtype='' access='r' input='main' default_value='' comment='Taxpayer ID'></field>
+		<field name='name' type='string' subtype='' access='r' input='main' default_value='' comment='Full name'></field>
+		<field name='ssn' type='string' subtype='' access='r' input='main' default_value='' comment='Social Security Number'></field>
+		<field name='date_of_birth' type='date' subtype='' access='r' input='main' default_value='' comment='Date of birth'></field>
+		<field name='occupation' type='string' subtype='' access='r' input='main' default_value='' comment='Occupation or profession'></field>
+		<field name='is_self_employed' type='boolean' subtype='' access='r' input='main' default_value='false' comment='Whether taxpayer is self-employed'></field>
+		<field name='is_primary' type='boolean' subtype='' access='r' input='main' default_value='false' comment='Primary taxpayer on return'></field>
+		<field name='w2_wages' type='double' subtype='' access='rw' input='main' default_value='0' comment='W-2 wage income'></field>
+		<field name='w2_withholding' type='double' subtype='' access='rw' input='main' default_value='0' comment='Federal tax withheld from W-2'></field>
+		<field name='se_gross_income' type='double' subtype='' access='rw' input='main' default_value='0' comment='Self-employment gross receipts'></field>
+		<field name='se_expenses' type='double' subtype='' access='rw' input='' default_value='0' comment='Total Schedule C expenses (computed)'></field>
+		<field name='se_net_profit' type='double' subtype='' access='rw' input='' default_value='0' comment='Schedule C net profit (computed)'></field>
+		<field name='se_tax' type='double' subtype='' access='rw' input='' default_value='0' comment='Self-employment tax (computed)'></field>
+		<field name='se_tax_deduction' type='double' subtype='' access='rw' input='' default_value='0' comment='Deductible portion of SE tax (computed)'></field>
+		<field name='estimated_payments' type='double' subtype='' access='rw' input='main' default_value='0' comment='Estimated tax payments made'></field>
+		<field name='incomes' type='array' subtype='income' access='r' input='' default_value='' comment='Income sources for this taxpayer'></field>
+		<field name='total_income' type='double' subtype='' access='rw' input='' default_value='0' comment='Total income (computed)'></field>
+		<field name='notes' type='array' subtype='' access='rw' input='' default_value='' comment='Notes and explanations'></field>
+	</entity>
+
+	<!-- ================================================================== -->
+	<!-- DEPENDENT - Children and other dependents                         -->
+	<!-- ================================================================== -->
+	<entity name='dependent' access='rw' comment='Dependent (child or qualifying relative)'>
+		<field name='dependent' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='mapping*key' type='string' subtype='' access='r' input='' default_value='' comment='Mapping Key'></field>
+		<field name='id' type='integer' subtype='' access='r' input='main' default_value='' comment='Dependent ID'></field>
+		<field name='name' type='string' subtype='' access='r' input='main' default_value='' comment='Full name'></field>
+		<field name='ssn' type='string' subtype='' access='r' input='main' default_value='' comment='Social Security Number'></field>
+		<field name='date_of_birth' type='date' subtype='' access='r' input='main' default_value='' comment='Date of birth'></field>
+		<field name='age' type='integer' subtype='' access='r' input='main' default_value='0' comment='Age at end of tax year'></field>
+		<field name='relationship' type='string' subtype='' access='r' input='main' default_value='child' comment='Relationship: child, parent, relative, other'></field>
+		<field name='months_lived_with' type='integer' subtype='' access='r' input='main' default_value='12' comment='Months lived with taxpayer'></field>
+		<field name='is_student' type='boolean' subtype='' access='r' input='main' default_value='false' comment='Full-time student'></field>
+		<field name='school_type' type='string' subtype='' access='r' input='main' default_value='' comment='Type of school: public, private, homeschool'></field>
+		<field name='tuition_paid' type='double' subtype='' access='r' input='main' default_value='0' comment='Tuition paid (not deductible but tracked)'></field>
+		<field name='has_ssn' type='boolean' subtype='' access='r' input='main' default_value='true' comment='Has valid SSN (required for CTC)'></field>
+		<field name='qualifies_for_ctc' type='boolean' subtype='' access='rw' input='' default_value='false' comment='Qualifies for Child Tax Credit (computed)'></field>
+		<field name='qualifies_for_odc' type='boolean' subtype='' access='rw' input='' default_value='false' comment='Qualifies for Other Dependent Credit (computed)'></field>
+		<field name='ctc_amount' type='double' subtype='' access='rw' input='' default_value='0' comment='Child Tax Credit amount (computed)'></field>
+		<field name='odc_amount' type='double' subtype='' access='rw' input='' default_value='0' comment='Other Dependent Credit amount (computed)'></field>
+		<field name='notes' type='array' subtype='' access='rw' input='' default_value='' comment='Notes about dependent eligibility'></field>
+	</entity>
+
+	<!-- ================================================================== -->
+	<!-- INCOME - Individual income sources                                -->
+	<!-- ================================================================== -->
+	<entity name='income' access='rw' comment='Income source'>
+		<field name='income' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='mapping*key' type='string' subtype='' access='r' input='' default_value='' comment='Mapping Key'></field>
+		<field name='id' type='integer' subtype='' access='r' input='main' default_value='' comment='Income ID'></field>
+		<field name='taxpayer_id' type='integer' subtype='' access='r' input='main' default_value='' comment='Associated taxpayer ID'></field>
+		<field name='type' type='string' subtype='' access='r' input='main' default_value='' comment='Type: W2, 1099-NEC, 1099-MISC, rental, interest, dividend, capital_gain'></field>
+		<field name='source' type='string' subtype='' access='r' input='main' default_value='' comment='Source name (employer, payer, property)'></field>
+		<field name='gross_amount' type='double' subtype='' access='r' input='main' default_value='0' comment='Gross income amount'></field>
+		<field name='tax_withheld' type='double' subtype='' access='r' input='main' default_value='0' comment='Tax withheld at source'></field>
+		<field name='is_earned' type='boolean' subtype='' access='r' input='main' default_value='true' comment='Earned income (wages, SE) vs unearned (interest, dividends)'></field>
+		<field name='irs_form' type='string' subtype='' access='rw' input='' default_value='' comment='IRS form reference'></field>
+		<field name='irs_line' type='string' subtype='' access='rw' input='' default_value='' comment='IRS form line reference'></field>
+	</entity>
+
+	<!-- ================================================================== -->
+	<!-- PROPERTY - Real estate (primary residence, rental)                -->
+	<!-- ================================================================== -->
+	<entity name='property' access='rw' comment='Real estate property'>
+		<field name='property' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='mapping*key' type='string' subtype='' access='r' input='' default_value='' comment='Mapping Key'></field>
+		<field name='id' type='integer' subtype='' access='r' input='main' default_value='' comment='Property ID'></field>
+		<field name='type' type='string' subtype='' access='r' input='main' default_value='primary_residence' comment='Type: primary_residence, rental, second_home'></field>
+		<field name='address' type='string' subtype='' access='r' input='main' default_value='' comment='Property address'></field>
+		<field name='purchase_date' type='date' subtype='' access='r' input='main' default_value='' comment='Date purchased'></field>
+		<field name='purchase_price' type='double' subtype='' access='r' input='main' default_value='0' comment='Purchase price'></field>
+		<field name='current_fmv' type='double' subtype='' access='r' input='main' default_value='0' comment='Current fair market value'></field>
+		<field name='mortgage_balance' type='double' subtype='' access='r' input='main' default_value='0' comment='Outstanding mortgage balance'></field>
+		<field name='mortgage_origination_date' type='date' subtype='' access='r' input='main' default_value='' comment='Date mortgage originated'></field>
+		<field name='mortgage_interest' type='double' subtype='' access='r' input='main' default_value='0' comment='Annual mortgage interest paid (Form 1098)'></field>
+		<field name='property_taxes' type='double' subtype='' access='r' input='main' default_value='0' comment='Annual property taxes paid'></field>
+		<field name='rental_income' type='double' subtype='' access='r' input='main' default_value='0' comment='Gross rental income (Schedule E)'></field>
+		<field name='rental_expenses' type='double' subtype='' access='rw' input='main' default_value='0' comment='Total rental expenses'></field>
+		<field name='rental_advertising' type='double' subtype='' access='r' input='main' default_value='0' comment='Advertising expense'></field>
+		<field name='rental_insurance' type='double' subtype='' access='r' input='main' default_value='0' comment='Insurance expense'></field>
+		<field name='rental_repairs' type='double' subtype='' access='r' input='main' default_value='0' comment='Repairs and maintenance'></field>
+		<field name='rental_utilities' type='double' subtype='' access='r' input='main' default_value='0' comment='Utilities expense'></field>
+		<field name='rental_management' type='double' subtype='' access='r' input='main' default_value='0' comment='Property management fees'></field>
+		<field name='depreciation' type='double' subtype='' access='rw' input='main' default_value='0' comment='Annual depreciation'></field>
+		<field name='rental_net_income' type='double' subtype='' access='rw' input='' default_value='0' comment='Net rental income (computed)'></field>
+		<field name='is_qualified_residence' type='boolean' subtype='' access='rw' input='' default_value='true' comment='Meets qualified residence definition (computed)'></field>
+		<field name='mortgage_interest_deductible' type='double' subtype='' access='rw' input='' default_value='0' comment='Deductible mortgage interest (computed)'></field>
+	</entity>
+
+	<!-- ================================================================== -->
+	<!-- VEHICLE - Business vehicles (Schedule C)                          -->
+	<!-- ================================================================== -->
+	<entity name='vehicle' access='rw' comment='Business vehicle'>
+		<field name='vehicle' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='mapping*key' type='string' subtype='' access='r' input='' default_value='' comment='Mapping Key'></field>
+		<field name='id' type='integer' subtype='' access='r' input='main' default_value='' comment='Vehicle ID'></field>
+		<field name='taxpayer_id' type='integer' subtype='' access='r' input='main' default_value='' comment='Associated taxpayer ID'></field>
+		<field name='description' type='string' subtype='' access='r' input='main' default_value='' comment='Vehicle description (year, make, model)'></field>
+		<field name='purchase_date' type='date' subtype='' access='r' input='main' default_value='' comment='Date purchased'></field>
+		<field name='purchase_price' type='double' subtype='' access='r' input='main' default_value='0' comment='Purchase price'></field>
+		<field name='total_miles' type='integer' subtype='' access='r' input='main' default_value='0' comment='Total miles driven during year'></field>
+		<field name='business_miles' type='integer' subtype='' access='r' input='main' default_value='0' comment='Business miles driven'></field>
+		<field name='business_use_percentage' type='double' subtype='' access='rw' input='' default_value='0' comment='Business use percentage (computed)'></field>
+		<field name='method' type='string' subtype='' access='r' input='main' default_value='standard_mileage' comment='Deduction method: standard_mileage, actual_expense'></field>
+		<field name='standard_mileage_deduction' type='double' subtype='' access='rw' input='' default_value='0' comment='Standard mileage deduction (computed)'></field>
+		<field name='actual_expenses' type='double' subtype='' access='r' input='main' default_value='0' comment='Actual vehicle expenses if using actual method'></field>
+		<field name='vehicle_depreciation' type='double' subtype='' access='rw' input='main' default_value='0' comment='Vehicle depreciation'></field>
+		<field name='vehicle_deduction' type='double' subtype='' access='rw' input='' default_value='0' comment='Final vehicle deduction amount (computed)'></field>
+	</entity>
+
+	<!-- ================================================================== -->
+	<!-- DEDUCTION - Itemized deductions                                   -->
+	<!-- ================================================================== -->
+	<entity name='deduction' access='rw' comment='Itemized deduction'>
+		<field name='deduction' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='mapping*key' type='string' subtype='' access='r' input='' default_value='' comment='Mapping Key'></field>
+		<field name='id' type='integer' subtype='' access='r' input='main' default_value='' comment='Deduction ID'></field>
+		<field name='category' type='string' subtype='' access='r' input='main' default_value='' comment='Category: medical, taxes, interest, charity, casualty, other'></field>
+		<field name='description' type='string' subtype='' access='r' input='main' default_value='' comment='Description of deduction'></field>
+		<field name='amount' type='double' subtype='' access='r' input='main' default_value='0' comment='Claimed amount'></field>
+		<field name='irs_form' type='string' subtype='' access='rw' input='' default_value='Schedule A' comment='IRS form reference'></field>
+		<field name='irs_line' type='string' subtype='' access='rw' input='' default_value='' comment='IRS form line reference'></field>
+		<field name='irs_publication' type='string' subtype='' access='rw' input='' default_value='' comment='IRS publication reference'></field>
+		<field name='limitation_applies' type='boolean' subtype='' access='rw' input='' default_value='false' comment='Whether a limitation applies (computed)'></field>
+		<field name='allowed_amount' type='double' subtype='' access='rw' input='' default_value='0' comment='Allowed amount after limitations (computed)'></field>
+	</entity>
+
+	<!-- ================================================================== -->
+	<!-- CREDIT - Tax credits                                              -->
+	<!-- ================================================================== -->
+	<entity name='credit' access='rw' comment='Tax credit'>
+		<field name='credit' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='mapping*key' type='string' subtype='' access='r' input='' default_value='' comment='Mapping Key'></field>
+		<field name='id' type='integer' subtype='' access='r' input='main' default_value='' comment='Credit ID'></field>
+		<field name='type' type='string' subtype='' access='rw' input='' default_value='' comment='Credit type: CTC, ODC, ACTC, EITC, education, etc.'></field>
+		<field name='description' type='string' subtype='' access='rw' input='' default_value='' comment='Description'></field>
+		<field name='amount' type='double' subtype='' access='rw' input='' default_value='0' comment='Credit amount (computed)'></field>
+		<field name='is_refundable' type='boolean' subtype='' access='rw' input='' default_value='false' comment='Whether credit is refundable'></field>
+		<field name='irs_form' type='string' subtype='' access='rw' input='' default_value='' comment='IRS form reference'></field>
+		<field name='irs_line' type='string' subtype='' access='rw' input='' default_value='' comment='IRS form line reference'></field>
+		<field name='irs_publication' type='string' subtype='' access='rw' input='' default_value='' comment='IRS publication reference'></field>
+		<field name='irc_section' type='string' subtype='' access='rw' input='' default_value='' comment='IRC section reference'></field>
+	</entity>
+
+	<!-- ================================================================== -->
+	<!-- CONSTANTS - Tax rates, limits, and thresholds for 2025            -->
+	<!-- ================================================================== -->
+	<entity name='constants' access='rw' comment='Tax constants and rates for 2025'>
+		<field name='constants' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='mapping*key' type='string' subtype='' access='r' input='' default_value='' comment='Mapping Key'></field>
+
+		<!-- Filing Status Constants -->
+		<field name='MFJ' type='string' subtype='' access='r' input='' default_value='MFJ' comment='Married Filing Jointly'></field>
+		<field name='MFS' type='string' subtype='' access='r' input='' default_value='MFS' comment='Married Filing Separately'></field>
+		<field name='SINGLE' type='string' subtype='' access='r' input='' default_value='Single' comment='Single'></field>
+		<field name='HOH' type='string' subtype='' access='r' input='' default_value='HOH' comment='Head of Household'></field>
+		<field name='QSS' type='string' subtype='' access='r' input='' default_value='QSS' comment='Qualifying Surviving Spouse'></field>
+
+		<!-- Standard Deduction (2025 estimated) -->
+		<field name='standard_deduction_mfj' type='double' subtype='' access='r' input='' default_value='30000' comment='Standard deduction for MFJ/QSS (2025 est.)'></field>
+		<field name='standard_deduction_single' type='double' subtype='' access='r' input='' default_value='15000' comment='Standard deduction for Single'></field>
+		<field name='standard_deduction_hoh' type='double' subtype='' access='r' input='' default_value='22500' comment='Standard deduction for HOH'></field>
+		<field name='standard_deduction_mfs' type='double' subtype='' access='r' input='' default_value='15000' comment='Standard deduction for MFS'></field>
+
+		<!-- Child Tax Credit -->
+		<field name='ctc_amount' type='double' subtype='' access='r' input='' default_value='2000' comment='Child Tax Credit per qualifying child (IRC 24(a))'></field>
+		<field name='ctc_refundable_max' type='double' subtype='' access='r' input='' default_value='1700' comment='Max refundable portion (ACTC) per child (2025 est.)'></field>
+		<field name='ctc_phase_out_mfj' type='double' subtype='' access='r' input='' default_value='400000' comment='CTC phase-out threshold MFJ (IRC 24(b)(2))'></field>
+		<field name='ctc_phase_out_single' type='double' subtype='' access='r' input='' default_value='200000' comment='CTC phase-out threshold Single'></field>
+		<field name='ctc_phase_out_rate' type='double' subtype='' access='r' input='' default_value='50' comment='Phase-out rate: $50 per $1,000 over threshold'></field>
+		<field name='ctc_age_limit' type='integer' subtype='' access='r' input='' default_value='17' comment='Age limit for CTC (must be under this age)'></field>
+
+		<!-- Other Dependent Credit -->
+		<field name='odc_amount' type='double' subtype='' access='r' input='' default_value='500' comment='Other Dependent Credit amount (IRC 24(h)(4))'></field>
+
+		<!-- SALT Cap (TCJA) -->
+		<field name='salt_cap' type='double' subtype='' access='r' input='' default_value='10000' comment='SALT deduction cap (IRC 164(b)(6)(B), TCJA 11042)'></field>
+
+		<!-- Mortgage Interest Limits -->
+		<field name='mortgage_limit_pre_tcja' type='double' subtype='' access='r' input='' default_value='1000000' comment='Pre-TCJA mortgage limit (before 12/15/2017)'></field>
+		<field name='mortgage_limit_post_tcja' type='double' subtype='' access='r' input='' default_value='750000' comment='Post-TCJA mortgage limit (IRC 163(h)(3)(F)(i)(I))'></field>
+		<field name='tcja_cutoff_date' type='date' subtype='' access='r' input='' default_value='12/15/2017' comment='TCJA mortgage rule cutoff date'></field>
+
+		<!-- Self-Employment Tax -->
+		<field name='se_tax_rate' type='double' subtype='' access='r' input='' default_value='0.153' comment='SE tax rate: 15.3% (12.4% SS + 2.9% Medicare)'></field>
+		<field name='se_income_multiplier' type='double' subtype='' access='r' input='' default_value='0.9235' comment='92.35% of net SE earnings (IRC 1402(a)(12))'></field>
+		<field name='se_deduction_rate' type='double' subtype='' access='r' input='' default_value='0.5' comment='Deductible portion of SE tax (IRC 164(f))'></field>
+		<field name='ss_wage_base' type='double' subtype='' access='r' input='' default_value='176100' comment='Social Security wage base (2025 est.)'></field>
+		<field name='se_threshold' type='double' subtype='' access='r' input='' default_value='400' comment='Minimum SE income to file SE tax'></field>
+
+		<!-- Standard Mileage Rate -->
+		<field name='mileage_rate' type='double' subtype='' access='r' input='' default_value='0.70' comment='Standard mileage rate (2025 est.) per Pub 463'></field>
+
+		<!-- Tax Brackets MFJ 2025 (estimated) -->
+		<field name='bracket_1_rate' type='double' subtype='' access='r' input='' default_value='0.10' comment='10% bracket rate'></field>
+		<field name='bracket_1_mfj' type='double' subtype='' access='r' input='' default_value='23200' comment='10% bracket ceiling MFJ'></field>
+		<field name='bracket_2_rate' type='double' subtype='' access='r' input='' default_value='0.12' comment='12% bracket rate'></field>
+		<field name='bracket_2_mfj' type='double' subtype='' access='r' input='' default_value='94300' comment='12% bracket ceiling MFJ'></field>
+		<field name='bracket_3_rate' type='double' subtype='' access='r' input='' default_value='0.22' comment='22% bracket rate'></field>
+		<field name='bracket_3_mfj' type='double' subtype='' access='r' input='' default_value='201050' comment='22% bracket ceiling MFJ'></field>
+		<field name='bracket_4_rate' type='double' subtype='' access='r' input='' default_value='0.24' comment='24% bracket rate'></field>
+		<field name='bracket_4_mfj' type='double' subtype='' access='r' input='' default_value='383900' comment='24% bracket ceiling MFJ'></field>
+		<field name='bracket_5_rate' type='double' subtype='' access='r' input='' default_value='0.32' comment='32% bracket rate'></field>
+		<field name='bracket_5_mfj' type='double' subtype='' access='r' input='' default_value='487450' comment='32% bracket ceiling MFJ'></field>
+		<field name='bracket_6_rate' type='double' subtype='' access='r' input='' default_value='0.35' comment='35% bracket rate'></field>
+		<field name='bracket_6_mfj' type='double' subtype='' access='r' input='' default_value='731200' comment='35% bracket ceiling MFJ'></field>
+		<field name='bracket_7_rate' type='double' subtype='' access='r' input='' default_value='0.37' comment='37% top bracket rate'></field>
+
+		<!-- Tax Brackets Single 2025 (estimated) -->
+		<field name='bracket_1_single' type='double' subtype='' access='r' input='' default_value='11600' comment='10% bracket ceiling Single'></field>
+		<field name='bracket_2_single' type='double' subtype='' access='r' input='' default_value='47150' comment='12% bracket ceiling Single'></field>
+		<field name='bracket_3_single' type='double' subtype='' access='r' input='' default_value='100525' comment='22% bracket ceiling Single'></field>
+		<field name='bracket_4_single' type='double' subtype='' access='r' input='' default_value='191950' comment='24% bracket ceiling Single'></field>
+		<field name='bracket_5_single' type='double' subtype='' access='r' input='' default_value='243725' comment='32% bracket ceiling Single'></field>
+		<field name='bracket_6_single' type='double' subtype='' access='r' input='' default_value='609350' comment='35% bracket ceiling Single'></field>
+
+		<!-- States without income tax -->
+		<field name='no_income_tax_states' type='array' subtype='' access='r' input='' default_value='{ "TX" "FL" "WA" "NV" "SD" "WY" "AK" "TN" "NH" }' comment='States with no income tax'></field>
+
+		<!-- QBI Deduction (199A) -->
+		<field name='qbi_rate' type='double' subtype='' access='r' input='' default_value='0.20' comment='QBI deduction rate (IRC 199A)'></field>
+
+		<!-- Medical Expense Floor -->
+		<field name='medical_floor_rate' type='double' subtype='' access='r' input='' default_value='0.075' comment='Medical expense floor (7.5% of AGI)'></field>
+	</entity>
+
+	<!-- ================================================================== -->
+	<!-- RESULT - Computed tax return results                              -->
+	<!-- ================================================================== -->
+	<entity name='result' access='rw' comment='Tax calculation results'>
+		<field name='result' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='mapping*key' type='string' subtype='' access='r' input='' default_value='' comment='Mapping Key'></field>
+		<field name='id' type='integer' subtype='' access='rw' input='main' default_value='' comment='Result ID'></field>
+
+		<!-- Income Summary -->
+		<field name='total_w2_wages' type='double' subtype='' access='rw' input='' default_value='0' comment='Total W-2 wages (Form 1040 Line 1a)'></field>
+		<field name='total_se_income' type='double' subtype='' access='rw' input='' default_value='0' comment='Net self-employment income (Schedule C)'></field>
+		<field name='total_rental_income' type='double' subtype='' access='rw' input='' default_value='0' comment='Net rental income (Schedule E)'></field>
+		<field name='total_other_income' type='double' subtype='' access='rw' input='' default_value='0' comment='Other income'></field>
+		<field name='gross_income' type='double' subtype='' access='rw' input='' default_value='0' comment='Total gross income (Form 1040 Line 9)'></field>
+
+		<!-- Adjustments -->
+		<field name='total_adjustments' type='double' subtype='' access='rw' input='' default_value='0' comment='Total adjustments to income (Schedule 1 Part II)'></field>
+		<field name='agi' type='double' subtype='' access='rw' input='' default_value='0' comment='Adjusted Gross Income (Form 1040 Line 11)'></field>
+
+		<!-- Deductions -->
+		<field name='total_itemized' type='double' subtype='' access='rw' input='' default_value='0' comment='Total itemized deductions'></field>
+		<field name='standard_deduction' type='double' subtype='' access='rw' input='' default_value='0' comment='Standard deduction amount'></field>
+		<field name='deduction_used' type='string' subtype='' access='rw' input='' default_value='standard' comment='Which deduction used: standard or itemized'></field>
+		<field name='total_deduction' type='double' subtype='' access='rw' input='' default_value='0' comment='Total deduction (Form 1040 Line 12)'></field>
+		<field name='qbi_deduction' type='double' subtype='' access='rw' input='' default_value='0' comment='QBI deduction (Form 1040 Line 13)'></field>
+
+		<!-- Taxable Income -->
+		<field name='taxable_income' type='double' subtype='' access='rw' input='' default_value='0' comment='Taxable income (Form 1040 Line 15)'></field>
+
+		<!-- Tax Calculation -->
+		<field name='regular_tax' type='double' subtype='' access='rw' input='' default_value='0' comment='Regular tax (Form 1040 Line 16)'></field>
+		<field name='se_tax' type='double' subtype='' access='rw' input='' default_value='0' comment='Self-employment tax (Schedule SE)'></field>
+		<field name='total_tax_before_credits' type='double' subtype='' access='rw' input='' default_value='0' comment='Total tax before credits'></field>
+
+		<!-- Credits -->
+		<field name='total_ctc' type='double' subtype='' access='rw' input='' default_value='0' comment='Total Child Tax Credit'></field>
+		<field name='total_odc' type='double' subtype='' access='rw' input='' default_value='0' comment='Total Other Dependent Credit'></field>
+		<field name='total_actc' type='double' subtype='' access='rw' input='' default_value='0' comment='Additional Child Tax Credit (refundable)'></field>
+		<field name='total_credits' type='double' subtype='' access='rw' input='' default_value='0' comment='Total credits'></field>
+
+		<!-- Final -->
+		<field name='total_tax' type='double' subtype='' access='rw' input='' default_value='0' comment='Total tax after credits (Form 1040 Line 24)'></field>
+		<field name='total_payments' type='double' subtype='' access='rw' input='' default_value='0' comment='Total payments and credits (Form 1040 Line 33)'></field>
+		<field name='refund_or_owed' type='double' subtype='' access='rw' input='' default_value='0' comment='Refund (positive) or amount owed (negative)'></field>
+
+		<!-- Audit Trail -->
+		<field name='form_references' type='array' subtype='' access='rw' input='' default_value='' comment='IRS forms used in calculation'></field>
+		<field name='notes' type='array' subtype='' access='rw' input='' default_value='' comment='Detailed calculation notes'></field>
+	</entity>
+
+</entity_data_dictionary>

--- a/sampleprojects/TaxReturn/xml/TaxReturn_map.xml
+++ b/sampleprojects/TaxReturn/xml/TaxReturn_map.xml
@@ -1,0 +1,118 @@
+<mapping>
+	<XMLtoEDD>
+		<map>
+			<!-- Job (root entity) mappings -->
+			<setattribute tag='id' RAttribute='id' enclosure='job' type='integer'></setattribute>
+			<setattribute tag='tax_year' RAttribute='tax_year' enclosure='job' type='integer'></setattribute>
+			<setattribute tag='filing_status' RAttribute='filing_status' enclosure='job' type='string'></setattribute>
+			<setattribute tag='state' RAttribute='state' enclosure='job' type='string'></setattribute>
+			<setattribute tag='city' RAttribute='city' enclosure='job' type='string'></setattribute>
+
+			<!-- Taxpayer mappings -->
+			<setattribute tag='id' RAttribute='id' enclosure='taxpayer' type='integer'></setattribute>
+			<setattribute tag='name' RAttribute='name' enclosure='taxpayer' type='string'></setattribute>
+			<setattribute tag='ssn' RAttribute='ssn' enclosure='taxpayer' type='string'></setattribute>
+			<setattribute tag='date_of_birth' RAttribute='date_of_birth' enclosure='taxpayer' type='date'></setattribute>
+			<setattribute tag='occupation' RAttribute='occupation' enclosure='taxpayer' type='string'></setattribute>
+			<setattribute tag='is_self_employed' RAttribute='is_self_employed' enclosure='taxpayer' type='boolean'></setattribute>
+			<setattribute tag='is_primary' RAttribute='is_primary' enclosure='taxpayer' type='boolean'></setattribute>
+			<setattribute tag='w2_wages' RAttribute='w2_wages' enclosure='taxpayer' type='double'></setattribute>
+			<setattribute tag='w2_withholding' RAttribute='w2_withholding' enclosure='taxpayer' type='double'></setattribute>
+			<setattribute tag='se_gross_income' RAttribute='se_gross_income' enclosure='taxpayer' type='double'></setattribute>
+			<setattribute tag='estimated_payments' RAttribute='estimated_payments' enclosure='taxpayer' type='double'></setattribute>
+
+			<!-- Dependent mappings -->
+			<setattribute tag='id' RAttribute='id' enclosure='dependent' type='integer'></setattribute>
+			<setattribute tag='name' RAttribute='name' enclosure='dependent' type='string'></setattribute>
+			<setattribute tag='ssn' RAttribute='ssn' enclosure='dependent' type='string'></setattribute>
+			<setattribute tag='date_of_birth' RAttribute='date_of_birth' enclosure='dependent' type='date'></setattribute>
+			<setattribute tag='age' RAttribute='age' enclosure='dependent' type='integer'></setattribute>
+			<setattribute tag='relationship' RAttribute='relationship' enclosure='dependent' type='string'></setattribute>
+			<setattribute tag='months_lived_with' RAttribute='months_lived_with' enclosure='dependent' type='integer'></setattribute>
+			<setattribute tag='is_student' RAttribute='is_student' enclosure='dependent' type='boolean'></setattribute>
+			<setattribute tag='school_type' RAttribute='school_type' enclosure='dependent' type='string'></setattribute>
+			<setattribute tag='tuition_paid' RAttribute='tuition_paid' enclosure='dependent' type='double'></setattribute>
+			<setattribute tag='has_ssn' RAttribute='has_ssn' enclosure='dependent' type='boolean'></setattribute>
+
+			<!-- Income mappings -->
+			<setattribute tag='id' RAttribute='id' enclosure='income' type='integer'></setattribute>
+			<setattribute tag='taxpayer_id' RAttribute='taxpayer_id' enclosure='income' type='integer'></setattribute>
+			<setattribute tag='type' RAttribute='type' enclosure='income' type='string'></setattribute>
+			<setattribute tag='source' RAttribute='source' enclosure='income' type='string'></setattribute>
+			<setattribute tag='gross_amount' RAttribute='gross_amount' enclosure='income' type='double'></setattribute>
+			<setattribute tag='tax_withheld' RAttribute='tax_withheld' enclosure='income' type='double'></setattribute>
+			<setattribute tag='is_earned' RAttribute='is_earned' enclosure='income' type='boolean'></setattribute>
+
+			<!-- Property mappings -->
+			<setattribute tag='id' RAttribute='id' enclosure='property' type='integer'></setattribute>
+			<setattribute tag='type' RAttribute='type' enclosure='property' type='string'></setattribute>
+			<setattribute tag='address' RAttribute='address' enclosure='property' type='string'></setattribute>
+			<setattribute tag='purchase_date' RAttribute='purchase_date' enclosure='property' type='date'></setattribute>
+			<setattribute tag='purchase_price' RAttribute='purchase_price' enclosure='property' type='double'></setattribute>
+			<setattribute tag='current_fmv' RAttribute='current_fmv' enclosure='property' type='double'></setattribute>
+			<setattribute tag='mortgage_balance' RAttribute='mortgage_balance' enclosure='property' type='double'></setattribute>
+			<setattribute tag='mortgage_origination_date' RAttribute='mortgage_origination_date' enclosure='property' type='date'></setattribute>
+			<setattribute tag='mortgage_interest' RAttribute='mortgage_interest' enclosure='property' type='double'></setattribute>
+			<setattribute tag='property_taxes' RAttribute='property_taxes' enclosure='property' type='double'></setattribute>
+			<setattribute tag='rental_income' RAttribute='rental_income' enclosure='property' type='double'></setattribute>
+			<setattribute tag='rental_expenses' RAttribute='rental_expenses' enclosure='property' type='double'></setattribute>
+			<setattribute tag='rental_advertising' RAttribute='rental_advertising' enclosure='property' type='double'></setattribute>
+			<setattribute tag='rental_insurance' RAttribute='rental_insurance' enclosure='property' type='double'></setattribute>
+			<setattribute tag='rental_repairs' RAttribute='rental_repairs' enclosure='property' type='double'></setattribute>
+			<setattribute tag='rental_utilities' RAttribute='rental_utilities' enclosure='property' type='double'></setattribute>
+			<setattribute tag='rental_management' RAttribute='rental_management' enclosure='property' type='double'></setattribute>
+			<setattribute tag='depreciation' RAttribute='depreciation' enclosure='property' type='double'></setattribute>
+
+			<!-- Vehicle mappings -->
+			<setattribute tag='id' RAttribute='id' enclosure='vehicle' type='integer'></setattribute>
+			<setattribute tag='taxpayer_id' RAttribute='taxpayer_id' enclosure='vehicle' type='integer'></setattribute>
+			<setattribute tag='description' RAttribute='description' enclosure='vehicle' type='string'></setattribute>
+			<setattribute tag='purchase_date' RAttribute='purchase_date' enclosure='vehicle' type='date'></setattribute>
+			<setattribute tag='purchase_price' RAttribute='purchase_price' enclosure='vehicle' type='double'></setattribute>
+			<setattribute tag='total_miles' RAttribute='total_miles' enclosure='vehicle' type='integer'></setattribute>
+			<setattribute tag='business_miles' RAttribute='business_miles' enclosure='vehicle' type='integer'></setattribute>
+			<setattribute tag='method' RAttribute='method' enclosure='vehicle' type='string'></setattribute>
+			<setattribute tag='actual_expenses' RAttribute='actual_expenses' enclosure='vehicle' type='double'></setattribute>
+			<setattribute tag='vehicle_depreciation' RAttribute='vehicle_depreciation' enclosure='vehicle' type='double'></setattribute>
+
+			<!-- Deduction mappings -->
+			<setattribute tag='id' RAttribute='id' enclosure='deduction' type='integer'></setattribute>
+			<setattribute tag='category' RAttribute='category' enclosure='deduction' type='string'></setattribute>
+			<setattribute tag='description' RAttribute='description' enclosure='deduction' type='string'></setattribute>
+			<setattribute tag='amount' RAttribute='amount' enclosure='deduction' type='double'></setattribute>
+
+			<!-- Create entities from XML tags -->
+			<createentity entity='job' tag='job' id='id'></createentity>
+			<createentity entity='taxpayer' tag='taxpayer' id='id'></createentity>
+			<createentity entity='dependent' tag='dependent' id='id'></createentity>
+			<createentity entity='income' tag='income' id='id'></createentity>
+			<createentity entity='property' tag='property' id='id'></createentity>
+			<createentity entity='vehicle' tag='vehicle' id='id'></createentity>
+			<createentity entity='deduction' tag='deduction' id='id'></createentity>
+			<createentity entity='credit' tag='credit' id='id'></createentity>
+			<createentity entity='constants' tag='constants' id='id'></createentity>
+			<createentity entity='result' tag='result' id='id'></createentity>
+		</map>
+
+		<entities>
+			<!-- Singleton entities -->
+			<entity name='constants' number='1'></entity>
+			<entity name='job' number='1'></entity>
+			<entity name='result' number='1'></entity>
+
+			<!-- Multiple instance entities -->
+			<entity name='taxpayer' number='*'></entity>
+			<entity name='dependent' number='*'></entity>
+			<entity name='income' number='*'></entity>
+			<entity name='property' number='*'></entity>
+			<entity name='vehicle' number='*'></entity>
+			<entity name='deduction' number='*'></entity>
+			<entity name='credit' number='*'></entity>
+		</entities>
+
+		<initialization>
+			<initialentity entity='constants' epush='true'></initialentity>
+			<initialentity entity='job' epush='true'></initialentity>
+		</initialization>
+	</XMLtoEDD>
+</mapping>

--- a/sampleprojects/pom.xml
+++ b/sampleprojects/pom.xml
@@ -31,6 +31,7 @@
 		<module>KidAid</module>
 		<module>KidAid_Application</module>
 		<module>SyntaxTests</module>
+		<module>TaxReturn</module>
 		<module>TestProject</module>
 	</modules>
 


### PR DESCRIPTION
## Summary

- Fix XML struct tag mismatch in Go loader that prevented initial_actions from being parsed
- Fix TaxReturn decision table postfix syntax errors (if/ifelse order, float operators, local variables)
- Add TaxReturn sample project with complete tax calculation decision tables

Fixes #83, Fixes #84

## Test plan

- [x] TaxReturn compiles successfully in Go test suite
- [x] `go run /tmp/test_full.go` executes Compute_Tax_Return without errors
- [x] All existing sample project tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)