### PR TITLE
feat: rename XML *_description tags to *_dsl for clarity

### DIFF
--- a/cmd/dtrules/docs.go
+++ b/cmd/dtrules/docs.go
@@ -101,7 +101,8 @@ Why EL is Required
 - VALIDATED: Syntax errors caught at compile time, not runtime
 - CONSISTENT: Eliminates hand-coded postfix errors
 
-IMPORTANT: Do NOT hand-code postfix. Always use EL descriptions.
+IMPORTANT: Do NOT hand-code postfix. Always use EL in *_dsl tags
+(e.g., condition_dsl, action_dsl, context_dsl, initial_action_dsl).
 
 
 Conditions
@@ -325,7 +326,7 @@ Decision Table XML Structure (EL Format - REQUIRED)
 
         <contexts>
             <context_details>
-                <context_description>for all dependents</context_description>
+                <context_dsl>for all dependents</context_dsl>
             </context_details>
         </contexts>
 
@@ -367,6 +368,15 @@ Key Elements:
   - <expression>: EL condition (compiled to postfix automatically)
   - <action>: EL statements separated by semicolons
   - Y/N/-: Condition values (Yes/No/Don't care)
+
+DSL Tag Names:
+  - <context_dsl>: Context statement in EL (inside <context_details>)
+  - <condition_dsl>: Condition expression in EL (inside <condition_details>)
+  - <action_dsl>: Action statement in EL (inside <action_details>)
+  - <initial_action_dsl>: Initial action in EL (executed before conditions)
+
+Note: For backward compatibility, the system also reads legacy tag names
+(*_description instead of *_dsl). New code should use *_dsl tags.
 
 Table Types (in <attribute_fields>):
   - FIRST:    Execute only the first matching row (most common)
@@ -1560,7 +1570,7 @@ Required workflow:
   3. dtrules -rules xml    <- Use compiled rules
 
 If AI/developers modify XML directly:
-  1. Edit XML (add/modify EL expressions in descriptions)
+  1. Edit XML (add/modify EL expressions in *_dsl tags)
   2. dtrules sync export   <- Update Excel with standard formatting
   3. dtrules sync import   <- Re-import to compile EL to postfix
 
@@ -1590,9 +1600,9 @@ Best for: Programmatic rule editing
 1. Check for pending user edits FIRST
    dtrules sync check
 
-2. Edit XML files (EL descriptions only, NOT postfix)
+2. Edit XML files (EL in *_dsl tags only, NOT postfix)
    - *_edd.xml: entity definitions
-   - *_dt.xml: decision tables
+   - *_dt.xml: decision tables (use condition_dsl, action_dsl, context_dsl)
 
 3. Export to Excel (records changes)
    dtrules sync export
@@ -1604,7 +1614,7 @@ Best for: Programmatic rule editing
    dtrules -rules ./xml -test ./testfiles
 
 IMPORTANT: Never hand-code postfix. Always use EL expressions in
-the description fields. The import process compiles them automatically.
+the *_dsl tags. The import process compiles them automatically.
 
 
 Validate Command
@@ -1651,7 +1661,7 @@ project/
 
 EL vs Postfix
 -------------
-EL (in Excel/XML descriptions):
+EL (in Excel cells or XML *_dsl tags):
     taxpayer.income > 50000
     taxpayer.filing_status == "SINGLE"
     set result.tax = income * rate
@@ -1669,7 +1679,7 @@ If 'dtrules sync export' fails because Excel was modified:
 1. Import their changes first:
    dtrules sync import
 
-2. Re-apply your XML changes (edit descriptions, not postfix)
+2. Re-apply your XML changes (edit *_dsl tags, not postfix)
 
 3. Export the merged result:
    dtrules sync export
@@ -1702,7 +1712,7 @@ If you have existing XML with hand-coded postfix:
 
 2. For each legacy file:
    a. Open the corresponding Excel file
-   b. Add EL expressions to the description column
+   b. Add EL expressions to the DSL column (or description column for legacy)
    c. Run: dtrules sync import
 
 3. Verify migration:

--- a/pkg/dtrules/excel/dt_importer.go
+++ b/pkg/dtrules/excel/dt_importer.go
@@ -104,26 +104,26 @@ type AttributeFieldsXML struct {
 
 // InitialActionXML represents an initial action.
 type InitialActionXML struct {
-	Description string `xml:"action_description"`
-	Postfix     string `xml:"action_postfix"`
+	DSL     string `xml:"initial_action_dsl"`
+	Postfix string `xml:"action_postfix"`
 }
 
 // ConditionXML represents a condition row with its column values.
 type ConditionXML struct {
-	Number      string           `xml:"condition_number"`
-	Comment     string           `xml:"condition_comment"`
-	Description string           `xml:"condition_description"`
-	Postfix     string           `xml:"condition_postfix"`
-	Columns     []ColumnValueXML `xml:"condition_column"`
+	Number  string           `xml:"condition_number"`
+	Comment string           `xml:"condition_comment"`
+	DSL     string           `xml:"condition_dsl"`
+	Postfix string           `xml:"condition_postfix"`
+	Columns []ColumnValueXML `xml:"condition_column"`
 }
 
 // ActionXML represents an action row with its column values.
 type ActionXML struct {
-	Number      string           `xml:"action_number"`
-	Comment     string           `xml:"action_comment"`
-	Description string           `xml:"action_description"`
-	Postfix     string           `xml:"action_postfix"`
-	Columns     []ColumnValueXML `xml:"action_column"`
+	Number  string           `xml:"action_number"`
+	Comment string           `xml:"action_comment"`
+	DSL     string           `xml:"action_dsl"`
+	Postfix string           `xml:"action_postfix"`
+	Columns []ColumnValueXML `xml:"action_column"`
 }
 
 // ColumnValueXML represents a column value in conditions or actions.
@@ -309,7 +309,7 @@ func (i *DTImporter) writeTable(f *os.File, table *DecisionTableXML) error {
 	f.WriteString("<initial_actions>\n")
 	for _, action := range table.InitialActions {
 		f.WriteString("<initial_action>\n")
-		f.WriteString(fmt.Sprintf("<action_description>%s</action_description>\n", xmlEscape(action.Description)))
+		f.WriteString(fmt.Sprintf("<initial_action_dsl>%s</initial_action_dsl>\n", xmlEscape(action.DSL)))
 		f.WriteString(fmt.Sprintf("<action_postfix>\n%s\n</action_postfix>\n", xmlEscape(action.Postfix)))
 		f.WriteString("</initial_action>\n")
 	}
@@ -321,7 +321,7 @@ func (i *DTImporter) writeTable(f *os.File, table *DecisionTableXML) error {
 		f.WriteString("<condition_details>\n")
 		f.WriteString(fmt.Sprintf("<condition_number>%s</condition_number>\n", xmlEscape(cond.Number)))
 		f.WriteString(fmt.Sprintf("<condition_comment>%s</condition_comment>\n", xmlEscape(cond.Comment)))
-		f.WriteString(fmt.Sprintf("<condition_description>%s</condition_description>\n", xmlEscape(cond.Description)))
+		f.WriteString(fmt.Sprintf("<condition_dsl>%s</condition_dsl>\n", xmlEscape(cond.DSL)))
 		f.WriteString(fmt.Sprintf("<condition_postfix>\n%s\n</condition_postfix>\n", xmlEscape(cond.Postfix)))
 		for _, col := range cond.Columns {
 			f.WriteString(fmt.Sprintf("<condition_column column_number=\"%d\" column_value=\"%s\"></condition_column>\n",
@@ -337,7 +337,7 @@ func (i *DTImporter) writeTable(f *os.File, table *DecisionTableXML) error {
 		f.WriteString("<action_details>\n")
 		f.WriteString(fmt.Sprintf("<action_number>%s</action_number>\n", xmlEscape(action.Number)))
 		f.WriteString(fmt.Sprintf("<action_comment>%s</action_comment>\n", xmlEscape(action.Comment)))
-		f.WriteString(fmt.Sprintf("<action_description>%s</action_description>\n", xmlEscape(action.Description)))
+		f.WriteString(fmt.Sprintf("<action_dsl>%s</action_dsl>\n", xmlEscape(action.DSL)))
 		f.WriteString(fmt.Sprintf("<action_postfix>\n%s\n</action_postfix>\n", xmlEscape(action.Postfix)))
 		for _, col := range action.Columns {
 			f.WriteString(fmt.Sprintf("<action_column column_number=\"%d\" column_value=\"%s\"></action_column>\n",
@@ -496,21 +496,21 @@ func (i *DTImporter) parseDT2ExcelFormat(rows [][]string, table *DecisionTableXM
 			case "initial_actions":
 				if len(row) > 1 && firstCell != "" {
 					action := InitialActionXML{
-						Description: firstCell,
-						Postfix:     strings.TrimSpace(row[1]),
+						DSL:     firstCell,
+						Postfix: strings.TrimSpace(row[1]),
 					}
 					table.InitialActions = append(table.InitialActions, action)
 				}
 
 			case "conditions":
-				// Parse condition row: #, Description, Col1, Col2, ...
+				// Parse condition row: #, DSL, Col1, Col2, ...
 				// Only process rows that start with a number
 				if len(row) > 1 && firstCell != "" {
 					if _, err := strconv.Atoi(firstCell); err == nil {
 						cond := ConditionXML{
-							Number:      firstCell,
-							Comment:     strings.TrimSpace(safeGet(row, 1)),
-							Description: strings.TrimSpace(safeGet(row, 1)), // Use comment as description
+							Number:  firstCell,
+							Comment: strings.TrimSpace(safeGet(row, 1)),
+							DSL:     strings.TrimSpace(safeGet(row, 1)), // Use comment as DSL
 						}
 						// Parse column values - columns start at index 2
 						for col := 2; col < len(row); col++ {
@@ -527,14 +527,14 @@ func (i *DTImporter) parseDT2ExcelFormat(rows [][]string, table *DecisionTableXM
 				}
 
 			case "actions":
-				// Parse action row: #, Description, Col1, Col2, ...
+				// Parse action row: #, DSL, Col1, Col2, ...
 				// Only process rows that start with a number
 				if len(row) > 1 && firstCell != "" {
 					if _, err := strconv.Atoi(firstCell); err == nil {
 						action := ActionXML{
-							Number:      firstCell,
-							Comment:     strings.TrimSpace(safeGet(row, 1)),
-							Description: strings.TrimSpace(safeGet(row, 1)), // Use comment as description
+							Number:  firstCell,
+							Comment: strings.TrimSpace(safeGet(row, 1)),
+							DSL:     strings.TrimSpace(safeGet(row, 1)), // Use comment as DSL
 						}
 						// Parse column values - columns start at index 2
 						for col := 2; col < len(row); col++ {
@@ -662,8 +662,8 @@ func (i *DTImporter) parseExporterFormat(rows [][]string, sheetName string, tabl
 					num, err := strconv.Atoi(firstCell)
 					if err == nil && num > 0 {
 						action := InitialActionXML{
-							Description: strings.TrimSpace(row[1]),
-							Postfix:     strings.TrimSpace(row[2]),
+							DSL:     strings.TrimSpace(row[1]),
+							Postfix: strings.TrimSpace(row[2]),
 						}
 						table.InitialActions = append(table.InitialActions, action)
 					}
@@ -683,10 +683,10 @@ func (i *DTImporter) parseExporterFormat(rows [][]string, sheetName string, tabl
 					num, err := strconv.Atoi(firstCell)
 					if err == nil && num > 0 {
 						cond := ConditionXML{
-							Number:      firstCell,
-							Comment:     strings.TrimSpace(safeGet(row, 1)),
-							Description: strings.TrimSpace(safeGet(row, 1)),
-							Postfix:     strings.TrimSpace(safeGet(row, 2)),
+							Number:  firstCell,
+							Comment: strings.TrimSpace(safeGet(row, 1)),
+							DSL:     strings.TrimSpace(safeGet(row, 1)),
+							Postfix: strings.TrimSpace(safeGet(row, 2)),
 						}
 						// Parse column values (columns start at index 3)
 						for col := 3; col < len(row) && col < numCols+3; col++ {
@@ -716,10 +716,10 @@ func (i *DTImporter) parseExporterFormat(rows [][]string, sheetName string, tabl
 					num, err := strconv.Atoi(firstCell)
 					if err == nil && num > 0 {
 						action := ActionXML{
-							Number:      firstCell,
-							Comment:     strings.TrimSpace(safeGet(row, 1)),
-							Description: strings.TrimSpace(safeGet(row, 1)),
-							Postfix:     strings.TrimSpace(safeGet(row, 2)),
+							Number:  firstCell,
+							Comment: strings.TrimSpace(safeGet(row, 1)),
+							DSL:     strings.TrimSpace(safeGet(row, 1)),
+							Postfix: strings.TrimSpace(safeGet(row, 2)),
 						}
 						// Parse column values (columns start at index 3)
 						for col := 3; col < len(row) && col < numCols+3; col++ {
@@ -836,8 +836,8 @@ func (i *DTImporter) compileTableEL(table *DecisionTableXML) error {
 	// Compile initial actions
 	for idx := range table.InitialActions {
 		action := &table.InitialActions[idx]
-		if action.Description != "" {
-			postfix, err := i.elCompiler.CompileAction(action.Description)
+		if action.DSL != "" {
+			postfix, err := i.elCompiler.CompileAction(action.DSL)
 			if err != nil {
 				errors = append(errors, fmt.Sprintf("initial action %d: %v", idx+1, err))
 				continue
@@ -849,8 +849,8 @@ func (i *DTImporter) compileTableEL(table *DecisionTableXML) error {
 	// Compile conditions
 	for idx := range table.Conditions {
 		cond := &table.Conditions[idx]
-		if cond.Description != "" {
-			postfix, err := i.elCompiler.CompileCondition(cond.Description)
+		if cond.DSL != "" {
+			postfix, err := i.elCompiler.CompileCondition(cond.DSL)
 			if err != nil {
 				errors = append(errors, fmt.Sprintf("condition %s: %v", cond.Number, err))
 				continue
@@ -862,8 +862,8 @@ func (i *DTImporter) compileTableEL(table *DecisionTableXML) error {
 	// Compile actions
 	for idx := range table.Actions {
 		action := &table.Actions[idx]
-		if action.Description != "" {
-			postfix, err := i.elCompiler.CompileAction(action.Description)
+		if action.DSL != "" {
+			postfix, err := i.elCompiler.CompileAction(action.DSL)
 			if err != nil {
 				errors = append(errors, fmt.Sprintf("action %s: %v", action.Number, err))
 				continue

--- a/pkg/dtrules/loader/dt.go
+++ b/pkg/dtrules/loader/dt.go
@@ -130,8 +130,17 @@ type DTContexts struct {
 type DTContextDetail struct {
 	Number      int    `xml:"context_number" json:"context_number"`
 	Comment     string `xml:"context_comment" json:"context_comment,omitempty"`
+	DSL         string `xml:"context_dsl" json:"context_dsl,omitempty"`
 	Description string `xml:"context_description" json:"context_description"`
 	Postfix     string `xml:"context_postfix" json:"context_postfix"`
+}
+
+// GetDSL returns the DSL expression, preferring DSL over Description for backward compatibility.
+func (c *DTContextDetail) GetDSL() string {
+	if c.DSL != "" {
+		return c.DSL
+	}
+	return c.Description
 }
 
 // DTInitialActions represents the initial actions section
@@ -143,8 +152,17 @@ type DTInitialActions struct {
 type DTInitialAction struct {
 	Number      int    `xml:"action_number" json:"action_number"`
 	Comment     string `xml:"action_comment" json:"action_comment,omitempty"`
+	DSL         string `xml:"initial_action_dsl" json:"initial_action_dsl,omitempty"`
 	Description string `xml:"action_description" json:"action_description"`
 	Postfix     string `xml:"action_postfix" json:"action_postfix"`
+}
+
+// GetDSL returns the DSL expression, preferring DSL over Description for backward compatibility.
+func (a *DTInitialAction) GetDSL() string {
+	if a.DSL != "" {
+		return a.DSL
+	}
+	return a.Description
 }
 
 // DTConditions represents the conditions section
@@ -157,9 +175,18 @@ type DTConditionDetail struct {
 	Number      int              `xml:"condition_number" json:"condition_number"`
 	Comment     string           `xml:"condition_comment" json:"condition_comment,omitempty"`
 	Requirement string           `xml:"condition_requirement" json:"condition_requirement,omitempty"`
+	DSL         string           `xml:"condition_dsl" json:"condition_dsl,omitempty"`
 	Description string           `xml:"condition_description" json:"condition_description"`
 	Postfix     string           `xml:"condition_postfix" json:"condition_postfix"`
 	Columns     []DTConditionCol `xml:"condition_column" json:"condition_columns"`
+}
+
+// GetDSL returns the DSL expression, preferring DSL over Description for backward compatibility.
+func (c *DTConditionDetail) GetDSL() string {
+	if c.DSL != "" {
+		return c.DSL
+	}
+	return c.Description
 }
 
 // DTConditionCol represents a condition column entry
@@ -178,9 +205,18 @@ type DTActionDetail struct {
 	Number      int           `xml:"action_number" json:"action_number"`
 	Comment     string        `xml:"action_comment" json:"action_comment,omitempty"`
 	Requirement string        `xml:"initial_action_requirement" json:"action_requirement,omitempty"`
+	DSL         string        `xml:"action_dsl" json:"action_dsl,omitempty"`
 	Description string        `xml:"action_description" json:"action_description"`
 	Postfix     string        `xml:"action_postfix" json:"action_postfix"`
 	Columns     []DTActionCol `xml:"action_column" json:"action_columns"`
+}
+
+// GetDSL returns the DSL expression, preferring DSL over Description for backward compatibility.
+func (a *DTActionDetail) GetDSL() string {
+	if a.DSL != "" {
+		return a.DSL
+	}
+	return a.Description
 }
 
 // DTActionCol represents an action column entry
@@ -288,14 +324,15 @@ func (l *DTLoader) processTable(table *DTTable) error {
 	contextsPostfix := make([]string, len(table.Contexts.Contexts))
 	contextsComment := make([]string, len(table.Contexts.Contexts))
 	for i, ctx := range table.Contexts.Contexts {
-		contexts[i] = ctx.Description
+		dsl := ctx.GetDSL()
+		contexts[i] = dsl
 		postfix := strings.TrimSpace(ctx.Postfix)
 
-		// Auto-compile EL description to postfix if postfix is empty
-		if postfix == "" && strings.TrimSpace(ctx.Description) != "" {
-			compiled, err := l.elCompiler.CompileContext(ctx.Description)
+		// Auto-compile EL DSL to postfix if postfix is empty
+		if postfix == "" && strings.TrimSpace(dsl) != "" {
+			compiled, err := l.elCompiler.CompileContext(dsl)
 			if err != nil {
-				return fmt.Errorf("failed to compile EL context %d ('%s'): %w", i+1, ctx.Description, err)
+				return fmt.Errorf("failed to compile EL context %d ('%s'): %w", i+1, dsl, err)
 			}
 			postfix = compiled
 		}
@@ -309,23 +346,24 @@ func (l *DTLoader) processTable(table *DTTable) error {
 	initialActions := make([]string, len(table.InitialActions.Actions))
 	initialActionsPostfix := make([]string, len(table.InitialActions.Actions))
 	for i, action := range table.InitialActions.Actions {
-		initialActions[i] = action.Description
+		dsl := action.GetDSL()
+		initialActions[i] = dsl
 		postfix := strings.TrimSpace(action.Postfix)
 
-		// Auto-compile EL description to postfix if postfix is empty or only comments
-		descTrimmed := strings.TrimSpace(action.Description)
-		if isEmptyOrCommentOnly(postfix) && descTrimmed != "" && !isCommentLine(descTrimmed) {
-			compiled, err := l.elCompiler.CompileAction(action.Description)
+		// Auto-compile EL DSL to postfix if postfix is empty or only comments
+		dslTrimmed := strings.TrimSpace(dsl)
+		if isEmptyOrCommentOnly(postfix) && dslTrimmed != "" && !isCommentLine(dslTrimmed) {
+			compiled, err := l.elCompiler.CompileAction(dsl)
 			if err != nil {
-				// Description is not valid EL - log warning and use no-op as fallback
+				// DSL is not valid EL - log warning and use no-op as fallback
 				log.Printf("Warning: Initial action %d ('%s') is not valid EL, using no-op: %v",
-					i+1, action.Description, err)
+					i+1, dsl, err)
 				postfix = "" // No-op
 			} else {
 				postfix = compiled
 			}
 		}
-		// If description is a comment, postfix stays as-is (could be empty, which is no-op)
+		// If DSL is a comment, postfix stays as-is (could be empty, which is no-op)
 		initialActionsPostfix[i] = postfix
 	}
 	builder.SetInitialActions(initialActions)
@@ -342,23 +380,24 @@ func (l *DTLoader) processTable(table *DTTable) error {
 	conditionTable := make([][]string, numConditions)
 
 	for i, cond := range table.Conditions.Conditions {
-		conditions[i] = cond.Description
+		dsl := cond.GetDSL()
+		conditions[i] = dsl
 		postfix := strings.TrimSpace(cond.Postfix)
 
-		// Auto-compile EL description to postfix if postfix is empty or only comments
-		descTrimmed := strings.TrimSpace(cond.Description)
-		if isEmptyOrCommentOnly(postfix) && descTrimmed != "" && !isCommentLine(descTrimmed) {
-			compiled, err := l.elCompiler.CompileCondition(cond.Description)
+		// Auto-compile EL DSL to postfix if postfix is empty or only comments
+		dslTrimmed := strings.TrimSpace(dsl)
+		if isEmptyOrCommentOnly(postfix) && dslTrimmed != "" && !isCommentLine(dslTrimmed) {
+			compiled, err := l.elCompiler.CompileCondition(dsl)
 			if err != nil {
-				// Description is not valid EL - log warning and use "true always" as fallback
+				// DSL is not valid EL - log warning and use "true always" as fallback
 				log.Printf("Warning: Condition %d ('%s') is not valid EL, using 'always true': %v",
-					i+1, cond.Description, err)
+					i+1, dsl, err)
 				postfix = "true always"
 			} else {
 				postfix = compiled
 			}
-		} else if isEmptyOrCommentOnly(postfix) && isCommentLine(descTrimmed) {
-			// Description is a comment - use "true always" as fallback
+		} else if isEmptyOrCommentOnly(postfix) && isCommentLine(dslTrimmed) {
+			// DSL is a comment - use "true always" as fallback
 			postfix = "true always"
 		}
 		conditionsPostfix[i] = postfix
@@ -389,23 +428,24 @@ func (l *DTLoader) processTable(table *DTTable) error {
 	actionTable := make([][]string, numActions)
 
 	for i, action := range table.Actions.Actions {
-		actions[i] = action.Description
+		dsl := action.GetDSL()
+		actions[i] = dsl
 		postfix := strings.TrimSpace(action.Postfix)
 
-		// Auto-compile EL description to postfix if postfix is empty or only comments
-		descTrimmed := strings.TrimSpace(action.Description)
-		if isEmptyOrCommentOnly(postfix) && descTrimmed != "" && !isCommentLine(descTrimmed) {
-			compiled, err := l.elCompiler.CompileAction(action.Description)
+		// Auto-compile EL DSL to postfix if postfix is empty or only comments
+		dslTrimmed := strings.TrimSpace(dsl)
+		if isEmptyOrCommentOnly(postfix) && dslTrimmed != "" && !isCommentLine(dslTrimmed) {
+			compiled, err := l.elCompiler.CompileAction(dsl)
 			if err != nil {
-				// Description is not valid EL - log warning and use no-op as fallback
+				// DSL is not valid EL - log warning and use no-op as fallback
 				log.Printf("Warning: Action %d ('%s') is not valid EL, using no-op: %v",
-					i+1, action.Description, err)
+					i+1, dsl, err)
 				postfix = "" // No-op
 			} else {
 				postfix = compiled
 			}
 		}
-		// If description is a comment, postfix stays as-is (could be empty, which is no-op)
+		// If DSL is a comment, postfix stays as-is (could be empty, which is no-op)
 		actionsPostfix[i] = postfix
 		actionsComment[i] = action.Comment
 
@@ -838,20 +878,20 @@ func (l *DTLoader) GetErrors() []error {
 	return l.errors
 }
 
-// detectLegacyPostfix checks if a table has hand-coded postfix without EL descriptions.
-// A table is considered legacy if it has postfix but no EL descriptions in
+// detectLegacyPostfix checks if a table has hand-coded postfix without EL DSL.
+// A table is considered legacy if it has postfix but no EL DSL in
 // its conditions, actions, or contexts.
 func (l *DTLoader) detectLegacyPostfix(table *DTTable) bool {
 	hasPostfix := false
-	hasDescription := false
+	hasDSL := false
 
 	// Check conditions
 	for _, cond := range table.Conditions.Conditions {
 		if strings.TrimSpace(cond.Postfix) != "" {
 			hasPostfix = true
 		}
-		if strings.TrimSpace(cond.Description) != "" {
-			hasDescription = true
+		if strings.TrimSpace(cond.GetDSL()) != "" {
+			hasDSL = true
 		}
 	}
 
@@ -860,8 +900,8 @@ func (l *DTLoader) detectLegacyPostfix(table *DTTable) bool {
 		if strings.TrimSpace(action.Postfix) != "" {
 			hasPostfix = true
 		}
-		if strings.TrimSpace(action.Description) != "" {
-			hasDescription = true
+		if strings.TrimSpace(action.GetDSL()) != "" {
+			hasDSL = true
 		}
 	}
 
@@ -870,8 +910,8 @@ func (l *DTLoader) detectLegacyPostfix(table *DTTable) bool {
 		if strings.TrimSpace(action.Postfix) != "" {
 			hasPostfix = true
 		}
-		if strings.TrimSpace(action.Description) != "" {
-			hasDescription = true
+		if strings.TrimSpace(action.GetDSL()) != "" {
+			hasDSL = true
 		}
 	}
 
@@ -880,18 +920,18 @@ func (l *DTLoader) detectLegacyPostfix(table *DTTable) bool {
 		if strings.TrimSpace(ctx.Postfix) != "" {
 			hasPostfix = true
 		}
-		if strings.TrimSpace(ctx.Description) != "" {
-			hasDescription = true
+		if strings.TrimSpace(ctx.GetDSL()) != "" {
+			hasDSL = true
 		}
 	}
 
-	// Legacy: has postfix but no descriptions
-	return hasPostfix && !hasDescription
+	// Legacy: has postfix but no DSL
+	return hasPostfix && !hasDSL
 }
 
 // warnLegacyPostfix logs a warning about a table with hand-coded postfix.
 func (l *DTLoader) warnLegacyPostfix(tableName, filePath string) {
-	log.Printf("WARNING: %s in %s has hand-coded postfix without EL descriptions.", tableName, filePath)
+	log.Printf("WARNING: %s in %s has hand-coded postfix without EL DSL.", tableName, filePath)
 	log.Printf("         All postfix should come from EL compilation. Use 'dtrules sync import' to compile EL.")
 }
 

--- a/pkg/dtrules/sync/validation.go
+++ b/pkg/dtrules/sync/validation.go
@@ -281,8 +281,9 @@ func validateTable(table *dtTableXML) TableValidationResult {
 	}
 
 	// Check contexts
-	for _, ctx := range table.Contexts.Contexts {
-		if hasContent(ctx.Description) {
+	for i := range table.Contexts.Contexts {
+		ctx := &table.Contexts.Contexts[i]
+		if hasContent(ctx.GetDSL()) {
 			result.HasELContexts = true
 		}
 		if hasContent(ctx.Postfix) {
@@ -291,8 +292,9 @@ func validateTable(table *dtTableXML) TableValidationResult {
 	}
 
 	// Check conditions
-	for _, cond := range table.Conditions.Conditions {
-		if hasContent(cond.Description) {
+	for i := range table.Conditions.Conditions {
+		cond := &table.Conditions.Conditions[i]
+		if hasContent(cond.GetDSL()) {
 			result.HasELConditions = true
 		}
 		if hasContent(cond.Postfix) {
@@ -301,8 +303,9 @@ func validateTable(table *dtTableXML) TableValidationResult {
 	}
 
 	// Check actions
-	for _, action := range table.Actions.Actions {
-		if hasContent(action.Description) {
+	for i := range table.Actions.Actions {
+		action := &table.Actions.Actions[i]
+		if hasContent(action.GetDSL()) {
 			result.HasELActions = true
 		}
 		if hasContent(action.Postfix) {
@@ -311,8 +314,9 @@ func validateTable(table *dtTableXML) TableValidationResult {
 	}
 
 	// Check initial actions
-	for _, action := range table.InitialActions.Actions {
-		if hasContent(action.Description) {
+	for i := range table.InitialActions.Actions {
+		action := &table.InitialActions.Actions[i]
+		if hasContent(action.GetDSL()) {
 			result.HasELActions = true
 		}
 		if hasContent(action.Postfix) {
@@ -368,7 +372,15 @@ type dtContextsXML struct {
 
 type dtContextDetailXML struct {
 	Description string `xml:"context_description"`
+	DSL         string `xml:"context_dsl"`
 	Postfix     string `xml:"context_postfix"`
+}
+
+func (c *dtContextDetailXML) GetDSL() string {
+	if c.DSL != "" {
+		return c.DSL
+	}
+	return c.Description
 }
 
 type dtInitialActionsXML struct {
@@ -377,7 +389,15 @@ type dtInitialActionsXML struct {
 
 type dtInitialActionXML struct {
 	Description string `xml:"initial_action_description"`
+	DSL         string `xml:"initial_action_dsl"`
 	Postfix     string `xml:"initial_action_postfix"`
+}
+
+func (a *dtInitialActionXML) GetDSL() string {
+	if a.DSL != "" {
+		return a.DSL
+	}
+	return a.Description
 }
 
 type dtConditionsXML struct {
@@ -386,7 +406,15 @@ type dtConditionsXML struct {
 
 type dtConditionDetailXML struct {
 	Description string `xml:"condition_description"`
+	DSL         string `xml:"condition_dsl"`
 	Postfix     string `xml:"condition_postfix"`
+}
+
+func (c *dtConditionDetailXML) GetDSL() string {
+	if c.DSL != "" {
+		return c.DSL
+	}
+	return c.Description
 }
 
 type dtActionsXML struct {
@@ -395,7 +423,15 @@ type dtActionsXML struct {
 
 type dtActionDetailXML struct {
 	Description string `xml:"action_description"`
+	DSL         string `xml:"action_dsl"`
 	Postfix     string `xml:"action_postfix"`
+}
+
+func (a *dtActionDetailXML) GetDSL() string {
+	if a.DSL != "" {
+		return a.DSL
+	}
+	return a.Description
 }
 
 // parseDTXML parses a decision table XML file.

--- a/sampleprojects/CHIP/repository/xml/CHIP_dt.xml
+++ b/sampleprojects/CHIP/repository/xml/CHIP_dt.xml
@@ -15,7 +15,7 @@
 <condition_number>1</condition_number>
 <condition_comment>CHIP</condition_comment>
 <condition_requirement />
-<condition_description>job.program is equal to CHIP</condition_description>
+<condition_dsl>job.program is equal to CHIP</condition_dsl>
 <condition_postfix>
 job.program CHIP streq 
 </condition_postfix>
@@ -24,7 +24,7 @@ job.program CHIP streq
 <condition_number>2</condition_number>
 <condition_comment>MEDICAID</condition_comment>
 <condition_requirement />
-<condition_description>job.program is equal to MEDICAID</condition_description>
+<condition_dsl>job.program is equal to MEDICAID</condition_dsl>
 <condition_postfix>
 job.program MEDICAID streq 
 </condition_postfix>
@@ -33,7 +33,7 @@ job.program MEDICAID streq
 <condition_number>3</condition_number>
 <condition_comment>FOODSTAMPS</condition_comment>
 <condition_requirement />
-<condition_description>job.program is equal to FOODSTAMPS</condition_description>
+<condition_dsl>job.program is equal to FOODSTAMPS</condition_dsl>
 <condition_postfix>
 job.program FOODSTAMPS streq 
 </condition_postfix>
@@ -42,7 +42,7 @@ job.program FOODSTAMPS streq
 <condition_number>4</condition_number>
 <condition_comment>If Not Any of these programs, Report Results Anyway</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>
 otherwise 
 </condition_postfix>
@@ -52,7 +52,7 @@ otherwise
 <action_number>1</action_number>
 <action_comment>Calculate the Individual Incomes</action_comment>
 <initial_action_requirement />
-<action_description>perform Calculate_Individual_Income</action_description>
+<action_dsl>perform Calculate_Individual_Income</action_dsl>
 <action_postfix>
 Calculate_Individual_Income 
 </action_postfix>
@@ -63,7 +63,7 @@ Calculate_Individual_Income
 <action_number>2</action_number>
 <action_comment>Get the Group Size for each individual</action_comment>
 <initial_action_requirement />
-<action_description>perform Calculate_Group_Size</action_description>
+<action_dsl>perform Calculate_Group_Size</action_dsl>
 <action_postfix>
 Calculate_Group_Size 
 </action_postfix>
@@ -74,7 +74,7 @@ Calculate_Group_Size
 <action_number>3</action_number>
 <action_comment>Evaluate for CHIP</action_comment>
 <initial_action_requirement />
-<action_description>perform Evaluate_CHIP_Eligibility</action_description>
+<action_dsl>perform Evaluate_CHIP_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_CHIP_Eligibility 
 </action_postfix>
@@ -83,7 +83,7 @@ Evaluate_CHIP_Eligibility
 <action_number>4</action_number>
 <action_comment>Evaluate for MEDICAID</action_comment>
 <initial_action_requirement />
-<action_description>perform Evaluate_MEDICAID_Eligibility</action_description>
+<action_dsl>perform Evaluate_MEDICAID_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_MEDICAID_Eligibility 
 </action_postfix>
@@ -92,7 +92,7 @@ Evaluate_MEDICAID_Eligibility
 <action_number>5</action_number>
 <action_comment>Evaluate for FOODSTAMPS</action_comment>
 <initial_action_requirement />
-<action_description>perform Evaluate_FOODSTAMPS_Eligibilty</action_description>
+<action_dsl>perform Evaluate_FOODSTAMPS_Eligibilty</action_dsl>
 <action_postfix>
 Evaluate_FOODSTAMPS_Eligibilty 
 </action_postfix>
@@ -101,7 +101,7 @@ Evaluate_FOODSTAMPS_Eligibilty
 <action_number>6</action_number>
 <action_comment>Build a set of Result Objects to report to the caller</action_comment>
 <initial_action_requirement />
-<action_description>perform Evaluate_Results</action_description>
+<action_dsl>perform Evaluate_Results</action_dsl>
 <action_postfix>
 Evaluate_Results 
 </action_postfix>
@@ -134,14 +134,14 @@ Evaluate_Results
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment />
-<context_description>for all incomes</context_description>
+<context_dsl>for all incomes</context_dsl>
 <context_postfix>
 dup incomes forall pop 
 </context_postfix></context_details></contexts>
@@ -151,7 +151,7 @@ dup incomes forall pop
 <condition_number>1</condition_number>
 <condition_comment>We include all earned income</condition_comment>
 <condition_requirement />
-<condition_description>income.earned == true</condition_description>
+<condition_dsl>income.earned == true</condition_dsl>
 <condition_postfix>
 income.earned true beq 
 </condition_postfix>
@@ -161,7 +161,7 @@ income.earned true beq
 <condition_number>2</condition_number>
 <condition_comment>We don't include all unearned income types</condition_comment>
 <condition_requirement />
-<condition_description>ExcludedIncomeTypes includes the string income.type</condition_description>
+<condition_dsl>ExcludedIncomeTypes includes the string income.type</condition_dsl>
 <condition_postfix>
 ExcludedIncomeTypes income.type memberof 
 </condition_postfix>
@@ -171,7 +171,7 @@ ExcludedIncomeTypes income.type memberof
 <action_number>1</action_number>
 <action_comment>Add this income to the total income for this client</action_comment>
 <initial_action_requirement />
-<action_description>add income.amount to the client.totalIncome</action_description>
+<action_dsl>add income.amount to the client.totalIncome</action_dsl>
 <action_postfix>
 income.amount  client.totalIncome + /client.totalIncome xdef 
 </action_postfix>
@@ -194,21 +194,21 @@ Note that this table doesn't actually create the income group.  It just counts t
 <context_details>
 <context_number>1</context_number>
 <context_comment>For each client in the group, we need to calculate a group size (we only need to do this for applying clients)</context_comment>
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>We want to compare a client against every other client in the case, so we set up a local variable to point to ThisClient</context_comment>
-<context_description>local entity ThisClient = client</context_description>
+<context_dsl>local entity ThisClient = client</context_dsl>
 <context_postfix>
 client cve allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment>Now consider the client in respect to all the other clients in the case (We need to consider all clients in the case, even if not applying)</context_comment>
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -218,7 +218,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Are we consider the client themselves?</condition_comment>
 <condition_requirement />
-<condition_description>ThisClient == client</condition_description>
+<condition_dsl>ThisClient == client</condition_dsl>
 <condition_postfix>
 0 local@  client req  
 </condition_postfix>
@@ -229,7 +229,7 @@ dup clients forall pop
 <condition_number>2</condition_number>
 <condition_comment>Include ThisClient's parents</condition_comment>
 <condition_requirement />
-<condition_description>the client is the parent of ThisClient</condition_description>
+<condition_dsl>the client is the parent of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type parent relationships findmatch swap pop
 </condition_postfix>
@@ -240,7 +240,7 @@ dup clients forall pop
 <condition_number>3</condition_number>
 <condition_comment>Include ThisClient's siblings</condition_comment>
 <condition_requirement />
-<condition_description>the client is the sibling of ThisClient</condition_description>
+<condition_dsl>the client is the sibling of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type sibling relationships findmatch swap pop
 </condition_postfix>
@@ -251,7 +251,7 @@ dup clients forall pop
 <condition_number>4</condition_number>
 <condition_comment>Include ThisClient's children</condition_comment>
 <condition_requirement />
-<condition_description>the client is the child of ThisClient</condition_description>
+<condition_dsl>the client is the child of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type child relationships findmatch swap pop
 </condition_postfix>
@@ -261,7 +261,7 @@ dup clients forall pop
 <condition_number>5</condition_number>
 <condition_comment>Include the unborn children in some cases</condition_comment>
 <condition_requirement />
-<condition_description>the client.pregnant == true</condition_description>
+<condition_dsl>the client.pregnant == true</condition_dsl>
 <condition_postfix>
 client.pregnant true beq 
 </condition_postfix>
@@ -275,7 +275,7 @@ client.pregnant true beq
 <condition_number>6</condition_number>
 <condition_comment>Is this client older than 18</condition_comment>
 <condition_requirement />
-<condition_description>client.age &gt; 18</condition_description>
+<condition_dsl>client.age &gt; 18</condition_dsl>
 <condition_postfix>
 client.age 18 &gt; 
 </condition_postfix>
@@ -288,7 +288,7 @@ client.age 18 &gt;
 <action_number>1</action_number>
 <action_comment>Count the Client himself and particular relatives</action_comment>
 <initial_action_requirement />
-<action_description>add 1 to ThisClient's IncomeGroupCount</action_description>
+<action_dsl>add 1 to ThisClient's IncomeGroupCount</action_dsl>
 <action_postfix>
 1  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -303,7 +303,7 @@ client.age 18 &gt;
 <action_number>2</action_number>
 <action_comment>Add 1 for each of the expected babies for a pregnant person</action_comment>
 <initial_action_requirement />
-<action_description>add expectedChildren to ThisClient's IncomeGroupCount</action_description>
+<action_dsl>add expectedChildren to ThisClient's IncomeGroupCount</action_dsl>
 <action_postfix>
 expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -314,7 +314,7 @@ expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef
 <action_number>3</action_number>
 <action_comment>Add this person's Income to the ThisPerson's total group income</action_comment>
 <initial_action_requirement />
-<action_description>add the client.totalIncome to ThisClient's totalGroupIncome</action_description>
+<action_dsl>add the client.totalIncome to ThisClient's totalGroupIncome</action_dsl>
 <action_postfix>
 client.totalIncome  0 local@  entitypush totalGroupIncome + /totalGroupIncome xdef entitypop 
 </action_postfix>
@@ -337,21 +337,21 @@ An appropriate income is only one requirement for CHIP.  All the others required
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>FPL = the Federal Poverty Limit calculated for the number of people in this client's Income Group.</context_comment>
-<context_description>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_description>
+<context_dsl>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_dsl>
 <context_postfix>
 FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment>FPL200 = 200 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL200 = FPL * 2</context_description>
+<context_dsl>local int FPL200 = FPL * 2</context_dsl>
 <context_postfix>
 0 local@  2 *  cvi allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -361,7 +361,7 @@ FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate 
 <condition_number>1</condition_number>
 <condition_comment>Are you a citizen?</condition_comment>
 <condition_requirement />
-<condition_description>validatedCitizenship == true</condition_description>
+<condition_dsl>validatedCitizenship == true</condition_dsl>
 <condition_postfix>
 validatedCitizenship true beq 
 </condition_postfix>
@@ -370,7 +370,7 @@ validatedCitizenship true beq
 <condition_number>2</condition_number>
 <condition_comment>If not a citizen,  are you a legal immigrant(Lawfully present immigrant children who have not been in the country for 5 years)</condition_comment>
 <condition_requirement />
-<condition_description>validatedImmigrationStatus == true</condition_description>
+<condition_dsl>validatedImmigrationStatus == true</condition_dsl>
 <condition_postfix>
 validatedImmigrationStatus true beq 
 </condition_postfix>
@@ -379,7 +379,7 @@ validatedImmigrationStatus true beq
 <condition_number>3</condition_number>
 <condition_comment>Group income must be &lt;=200 percent of the Federal Poverty Limit</condition_comment>
 <condition_requirement />
-<condition_description>client.totalGroupIncome &lt;= FPL200</condition_description>
+<condition_dsl>client.totalGroupIncome &lt;= FPL200</condition_dsl>
 <condition_postfix>
 client.totalGroupIncome 1 local@  &lt;= 
 </condition_postfix>
@@ -388,7 +388,7 @@ client.totalGroupIncome 1 local@  &lt;=
 <condition_number>4</condition_number>
 <condition_comment>Children should be uninsured to qualify for CHIP-funded coverage</condition_comment>
 <condition_requirement />
-<condition_description>uninsured</condition_description>
+<condition_dsl>uninsured</condition_dsl>
 <condition_postfix>
 uninsured 
 </condition_postfix>
@@ -398,7 +398,7 @@ uninsured
 <condition_number>5</condition_number>
 <condition_comment>If we have no lost Insurance date, and we are uninsured, then the client was never insured.</condition_comment>
 <condition_requirement />
-<condition_description>lostInsuranceDate is null</condition_description>
+<condition_dsl>lostInsuranceDate is null</condition_dsl>
 <condition_postfix>
 lostInsuranceDate  isnull 
 </condition_postfix>
@@ -407,7 +407,7 @@ lostInsuranceDate  isnull
 <condition_number>6</condition_number>
 <condition_comment>Children should be uninsured to qualify for CHIP-funded coverage</condition_comment>
 <condition_requirement />
-<condition_description>lostInsuranceDate + 90 days is greater than the currentdate</condition_description>
+<condition_dsl>lostInsuranceDate + 90 days is greater than the currentdate</condition_dsl>
 <condition_postfix>
 lostInsuranceDate  90  adddays currentdate d&gt; 
 </condition_postfix>
@@ -416,7 +416,7 @@ lostInsuranceDate  90  adddays currentdate d&gt;
 <condition_number>7</condition_number>
 <condition_comment>Make sure this case is in the appropriate county</condition_comment>
 <condition_requirement />
-<condition_description>The CoveredCounties includes the string case.county_Cd</condition_description>
+<condition_dsl>The CoveredCounties includes the string case.county_Cd</condition_dsl>
 <condition_postfix>
 CoveredCounties case.county_Cd memberof 
 </condition_postfix>
@@ -425,7 +425,7 @@ CoveredCounties case.county_Cd memberof
 <condition_number>8</condition_number>
 <condition_comment>Age limit should be &lt;=18 years</condition_comment>
 <condition_requirement />
-<condition_description>client.age &lt;= 18</condition_description>
+<condition_dsl>client.age &lt;= 18</condition_dsl>
 <condition_postfix>
 client.age 18 &lt;= 
 </condition_postfix>
@@ -434,7 +434,7 @@ client.age 18 &lt;=
 <condition_number>9</condition_number>
 <condition_comment>If you are eligible for Medicaid, then you are not eligible for CHIP</condition_comment>
 <condition_requirement />
-<condition_description>eligibleForMedicaid == true</condition_description>
+<condition_dsl>eligibleForMedicaid == true</condition_dsl>
 <condition_postfix>
 eligibleForMedicaid true beq 
 </condition_postfix>
@@ -443,7 +443,7 @@ eligibleForMedicaid true beq
 <condition_number>10</condition_number>
 <condition_comment>Otherwise the client is eligible</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>
 otherwise 
 </condition_postfix>
@@ -453,7 +453,7 @@ otherwise
 <action_number>1</action_number>
 <action_comment>Record the fpl for this client</action_comment>
 <initial_action_requirement />
-<action_description>set the client_fpl = fpl</action_description>
+<action_dsl>set the client_fpl = fpl</action_dsl>
 <action_postfix>
 0 local@   cvi /client_fpl xdef  
 </action_postfix>
@@ -469,7 +469,7 @@ otherwise
 <action_number>2</action_number>
 <action_comment>Provide reasons for rejection</action_comment>
 <initial_action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -484,7 +484,7 @@ false cvb /client.eligible xdef
 <action_number>3</action_number>
 <action_comment>If none of the eligiblity exclusions fired, then the client is eligible</action_comment>
 <initial_action_requirement />
-<action_description>set client.eligible = true</action_description>
+<action_dsl>set client.eligible = true</action_dsl>
 <action_postfix>
 true cvb /client.eligible xdef  
 </action_postfix>
@@ -493,7 +493,7 @@ true cvb /client.eligible xdef
 <action_number>4</action_number>
 <action_comment>Record the client's income</action_comment>
 <initial_action_requirement />
-<action_description>add "Client Income = " + client.totalGroupIncome to the client.notes</action_description>
+<action_dsl>add "Client Income = " + client.totalGroupIncome to the client.notes</action_dsl>
 <action_postfix>
 "Client Income = " client.totalGroupIncome strconcat client.notes swap addto 
 </action_postfix>
@@ -509,7 +509,7 @@ true cvb /client.eligible xdef
 <action_number>5</action_number>
 <action_comment>Record the reasoning.</action_comment>
 <initial_action_requirement />
-<action_description>add the policy statements to the client.notes</action_description>
+<action_dsl>add the policy statements to the client.notes</action_dsl>
 <action_postfix>
 policystatements client.notes true  addarray 
 </action_postfix>
@@ -558,7 +558,7 @@ policystatements client.notes true  addarray
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -568,7 +568,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
 <condition_requirement />
-<condition_description>client.applying == true</condition_description>
+<condition_dsl>client.applying == true</condition_dsl>
 <condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -578,7 +578,7 @@ client.applying true beq
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
 <initial_action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -587,7 +587,7 @@ false cvb /client.eligible xdef
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Medicaid Applications" to client.notes</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "The System does not yet support Medicaid Applications" client.notes swap addto 
 </action_postfix>
@@ -605,7 +605,7 @@ false cvb /client.eligible xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -615,7 +615,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
 <condition_requirement />
-<condition_description>client.applying == true</condition_description>
+<condition_dsl>client.applying == true</condition_dsl>
 <condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -625,7 +625,7 @@ client.applying true beq
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
 <initial_action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -634,7 +634,7 @@ false cvb /client.eligible xdef
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Food Stamp Applications" to client.notes</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "The System does not yet support Food Stamp Applications" client.notes swap addto 
 </action_postfix>
@@ -652,7 +652,7 @@ false cvb /client.eligible xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details></contexts>
@@ -662,7 +662,7 @@ false cvb /client.eligible xdef
 <condition_number>1</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called 
 </condition_postfix>
@@ -672,7 +672,7 @@ perform when called
 <action_number>1</action_number>
 <action_comment>Create a Result Record</action_comment>
 <initial_action_requirement />
-<action_description>add a new Result entity to the context of this table</action_description>
+<action_dsl>add a new Result entity to the context of this table</action_dsl>
 <action_postfix>
 /Result createentity entitypush 
 </action_postfix>
@@ -681,7 +681,7 @@ perform when called
 <action_number>2</action_number>
 <action_comment>Add the record to the list on the job</action_comment>
 <initial_action_requirement />
-<action_description>add the result to the job.results</action_description>
+<action_dsl>add the result to the job.results</action_dsl>
 <action_postfix>
 result job.results swap addto 
 </action_postfix>
@@ -690,7 +690,7 @@ result job.results swap addto
 <action_number>3</action_number>
 <action_comment>Point the Result notes to the Client notes</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.notes = client.notes</action_description>
+<action_dsl>Set Result.notes = client.notes</action_dsl>
 <action_postfix>
 client.notes /Result.notes xdef 
 </action_postfix>
@@ -699,7 +699,7 @@ client.notes /Result.notes xdef
 <action_number>4</action_number>
 <action_comment>Copy the client ID</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.client_id = client.id</action_description>
+<action_dsl>Set Result.client_id = client.id</action_dsl>
 <action_postfix>
 client.id  cvs /Result.client_id xdef  
 </action_postfix>
@@ -708,7 +708,7 @@ client.id  cvs /Result.client_id xdef
 <action_number>5</action_number>
 <action_comment>Point the Result to the client</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.client = client.client</action_description>
+<action_dsl>Set Result.client = client.client</action_dsl>
 <action_postfix>
 client.client cve /Result.client xdef  
 </action_postfix>
@@ -717,7 +717,7 @@ client.client cve /Result.client xdef
 <action_number>6</action_number>
 <action_comment>Set the Result to the program we processed</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.program = job.program</action_description>
+<action_dsl>Set Result.program = job.program</action_dsl>
 <action_postfix>
 job.program cvs /Result.program xdef  
 </action_postfix>
@@ -726,7 +726,7 @@ job.program cvs /Result.program xdef
 <action_number>7</action_number>
 <action_comment>Set the Result programLevel to that recorded on the client</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.programLevel = client.programLevel</action_description>
+<action_dsl>Set Result.programLevel = client.programLevel</action_dsl>
 <action_postfix>
 client.programLevel cvs /Result.programLevel xdef  
 </action_postfix>
@@ -735,7 +735,7 @@ client.programLevel cvs /Result.programLevel xdef
 <action_number>8</action_number>
 <action_comment>Set the Result eligible flag to that recorded on the client</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.eligible = client.eligible</action_description>
+<action_dsl>Set Result.eligible = client.eligible</action_dsl>
 <action_postfix>
 client.eligible cvb /Result.eligible xdef  
 </action_postfix>
@@ -744,7 +744,7 @@ client.eligible cvb /Result.eligible xdef
 <action_number>9</action_number>
 <action_comment>Set the Result Federal Poverty Level to the client's</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.client_fpl = client.client_fpl</action_description>
+<action_dsl>Set Result.client_fpl = client.client_fpl</action_dsl>
 <action_postfix>
 client.client_fpl  cvi /Result.client_fpl xdef  
 </action_postfix>
@@ -753,7 +753,7 @@ client.client_fpl  cvi /Result.client_fpl xdef
 <action_number>10</action_number>
 <action_comment>Set the Result's totalGroupIncome to the clients.</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.totalGroupIncome = client.totalGroupIncome</action_description>
+<action_dsl>Set Result.totalGroupIncome = client.totalGroupIncome</action_dsl>
 <action_postfix>
 client.totalGroupIncome  cvi /Result.totalGroupIncome xdef  
 </action_postfix>

--- a/sampleprojects/CHIP/xml/CHIP_dt.xml
+++ b/sampleprojects/CHIP/xml/CHIP_dt.xml
@@ -15,7 +15,7 @@
 <condition_number>1</condition_number>
 <condition_comment>CHIP</condition_comment>
 <condition_requirement />
-<condition_description>job.program is equal to CHIP</condition_description>
+<condition_dsl>job.program is equal to CHIP</condition_dsl>
 <condition_postfix>
 job.program CHIP streq 
 </condition_postfix>
@@ -24,7 +24,7 @@ job.program CHIP streq
 <condition_number>2</condition_number>
 <condition_comment>MEDICAID</condition_comment>
 <condition_requirement />
-<condition_description>job.program is equal to MEDICAID</condition_description>
+<condition_dsl>job.program is equal to MEDICAID</condition_dsl>
 <condition_postfix>
 job.program MEDICAID streq 
 </condition_postfix>
@@ -33,7 +33,7 @@ job.program MEDICAID streq
 <condition_number>3</condition_number>
 <condition_comment>FOODSTAMPS</condition_comment>
 <condition_requirement />
-<condition_description>job.program is equal to FOODSTAMPS</condition_description>
+<condition_dsl>job.program is equal to FOODSTAMPS</condition_dsl>
 <condition_postfix>
 job.program FOODSTAMPS streq 
 </condition_postfix>
@@ -42,7 +42,7 @@ job.program FOODSTAMPS streq
 <condition_number>4</condition_number>
 <condition_comment>If Not Any of these programs, Report Results Anyway</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>
 otherwise 
 </condition_postfix>
@@ -52,7 +52,7 @@ otherwise
 <action_number>1</action_number>
 <action_comment>Calculate the Individual Incomes</action_comment>
 <action_requirement />
-<action_description>perform Calculate_Individual_Income</action_description>
+<action_dsl>perform Calculate_Individual_Income</action_dsl>
 <action_postfix>
 Calculate_Individual_Income 
 </action_postfix>
@@ -63,7 +63,7 @@ Calculate_Individual_Income
 <action_number>2</action_number>
 <action_comment>Get the Group Size for each individual</action_comment>
 <action_requirement />
-<action_description>perform Calculate_Group_Size</action_description>
+<action_dsl>perform Calculate_Group_Size</action_dsl>
 <action_postfix>
 Calculate_Group_Size 
 </action_postfix>
@@ -74,7 +74,7 @@ Calculate_Group_Size
 <action_number>3</action_number>
 <action_comment>Evaluate for CHIP</action_comment>
 <action_requirement />
-<action_description>perform Evaluate_CHIP_Eligibility</action_description>
+<action_dsl>perform Evaluate_CHIP_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_CHIP_Eligibility 
 </action_postfix>
@@ -83,7 +83,7 @@ Evaluate_CHIP_Eligibility
 <action_number>4</action_number>
 <action_comment>Evaluate for MEDICAID</action_comment>
 <action_requirement />
-<action_description>perform Evaluate_MEDICAID_Eligibility</action_description>
+<action_dsl>perform Evaluate_MEDICAID_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_MEDICAID_Eligibility 
 </action_postfix>
@@ -92,7 +92,7 @@ Evaluate_MEDICAID_Eligibility
 <action_number>5</action_number>
 <action_comment>Evaluate for FOODSTAMPS</action_comment>
 <action_requirement />
-<action_description>perform Evaluate_FOODSTAMPS_Eligibilty</action_description>
+<action_dsl>perform Evaluate_FOODSTAMPS_Eligibilty</action_dsl>
 <action_postfix>
 Evaluate_FOODSTAMPS_Eligibilty 
 </action_postfix>
@@ -101,7 +101,7 @@ Evaluate_FOODSTAMPS_Eligibilty
 <action_number>6</action_number>
 <action_comment>Build a set of Result Objects to report to the caller</action_comment>
 <action_requirement />
-<action_description>perform Evaluate_Results</action_description>
+<action_dsl>perform Evaluate_Results</action_dsl>
 <action_postfix>
 Evaluate_Results 
 </action_postfix>
@@ -134,14 +134,14 @@ Evaluate_Results
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment />
-<context_description>for all incomes</context_description>
+<context_dsl>for all incomes</context_dsl>
 <context_postfix>
 dup incomes forall pop 
 </context_postfix></context_details></contexts>
@@ -151,7 +151,7 @@ dup incomes forall pop
 <condition_number>1</condition_number>
 <condition_comment>We include all earned income</condition_comment>
 <condition_requirement />
-<condition_description>income.earned == true</condition_description>
+<condition_dsl>income.earned == true</condition_dsl>
 <condition_postfix>
 income.earned true beq 
 </condition_postfix>
@@ -161,7 +161,7 @@ income.earned true beq
 <condition_number>2</condition_number>
 <condition_comment>We don't include all unearned income types</condition_comment>
 <condition_requirement />
-<condition_description>ExcludedIncomeTypes includes the string income.type</condition_description>
+<condition_dsl>ExcludedIncomeTypes includes the string income.type</condition_dsl>
 <condition_postfix>
 ExcludedIncomeTypes income.type memberof 
 </condition_postfix>
@@ -171,7 +171,7 @@ ExcludedIncomeTypes income.type memberof
 <action_number>1</action_number>
 <action_comment>Add this income to the total income for this client</action_comment>
 <action_requirement />
-<action_description>add income.amount to the client.totalIncome</action_description>
+<action_dsl>add income.amount to the client.totalIncome</action_dsl>
 <action_postfix>
 income.amount  client.totalIncome + /client.totalIncome xdef 
 </action_postfix>
@@ -194,21 +194,21 @@ Note that this table doesn't actually create the income group.  It just counts t
 <context_details>
 <context_number>1</context_number>
 <context_comment>For each client in the group, we need to calculate a group size (we only need to do this for applying clients)</context_comment>
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>We want to compare a client against every other client in the case, so we set up a local variable to point to ApplyingClient</context_comment>
-<context_description>local entity ApplyingClient = client</context_description>
+<context_dsl>local entity ApplyingClient = client</context_dsl>
 <context_postfix>
 client cve allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment>Now consider the client in respect to all the other clients in the case (We need to consider all clients in the case, even if not applying)</context_comment>
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -218,7 +218,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Are we consider the client themselves?</condition_comment>
 <condition_requirement />
-<condition_description>ApplyingClient == client</condition_description>
+<condition_dsl>ApplyingClient == client</condition_dsl>
 <condition_postfix>
 0 local@  client req  
 </condition_postfix>
@@ -229,7 +229,7 @@ dup clients forall pop
 <condition_number>2</condition_number>
 <condition_comment>Include ApplyingClient's parents</condition_comment>
 <condition_requirement />
-<condition_description>the client is the parent of ApplyingClient</condition_description>
+<condition_dsl>the client is the parent of ApplyingClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type parent relationships findmatch swap pop
 </condition_postfix>
@@ -240,7 +240,7 @@ dup clients forall pop
 <condition_number>3</condition_number>
 <condition_comment>Include ApplyingClient's siblings</condition_comment>
 <condition_requirement />
-<condition_description>the client is the sibling of ApplyingClient</condition_description>
+<condition_dsl>the client is the sibling of ApplyingClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type sibling relationships findmatch swap pop
 </condition_postfix>
@@ -251,7 +251,7 @@ dup clients forall pop
 <condition_number>4</condition_number>
 <condition_comment>Include ApplyingClient's children</condition_comment>
 <condition_requirement />
-<condition_description>the client is the child of ApplyingClient</condition_description>
+<condition_dsl>the client is the child of ApplyingClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type child relationships findmatch swap pop
 </condition_postfix>
@@ -261,7 +261,7 @@ dup clients forall pop
 <condition_number>5</condition_number>
 <condition_comment>Include the unborn children in some cases</condition_comment>
 <condition_requirement />
-<condition_description>the client.pregnant == true</condition_description>
+<condition_dsl>the client.pregnant == true</condition_dsl>
 <condition_postfix>
 client.pregnant true beq 
 </condition_postfix>
@@ -275,7 +275,7 @@ client.pregnant true beq
 <condition_number>6</condition_number>
 <condition_comment>Is this client older than 18</condition_comment>
 <condition_requirement />
-<condition_description>client.age &gt; 18</condition_description>
+<condition_dsl>client.age &gt; 18</condition_dsl>
 <condition_postfix>
 client.age 18 &gt; 
 </condition_postfix>
@@ -288,7 +288,7 @@ client.age 18 &gt;
 <action_number>1</action_number>
 <action_comment>Count the Client himself and particular relatives</action_comment>
 <action_requirement />
-<action_description>add 1 to ApplyingClient's IncomeGroupCount</action_description>
+<action_dsl>add 1 to ApplyingClient's IncomeGroupCount</action_dsl>
 <action_postfix>
 1  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -303,7 +303,7 @@ client.age 18 &gt;
 <action_number>2</action_number>
 <action_comment>Add 1 for each of the expected babies for a pregnant person</action_comment>
 <action_requirement />
-<action_description>add expectedChildren to ApplyingClient's IncomeGroupCount</action_description>
+<action_dsl>add expectedChildren to ApplyingClient's IncomeGroupCount</action_dsl>
 <action_postfix>
 expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -314,7 +314,7 @@ expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef
 <action_number>3</action_number>
 <action_comment>Add this person's Income to the ThisPerson's total group income</action_comment>
 <action_requirement />
-<action_description>add the client.totalIncome to ApplyingClient's totalGroupIncome</action_description>
+<action_dsl>add the client.totalIncome to ApplyingClient's totalGroupIncome</action_dsl>
 <action_postfix>
 client.totalIncome  0 local@  entitypush totalGroupIncome + /totalGroupIncome xdef entitypop 
 </action_postfix>
@@ -337,21 +337,21 @@ An appropriate income is only one requirement for CHIP.  All the others required
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>FPL = the Federal Poverty Limit calculated for the number of people in this client's Income Group.</context_comment>
-<context_description>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_description>
+<context_dsl>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_dsl>
 <context_postfix>
 FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment>FPL200 = 200 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL200 = FPL * 2</context_description>
+<context_dsl>local int FPL200 = FPL * 2</context_dsl>
 <context_postfix>
 0 local@  2 *  cvi allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -361,7 +361,7 @@ FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate 
 <condition_number>1</condition_number>
 <condition_comment>Are you a citizen?</condition_comment>
 <condition_requirement />
-<condition_description>ValidatedCitizenship == true</condition_description>
+<condition_dsl>ValidatedCitizenship == true</condition_dsl>
 <condition_postfix>
 ValidatedCitizenship true beq 
 </condition_postfix>
@@ -370,7 +370,7 @@ ValidatedCitizenship true beq
 <condition_number>2</condition_number>
 <condition_comment>If not a citizen,  are you a legal immigrant(Lawfully present immigrant children who have not been in the country for 5 years)</condition_comment>
 <condition_requirement />
-<condition_description>validatedImmigrationStatus == true</condition_description>
+<condition_dsl>validatedImmigrationStatus == true</condition_dsl>
 <condition_postfix>
 validatedImmigrationStatus true beq 
 </condition_postfix>
@@ -379,7 +379,7 @@ validatedImmigrationStatus true beq
 <condition_number>3</condition_number>
 <condition_comment>Group income must be &lt;=200 percent of the Federal Poverty Limit</condition_comment>
 <condition_requirement />
-<condition_description>client.totalGroupIncome &lt;= FPL200</condition_description>
+<condition_dsl>client.totalGroupIncome &lt;= FPL200</condition_dsl>
 <condition_postfix>
 client.totalGroupIncome 1 local@  &lt;= 
 </condition_postfix>
@@ -388,7 +388,7 @@ client.totalGroupIncome 1 local@  &lt;=
 <condition_number>4</condition_number>
 <condition_comment>Children should be uninsured to qualify for CHIP-funded coverage</condition_comment>
 <condition_requirement />
-<condition_description>uninsured</condition_description>
+<condition_dsl>uninsured</condition_dsl>
 <condition_postfix>
 uninsured 
 </condition_postfix>
@@ -398,7 +398,7 @@ uninsured
 <condition_number>5</condition_number>
 <condition_comment>If we have no lost Insurance date, and we are uninsured, then the client was never insured.</condition_comment>
 <condition_requirement />
-<condition_description>lostInsuranceDate is null</condition_description>
+<condition_dsl>lostInsuranceDate is null</condition_dsl>
 <condition_postfix>
 lostInsuranceDate  isnull 
 </condition_postfix>
@@ -407,7 +407,7 @@ lostInsuranceDate  isnull
 <condition_number>6</condition_number>
 <condition_comment>Children should be uninsured to qualify for CHIP-funded coverage</condition_comment>
 <condition_requirement />
-<condition_description>lostInsuranceDate + 90 days is greater than the currentdate</condition_description>
+<condition_dsl>lostInsuranceDate + 90 days is greater than the currentdate</condition_dsl>
 <condition_postfix>
 lostInsuranceDate  90  adddays currentdate d&gt; 
 </condition_postfix>
@@ -416,7 +416,7 @@ lostInsuranceDate  90  adddays currentdate d&gt;
 <condition_number>7</condition_number>
 <condition_comment>Make sure this case is in the appropriate county</condition_comment>
 <condition_requirement />
-<condition_description>The CoveredCounties includes the string case.county_Cd</condition_description>
+<condition_dsl>The CoveredCounties includes the string case.county_Cd</condition_dsl>
 <condition_postfix>
 CoveredCounties case.county_Cd memberof 
 </condition_postfix>
@@ -425,7 +425,7 @@ CoveredCounties case.county_Cd memberof
 <condition_number>8</condition_number>
 <condition_comment>Age limit should be &lt;=18 years</condition_comment>
 <condition_requirement />
-<condition_description>client.age &lt;= 18</condition_description>
+<condition_dsl>client.age &lt;= 18</condition_dsl>
 <condition_postfix>
 client.age 18 &lt;= 
 </condition_postfix>
@@ -434,7 +434,7 @@ client.age 18 &lt;=
 <condition_number>9</condition_number>
 <condition_comment>If you are eligible for Medicaid, then you are not eligible for CHIP</condition_comment>
 <condition_requirement />
-<condition_description>eligibleForMedicaid == true</condition_description>
+<condition_dsl>eligibleForMedicaid == true</condition_dsl>
 <condition_postfix>
 eligibleForMedicaid true beq 
 </condition_postfix>
@@ -443,7 +443,7 @@ eligibleForMedicaid true beq
 <condition_number>10</condition_number>
 <condition_comment>Otherwise the client is eligible</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>
 otherwise 
 </condition_postfix>
@@ -453,7 +453,7 @@ otherwise
 <action_number>1</action_number>
 <action_comment>Record the fpl for this client</action_comment>
 <action_requirement />
-<action_description>set the client_fpl = fpl</action_description>
+<action_dsl>set the client_fpl = fpl</action_dsl>
 <action_postfix>
 0 local@   cvi /client_fpl xdef  
 </action_postfix>
@@ -469,7 +469,7 @@ otherwise
 <action_number>2</action_number>
 <action_comment>Provide reasons for rejection</action_comment>
 <action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -484,7 +484,7 @@ false cvb /client.eligible xdef
 <action_number>3</action_number>
 <action_comment>If none of the eligiblity exclusions fired, then the client is eligible</action_comment>
 <action_requirement />
-<action_description>set client.eligible = true</action_description>
+<action_dsl>set client.eligible = true</action_dsl>
 <action_postfix>
 true cvb /client.eligible xdef  
 </action_postfix>
@@ -493,7 +493,7 @@ true cvb /client.eligible xdef
 <action_number>4</action_number>
 <action_comment>Record the client's income</action_comment>
 <action_requirement />
-<action_description>add "Client Income = " + client.totalGroupIncome to the client.notes</action_description>
+<action_dsl>add "Client Income = " + client.totalGroupIncome to the client.notes</action_dsl>
 <action_postfix>
 "Client Income = " client.totalGroupIncome strconcat client.notes swap addto 
 </action_postfix></action_details>
@@ -501,7 +501,7 @@ true cvb /client.eligible xdef
 <action_number>5</action_number>
 <action_comment>Record the reasoning.</action_comment>
 <action_requirement />
-<action_description>add the policy statements to the client.notes</action_description>
+<action_dsl>add the policy statements to the client.notes</action_dsl>
 <action_postfix>
 policystatements client.notes true  addarray 
 </action_postfix>
@@ -550,7 +550,7 @@ policystatements client.notes true  addarray
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -560,7 +560,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
 <condition_requirement />
-<condition_description>client.applying == true</condition_description>
+<condition_dsl>client.applying == true</condition_dsl>
 <condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -570,7 +570,7 @@ client.applying true beq
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
 <action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -579,7 +579,7 @@ false cvb /client.eligible xdef
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Medicaid Applications" to client.notes</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "The System does not yet support Medicaid Applications" client.notes swap addto 
 </action_postfix>
@@ -597,7 +597,7 @@ false cvb /client.eligible xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -607,7 +607,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
 <condition_requirement />
-<condition_description>client.applying == true</condition_description>
+<condition_dsl>client.applying == true</condition_dsl>
 <condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -617,7 +617,7 @@ client.applying true beq
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
 <action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -626,7 +626,7 @@ false cvb /client.eligible xdef
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Food Stamp Applications" to client.notes</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "The System does not yet support Food Stamp Applications" client.notes swap addto 
 </action_postfix>
@@ -644,7 +644,7 @@ false cvb /client.eligible xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details></contexts>
@@ -654,7 +654,7 @@ false cvb /client.eligible xdef
 <condition_number>1</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called 
 </condition_postfix>
@@ -664,7 +664,7 @@ perform when called
 <action_number>1</action_number>
 <action_comment>Create a Result Record</action_comment>
 <action_requirement />
-<action_description>add a new Result entity to the context of this table</action_description>
+<action_dsl>add a new Result entity to the context of this table</action_dsl>
 <action_postfix>
 /Result createentity entitypush 
 </action_postfix>
@@ -673,7 +673,7 @@ perform when called
 <action_number>2</action_number>
 <action_comment>Add the record to the list on the job</action_comment>
 <action_requirement />
-<action_description>add the result to the job.results</action_description>
+<action_dsl>add the result to the job.results</action_dsl>
 <action_postfix>
 result job.results swap addto 
 </action_postfix>
@@ -682,7 +682,7 @@ result job.results swap addto
 <action_number>3</action_number>
 <action_comment>Point the Result notes to the Client notes</action_comment>
 <action_requirement />
-<action_description>Set Result.notes = client.notes</action_description>
+<action_dsl>Set Result.notes = client.notes</action_dsl>
 <action_postfix>
 client.notes /Result.notes xdef 
 </action_postfix>
@@ -691,7 +691,7 @@ client.notes /Result.notes xdef
 <action_number>4</action_number>
 <action_comment>Copy the client ID</action_comment>
 <action_requirement />
-<action_description>Set Result.client_id = client.id</action_description>
+<action_dsl>Set Result.client_id = client.id</action_dsl>
 <action_postfix>
 client.id  cvs /Result.client_id xdef  
 </action_postfix>
@@ -700,7 +700,7 @@ client.id  cvs /Result.client_id xdef
 <action_number>5</action_number>
 <action_comment>Point the Result to the client</action_comment>
 <action_requirement />
-<action_description>Set Result.client = client.client</action_description>
+<action_dsl>Set Result.client = client.client</action_dsl>
 <action_postfix>
 client.client cve /Result.client xdef  
 </action_postfix>
@@ -709,7 +709,7 @@ client.client cve /Result.client xdef
 <action_number>6</action_number>
 <action_comment>Set the Result to the program we processed</action_comment>
 <action_requirement />
-<action_description>Set Result.program = job.program</action_description>
+<action_dsl>Set Result.program = job.program</action_dsl>
 <action_postfix>
 job.program cvs /Result.program xdef  
 </action_postfix>
@@ -718,7 +718,7 @@ job.program cvs /Result.program xdef
 <action_number>7</action_number>
 <action_comment>Set the Result programLevel to that recorded on the client</action_comment>
 <action_requirement />
-<action_description>Set Result.programLevel = client.programLevel</action_description>
+<action_dsl>Set Result.programLevel = client.programLevel</action_dsl>
 <action_postfix>
 client.programLevel cvs /Result.programLevel xdef  
 </action_postfix>
@@ -727,7 +727,7 @@ client.programLevel cvs /Result.programLevel xdef
 <action_number>8</action_number>
 <action_comment>Set the Result eligible flag to that recorded on the client</action_comment>
 <action_requirement />
-<action_description>Set Result.eligible = client.eligible</action_description>
+<action_dsl>Set Result.eligible = client.eligible</action_dsl>
 <action_postfix>
 client.eligible cvb /Result.eligible xdef  
 </action_postfix>
@@ -736,7 +736,7 @@ client.eligible cvb /Result.eligible xdef
 <action_number>9</action_number>
 <action_comment>Set the Result Federal Poverty Level to the client's</action_comment>
 <action_requirement />
-<action_description>Set Result.client_fpl = client.client_fpl</action_description>
+<action_dsl>Set Result.client_fpl = client.client_fpl</action_dsl>
 <action_postfix>
 client.client_fpl  cvi /Result.client_fpl xdef  
 </action_postfix>
@@ -745,7 +745,7 @@ client.client_fpl  cvi /Result.client_fpl xdef
 <action_number>10</action_number>
 <action_comment>Set the Result's totalGroupIncome to the clients.</action_comment>
 <action_requirement />
-<action_description>Set Result.totalGroupIncome = client.totalGroupIncome</action_description>
+<action_dsl>Set Result.totalGroupIncome = client.totalGroupIncome</action_dsl>
 <action_postfix>
 client.totalGroupIncome  cvi /Result.totalGroupIncome xdef  
 </action_postfix>

--- a/sampleprojects/CHIP/xml/CHIP_dt_strip.xml
+++ b/sampleprojects/CHIP/xml/CHIP_dt_strip.xml
@@ -16,7 +16,7 @@
 					<condition_number>1</condition_number>
 					<condition_comment>CHIP</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>job.program is equal to CHIP</condition_description>
+					<condition_dsl>job.program is equal to CHIP</condition_dsl>
 					<condition_postfix>
 job.program CHIP streq 
 </condition_postfix>
@@ -26,7 +26,7 @@ job.program CHIP streq
 					<condition_number>2</condition_number>
 					<condition_comment>MEDICAID</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>job.program is equal to MEDICAID</condition_description>
+					<condition_dsl>job.program is equal to MEDICAID</condition_dsl>
 					<condition_postfix>
 job.program MEDICAID streq 
 </condition_postfix>
@@ -36,7 +36,7 @@ job.program MEDICAID streq
 					<condition_number>3</condition_number>
 					<condition_comment>FOODSTAMPS</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>job.program is equal to FOODSTAMPS</condition_description>
+					<condition_dsl>job.program is equal to FOODSTAMPS</condition_dsl>
 					<condition_postfix>
 job.program FOODSTAMPS streq 
 </condition_postfix>
@@ -46,7 +46,7 @@ job.program FOODSTAMPS streq
 					<condition_number>4</condition_number>
 					<condition_comment>If Not Any of these programs, Report Results Anyway</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>otherwise</condition_description>
+					<condition_dsl>otherwise</condition_dsl>
 					<condition_postfix>
 otherwise 
 </condition_postfix>
@@ -58,7 +58,7 @@ otherwise
 					<action_number>1</action_number>
 					<action_comment>Calculate the Individual Incomes</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>Calculate_Individual_Income</action_description>
+					<action_dsl>Calculate_Individual_Income</action_dsl>
 					<action_postfix>
 Calculate_Individual_Income 
 </action_postfix>
@@ -70,7 +70,7 @@ Calculate_Individual_Income
 					<action_number>2</action_number>
 					<action_comment>Get the Group Size for each individual</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>Calculate_Group_Size</action_description>
+					<action_dsl>Calculate_Group_Size</action_dsl>
 					<action_postfix>
 Calculate_Group_Size 
 </action_postfix>
@@ -82,7 +82,7 @@ Calculate_Group_Size
 					<action_number>3</action_number>
 					<action_comment>Evaluate for CHIP</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>Evaluate_CHIP_Eligibility</action_description>
+					<action_dsl>Evaluate_CHIP_Eligibility</action_dsl>
 					<action_postfix>
 Evaluate_CHIP_Eligibility 
 </action_postfix>
@@ -92,7 +92,7 @@ Evaluate_CHIP_Eligibility
 					<action_number>4</action_number>
 					<action_comment>Evaluate for MEDICAID</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>Evaluate_MEDICAID_Eligibility</action_description>
+					<action_dsl>Evaluate_MEDICAID_Eligibility</action_dsl>
 					<action_postfix>
 Evaluate_MEDICAID_Eligibility 
 </action_postfix>
@@ -102,7 +102,7 @@ Evaluate_MEDICAID_Eligibility
 					<action_number>5</action_number>
 					<action_comment>Evaluate for FOODSTAMPS</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>Evaluate_FOODSTAMPS_Eligibilty</action_description>
+					<action_dsl>Evaluate_FOODSTAMPS_Eligibilty</action_dsl>
 					<action_postfix>
 Evaluate_FOODSTAMPS_Eligibilty 
 </action_postfix>
@@ -112,7 +112,7 @@ Evaluate_FOODSTAMPS_Eligibilty
 					<action_number>6</action_number>
 					<action_comment>Build a set of Result Objects to report to the caller</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>Evaluate_Results</action_description>
+					<action_dsl>Evaluate_Results</action_dsl>
 					<action_postfix>
 Evaluate_Results 
 </action_postfix>
@@ -154,7 +154,7 @@ Evaluate_Results
 				<context_details>
 					<context_number>1</context_number>
 					<context_comment></context_comment>
-					<context_description>for all clients</context_description>
+					<context_dsl>for all clients</context_dsl>
 					<context_postfix>
 dup clients forall pop 
 </context_postfix>
@@ -162,7 +162,7 @@ dup clients forall pop
 				<context_details>
 					<context_number>2</context_number>
 					<context_comment></context_comment>
-					<context_description>for all incomes</context_description>
+					<context_dsl>for all incomes</context_dsl>
 					<context_postfix>
 dup incomes forall pop 
 </context_postfix>
@@ -174,7 +174,7 @@ dup incomes forall pop
 					<condition_number>1</condition_number>
 					<condition_comment>We include all earned income</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>income.earned == true</condition_description>
+					<condition_dsl>income.earned == true</condition_dsl>
 					<condition_postfix>
 income.earned true beq 
 </condition_postfix>
@@ -185,7 +185,7 @@ income.earned true beq
 					<condition_number>2</condition_number>
 					<condition_comment>We don&apos;t include all unearned income types</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>ExcludedIncomeTypes includes the string income.type</condition_description>
+					<condition_dsl>ExcludedIncomeTypes includes the string income.type</condition_dsl>
 					<condition_postfix>
 ExcludedIncomeTypes income.type memberof 
 </condition_postfix>
@@ -197,7 +197,7 @@ ExcludedIncomeTypes income.type memberof
 					<action_number>1</action_number>
 					<action_comment>Add this income to the total income for this client</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>add income.amount to the client.totalIncome</action_description>
+					<action_dsl>add income.amount to the client.totalIncome</action_dsl>
 					<action_postfix>
 income.amount  client.totalIncome + /client.totalIncome xdef 
 </action_postfix>
@@ -224,7 +224,7 @@ Note that this table doesn&apos;t actually create the income group.  It just cou
 				<context_details>
 					<context_number>1</context_number>
 					<context_comment>For each client in the group, we need to calculate a group size (we only need to do this for applying clients)</context_comment>
-					<context_description>for all clients whose applying == true</context_description>
+					<context_dsl>for all clients whose applying == true</context_dsl>
 					<context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix>
@@ -232,7 +232,7 @@ Note that this table doesn&apos;t actually create the income group.  It just cou
 				<context_details>
 					<context_number>2</context_number>
 					<context_comment>We want to compare a client against every other client in the case, so we set up a local variable to point to ApplyingClient</context_comment>
-					<context_description>local entity ApplyingClient = client</context_description>
+					<context_dsl>local entity ApplyingClient = client</context_dsl>
 					<context_postfix>
 client cve allocate execute deallocate pop 
 </context_postfix>
@@ -240,7 +240,7 @@ client cve allocate execute deallocate pop
 				<context_details>
 					<context_number>3</context_number>
 					<context_comment>Now consider the client in respect to all the other clients in the case (We need to consider all clients in the case, even if not applying)</context_comment>
-					<context_description>for all clients</context_description>
+					<context_dsl>for all clients</context_dsl>
 					<context_postfix>
 dup clients forall pop 
 </context_postfix>
@@ -252,7 +252,7 @@ dup clients forall pop
 					<condition_number>1</condition_number>
 					<condition_comment>Are we consider the client themselves?</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>ApplyingClient == client</condition_description>
+					<condition_dsl>ApplyingClient == client</condition_dsl>
 					<condition_postfix>
 0 local@  client req  
 </condition_postfix>
@@ -264,7 +264,7 @@ dup clients forall pop
 					<condition_number>2</condition_number>
 					<condition_comment>Include ApplyingClient&apos;s parents</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>the client is the parent of ApplyingClient</condition_description>
+					<condition_dsl>the client is the parent of ApplyingClient</condition_dsl>
 					<condition_postfix>
 /source client /target 0 local@  /type parent relationships findmatch swap pop
 </condition_postfix>
@@ -276,7 +276,7 @@ dup clients forall pop
 					<condition_number>3</condition_number>
 					<condition_comment>Include ApplyingClient&apos;s siblings</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>the client is the sibling of ApplyingClient</condition_description>
+					<condition_dsl>the client is the sibling of ApplyingClient</condition_dsl>
 					<condition_postfix>
 /source client /target 0 local@  /type sibling relationships findmatch swap pop
 </condition_postfix>
@@ -288,7 +288,7 @@ dup clients forall pop
 					<condition_number>4</condition_number>
 					<condition_comment>Include ApplyingClient&apos;s children</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>the client is the child of ApplyingClient</condition_description>
+					<condition_dsl>the client is the child of ApplyingClient</condition_dsl>
 					<condition_postfix>
 /source client /target 0 local@  /type child relationships findmatch swap pop
 </condition_postfix>
@@ -299,7 +299,7 @@ dup clients forall pop
 					<condition_number>5</condition_number>
 					<condition_comment>Include the unborn children in some cases</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>the client.pregnant == true</condition_description>
+					<condition_dsl>the client.pregnant == true</condition_dsl>
 					<condition_postfix>
 client.pregnant true beq 
 </condition_postfix>
@@ -314,7 +314,7 @@ client.pregnant true beq
 					<condition_number>6</condition_number>
 					<condition_comment>Is this client older than 18</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>client.age &gt; 18</condition_description>
+					<condition_dsl>client.age &gt; 18</condition_dsl>
 					<condition_postfix>
 client.age 18 &gt; 
 </condition_postfix>
@@ -329,7 +329,7 @@ client.age 18 &gt;
 					<action_number>1</action_number>
 					<action_comment>Count the Client himself and particular relatives</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>add 1 to ApplyingClient&apos;s IncomeGroupCount</action_description>
+					<action_dsl>add 1 to ApplyingClient&apos;s IncomeGroupCount</action_dsl>
 					<action_postfix>
 1  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -345,7 +345,7 @@ client.age 18 &gt;
 					<action_number>2</action_number>
 					<action_comment>Add 1 for each of the expected babies for a pregnant person</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>add expectedChildren to ApplyingClient&apos;s IncomeGroupCount</action_description>
+					<action_dsl>add expectedChildren to ApplyingClient&apos;s IncomeGroupCount</action_dsl>
 					<action_postfix>
 expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -357,7 +357,7 @@ expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef
 					<action_number>3</action_number>
 					<action_comment>Add this person&apos;s Income to the ThisPerson&apos;s total group income</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>add the client.totalIncome to ApplyingClient&apos;s totalGroupIncome</action_description>
+					<action_dsl>add the client.totalIncome to ApplyingClient&apos;s totalGroupIncome</action_dsl>
 					<action_postfix>
 client.totalIncome  0 local@  entitypush totalGroupIncome + /totalGroupIncome xdef entitypop 
 </action_postfix>
@@ -384,7 +384,7 @@ An appropriate income is only one requirement for CHIP.  All the others required
 				<context_details>
 					<context_number>1</context_number>
 					<context_comment></context_comment>
-					<context_description>for all clients whose applying == true</context_description>
+					<context_dsl>for all clients whose applying == true</context_dsl>
 					<context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix>
@@ -392,7 +392,7 @@ An appropriate income is only one requirement for CHIP.  All the others required
 				<context_details>
 					<context_number>2</context_number>
 					<context_comment>FPL = the Federal Poverty Limit calculated for the number of people in this client&apos;s Income Group.</context_comment>
-					<context_description>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_description>
+					<context_dsl>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_dsl>
 					<context_postfix>
 FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate execute deallocate pop 
 </context_postfix>
@@ -400,7 +400,7 @@ FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate 
 				<context_details>
 					<context_number>3</context_number>
 					<context_comment>FPL200 = 200 percent of the Federal Poverty Limit</context_comment>
-					<context_description>local int FPL200 = FPL * 2</context_description>
+					<context_dsl>local int FPL200 = FPL * 2</context_dsl>
 					<context_postfix>
 0 local@  2 *  cvi allocate execute deallocate pop 
 </context_postfix>
@@ -412,7 +412,7 @@ FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate 
 					<condition_number>1</condition_number>
 					<condition_comment>Are you a citizen?</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>ValidatedCitizenship == true</condition_description>
+					<condition_dsl>ValidatedCitizenship == true</condition_dsl>
 					<condition_postfix>
 ValidatedCitizenship true beq 
 </condition_postfix>
@@ -422,7 +422,7 @@ ValidatedCitizenship true beq
 					<condition_number>2</condition_number>
 					<condition_comment>If not a citizen,  are you a legal immigrant(Lawfully present immigrant children who have not been in the country for 5 years)</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>validatedImmigrationStatus == true</condition_description>
+					<condition_dsl>validatedImmigrationStatus == true</condition_dsl>
 					<condition_postfix>
 validatedImmigrationStatus true beq 
 </condition_postfix>
@@ -432,7 +432,7 @@ validatedImmigrationStatus true beq
 					<condition_number>3</condition_number>
 					<condition_comment>Group income must be &lt;=200 percent of the Federal Poverty Limit</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>client.totalGroupIncome &lt;= FPL200</condition_description>
+					<condition_dsl>client.totalGroupIncome &lt;= FPL200</condition_dsl>
 					<condition_postfix>
 client.totalGroupIncome 1 local@  &lt;= 
 </condition_postfix>
@@ -442,7 +442,7 @@ client.totalGroupIncome 1 local@  &lt;=
 					<condition_number>4</condition_number>
 					<condition_comment>Children should be uninsured to qualify for CHIP-funded coverage</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>uninsured</condition_description>
+					<condition_dsl>uninsured</condition_dsl>
 					<condition_postfix>
 uninsured 
 </condition_postfix>
@@ -453,7 +453,7 @@ uninsured
 					<condition_number>5</condition_number>
 					<condition_comment>If we have no lost Insurance date, and we are uninsured, then the client was never insured.</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>lostInsuranceDate is null</condition_description>
+					<condition_dsl>lostInsuranceDate is null</condition_dsl>
 					<condition_postfix>
 lostInsuranceDate  isnull 
 </condition_postfix>
@@ -463,7 +463,7 @@ lostInsuranceDate  isnull
 					<condition_number>6</condition_number>
 					<condition_comment>Children should be uninsured to qualify for CHIP-funded coverage</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>lostInsuranceDate + 90 days is greater than the currentdate</condition_description>
+					<condition_dsl>lostInsuranceDate + 90 days is greater than the currentdate</condition_dsl>
 					<condition_postfix>
 lostInsuranceDate  90  adddays currentdate d&gt; 
 </condition_postfix>
@@ -473,7 +473,7 @@ lostInsuranceDate  90  adddays currentdate d&gt;
 					<condition_number>7</condition_number>
 					<condition_comment>Make sure this case is in the appropriate county</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>The CoveredCounties includes the string case.county_Cd</condition_description>
+					<condition_dsl>The CoveredCounties includes the string case.county_Cd</condition_dsl>
 					<condition_postfix>
 CoveredCounties case.county_Cd memberof 
 </condition_postfix>
@@ -483,7 +483,7 @@ CoveredCounties case.county_Cd memberof
 					<condition_number>8</condition_number>
 					<condition_comment>Age limit should be &lt;=18 years</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>client.age &lt;= 18</condition_description>
+					<condition_dsl>client.age &lt;= 18</condition_dsl>
 					<condition_postfix>
 client.age 18 &lt;= 
 </condition_postfix>
@@ -493,7 +493,7 @@ client.age 18 &lt;=
 					<condition_number>9</condition_number>
 					<condition_comment>If you are eligible for Medicaid, then you are not eligible for CHIP</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>eligibleForMedicaid == true</condition_description>
+					<condition_dsl>eligibleForMedicaid == true</condition_dsl>
 					<condition_postfix>
 eligibleForMedicaid true beq 
 </condition_postfix>
@@ -503,7 +503,7 @@ eligibleForMedicaid true beq
 					<condition_number>10</condition_number>
 					<condition_comment>Otherwise the client is eligible</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>otherwise</condition_description>
+					<condition_dsl>otherwise</condition_dsl>
 					<condition_postfix>
 otherwise 
 </condition_postfix>
@@ -515,7 +515,7 @@ otherwise
 					<action_number>1</action_number>
 					<action_comment>Record the fpl for this client</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>set the client_fpl = fpl</action_description>
+					<action_dsl>set the client_fpl = fpl</action_dsl>
 					<action_postfix>
 0 local@   cvi /client_fpl xdef  
 </action_postfix>
@@ -532,7 +532,7 @@ otherwise
 					<action_number>2</action_number>
 					<action_comment>Provide reasons for rejection</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>set client.eligible = false</action_description>
+					<action_dsl>set client.eligible = false</action_dsl>
 					<action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -548,7 +548,7 @@ false cvb /client.eligible xdef
 					<action_number>3</action_number>
 					<action_comment>If none of the eligiblity exclusions fired, then the client is eligible</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>set client.eligible = true</action_description>
+					<action_dsl>set client.eligible = true</action_dsl>
 					<action_postfix>
 true cvb /client.eligible xdef  
 </action_postfix>
@@ -558,7 +558,7 @@ true cvb /client.eligible xdef
 					<action_number>4</action_number>
 					<action_comment>Record the client&apos;s income</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>add &quot;Client Income = &quot; + client.totalGroupIncome to the client.notes</action_description>
+					<action_dsl>add &quot;Client Income = &quot; + client.totalGroupIncome to the client.notes</action_dsl>
 					<action_postfix>
 &quot;Client Income = &quot; client.totalGroupIncome strconcat client.notes swap addto 
 </action_postfix>
@@ -567,7 +567,7 @@ true cvb /client.eligible xdef
 					<action_number>5</action_number>
 					<action_comment>Record the reasoning.</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>add the policy statements to the client.notes</action_description>
+					<action_dsl>add the policy statements to the client.notes</action_dsl>
 					<action_postfix>
 policystatements client.notes true  addarray 
 </action_postfix>
@@ -629,7 +629,7 @@ policystatements client.notes true  addarray
 				<context_details>
 					<context_number>1</context_number>
 					<context_comment></context_comment>
-					<context_description>for all clients</context_description>
+					<context_dsl>for all clients</context_dsl>
 					<context_postfix>
 dup clients forall pop 
 </context_postfix>
@@ -641,7 +641,7 @@ dup clients forall pop
 					<condition_number>1</condition_number>
 					<condition_comment>Is this client applying for this program?</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>client.applying == true</condition_description>
+					<condition_dsl>client.applying == true</condition_dsl>
 					<condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -653,7 +653,7 @@ client.applying true beq
 					<action_number>1</action_number>
 					<action_comment>Reject the client</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>set client.eligible = false</action_description>
+					<action_dsl>set client.eligible = false</action_dsl>
 					<action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -663,7 +663,7 @@ false cvb /client.eligible xdef
 					<action_number>2</action_number>
 					<action_comment>Note rejection reason</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>add &quot;The System does not yet support Medicaid Applications&quot; to client.notes</action_description>
+					<action_dsl>add &quot;The System does not yet support Medicaid Applications&quot; to client.notes</action_dsl>
 					<action_postfix>
 &quot;The System does not yet support Medicaid Applications&quot; client.notes swap addto 
 </action_postfix>
@@ -685,7 +685,7 @@ false cvb /client.eligible xdef
 				<context_details>
 					<context_number>1</context_number>
 					<context_comment></context_comment>
-					<context_description>for all clients</context_description>
+					<context_dsl>for all clients</context_dsl>
 					<context_postfix>
 dup clients forall pop 
 </context_postfix>
@@ -697,7 +697,7 @@ dup clients forall pop
 					<condition_number>1</condition_number>
 					<condition_comment>Is this client applying for this program?</condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>client.applying == true</condition_description>
+					<condition_dsl>client.applying == true</condition_dsl>
 					<condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -709,7 +709,7 @@ client.applying true beq
 					<action_number>1</action_number>
 					<action_comment>Reject the client</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>set client.eligible = false</action_description>
+					<action_dsl>set client.eligible = false</action_dsl>
 					<action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -719,7 +719,7 @@ false cvb /client.eligible xdef
 					<action_number>2</action_number>
 					<action_comment>Note rejection reason</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>add &quot;The System does not yet support Food Stamp Applications&quot; to client.notes</action_description>
+					<action_dsl>add &quot;The System does not yet support Food Stamp Applications&quot; to client.notes</action_dsl>
 					<action_postfix>
 &quot;The System does not yet support Food Stamp Applications&quot; client.notes swap addto 
 </action_postfix>
@@ -741,7 +741,7 @@ false cvb /client.eligible xdef
 				<context_details>
 					<context_number>1</context_number>
 					<context_comment></context_comment>
-					<context_description>for all clients whose applying == true</context_description>
+					<context_dsl>for all clients whose applying == true</context_dsl>
 					<context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix>
@@ -753,7 +753,7 @@ false cvb /client.eligible xdef
 					<condition_number>1</condition_number>
 					<condition_comment></condition_comment>
 					<condition_requirement></condition_requirement>
-					<condition_description>perform when called</condition_description>
+					<condition_dsl>perform when called</condition_dsl>
 					<condition_postfix>
 perform when called 
 </condition_postfix>
@@ -765,7 +765,7 @@ perform when called
 					<action_number>1</action_number>
 					<action_comment>Create a Result Record</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>add a new Result entity to the context of this table</action_description>
+					<action_dsl>add a new Result entity to the context of this table</action_dsl>
 					<action_postfix>
 /Result createentity entitypush 
 </action_postfix>
@@ -775,7 +775,7 @@ perform when called
 					<action_number>2</action_number>
 					<action_comment>Add the record to the list on the job</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>add the result to the job.results</action_description>
+					<action_dsl>add the result to the job.results</action_dsl>
 					<action_postfix>
 result job.results swap addto 
 </action_postfix>
@@ -785,7 +785,7 @@ result job.results swap addto
 					<action_number>3</action_number>
 					<action_comment>Point the Result notes to the Client notes</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>Set Result.notes = client.notes</action_description>
+					<action_dsl>Set Result.notes = client.notes</action_dsl>
 					<action_postfix>
 client.notes /Result.notes xdef 
 </action_postfix>
@@ -795,7 +795,7 @@ client.notes /Result.notes xdef
 					<action_number>4</action_number>
 					<action_comment>Copy the client ID</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>Set Result.client_id = client.id</action_description>
+					<action_dsl>Set Result.client_id = client.id</action_dsl>
 					<action_postfix>
 client.id  cvs /Result.client_id xdef  
 </action_postfix>
@@ -805,7 +805,7 @@ client.id  cvs /Result.client_id xdef
 					<action_number>5</action_number>
 					<action_comment>Point the Result to the client</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>Set Result.client = client.client</action_description>
+					<action_dsl>Set Result.client = client.client</action_dsl>
 					<action_postfix>
 client.client cve /Result.client xdef  
 </action_postfix>
@@ -815,7 +815,7 @@ client.client cve /Result.client xdef
 					<action_number>6</action_number>
 					<action_comment>Set the Result to the program we processed</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>Set Result.program = job.program</action_description>
+					<action_dsl>Set Result.program = job.program</action_dsl>
 					<action_postfix>
 job.program cvs /Result.program xdef  
 </action_postfix>
@@ -825,7 +825,7 @@ job.program cvs /Result.program xdef
 					<action_number>7</action_number>
 					<action_comment>Set the Result programLevel to that recorded on the client</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>Set Result.programLevel = client.programLevel</action_description>
+					<action_dsl>Set Result.programLevel = client.programLevel</action_dsl>
 					<action_postfix>
 client.programLevel cvs /Result.programLevel xdef  
 </action_postfix>
@@ -835,7 +835,7 @@ client.programLevel cvs /Result.programLevel xdef
 					<action_number>8</action_number>
 					<action_comment>Set the Result eligible flag to that recorded on the client</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>Set Result.eligible = client.eligible</action_description>
+					<action_dsl>Set Result.eligible = client.eligible</action_dsl>
 					<action_postfix>
 client.eligible cvb /Result.eligible xdef  
 </action_postfix>
@@ -845,7 +845,7 @@ client.eligible cvb /Result.eligible xdef
 					<action_number>9</action_number>
 					<action_comment>Set the Result Federal Poverty Level to the client&apos;s</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>Set Result.client_fpl = client.client_fpl</action_description>
+					<action_dsl>Set Result.client_fpl = client.client_fpl</action_dsl>
 					<action_postfix>
 client.client_fpl  cvi /Result.client_fpl xdef  
 </action_postfix>
@@ -855,7 +855,7 @@ client.client_fpl  cvi /Result.client_fpl xdef
 					<action_number>10</action_number>
 					<action_comment>Set the Result&apos;s totalGroupIncome to the clients.</action_comment>
 					<action_requirement></action_requirement>
-					<action_description>Set Result.totalGroupIncome = client.totalGroupIncome</action_description>
+					<action_dsl>Set Result.totalGroupIncome = client.totalGroupIncome</action_dsl>
 					<action_postfix>
 client.totalGroupIncome  cvi /Result.totalGroupIncome xdef  
 </action_postfix>

--- a/sampleprojects/ChipApp/xml/CHIP_dt.xml
+++ b/sampleprojects/ChipApp/xml/CHIP_dt.xml
@@ -15,7 +15,7 @@
 <condition_number>1</condition_number>
 <condition_comment>CHIP</condition_comment>
 <condition_requirement />
-<condition_description>job.program is equal to CHIP</condition_description>
+<condition_dsl>job.program is equal to CHIP</condition_dsl>
 <condition_postfix>
 job.program CHIP streq 
 </condition_postfix>
@@ -24,7 +24,7 @@ job.program CHIP streq
 <condition_number>2</condition_number>
 <condition_comment>MEDICAID</condition_comment>
 <condition_requirement />
-<condition_description>job.program is equal to MEDICAID</condition_description>
+<condition_dsl>job.program is equal to MEDICAID</condition_dsl>
 <condition_postfix>
 job.program MEDICAID streq 
 </condition_postfix>
@@ -33,7 +33,7 @@ job.program MEDICAID streq
 <condition_number>3</condition_number>
 <condition_comment>FOODSTAMPS</condition_comment>
 <condition_requirement />
-<condition_description>job.program is equal to FOODSTAMPS</condition_description>
+<condition_dsl>job.program is equal to FOODSTAMPS</condition_dsl>
 <condition_postfix>
 job.program FOODSTAMPS streq 
 </condition_postfix>
@@ -42,7 +42,7 @@ job.program FOODSTAMPS streq
 <condition_number>4</condition_number>
 <condition_comment>If Not Any of these programs, Report Results Anyway</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>
 otherwise 
 </condition_postfix>
@@ -52,7 +52,7 @@ otherwise
 <action_number>1</action_number>
 <action_comment>Calculate the Individual Incomes</action_comment>
 <action_requirement />
-<action_description>perform Calculate_Individual_Income</action_description>
+<action_dsl>perform Calculate_Individual_Income</action_dsl>
 <action_postfix>
 Calculate_Individual_Income 
 </action_postfix>
@@ -63,7 +63,7 @@ Calculate_Individual_Income
 <action_number>2</action_number>
 <action_comment>Get the Group Size for each individual</action_comment>
 <action_requirement />
-<action_description>perform Calculate_Group_Size</action_description>
+<action_dsl>perform Calculate_Group_Size</action_dsl>
 <action_postfix>
 Calculate_Group_Size 
 </action_postfix>
@@ -74,7 +74,7 @@ Calculate_Group_Size
 <action_number>3</action_number>
 <action_comment>Evaluate for CHIP</action_comment>
 <action_requirement />
-<action_description>perform Evaluate_CHIP_Eligibility</action_description>
+<action_dsl>perform Evaluate_CHIP_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_CHIP_Eligibility 
 </action_postfix>
@@ -83,7 +83,7 @@ Evaluate_CHIP_Eligibility
 <action_number>4</action_number>
 <action_comment>Evaluate for MEDICAID</action_comment>
 <action_requirement />
-<action_description>perform Evaluate_MEDICAID_Eligibility</action_description>
+<action_dsl>perform Evaluate_MEDICAID_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_MEDICAID_Eligibility 
 </action_postfix>
@@ -92,7 +92,7 @@ Evaluate_MEDICAID_Eligibility
 <action_number>5</action_number>
 <action_comment>Evaluate for FOODSTAMPS</action_comment>
 <action_requirement />
-<action_description>perform Evaluate_FOODSTAMPS_Eligibilty</action_description>
+<action_dsl>perform Evaluate_FOODSTAMPS_Eligibilty</action_dsl>
 <action_postfix>
 Evaluate_FOODSTAMPS_Eligibilty 
 </action_postfix>
@@ -101,7 +101,7 @@ Evaluate_FOODSTAMPS_Eligibilty
 <action_number>6</action_number>
 <action_comment>Build a set of Result Objects to report to the caller</action_comment>
 <action_requirement />
-<action_description>perform Evaluate_Results</action_description>
+<action_dsl>perform Evaluate_Results</action_dsl>
 <action_postfix>
 Evaluate_Results 
 </action_postfix>
@@ -134,14 +134,14 @@ Evaluate_Results
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment />
-<context_description>for all incomes</context_description>
+<context_dsl>for all incomes</context_dsl>
 <context_postfix>
 dup incomes forall pop 
 </context_postfix></context_details></contexts>
@@ -151,7 +151,7 @@ dup incomes forall pop
 <condition_number>1</condition_number>
 <condition_comment>We include all earned income</condition_comment>
 <condition_requirement />
-<condition_description>income.earned == true</condition_description>
+<condition_dsl>income.earned == true</condition_dsl>
 <condition_postfix>
 income.earned true beq 
 </condition_postfix>
@@ -161,7 +161,7 @@ income.earned true beq
 <condition_number>2</condition_number>
 <condition_comment>We don't include all unearned income types</condition_comment>
 <condition_requirement />
-<condition_description>ExcludedIncomeTypes includes the string income.type</condition_description>
+<condition_dsl>ExcludedIncomeTypes includes the string income.type</condition_dsl>
 <condition_postfix>
 ExcludedIncomeTypes income.type memberof 
 </condition_postfix>
@@ -171,7 +171,7 @@ ExcludedIncomeTypes income.type memberof
 <action_number>1</action_number>
 <action_comment>Add this income to the total income for this client</action_comment>
 <action_requirement />
-<action_description>add income.amount to the client.totalIncome</action_description>
+<action_dsl>add income.amount to the client.totalIncome</action_dsl>
 <action_postfix>
 income.amount  client.totalIncome + /client.totalIncome xdef 
 </action_postfix>
@@ -194,21 +194,21 @@ Note that this table doesn't actually create the income group.  It just counts t
 <context_details>
 <context_number>1</context_number>
 <context_comment>For each client in the group, we need to calculate a group size (we only need to do this for applying clients)</context_comment>
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>We want to compare a client against every other client in the case, so we set up a local variable to point to ThisClient</context_comment>
-<context_description>local entity ThisClient = client</context_description>
+<context_dsl>local entity ThisClient = client</context_dsl>
 <context_postfix>
 client cve allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment>Now consider the client in respect to all the other clients in the case (We need to consider all clients in the case, even if not applying)</context_comment>
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -218,7 +218,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Are we consider the client themselves?</condition_comment>
 <condition_requirement />
-<condition_description>ThisClient == client</condition_description>
+<condition_dsl>ThisClient == client</condition_dsl>
 <condition_postfix>
 0 local@  client req  
 </condition_postfix>
@@ -229,7 +229,7 @@ dup clients forall pop
 <condition_number>2</condition_number>
 <condition_comment>Include ThisClient's parents</condition_comment>
 <condition_requirement />
-<condition_description>the client is the parent of ThisClient</condition_description>
+<condition_dsl>the client is the parent of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type parent relationships findmatch swap pop
 </condition_postfix>
@@ -240,7 +240,7 @@ dup clients forall pop
 <condition_number>3</condition_number>
 <condition_comment>Include ThisClient's siblings</condition_comment>
 <condition_requirement />
-<condition_description>the client is the sibling of ThisClient</condition_description>
+<condition_dsl>the client is the sibling of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type sibling relationships findmatch swap pop
 </condition_postfix>
@@ -251,7 +251,7 @@ dup clients forall pop
 <condition_number>4</condition_number>
 <condition_comment>Include ThisClient's children</condition_comment>
 <condition_requirement />
-<condition_description>the client is the child of ThisClient</condition_description>
+<condition_dsl>the client is the child of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type child relationships findmatch swap pop
 </condition_postfix>
@@ -261,7 +261,7 @@ dup clients forall pop
 <condition_number>5</condition_number>
 <condition_comment>Include the unborn children in some cases</condition_comment>
 <condition_requirement />
-<condition_description>the client.pregnant == true</condition_description>
+<condition_dsl>the client.pregnant == true</condition_dsl>
 <condition_postfix>
 client.pregnant true beq 
 </condition_postfix>
@@ -275,7 +275,7 @@ client.pregnant true beq
 <condition_number>6</condition_number>
 <condition_comment>Is this client older than 18</condition_comment>
 <condition_requirement />
-<condition_description>client.age &gt; 18</condition_description>
+<condition_dsl>client.age &gt; 18</condition_dsl>
 <condition_postfix>
 client.age 18 &gt; 
 </condition_postfix>
@@ -288,7 +288,7 @@ client.age 18 &gt;
 <action_number>1</action_number>
 <action_comment>Count the Client himself and particular relatives</action_comment>
 <action_requirement />
-<action_description>add 1 to ThisClient's IncomeGroupCount</action_description>
+<action_dsl>add 1 to ThisClient's IncomeGroupCount</action_dsl>
 <action_postfix>
 1  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -303,7 +303,7 @@ client.age 18 &gt;
 <action_number>2</action_number>
 <action_comment>Add 1 for each of the expected babies for a pregnant person</action_comment>
 <action_requirement />
-<action_description>add expectedChildren to ThisClient's IncomeGroupCount</action_description>
+<action_dsl>add expectedChildren to ThisClient's IncomeGroupCount</action_dsl>
 <action_postfix>
 expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -314,7 +314,7 @@ expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef
 <action_number>3</action_number>
 <action_comment>Add this person's Income to the ThisPerson's total group income</action_comment>
 <action_requirement />
-<action_description>add the client.totalIncome to ThisClient's totalGroupIncome</action_description>
+<action_dsl>add the client.totalIncome to ThisClient's totalGroupIncome</action_dsl>
 <action_postfix>
 client.totalIncome  0 local@  entitypush totalGroupIncome + /totalGroupIncome xdef entitypop 
 </action_postfix>
@@ -337,21 +337,21 @@ An appropriate income is only one requirement for CHIP.  All the others required
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>FPL = the Federal Poverty Limit calculated for the number of people in this client's Income Group.</context_comment>
-<context_description>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_description>
+<context_dsl>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_dsl>
 <context_postfix>
 FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment>FPL200 = 200 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL200 = FPL * 2</context_description>
+<context_dsl>local int FPL200 = FPL * 2</context_dsl>
 <context_postfix>
 0 local@  2 *  cvi allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -361,7 +361,7 @@ FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate 
 <condition_number>1</condition_number>
 <condition_comment>Are you a citizen?</condition_comment>
 <condition_requirement />
-<condition_description>validatedCitizenship == true</condition_description>
+<condition_dsl>validatedCitizenship == true</condition_dsl>
 <condition_postfix>
 validatedCitizenship true beq 
 </condition_postfix>
@@ -370,7 +370,7 @@ validatedCitizenship true beq
 <condition_number>2</condition_number>
 <condition_comment>If not a citizen,  are you a legal immigrant(Lawfully present immigrant children who have not been in the country for 5 years)</condition_comment>
 <condition_requirement />
-<condition_description>validatedImmigrationStatus == true</condition_description>
+<condition_dsl>validatedImmigrationStatus == true</condition_dsl>
 <condition_postfix>
 validatedImmigrationStatus true beq 
 </condition_postfix>
@@ -379,7 +379,7 @@ validatedImmigrationStatus true beq
 <condition_number>3</condition_number>
 <condition_comment>Group income must be &lt;=200 percent of the Federal Poverty Limit</condition_comment>
 <condition_requirement />
-<condition_description>client.totalGroupIncome &lt;= FPL200</condition_description>
+<condition_dsl>client.totalGroupIncome &lt;= FPL200</condition_dsl>
 <condition_postfix>
 client.totalGroupIncome 1 local@  &lt;= 
 </condition_postfix>
@@ -388,7 +388,7 @@ client.totalGroupIncome 1 local@  &lt;=
 <condition_number>4</condition_number>
 <condition_comment>Children should be uninsured to qualify for CHIP-funded coverage</condition_comment>
 <condition_requirement />
-<condition_description>uninsured</condition_description>
+<condition_dsl>uninsured</condition_dsl>
 <condition_postfix>
 uninsured 
 </condition_postfix>
@@ -398,7 +398,7 @@ uninsured
 <condition_number>5</condition_number>
 <condition_comment>If we have no lost Insurance date, and we are uninsured, then the client was never insured.</condition_comment>
 <condition_requirement />
-<condition_description>lostInsuranceDate is null</condition_description>
+<condition_dsl>lostInsuranceDate is null</condition_dsl>
 <condition_postfix>
 lostInsuranceDate  isnull 
 </condition_postfix>
@@ -407,7 +407,7 @@ lostInsuranceDate  isnull
 <condition_number>6</condition_number>
 <condition_comment>Children should be uninsured to qualify for CHIP-funded coverage</condition_comment>
 <condition_requirement />
-<condition_description>lostInsuranceDate + 90 days is greater than the currentdate</condition_description>
+<condition_dsl>lostInsuranceDate + 90 days is greater than the currentdate</condition_dsl>
 <condition_postfix>
 lostInsuranceDate  90  adddays currentdate d&gt; 
 </condition_postfix>
@@ -416,7 +416,7 @@ lostInsuranceDate  90  adddays currentdate d&gt;
 <condition_number>7</condition_number>
 <condition_comment>Make sure this case is in the appropriate county</condition_comment>
 <condition_requirement />
-<condition_description>The CoveredCounties includes the string case.county_Cd</condition_description>
+<condition_dsl>The CoveredCounties includes the string case.county_Cd</condition_dsl>
 <condition_postfix>
 CoveredCounties case.county_Cd memberof 
 </condition_postfix>
@@ -425,7 +425,7 @@ CoveredCounties case.county_Cd memberof
 <condition_number>8</condition_number>
 <condition_comment>Age limit should be &lt;=18 years</condition_comment>
 <condition_requirement />
-<condition_description>client.age &lt;= 18</condition_description>
+<condition_dsl>client.age &lt;= 18</condition_dsl>
 <condition_postfix>
 client.age 18 &lt;= 
 </condition_postfix>
@@ -434,7 +434,7 @@ client.age 18 &lt;=
 <condition_number>9</condition_number>
 <condition_comment>If you are eligible for Medicaid, then you are not eligible for CHIP</condition_comment>
 <condition_requirement />
-<condition_description>eligibleForMedicaid == true</condition_description>
+<condition_dsl>eligibleForMedicaid == true</condition_dsl>
 <condition_postfix>
 eligibleForMedicaid true beq 
 </condition_postfix>
@@ -443,7 +443,7 @@ eligibleForMedicaid true beq
 <condition_number>10</condition_number>
 <condition_comment>Otherwise the client is eligible</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>
 otherwise 
 </condition_postfix>
@@ -453,7 +453,7 @@ otherwise
 <action_number>1</action_number>
 <action_comment>Record the fpl for this client</action_comment>
 <action_requirement />
-<action_description>set the client_fpl = fpl</action_description>
+<action_dsl>set the client_fpl = fpl</action_dsl>
 <action_postfix>
 0 local@   cvi /client_fpl xdef  
 </action_postfix>
@@ -469,7 +469,7 @@ otherwise
 <action_number>2</action_number>
 <action_comment>Provide reasons for rejection</action_comment>
 <action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -484,7 +484,7 @@ false cvb /client.eligible xdef
 <action_number>3</action_number>
 <action_comment>If none of the eligiblity exclusions fired, then the client is eligible</action_comment>
 <action_requirement />
-<action_description>set client.eligible = true</action_description>
+<action_dsl>set client.eligible = true</action_dsl>
 <action_postfix>
 true cvb /client.eligible xdef  
 </action_postfix>
@@ -493,7 +493,7 @@ true cvb /client.eligible xdef
 <action_number>4</action_number>
 <action_comment>Record the client's income</action_comment>
 <action_requirement />
-<action_description>add "Client Income = " + client.totalGroupIncome to the client.notes</action_description>
+<action_dsl>add "Client Income = " + client.totalGroupIncome to the client.notes</action_dsl>
 <action_postfix>
 "Client Income = " client.totalGroupIncome strconcat client.notes swap addto 
 </action_postfix></action_details>
@@ -501,7 +501,7 @@ true cvb /client.eligible xdef
 <action_number>5</action_number>
 <action_comment>Record the reasoning.</action_comment>
 <action_requirement />
-<action_description>add the policy statements to the client.notes</action_description>
+<action_dsl>add the policy statements to the client.notes</action_dsl>
 <action_postfix>
 policystatements client.notes true  addarray 
 </action_postfix>
@@ -550,7 +550,7 @@ policystatements client.notes true  addarray
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -560,7 +560,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
 <condition_requirement />
-<condition_description>client.applying == true</condition_description>
+<condition_dsl>client.applying == true</condition_dsl>
 <condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -570,7 +570,7 @@ client.applying true beq
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
 <action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -579,7 +579,7 @@ false cvb /client.eligible xdef
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Medicaid Applications" to client.notes</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "The System does not yet support Medicaid Applications" client.notes swap addto 
 </action_postfix>
@@ -597,7 +597,7 @@ false cvb /client.eligible xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -607,7 +607,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
 <condition_requirement />
-<condition_description>client.applying == true</condition_description>
+<condition_dsl>client.applying == true</condition_dsl>
 <condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -617,7 +617,7 @@ client.applying true beq
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
 <action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -626,7 +626,7 @@ false cvb /client.eligible xdef
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Food Stamp Applications" to client.notes</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "The System does not yet support Food Stamp Applications" client.notes swap addto 
 </action_postfix>
@@ -644,7 +644,7 @@ false cvb /client.eligible xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details></contexts>
@@ -654,7 +654,7 @@ false cvb /client.eligible xdef
 <condition_number>1</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called 
 </condition_postfix>
@@ -664,7 +664,7 @@ perform when called
 <action_number>1</action_number>
 <action_comment>Create a Result Record</action_comment>
 <action_requirement />
-<action_description>add a new Result entity to the context of this table</action_description>
+<action_dsl>add a new Result entity to the context of this table</action_dsl>
 <action_postfix>
 /Result createentity entitypush 
 </action_postfix>
@@ -673,7 +673,7 @@ perform when called
 <action_number>2</action_number>
 <action_comment>Add the record to the list on the job</action_comment>
 <action_requirement />
-<action_description>add the result to the job.results</action_description>
+<action_dsl>add the result to the job.results</action_dsl>
 <action_postfix>
 result job.results swap addto 
 </action_postfix>
@@ -682,7 +682,7 @@ result job.results swap addto
 <action_number>3</action_number>
 <action_comment>Point the Result notes to the Client notes</action_comment>
 <action_requirement />
-<action_description>Set Result.notes = client.notes</action_description>
+<action_dsl>Set Result.notes = client.notes</action_dsl>
 <action_postfix>
 client.notes /Result.notes xdef 
 </action_postfix>
@@ -691,7 +691,7 @@ client.notes /Result.notes xdef
 <action_number>4</action_number>
 <action_comment>Copy the client ID</action_comment>
 <action_requirement />
-<action_description>Set Result.client_id = client.id</action_description>
+<action_dsl>Set Result.client_id = client.id</action_dsl>
 <action_postfix>
 client.id  cvs /Result.client_id xdef  
 </action_postfix>
@@ -700,7 +700,7 @@ client.id  cvs /Result.client_id xdef
 <action_number>5</action_number>
 <action_comment>Point the Result to the client</action_comment>
 <action_requirement />
-<action_description>Set Result.client = client.client</action_description>
+<action_dsl>Set Result.client = client.client</action_dsl>
 <action_postfix>
 client.client cve /Result.client xdef  
 </action_postfix>
@@ -709,7 +709,7 @@ client.client cve /Result.client xdef
 <action_number>6</action_number>
 <action_comment>Set the Result to the program we processed</action_comment>
 <action_requirement />
-<action_description>Set Result.program = job.program</action_description>
+<action_dsl>Set Result.program = job.program</action_dsl>
 <action_postfix>
 job.program cvs /Result.program xdef  
 </action_postfix>
@@ -718,7 +718,7 @@ job.program cvs /Result.program xdef
 <action_number>7</action_number>
 <action_comment>Set the Result programLevel to that recorded on the client</action_comment>
 <action_requirement />
-<action_description>Set Result.programLevel = client.programLevel</action_description>
+<action_dsl>Set Result.programLevel = client.programLevel</action_dsl>
 <action_postfix>
 client.programLevel cvs /Result.programLevel xdef  
 </action_postfix>
@@ -727,7 +727,7 @@ client.programLevel cvs /Result.programLevel xdef
 <action_number>8</action_number>
 <action_comment>Set the Result eligible flag to that recorded on the client</action_comment>
 <action_requirement />
-<action_description>Set Result.eligible = client.eligible</action_description>
+<action_dsl>Set Result.eligible = client.eligible</action_dsl>
 <action_postfix>
 client.eligible cvb /Result.eligible xdef  
 </action_postfix>
@@ -736,7 +736,7 @@ client.eligible cvb /Result.eligible xdef
 <action_number>9</action_number>
 <action_comment>Set the Result Federal Poverty Level to the client's</action_comment>
 <action_requirement />
-<action_description>Set Result.client_fpl = client.client_fpl</action_description>
+<action_dsl>Set Result.client_fpl = client.client_fpl</action_dsl>
 <action_postfix>
 client.client_fpl  cvi /Result.client_fpl xdef  
 </action_postfix>
@@ -745,7 +745,7 @@ client.client_fpl  cvi /Result.client_fpl xdef
 <action_number>10</action_number>
 <action_comment>Set the Result's totalGroupIncome to the clients.</action_comment>
 <action_requirement />
-<action_description>Set Result.totalGroupIncome = client.totalGroupIncome</action_description>
+<action_dsl>Set Result.totalGroupIncome = client.totalGroupIncome</action_dsl>
 <action_postfix>
 client.totalGroupIncome  cvi /Result.totalGroupIncome xdef  
 </action_postfix>

--- a/sampleprojects/CorporateTax/repository/xml/CorporateTax_dt.xml
+++ b/sampleprojects/CorporateTax/repository/xml/CorporateTax_dt.xml
@@ -6,7 +6,7 @@
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>revenue.gross_receipts &gt; 0</condition_description>
+        <condition_dsl>revenue.gross_receipts &gt; 0</condition_dsl>
         <condition_postfix>
 revenue.gross_receipts 0 &gt;
 </condition_postfix>
@@ -15,14 +15,14 @@ revenue.gross_receipts 0 &gt;
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set revenue.net_receipts = revenue.gross_receipts - revenue.returns_and_allowances</action_description>
+        <action_dsl>set revenue.net_receipts = revenue.gross_receipts - revenue.returns_and_allowances</action_dsl>
         <action_postfix>
 revenue.gross_receipts revenue.returns_and_allowances - cvi /revenue.net_receipts xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set revenue.net_receipts = 0.0</action_description>
+        <action_dsl>set revenue.net_receipts = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /revenue.net_receipts xdef
 </action_postfix>
@@ -35,7 +35,7 @@ revenue.gross_receipts revenue.returns_and_allowances - cvi /revenue.net_receipt
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>revenue.net_receipts &gt; 0</condition_description>
+        <condition_dsl>revenue.net_receipts &gt; 0</condition_dsl>
         <condition_postfix>
 revenue.net_receipts 0 &gt;
 </condition_postfix>
@@ -44,14 +44,14 @@ revenue.net_receipts 0 &gt;
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set revenue.gross_profit = revenue.net_receipts - revenue.cost_of_goods_sold</action_description>
+        <action_dsl>set revenue.gross_profit = revenue.net_receipts - revenue.cost_of_goods_sold</action_dsl>
         <action_postfix>
 revenue.net_receipts revenue.cost_of_goods_sold - cvi /revenue.gross_profit xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set revenue.gross_profit = 0.0 - revenue.cost_of_goods_sold</action_description>
+        <action_dsl>set revenue.gross_profit = 0.0 - revenue.cost_of_goods_sold</action_dsl>
         <action_postfix>
 0.0 revenue.cost_of_goods_sold - cvi /revenue.gross_profit xdef
 </action_postfix>
@@ -64,7 +64,7 @@ revenue.net_receipts revenue.cost_of_goods_sold - cvi /revenue.gross_profit xdef
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>true</condition_description>
+        <condition_dsl>true</condition_dsl>
         <condition_postfix>
 true
 </condition_postfix>
@@ -73,7 +73,7 @@ true
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set revenue.total_income = revenue.gross_profit + revenue.dividends_received + revenue.interest_income + revenue.gross_rents + revenue.gross_royalties + revenue.capital_gain_net_income + revenue.net_gain_loss_4797 + revenue.other_income; set result.total_income = revenue.total_income</action_description>
+        <action_dsl>set revenue.total_income = revenue.gross_profit + revenue.dividends_received + revenue.interest_income + revenue.gross_rents + revenue.gross_royalties + revenue.capital_gain_net_income + revenue.net_gain_loss_4797 + revenue.other_income; set result.total_income = revenue.total_income</action_dsl>
         <action_postfix>
 revenue.gross_profit revenue.dividends_received + revenue.interest_income + revenue.gross_rents + revenue.gross_royalties + revenue.capital_gain_net_income + revenue.net_gain_loss_4797 + revenue.other_income + cvi /revenue.total_income xdef revenue.total_income cvi /result.total_income xdef
 </action_postfix>
@@ -86,7 +86,7 @@ revenue.gross_profit revenue.dividends_received + revenue.interest_income + reve
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>result.compensation &gt; 0</condition_description>
+        <condition_dsl>result.compensation &gt; 0</condition_dsl>
         <condition_postfix>
 result.compensation 0 &gt;
 </condition_postfix>
@@ -95,7 +95,7 @@ result.compensation 0 &gt;
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set result.compensation = 0.0</action_description>
+        <action_dsl>set result.compensation = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /result.compensation xdef
 </action_postfix>
@@ -108,14 +108,14 @@ result.compensation 0 &gt;
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>result.interest_expense &gt; 0</condition_description>
+        <condition_dsl>result.interest_expense &gt; 0</condition_dsl>
         <condition_postfix>
 result.interest_expense 0 &gt;
 </condition_postfix>
       </condition_details>
       <condition_details>
         <condition_number>2</condition_number>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.interest_expense 0.30 result.taxable_income fmul f&gt;
 </condition_postfix>
@@ -124,14 +124,14 @@ result.interest_expense 0.30 result.taxable_income fmul f&gt;
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set result.interest_expense = 0.30 * result.taxable_income</action_description>
+        <action_dsl>set result.interest_expense = 0.30 * result.taxable_income</action_dsl>
         <action_postfix>
 0.30 result.taxable_income fmul cvi /result.interest_expense xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set result.interest_expense = 0.0</action_description>
+        <action_dsl>set result.interest_expense = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /result.interest_expense xdef
 </action_postfix>
@@ -144,14 +144,14 @@ result.interest_expense 0.30 result.taxable_income fmul f&gt;
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>result.charitable_contributions &gt; 0</condition_description>
+        <condition_dsl>result.charitable_contributions &gt; 0</condition_dsl>
         <condition_postfix>
 result.charitable_contributions 0 &gt;
 </condition_postfix>
       </condition_details>
       <condition_details>
         <condition_number>2</condition_number>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.charitable_contributions 0.10 result.taxable_income fmul f&gt;
 </condition_postfix>
@@ -160,14 +160,14 @@ result.charitable_contributions 0.10 result.taxable_income fmul f&gt;
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set result.charitable_contributions = 0.10 * result.taxable_income</action_description>
+        <action_dsl>set result.charitable_contributions = 0.10 * result.taxable_income</action_dsl>
         <action_postfix>
 0.10 result.taxable_income fmul cvi /result.charitable_contributions xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set result.charitable_contributions = 0.0</action_description>
+        <action_dsl>set result.charitable_contributions = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /result.charitable_contributions xdef
 </action_postfix>
@@ -180,7 +180,7 @@ result.charitable_contributions 0.10 result.taxable_income fmul f&gt;
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>true</condition_description>
+        <condition_dsl>true</condition_dsl>
         <condition_postfix>
 true
 </condition_postfix>
@@ -189,7 +189,7 @@ true
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set result.total_deductions = result.compensation + result.salaries_and_wages + result.repairs_and_maintenance + result.bad_debts + result.rents + result.taxes_and_licenses + result.interest_expense + result.charitable_contributions + result.depreciation + result.depletion + result.advertising + result.pension_profit_sharing + result.employee_benefit_programs + result.other_deductions</action_description>
+        <action_dsl>set result.total_deductions = result.compensation + result.salaries_and_wages + result.repairs_and_maintenance + result.bad_debts + result.rents + result.taxes_and_licenses + result.interest_expense + result.charitable_contributions + result.depreciation + result.depletion + result.advertising + result.pension_profit_sharing + result.employee_benefit_programs + result.other_deductions</action_dsl>
         <action_postfix>
 result.compensation result.salaries_and_wages + result.repairs_and_maintenance + result.bad_debts + result.rents + result.taxes_and_licenses + result.interest_expense + result.charitable_contributions + result.depreciation + result.depletion + result.advertising + result.pension_profit_sharing + result.employee_benefit_programs + result.other_deductions + cvi /result.total_deductions xdef
 </action_postfix>
@@ -202,7 +202,7 @@ result.compensation result.salaries_and_wages + result.repairs_and_maintenance +
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>result.total_income &gt; result.total_deductions</condition_description>
+        <condition_dsl>result.total_income &gt; result.total_deductions</condition_dsl>
         <condition_postfix>
 result.total_income result.total_deductions &gt;
 </condition_postfix>
@@ -211,14 +211,14 @@ result.total_income result.total_deductions &gt;
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set result.taxable_income = result.total_income - result.total_deductions</action_description>
+        <action_dsl>set result.taxable_income = result.total_income - result.total_deductions</action_dsl>
         <action_postfix>
 result.total_income result.total_deductions - cvi /result.taxable_income xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set result.taxable_income = 0.0</action_description>
+        <action_dsl>set result.taxable_income = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /result.taxable_income xdef
 </action_postfix>
@@ -231,7 +231,7 @@ result.total_income result.total_deductions - cvi /result.taxable_income xdef
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>result.taxable_income &gt; 0</condition_description>
+        <condition_dsl>result.taxable_income &gt; 0</condition_dsl>
         <condition_postfix>
 result.taxable_income 0 &gt;
 </condition_postfix>
@@ -240,14 +240,14 @@ result.taxable_income 0 &gt;
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set result.federal_tax = result.taxable_income * result.federal_tax_rate</action_description>
+        <action_dsl>set result.federal_tax = result.taxable_income * result.federal_tax_rate</action_dsl>
         <action_postfix>
 result.taxable_income result.federal_tax_rate * cvi /result.federal_tax xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set result.federal_tax = 0.0</action_description>
+        <action_dsl>set result.federal_tax = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /result.federal_tax xdef
 </action_postfix>
@@ -260,7 +260,7 @@ result.taxable_income result.federal_tax_rate * cvi /result.federal_tax xdef
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>true</condition_description>
+        <condition_dsl>true</condition_dsl>
         <condition_postfix>
 true
 </condition_postfix>
@@ -269,7 +269,7 @@ true
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set result.total_payments = result.estimated_tax_payments + result.total_credits; set result.refund_or_owed = result.total_payments - result.federal_tax</action_description>
+        <action_dsl>set result.total_payments = result.estimated_tax_payments + result.total_credits; set result.refund_or_owed = result.total_payments - result.federal_tax</action_dsl>
         <action_postfix>
 result.estimated_tax_payments result.total_credits + cvi /result.total_payments xdef result.total_payments result.federal_tax - cvi /result.refund_or_owed xdef
 </action_postfix>
@@ -282,7 +282,7 @@ result.estimated_tax_payments result.total_credits + cvi /result.total_payments 
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>result.research_development_credit &gt; 0</condition_description>
+        <condition_dsl>result.research_development_credit &gt; 0</condition_dsl>
         <condition_postfix>
 result.research_development_credit 0 &gt;
 </condition_postfix>
@@ -291,7 +291,7 @@ result.research_development_credit 0 &gt;
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set result.research_development_credit = 0.0</action_description>
+        <action_dsl>set result.research_development_credit = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /result.research_development_credit xdef
 </action_postfix>
@@ -304,7 +304,7 @@ result.research_development_credit 0 &gt;
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.research_development_credit 0 &gt; { pop result.work_opportunity_credit 0 &gt; } over not if
 </condition_postfix>
@@ -313,14 +313,14 @@ result.research_development_credit 0 &gt; { pop result.work_opportunity_credit 0
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set result.general_business_credit = result.research_development_credit + result.work_opportunity_credit; set result.total_credits = result.general_business_credit</action_description>
+        <action_dsl>set result.general_business_credit = result.research_development_credit + result.work_opportunity_credit; set result.total_credits = result.general_business_credit</action_dsl>
         <action_postfix>
 result.research_development_credit result.work_opportunity_credit + cvi /result.general_business_credit xdef result.general_business_credit cvi /result.total_credits xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set result.general_business_credit = 0.0; set result.total_credits = 0.0</action_description>
+        <action_dsl>set result.general_business_credit = 0.0; set result.total_credits = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /result.general_business_credit xdef 0.0 cvi /result.total_credits xdef
 </action_postfix>
@@ -333,7 +333,7 @@ result.research_development_credit result.work_opportunity_credit + cvi /result.
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>asset.asset_class is not null and asset.asset_class is not null</condition_description>
+        <condition_dsl>asset.asset_class is not null and asset.asset_class is not null</condition_dsl>
         <condition_postfix>
 asset.asset_class isnull not { pop asset.asset_class } over if isnull not
 </condition_postfix>
@@ -342,14 +342,14 @@ asset.asset_class isnull not { pop asset.asset_class } over if isnull not
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>Perform Lookup_MACRS_Recovery_Period</action_description>
+        <action_dsl>Perform Lookup_MACRS_Recovery_Period</action_dsl>
         <action_postfix>
 Lookup_MACRS_Recovery_Period
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set asset.asset_class = "7-year"; set asset.recovery_period = 7; set asset.depreciation_method = "MACRS-200DB"</action_description>
+        <action_dsl>set asset.asset_class = "7-year"; set asset.recovery_period = 7; set asset.depreciation_method = "MACRS-200DB"</action_dsl>
         <action_postfix>
 "7-year" cvs /asset.asset_class xdef 7 cvi /asset.recovery_period xdef "MACRS-200DB" cvs /asset.depreciation_method xdef
 </action_postfix>
@@ -362,21 +362,21 @@ Lookup_MACRS_Recovery_Period
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>asset.eligible_for_section_179 == true</condition_description>
+        <condition_dsl>asset.eligible_for_section_179 == true</condition_dsl>
         <condition_postfix>
 asset.eligible_for_section_179 true beq
 </condition_postfix>
       </condition_details>
       <condition_details>
         <condition_number>2</condition_number>
-        <condition_description>result.section_179_total &lt; result.section_179_limit</condition_description>
+        <condition_dsl>result.section_179_total &lt; result.section_179_limit</condition_dsl>
         <condition_postfix>
 result.section_179_total result.section_179_limit &lt;
 </condition_postfix>
       </condition_details>
       <condition_details>
         <condition_number>3</condition_number>
-        <condition_description>asset.cost_basis &gt; 0</condition_description>
+        <condition_dsl>asset.cost_basis &gt; 0</condition_dsl>
         <condition_postfix>
 asset.cost_basis 0 &gt;
 </condition_postfix>
@@ -385,14 +385,14 @@ asset.cost_basis 0 &gt;
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set asset.section_179_deduction = asset.cost_basis; add asset.cost_basis to result.section_179_total; set asset.cost_basis = 0.0</action_description>
+        <action_dsl>set asset.section_179_deduction = asset.cost_basis; add asset.cost_basis to result.section_179_total; set asset.cost_basis = 0.0</action_dsl>
         <action_postfix>
 asset.cost_basis cvi /asset.section_179_deduction xdef asset.cost_basis result.section_179_total true addarray 0.0 cvi /asset.cost_basis xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set asset.section_179_deduction = 0.0</action_description>
+        <action_dsl>set asset.section_179_deduction = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /asset.section_179_deduction xdef
 </action_postfix>
@@ -405,21 +405,21 @@ asset.cost_basis cvi /asset.section_179_deduction xdef asset.cost_basis result.s
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>asset.eligible_for_bonus == true</condition_description>
+        <condition_dsl>asset.eligible_for_bonus == true</condition_dsl>
         <condition_postfix>
 asset.eligible_for_bonus true beq
 </condition_postfix>
       </condition_details>
       <condition_details>
         <condition_number>2</condition_number>
-        <condition_description>result.bonus_depreciation_rate &gt; 0</condition_description>
+        <condition_dsl>result.bonus_depreciation_rate &gt; 0</condition_dsl>
         <condition_postfix>
 result.bonus_depreciation_rate 0 &gt;
 </condition_postfix>
       </condition_details>
       <condition_details>
         <condition_number>3</condition_number>
-        <condition_description>asset.cost_basis &gt; 0</condition_description>
+        <condition_dsl>asset.cost_basis &gt; 0</condition_dsl>
         <condition_postfix>
 asset.cost_basis 0 &gt;
 </condition_postfix>
@@ -428,14 +428,14 @@ asset.cost_basis 0 &gt;
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set asset.bonus_depreciation = asset.cost_basis * result.bonus_depreciation_rate; set asset.cost_basis = asset.cost_basis - asset.bonus_depreciation</action_description>
+        <action_dsl>set asset.bonus_depreciation = asset.cost_basis * result.bonus_depreciation_rate; set asset.cost_basis = asset.cost_basis - asset.bonus_depreciation</action_dsl>
         <action_postfix>
 asset.cost_basis result.bonus_depreciation_rate * cvi /asset.bonus_depreciation xdef asset.cost_basis asset.bonus_depreciation - cvi /asset.cost_basis xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set asset.bonus_depreciation = 0.0</action_description>
+        <action_dsl>set asset.bonus_depreciation = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /asset.bonus_depreciation xdef
 </action_postfix>
@@ -448,14 +448,14 @@ asset.cost_basis result.bonus_depreciation_rate * cvi /asset.bonus_depreciation 
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>asset.cost_basis &gt; 0</condition_description>
+        <condition_dsl>asset.cost_basis &gt; 0</condition_dsl>
         <condition_postfix>
 asset.cost_basis 0 &gt;
 </condition_postfix>
       </condition_details>
       <condition_details>
         <condition_number>2</condition_number>
-        <condition_description>asset.accumulated_depreciation == 0</condition_description>
+        <condition_dsl>asset.accumulated_depreciation == 0</condition_dsl>
         <condition_postfix>
 asset.accumulated_depreciation 0 ==
 </condition_postfix>
@@ -464,14 +464,14 @@ asset.accumulated_depreciation 0 ==
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set asset.current_year_depreciation = asset.cost_basis * 0.1429; add asset.current_year_depreciation to asset.accumulated_depreciation; add asset.current_year_depreciation to result.macrs_depreciation_total</action_description>
+        <action_dsl>set asset.current_year_depreciation = asset.cost_basis * 0.1429; add asset.current_year_depreciation to asset.accumulated_depreciation; add asset.current_year_depreciation to result.macrs_depreciation_total</action_dsl>
         <action_postfix>
 asset.cost_basis 0.1429 fmul cvi /asset.current_year_depreciation xdef asset.current_year_depreciation asset.accumulated_depreciation true addarray asset.current_year_depreciation result.macrs_depreciation_total true addarray
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set asset.current_year_depreciation = 0.0</action_description>
+        <action_dsl>set asset.current_year_depreciation = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /asset.current_year_depreciation xdef
 </action_postfix>
@@ -484,7 +484,7 @@ asset.cost_basis 0.1429 fmul cvi /asset.current_year_depreciation xdef asset.cur
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>true</condition_description>
+        <condition_dsl>true</condition_dsl>
         <condition_postfix>
 true
 </condition_postfix>
@@ -493,7 +493,7 @@ true
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set result.depreciation = result.section_179_total + result.bonus_depreciation_total + result.macrs_depreciation_total</action_description>
+        <action_dsl>set result.depreciation = result.section_179_total + result.bonus_depreciation_total + result.macrs_depreciation_total</action_dsl>
         <action_postfix>
 result.section_179_total result.bonus_depreciation_total + result.macrs_depreciation_total + cvi /result.depreciation xdef
 </action_postfix>
@@ -512,14 +512,14 @@ result.section_179_total result.bonus_depreciation_total + result.macrs_deprecia
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description>apportionment.has_physical_presence == true</condition_description>
+        <condition_dsl>apportionment.has_physical_presence == true</condition_dsl>
         <condition_postfix>
 apportionment.has_physical_presence true beq
 </condition_postfix>
       </condition_details>
       <condition_details>
         <condition_number>2</condition_number>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.gross_receipts_in_state apportionment.economic_nexus_threshold &gt;= { pop apportionment.transactions_in_state apportionment.transaction_threshold &gt;= } over not if
 </condition_postfix>
@@ -528,14 +528,14 @@ apportionment.gross_receipts_in_state apportionment.economic_nexus_threshold &gt
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set apportionment.has_economic_nexus = true</action_description>
+        <action_dsl>set apportionment.has_economic_nexus = true</action_dsl>
         <action_postfix>
 true cvb /apportionment.has_economic_nexus xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set apportionment.has_economic_nexus = false; set apportionment.apportionment_percentage = 0.0; set apportionment.state_tax = 0.0</action_description>
+        <action_dsl>set apportionment.has_economic_nexus = false; set apportionment.apportionment_percentage = 0.0; set apportionment.state_tax = 0.0</action_dsl>
         <action_postfix>
 false cvb /apportionment.has_economic_nexus xdef 0.0 cvi /apportionment.apportionment_percentage xdef 0.0 cvi /apportionment.state_tax xdef
 </action_postfix>
@@ -548,14 +548,14 @@ false cvb /apportionment.has_economic_nexus xdef 0.0 cvi /apportionment.apportio
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
       <condition_comment>apportionment.has_economic_nexus == true or apportionment.has_physical_presence == true</condition_comment></condition_details>
       <condition_details>
         <condition_number>2</condition_number>
-        <condition_description>apportionment.property_total_average &gt; 0</condition_description>
+        <condition_dsl>apportionment.property_total_average &gt; 0</condition_dsl>
         <condition_postfix>
 apportionment.property_total_average 0 &gt;
 </condition_postfix>
@@ -564,14 +564,14 @@ apportionment.property_total_average 0 &gt;
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set apportionment.property_average = (apportionment.property_beginning_balance + apportionment.property_ending_balance) / 2.0; set apportionment.property_factor = apportionment.property_average / apportionment.property_total_average</action_description>
+        <action_dsl>set apportionment.property_average = (apportionment.property_beginning_balance + apportionment.property_ending_balance) / 2.0; set apportionment.property_factor = apportionment.property_average / apportionment.property_total_average</action_dsl>
         <action_postfix>
 apportionment.property_beginning_balance apportionment.property_ending_balance + 2.0 fdiv cvi /apportionment.property_average xdef apportionment.property_average apportionment.property_total_average / cvi /apportionment.property_factor xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set apportionment.property_factor = 0.0</action_description>
+        <action_dsl>set apportionment.property_factor = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /apportionment.property_factor xdef
 </action_postfix>
@@ -584,14 +584,14 @@ apportionment.property_beginning_balance apportionment.property_ending_balance +
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
       <condition_comment>apportionment.has_economic_nexus == true or apportionment.has_physical_presence == true</condition_comment></condition_details>
       <condition_details>
         <condition_number>2</condition_number>
-        <condition_description>apportionment.payroll_total &gt; 0</condition_description>
+        <condition_dsl>apportionment.payroll_total &gt; 0</condition_dsl>
         <condition_postfix>
 apportionment.payroll_total 0 &gt;
 </condition_postfix>
@@ -600,14 +600,14 @@ apportionment.payroll_total 0 &gt;
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set apportionment.payroll_factor = apportionment.payroll_in_state / apportionment.payroll_total</action_description>
+        <action_dsl>set apportionment.payroll_factor = apportionment.payroll_in_state / apportionment.payroll_total</action_dsl>
         <action_postfix>
 apportionment.payroll_in_state apportionment.payroll_total / cvi /apportionment.payroll_factor xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set apportionment.payroll_factor = 0.0</action_description>
+        <action_dsl>set apportionment.payroll_factor = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /apportionment.payroll_factor xdef
 </action_postfix>
@@ -620,14 +620,14 @@ apportionment.payroll_in_state apportionment.payroll_total / cvi /apportionment.
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
       <condition_comment>apportionment.has_economic_nexus == true or apportionment.has_physical_presence == true</condition_comment></condition_details>
       <condition_details>
         <condition_number>2</condition_number>
-        <condition_description>apportionment.sales_total &gt; 0</condition_description>
+        <condition_dsl>apportionment.sales_total &gt; 0</condition_dsl>
         <condition_postfix>
 apportionment.sales_total 0 &gt;
 </condition_postfix>
@@ -636,14 +636,14 @@ apportionment.sales_total 0 &gt;
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set apportionment.sales_factor = apportionment.sales_in_state / apportionment.sales_total</action_description>
+        <action_dsl>set apportionment.sales_factor = apportionment.sales_in_state / apportionment.sales_total</action_dsl>
         <action_postfix>
 apportionment.sales_in_state apportionment.sales_total / cvi /apportionment.sales_factor xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set apportionment.sales_factor = 0.0</action_description>
+        <action_dsl>set apportionment.sales_factor = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /apportionment.sales_factor xdef
 </action_postfix>
@@ -656,28 +656,28 @@ apportionment.sales_in_state apportionment.sales_total / cvi /apportionment.sale
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
       <condition_comment>apportionment.has_economic_nexus == true or apportionment.has_physical_presence == true</condition_comment></condition_details>
       <condition_details>
         <condition_number>2</condition_number>
-        <condition_description>apportionment.apportionment_formula == "three_factor"</condition_description>
+        <condition_dsl>apportionment.apportionment_formula == "three_factor"</condition_dsl>
         <condition_postfix>
 apportionment.apportionment_formula "three_factor" streq
 </condition_postfix>
       </condition_details>
       <condition_details>
         <condition_number>3</condition_number>
-        <condition_description>apportionment.apportionment_formula == "single_sales"</condition_description>
+        <condition_dsl>apportionment.apportionment_formula == "single_sales"</condition_dsl>
         <condition_postfix>
 apportionment.apportionment_formula "single_sales" streq
 </condition_postfix>
       </condition_details>
       <condition_details>
         <condition_number>4</condition_number>
-        <condition_description>apportionment.apportionment_formula == "double_weighted_sales"</condition_description>
+        <condition_dsl>apportionment.apportionment_formula == "double_weighted_sales"</condition_dsl>
         <condition_postfix>
 apportionment.apportionment_formula "double_weighted_sales" streq
 </condition_postfix>
@@ -686,28 +686,28 @@ apportionment.apportionment_formula "double_weighted_sales" streq
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set apportionment.apportionment_percentage = (apportionment.property_factor + apportionment.payroll_factor + apportionment.sales_factor) / 3.0</action_description>
+        <action_dsl>set apportionment.apportionment_percentage = (apportionment.property_factor + apportionment.payroll_factor + apportionment.sales_factor) / 3.0</action_dsl>
         <action_postfix>
 apportionment.property_factor apportionment.payroll_factor + apportionment.sales_factor + 3.0 fdiv cvi /apportionment.apportionment_percentage xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set apportionment.apportionment_percentage = apportionment.sales_factor</action_description>
+        <action_dsl>set apportionment.apportionment_percentage = apportionment.sales_factor</action_dsl>
         <action_postfix>
 apportionment.sales_factor cvi /apportionment.apportionment_percentage xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>3</action_number>
-        <action_description>set apportionment.apportionment_percentage = (apportionment.property_factor + apportionment.payroll_factor + (2.0 * apportionment.sales_factor)) / 4.0</action_description>
+        <action_dsl>set apportionment.apportionment_percentage = (apportionment.property_factor + apportionment.payroll_factor + (2.0 * apportionment.sales_factor)) / 4.0</action_dsl>
         <action_postfix>
 apportionment.property_factor apportionment.payroll_factor + 2.0 apportionment.sales_factor fmul + 4.0 fdiv cvi /apportionment.apportionment_percentage xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>4</action_number>
-        <action_description>set apportionment.apportionment_percentage = 0.0</action_description>
+        <action_dsl>set apportionment.apportionment_percentage = 0.0</action_dsl>
         <action_postfix>
 0.0 cvi /apportionment.apportionment_percentage xdef
 </action_postfix>
@@ -720,14 +720,14 @@ apportionment.property_factor apportionment.payroll_factor + 2.0 apportionment.s
     <conditions>
       <condition_details>
         <condition_number>1</condition_number>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
       <condition_comment>apportionment.has_economic_nexus == true or apportionment.has_physical_presence == true</condition_comment></condition_details>
       <condition_details>
         <condition_number>2</condition_number>
-        <condition_description>result.taxable_income &gt; 0</condition_description>
+        <condition_dsl>result.taxable_income &gt; 0</condition_dsl>
         <condition_postfix>
 result.taxable_income 0 &gt;
 </condition_postfix>
@@ -736,14 +736,14 @@ result.taxable_income 0 &gt;
     <actions>
       <action_details>
         <action_number>1</action_number>
-        <action_description>set apportionment.apportioned_income = result.taxable_income * apportionment.apportionment_percentage; set apportionment.state_taxable_income = apportionment.apportioned_income + apportionment.state_additions - apportionment.state_subtractions; set apportionment.state_tax = apportionment.state_taxable_income * apportionment.state_tax_rate; set apportionment.state_tax = apportionment.state_tax - apportionment.state_credits; set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax</action_description>
+        <action_dsl>set apportionment.apportioned_income = result.taxable_income * apportionment.apportionment_percentage; set apportionment.state_taxable_income = apportionment.apportioned_income + apportionment.state_additions - apportionment.state_subtractions; set apportionment.state_tax = apportionment.state_taxable_income * apportionment.state_tax_rate; set apportionment.state_tax = apportionment.state_tax - apportionment.state_credits; set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax</action_dsl>
         <action_postfix>
 result.taxable_income apportionment.apportionment_percentage * cvi /apportionment.apportioned_income xdef apportionment.apportioned_income apportionment.state_additions + apportionment.state_subtractions - cvi /apportionment.state_taxable_income xdef apportionment.state_taxable_income apportionment.state_tax_rate * cvi /apportionment.state_tax xdef apportionment.state_tax apportionment.state_credits - cvi /apportionment.state_tax xdef apportionment.state_payments apportionment.state_tax - cvi /apportionment.state_refund_or_owed xdef
 </action_postfix>
       </action_details>
       <action_details>
         <action_number>2</action_number>
-        <action_description>set apportionment.apportioned_income = 0.0; set apportionment.state_taxable_income = 0.0; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments</action_description>
+        <action_dsl>set apportionment.apportioned_income = 0.0; set apportionment.state_taxable_income = 0.0; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments</action_dsl>
         <action_postfix>
 0.0 cvi /apportionment.apportioned_income xdef 0.0 cvi /apportionment.state_taxable_income xdef 0.0 cvi /apportionment.state_tax xdef apportionment.state_payments cvi /apportionment.state_refund_or_owed xdef
 </action_postfix>

--- a/sampleprojects/CorporateTax/xml/CorporateTax_dt.xml
+++ b/sampleprojects/CorporateTax/xml/CorporateTax_dt.xml
@@ -1060,7 +1060,7 @@
 <context_details>
 <context_number>1</context_number>
 <context_comment>Add a new result entity to the context of this table</context_comment>
-<context_description>add a new result entity to the context of this table</context_description>
+<context_dsl>add a new result entity to the context of this table</context_dsl>
 <context_postfix>
 /result createentity entitypush
 </context_postfix>
@@ -1068,7 +1068,7 @@
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.21 cvd /result.federal_tax_rate xdef
 "Corporate Tax Calculation Started - Form 1120" result.audit_trail swap addto
@@ -1079,7 +1079,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always execute full tax calculation</condition_comment>
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -1090,7 +1090,7 @@ true
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Net Receipts (Form 1120 Line 1c)</action_comment>
-<action_description>perform Calculate_Net_Receipts;</action_description>
+<action_dsl>perform Calculate_Net_Receipts;</action_dsl>
 <action_postfix>
 Calculate_Net_Receipts
 </action_postfix>
@@ -1099,7 +1099,7 @@ Calculate_Net_Receipts
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate Gross Profit (Form 1120 Line 3)</action_comment>
-<action_description>perform Calculate_Gross_Profit;</action_description>
+<action_dsl>perform Calculate_Gross_Profit;</action_dsl>
 <action_postfix>
 Calculate_Gross_Profit
 </action_postfix>
@@ -1108,7 +1108,7 @@ Calculate_Gross_Profit
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Total Income (Form 1120 Line 11)</action_comment>
-<action_description>perform Calculate_Total_Income;</action_description>
+<action_dsl>perform Calculate_Total_Income;</action_dsl>
 <action_postfix>
 Calculate_Total_Income
 </action_postfix>
@@ -1117,7 +1117,7 @@ Calculate_Total_Income
 <action_details>
 <action_number>4</action_number>
 <action_comment>Aggregate Depreciation (Form 4562)</action_comment>
-<action_description>perform Aggregate_Depreciation;</action_description>
+<action_dsl>perform Aggregate_Depreciation;</action_dsl>
 <action_postfix>
 Aggregate_Depreciation
 </action_postfix>
@@ -1126,7 +1126,7 @@ Aggregate_Depreciation
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate Compensation Deduction (Form 1120 Line 12)</action_comment>
-<action_description>perform Calculate_Compensation_Deduction;</action_description>
+<action_dsl>perform Calculate_Compensation_Deduction;</action_dsl>
 <action_postfix>
 Calculate_Compensation_Deduction
 </action_postfix>
@@ -1135,7 +1135,7 @@ Calculate_Compensation_Deduction
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate Interest Deduction with IRC 163(j) Limitation (Form 1120 Line 18)</action_comment>
-<action_description>perform Calculate_Interest_Deduction;</action_description>
+<action_dsl>perform Calculate_Interest_Deduction;</action_dsl>
 <action_postfix>
 Calculate_Interest_Deduction
 </action_postfix>
@@ -1144,7 +1144,7 @@ Calculate_Interest_Deduction
 <action_details>
 <action_number>7</action_number>
 <action_comment>Calculate Charitable Contributions with 10% Limitation (Form 1120 Line 19)</action_comment>
-<action_description>perform Calculate_Charitable_Contributions;</action_description>
+<action_dsl>perform Calculate_Charitable_Contributions;</action_dsl>
 <action_postfix>
 Calculate_Charitable_Contributions
 </action_postfix>
@@ -1153,7 +1153,7 @@ Calculate_Charitable_Contributions
 <action_details>
 <action_number>8</action_number>
 <action_comment>Calculate Total Deductions (Form 1120 Line 27)</action_comment>
-<action_description>perform Calculate_Total_Deductions;</action_description>
+<action_dsl>perform Calculate_Total_Deductions;</action_dsl>
 <action_postfix>
 Calculate_Total_Deductions
 </action_postfix>
@@ -1162,7 +1162,7 @@ Calculate_Total_Deductions
 <action_details>
 <action_number>9</action_number>
 <action_comment>Calculate Taxable Income (Form 1120 Line 28)</action_comment>
-<action_description>perform Calculate_Taxable_Income;</action_description>
+<action_dsl>perform Calculate_Taxable_Income;</action_dsl>
 <action_postfix>
 Calculate_Taxable_Income
 </action_postfix>
@@ -1171,7 +1171,7 @@ Calculate_Taxable_Income
 <action_details>
 <action_number>10</action_number>
 <action_comment>Apply Corporate Tax Rate (Schedule J - 21% flat rate)</action_comment>
-<action_description>perform Apply_Corporate_Tax_Rate;</action_description>
+<action_dsl>perform Apply_Corporate_Tax_Rate;</action_dsl>
 <action_postfix>
 Apply_Corporate_Tax_Rate
 </action_postfix>
@@ -1180,7 +1180,7 @@ Apply_Corporate_Tax_Rate
 <action_details>
 <action_number>11</action_number>
 <action_comment>Calculate R&amp;D Credit (Form 6765)</action_comment>
-<action_description>perform Calculate_RD_Credit;</action_description>
+<action_dsl>perform Calculate_RD_Credit;</action_dsl>
 <action_postfix>
 Calculate_RD_Credit
 </action_postfix>
@@ -1189,7 +1189,7 @@ Calculate_RD_Credit
 <action_details>
 <action_number>12</action_number>
 <action_comment>Calculate General Business Credit (Form 3800)</action_comment>
-<action_description>perform Calculate_General_Business_Credit;</action_description>
+<action_dsl>perform Calculate_General_Business_Credit;</action_dsl>
 <action_postfix>
 Calculate_General_Business_Credit
 </action_postfix>
@@ -1198,7 +1198,7 @@ Calculate_General_Business_Credit
 <action_details>
 <action_number>13</action_number>
 <action_comment>Calculate Refund or Amount Owed (Form 1120 Lines 32-35)</action_comment>
-<action_description>perform Calculate_Refund_Or_Owed;</action_description>
+<action_dsl>perform Calculate_Refund_Or_Owed;</action_dsl>
 <action_postfix>
 Calculate_Refund_Or_Owed
 </action_postfix>
@@ -1207,7 +1207,7 @@ Calculate_Refund_Or_Owed
 <action_details>
 <action_number>14</action_number>
 <action_comment>Log completion</action_comment>
-<action_description>add "Corporate Tax Calculation Complete" to result.audit_trail;</action_description>
+<action_dsl>add "Corporate Tax Calculation Complete" to result.audit_trail;</action_dsl>
 <action_postfix>
 "Corporate Tax Calculation Complete - Form 1120" result.audit_trail swap addto
 </action_postfix>

--- a/sampleprojects/CorporateTax/xml/states/AK_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/AK_corp_dt.xml
@@ -22,7 +22,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in Alaska (office, employees, property)</condition_comment>
-<condition_description>apportionment.has_physical_presence is true and apportionment.state_code == "AK"</condition_description>
+<condition_dsl>apportionment.has_physical_presence is true and apportionment.state_code == "AK"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true beq { pop apportionment.state_code "AK" streq } over if
 </condition_postfix>
@@ -34,7 +34,7 @@ apportionment.has_physical_presence true beq { pop apportionment.state_code "AK"
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets Alaska economic nexus threshold</condition_comment>
-<condition_description>apportionment.has_economic_nexus is true and apportionment.state_code == "AK"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus is true and apportionment.state_code == "AK"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.state_code "AK" streq } over if
 </condition_postfix>
@@ -48,7 +48,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AK" st
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - filing required</action_comment>
-<action_description>// Physical nexus established - filing required</action_description>
+<action_dsl>// Physical nexus established - filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="1" column_value="X" />
@@ -57,7 +57,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AK" st
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established per Wayfair - filing required</action_comment>
-<action_description>// Economic nexus established per Wayfair - filing required</action_description>
+<action_dsl>// Economic nexus established per Wayfair - filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -66,7 +66,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AK" st
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required; // No nexus - no filing required; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -97,7 +97,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AK" st
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -110,7 +110,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Alaska additions and subtractions; // Calculate Alaska additions and subtractions; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -120,7 +120,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no adjustments; // No nexus - no adjustments; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -151,7 +151,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -163,7 +163,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0.0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0.0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0.0 f&gt;
 </condition_postfix>
@@ -177,7 +177,7 @@ apportionment.state_taxable_income 0.0 f&gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate tax using 9.3% flat rate; // Alaska uses 9.3% flat rate; set apportionment.state_tax = apportionment.state_taxable_income * apportionment.state_tax_rate - apportionment.state_credits; set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - 0.0 f&gt; { apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - } { 0.0 } ifelse cvd /apportionment.state_tax xdef apportionment.state_payments apportionment.state_tax - cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -187,7 +187,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no tax liability; // No Alaska nexus - no tax liability; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -197,7 +197,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>3</action_number>
 <action_comment>No taxable income - no tax liability; // No Alaska taxable income - no tax liability; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>

--- a/sampleprojects/CorporateTax/xml/states/AL_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/AL_corp_dt.xml
@@ -22,7 +22,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in Alabama (office, employees, property)</condition_comment>
-<condition_description>apportionment.has_physical_presence is true and apportionment.state_code == "AL"</condition_description>
+<condition_dsl>apportionment.has_physical_presence is true and apportionment.state_code == "AL"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true beq { pop apportionment.state_code "AL" streq } over if
 </condition_postfix>
@@ -34,7 +34,7 @@ apportionment.has_physical_presence true beq { pop apportionment.state_code "AL"
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets Alabama economic nexus threshold ($250,000 gross receipts)</condition_comment>
-<condition_description>apportionment.has_economic_nexus is true and apportionment.state_code == "AL"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus is true and apportionment.state_code == "AL"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.state_code "AL" streq } over if
 </condition_postfix>
@@ -48,7 +48,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AL" st
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - filing required</action_comment>
-<action_description>// Physical nexus established - filing required</action_description>
+<action_dsl>// Physical nexus established - filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="1" column_value="X" />
@@ -57,7 +57,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AL" st
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established per Wayfair - filing required</action_comment>
-<action_description>// Economic nexus established per Wayfair - filing required</action_description>
+<action_dsl>// Economic nexus established per Wayfair - filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -66,7 +66,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AL" st
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required; // No nexus - no filing required; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -97,7 +97,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AL" st
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -110,7 +110,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Alabama additions and subtractions; // Calculate Alabama additions and subtractions; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -120,7 +120,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no adjustments; // No nexus - no adjustments; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -151,7 +151,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -163,7 +163,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0.0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0.0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0.0 f&gt;
 </condition_postfix>
@@ -177,7 +177,7 @@ apportionment.state_taxable_income 0.0 f&gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Alabama tax at 6.5% flat rate; // Alabama uses 6.5% flat rate; set apportionment.state_tax = apportionment.state_taxable_income * apportionment.state_tax_rate - apportionment.state_credits; set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - 0.0 f&gt; { apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - } { 0.0 } ifelse cvd /apportionment.state_tax xdef apportionment.state_payments apportionment.state_tax - cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -187,7 +187,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no tax liability; // No Alabama nexus - no tax liability; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -197,7 +197,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>3</action_number>
 <action_comment>Nexus but no taxable income - no tax liability; // No Alabama taxable income - no tax liability; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>

--- a/sampleprojects/CorporateTax/xml/states/AR_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/AR_corp_dt.xml
@@ -22,7 +22,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in AR (office, employees, property)</condition_comment>
-<condition_description>apportionment.has_physical_presence is true and apportionment.state_code == "AR"</condition_description>
+<condition_dsl>apportionment.has_physical_presence is true and apportionment.state_code == "AR"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true beq { pop apportionment.state_code "AR" streq } over if
 </condition_postfix>
@@ -34,7 +34,7 @@ apportionment.has_physical_presence true beq { pop apportionment.state_code "AR"
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets AR economic nexus threshold</condition_comment>
-<condition_description>apportionment.has_economic_nexus is true and apportionment.state_code == "AR"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus is true and apportionment.state_code == "AR"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.state_code "AR" streq } over if
 </condition_postfix>
@@ -48,7 +48,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AR" st
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - filing required</action_comment>
-<action_description>// Physical nexus established - filing required</action_description>
+<action_dsl>// Physical nexus established - filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="1" column_value="X" />
@@ -57,7 +57,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AR" st
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established per Wayfair - filing required</action_comment>
-<action_description>// Economic nexus established per Wayfair - filing required</action_description>
+<action_dsl>// Economic nexus established per Wayfair - filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -66,7 +66,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AR" st
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required; // No nexus - no filing required; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -97,7 +97,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AR" st
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -110,7 +110,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate state additions and subtractions; // Calculate state additions and subtractions; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -120,7 +120,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no adjustments; // No nexus - no adjustments; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -151,7 +151,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -163,7 +163,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0.0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0.0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0.0 f&gt;
 </condition_postfix>
@@ -177,7 +177,7 @@ apportionment.state_taxable_income 0.0 f&gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Flat rate calculation; // Arkansas uses 5.5% flat rate; set apportionment.state_tax = apportionment.state_taxable_income * apportionment.state_tax_rate - apportionment.state_credits; set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - 0.0 f&gt; { apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - } { 0.0 } ifelse cvd /apportionment.state_tax xdef apportionment.state_payments apportionment.state_tax - cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -187,7 +187,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no tax liability; // No Arkansas nexus - no tax liability; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -197,7 +197,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>3</action_number>
 <action_comment>No taxable income - no tax liability; // No Arkansas taxable income - no tax liability; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>

--- a/sampleprojects/CorporateTax/xml/states/AZ_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/AZ_corp_dt.xml
@@ -22,7 +22,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in AZ (office, employees, property)</condition_comment>
-<condition_description>apportionment.has_physical_presence is true and apportionment.state_code == "AZ"</condition_description>
+<condition_dsl>apportionment.has_physical_presence is true and apportionment.state_code == "AZ"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true beq { pop apportionment.state_code "AZ" streq } over if
 </condition_postfix>
@@ -34,7 +34,7 @@ apportionment.has_physical_presence true beq { pop apportionment.state_code "AZ"
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets AZ economic nexus threshold ($100,000 gross receipts)</condition_comment>
-<condition_description>apportionment.has_economic_nexus is true and apportionment.state_code == "AZ"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus is true and apportionment.state_code == "AZ"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.state_code "AZ" streq } over if
 </condition_postfix>
@@ -48,7 +48,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AZ" st
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - filing required</action_comment>
-<action_description>// Physical nexus established - filing required</action_description>
+<action_dsl>// Physical nexus established - filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="1" column_value="X" />
@@ -57,7 +57,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AZ" st
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established per Wayfair - filing required</action_comment>
-<action_description>// Economic nexus established per Wayfair - filing required</action_description>
+<action_dsl>// Economic nexus established per Wayfair - filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -66,7 +66,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AZ" st
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required; // No nexus - no filing required; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -97,7 +97,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AZ" st
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -110,7 +110,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Arizona additions and subtractions; // Calculate Arizona additions and subtractions; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -120,7 +120,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no adjustments; // No nexus - no adjustments; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -151,7 +151,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -163,7 +163,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0.0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0.0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0.0 f&gt;
 </condition_postfix>
@@ -177,7 +177,7 @@ apportionment.state_taxable_income 0.0 f&gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate tax at 4.9% flat rate; // Arizona uses 4.9% flat rate; set apportionment.state_tax = apportionment.state_taxable_income * apportionment.state_tax_rate - apportionment.state_credits; set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - 0.0 f&gt; { apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - } { 0.0 } ifelse cvd /apportionment.state_tax xdef apportionment.state_payments apportionment.state_tax - cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -187,7 +187,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no tax liability; // No Arizona nexus - no tax liability; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -197,7 +197,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>3</action_number>
 <action_comment>Nexus but no taxable income - no tax liability; // No Arizona taxable income - no tax liability; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>

--- a/sampleprojects/CorporateTax/xml/states/CA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/CA_corp_dt.xml
@@ -22,7 +22,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in CA</condition_comment>
-<condition_description>apportionment.has_physical_presence is true and apportionment.state_code == "CA"</condition_description>
+<condition_dsl>apportionment.has_physical_presence is true and apportionment.state_code == "CA"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true beq { pop apportionment.state_code "CA" streq } over if
 </condition_postfix>
@@ -34,7 +34,7 @@ apportionment.has_physical_presence true beq { pop apportionment.state_code "CA"
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets CA economic nexus threshold</condition_comment>
-<condition_description>apportionment.has_economic_nexus is true and apportionment.state_code == "CA"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus is true and apportionment.state_code == "CA"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.state_code "CA" streq } over if
 </condition_postfix>
@@ -48,7 +48,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "CA" st
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - filing required</action_comment>
-<action_description>// Physical nexus established - filing required</action_description>
+<action_dsl>// Physical nexus established - filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="1" column_value="X" />
@@ -57,7 +57,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "CA" st
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established - filing required</action_comment>
-<action_description>// Economic nexus established - filing required</action_description>
+<action_dsl>// Economic nexus established - filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -66,7 +66,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "CA" st
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required; // No CA nexus - no filing required; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -97,7 +97,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "CA" st
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have CA nexus; (apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true) and apportionment.state_code == "CA"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if { pop apportionment.state_code "CA" streq } over if
 </condition_postfix>
@@ -110,7 +110,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate CA additions and subtractions; // CA Additions and Subtractions - placeholder; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -120,7 +120,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>2</action_number>
 <action_comment>No CA nexus - no adjustments; // No CA nexus - no adjustments; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -151,7 +151,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have CA nexus; (apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true) and apportionment.state_code == "CA"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if { pop apportionment.state_code "CA" streq } over if
 </condition_postfix>
@@ -163,7 +163,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive CA taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0.0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0.0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0.0 f&gt;
 </condition_postfix>
@@ -177,7 +177,7 @@ apportionment.state_taxable_income 0.0 f&gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate CA income tax at 8.84% with $800 minimum; // Calculate CA income tax at 8.84%, enforce $800 minimum; set apportionment.state_tax = max(result.ca_minimum_franchise_tax, apportionment.state_taxable_income * apportionment.state_tax_rate - apportionment.state_credits); set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - result.ca_minimum_franchise_tax f&gt; { apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - } { result.ca_minimum_franchise_tax } ifelse cvd /apportionment.state_tax xdef apportionment.state_payments apportionment.state_tax - cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -187,7 +187,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>2</action_number>
 <action_comment>No income but still owe minimum franchise tax; // No CA taxable income, but $800 minimum franchise tax still applies; set apportionment.state_tax = result.ca_minimum_franchise_tax; set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.ca_minimum_franchise_tax cvd /apportionment.state_tax xdef apportionment.state_payments apportionment.state_tax - cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -197,7 +197,7 @@ result.ca_minimum_franchise_tax cvd /apportionment.state_tax xdef apportionment.
 <action_details>
 <action_number>3</action_number>
 <action_comment>No CA nexus - no tax or minimum franchise tax; // No CA nexus - no tax or minimum franchise tax; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -228,7 +228,7 @@ result.ca_minimum_franchise_tax cvd /apportionment.state_tax xdef apportionment.
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has elected water's edge treatment</condition_comment>
-<condition_description>result.ca_waters_edge_election is true</condition_description>
+<condition_dsl>result.ca_waters_edge_election is true</condition_dsl>
 <condition_postfix>
 result.ca_waters_edge_election true beq
 </condition_postfix>
@@ -240,7 +240,7 @@ result.ca_waters_edge_election true beq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has unitary group members</condition_comment>
-<condition_description>result.ca_unitary_group_count &gt; 1</condition_description>
+<condition_dsl>result.ca_unitary_group_count &gt; 1</condition_dsl>
 <condition_postfix>
 result.ca_unitary_group_count 1 &gt;
 </condition_postfix>
@@ -254,7 +254,7 @@ result.ca_unitary_group_count 1 &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Water's edge limits combined reporting</action_comment>
-<action_description>// Water's edge limits combined reporting to US corporations and certain foreign entities</action_description>
+<action_dsl>// Water's edge limits combined reporting to US corporations and certain foreign entities</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="1" column_value="X" />
@@ -263,7 +263,7 @@ result.ca_unitary_group_count 1 &gt;
 <action_details>
 <action_number>2</action_number>
 <action_comment>Worldwide combined reporting</action_comment>
-<action_description>// Worldwide combined reporting includes all unitary group members globally</action_description>
+<action_dsl>// Worldwide combined reporting includes all unitary group members globally</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -272,7 +272,7 @@ result.ca_unitary_group_count 1 &gt;
 <action_details>
 <action_number>3</action_number>
 <action_comment>Standalone corporation - no combined reporting; // Standalone corporation - no combined reporting required</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 </action_postfix>
 <action_column column_number="3" column_value="X" />

--- a/sampleprojects/CorporateTax/xml/states/CO_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/CO_corp_dt.xml
@@ -18,7 +18,7 @@
 
 <initial_actions>
 <initial_action>
-<action_description>// Initialize Colorado filing requirement check; set result.co_has_nexus = false;</action_description>
+<action_dsl>// Initialize Colorado filing requirement check; set result.co_has_nexus = false;</action_dsl>
 <action_postfix>
 false cvb /result.co_has_nexus xdef
 </action_postfix>
@@ -29,7 +29,7 @@ false cvb /result.co_has_nexus xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in Colorado</condition_comment>
-<condition_description>result.has_physical_presence_co is true</condition_description>
+<condition_dsl>result.has_physical_presence_co is true</condition_dsl>
 <condition_postfix>
 result.has_physical_presence_co true beq
 </condition_postfix>
@@ -41,7 +41,7 @@ result.has_physical_presence_co true beq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets economic nexus threshold; result.co_gross_receipts &gt;= result.co_economic_nexus_threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.co_gross_receipts result.co_economic_nexus_threshold f&gt;=
 </condition_postfix>
@@ -55,7 +55,7 @@ result.co_gross_receipts result.co_economic_nexus_threshold f&gt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus - filing required</action_comment>
-<action_description>// Physical nexus established - filing required; set result.co_has_nexus = true;</action_description>
+<action_dsl>// Physical nexus established - filing required; set result.co_has_nexus = true;</action_dsl>
 <action_postfix>
 true cvb /result.co_has_nexus xdef
 </action_postfix>
@@ -65,7 +65,7 @@ true cvb /result.co_has_nexus xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus - filing required</action_comment>
-<action_description>// Economic nexus established per Wayfair - filing required; set result.co_has_nexus = true;</action_description>
+<action_dsl>// Economic nexus established per Wayfair - filing required; set result.co_has_nexus = true;</action_dsl>
 <action_postfix>
 true cvb /result.co_has_nexus xdef
 </action_postfix>
@@ -75,7 +75,7 @@ true cvb /result.co_has_nexus xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required; // No nexus - no filing required; set result.co_has_nexus = false; set result.co_tax_liability = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 false cvb /result.co_has_nexus xdef 0.0 cvd /result.co_tax_liability xdef
 </action_postfix>
@@ -102,7 +102,7 @@ false cvb /result.co_has_nexus xdef 0.0 cvd /result.co_tax_liability xdef
 
 <initial_actions>
 <initial_action>
-<action_description>// Initialize Colorado income adjustments; set result.co_state_additions = 0.0; set result.co_state_subtractions = 0.0;</action_description>
+<action_dsl>// Initialize Colorado income adjustments; set result.co_state_additions = 0.0; set result.co_state_subtractions = 0.0;</action_dsl>
 <action_postfix>
 0.0 cvd /result.co_state_additions xdef 0.0 cvd /result.co_state_subtractions xdef
 </action_postfix>
@@ -113,7 +113,7 @@ false cvb /result.co_has_nexus xdef 0.0 cvd /result.co_tax_liability xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has Colorado nexus</condition_comment>
-<condition_description>result.co_has_nexus is true</condition_description>
+<condition_dsl>result.co_has_nexus is true</condition_dsl>
 <condition_postfix>
 result.co_has_nexus true beq
 </condition_postfix>
@@ -126,7 +126,7 @@ result.co_has_nexus true beq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Colorado state additions and subtractions; // Calculate Colorado state additions and subtractions; set result.co_state_additions = result.co_us_interest_income; set result.co_state_subtractions = result.co_state_tax_deduction;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.co_us_interest_income cvd /result.co_state_additions xdef result.co_state_tax_deduction cvd /result.co_state_subtractions xdef
 </action_postfix>
@@ -136,7 +136,7 @@ result.co_us_interest_income cvd /result.co_state_additions xdef result.co_state
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no adjustments; // No nexus - no adjustments; set result.co_state_additions = 0.0; set result.co_state_subtractions = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /result.co_state_additions xdef 0.0 cvd /result.co_state_subtractions xdef
 </action_postfix>
@@ -163,7 +163,7 @@ result.co_us_interest_income cvd /result.co_state_additions xdef result.co_state
 
 <initial_actions>
 <initial_action>
-<action_description>// Initialize Colorado tax calculation; set result.co_taxable_income = 0.0; set result.co_tax_liability = 0.0;</action_description>
+<action_dsl>// Initialize Colorado tax calculation; set result.co_taxable_income = 0.0; set result.co_tax_liability = 0.0;</action_dsl>
 <action_postfix>
 0.0 cvd /result.co_taxable_income xdef 0.0 cvd /result.co_tax_liability xdef
 </action_postfix>
@@ -174,7 +174,7 @@ result.co_us_interest_income cvd /result.co_state_additions xdef result.co_state
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has Colorado nexus</condition_comment>
-<condition_description>result.co_has_nexus is true</condition_description>
+<condition_dsl>result.co_has_nexus is true</condition_dsl>
 <condition_postfix>
 result.co_has_nexus true beq
 </condition_postfix>
@@ -186,7 +186,7 @@ result.co_has_nexus true beq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive taxable income</condition_comment>
-<condition_description>result.co_apportioned_income &gt; 0.0</condition_description>
+<condition_dsl>result.co_apportioned_income &gt; 0.0</condition_dsl>
 <condition_postfix>
 result.co_apportioned_income 0.0 f&gt;
 </condition_postfix>
@@ -200,7 +200,7 @@ result.co_apportioned_income 0.0 f&gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Colorado corporate tax (flat rate 4.55%); // Calculate Colorado taxable income and tax; set result.co_taxable_income = (result.co_apportioned_income + result.co_state_additions - result.co_state_subtractions); set result.co_tax_liability = result.co_taxable_income * result.co_corp_tax_rate - result.co_state_credits; set result.co_refund_or_owed = result.co_estimated_payments - result.co_tax_liability;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.co_apportioned_income result.co_state_additions + result.co_state_subtractions - 0.0 f&gt; { result.co_apportioned_income result.co_state_additions + result.co_state_subtractions - } { 0.0 } ifelse cvd /result.co_taxable_income xdef result.co_taxable_income result.co_corp_tax_rate fmul result.co_state_credits - 0.0 f&gt; { result.co_taxable_income result.co_corp_tax_rate fmul result.co_state_credits - } { 0.0 } ifelse cvd /result.co_tax_liability xdef result.co_estimated_payments result.co_tax_liability - cvd /result.co_refund_or_owed xdef
 </action_postfix>
@@ -210,7 +210,7 @@ result.co_apportioned_income result.co_state_additions + result.co_state_subtrac
 <action_details>
 <action_number>2</action_number>
 <action_comment>No taxable income - no tax liability; // No taxable income - no tax liability; set result.co_taxable_income = 0.0; set result.co_tax_liability = 0.0; set result.co_refund_or_owed = result.co_estimated_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /result.co_taxable_income xdef 0.0 cvd /result.co_tax_liability xdef result.co_estimated_payments cvd /result.co_refund_or_owed xdef
 </action_postfix>
@@ -220,7 +220,7 @@ result.co_apportioned_income result.co_state_additions + result.co_state_subtrac
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no tax liability; // No nexus - no tax liability; set result.co_taxable_income = 0.0; set result.co_tax_liability = 0.0; set result.co_refund_or_owed = result.co_estimated_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /result.co_taxable_income xdef 0.0 cvd /result.co_tax_liability xdef result.co_estimated_payments cvd /result.co_refund_or_owed xdef
 </action_postfix>

--- a/sampleprojects/CorporateTax/xml/states/CT_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/CT_corp_dt.xml
@@ -18,7 +18,7 @@
 
 <initial_actions>
 <initial_action>
-<action_description>// Initialize CT filing requirement determination</action_description>
+<action_dsl>// Initialize CT filing requirement determination</action_dsl>
 <action_postfix>
 </action_postfix>
 </initial_action>
@@ -29,7 +29,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in CT (office, employees, property)</condition_comment>
-<condition_description>apportionment.has_physical_presence is true and apportionment.state_code == "CT"</condition_description>
+<condition_dsl>apportionment.has_physical_presence is true and apportionment.state_code == "CT"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true beq { pop apportionment.state_code "CT" streq } over if
 </condition_postfix>
@@ -42,7 +42,7 @@ apportionment.has_physical_presence true beq { pop apportionment.state_code "CT"
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets CT economic nexus threshold ($500,000)</condition_comment>
-<condition_description>apportionment.has_economic_nexus is true and apportionment.state_code == "CT"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus is true and apportionment.state_code == "CT"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.state_code "CT" streq } over if
 </condition_postfix>
@@ -57,7 +57,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "CT" st
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - CT filing required</action_comment>
-<action_description>// Physical nexus established - CT filing required</action_description>
+<action_dsl>// Physical nexus established - CT filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="1" column_value="X" />
@@ -67,7 +67,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "CT" st
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established - CT filing required</action_comment>
-<action_description>// Economic nexus established per Wayfair - CT filing required</action_description>
+<action_dsl>// Economic nexus established per Wayfair - CT filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -77,7 +77,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "CT" st
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no CT filing required; // No nexus - no CT filing required; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -104,7 +104,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "CT" st
 
 <initial_actions>
 <initial_action>
-<action_description>// Initialize CT income adjustments; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_description>
+<action_dsl>// Initialize CT income adjustments; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_dsl>
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -116,7 +116,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "CT" st
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -130,7 +130,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate CT state additions and subtractions; // Calculate CT state additions and subtractions - placeholder for future implementation</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -141,7 +141,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no state adjustments calculated; // No nexus - no state adjustments; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -168,7 +168,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 
 <initial_actions>
 <initial_action>
-<action_description>// Initialize CT state tax calculation; set apportionment.state_tax = 0.0;</action_description>
+<action_dsl>// Initialize CT state tax calculation; set apportionment.state_tax = 0.0;</action_dsl>
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef
 </action_postfix>
@@ -180,7 +180,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -193,7 +193,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0.0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0.0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0.0 f&gt;
 </condition_postfix>
@@ -208,7 +208,7 @@ apportionment.state_taxable_income 0.0 f&gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate CT tax using 7.5% flat rate; // CT uses 7.5% flat rate on all corporate income; set apportionment.state_tax = apportionment.state_taxable_income * apportionment.state_tax_rate - apportionment.state_credits; set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - 0.0 f&gt; { apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - } { 0.0 } ifelse cvd /apportionment.state_tax xdef apportionment.state_payments apportionment.state_tax - cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -219,7 +219,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>2</action_number>
 <action_comment>No CT nexus - no tax liability; // No CT nexus - no tax liability; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -230,7 +230,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>3</action_number>
 <action_comment>No CT taxable income - no tax liability; // No CT taxable income - no tax liability; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>

--- a/sampleprojects/CorporateTax/xml/states/DC_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/DC_corp_dt.xml
@@ -40,7 +40,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in DC (office, employees, property)</condition_comment>
-<condition_description>apportionment.has_physical_presence is true and apportionment.state_code == "DC"</condition_description>
+<condition_dsl>apportionment.has_physical_presence is true and apportionment.state_code == "DC"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true beq { pop apportionment.state_code "DC" streq } over if
 </condition_postfix>
@@ -52,7 +52,7 @@ apportionment.has_physical_presence true beq { pop apportionment.state_code "DC"
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets DC economic nexus threshold</condition_comment>
-<condition_description>apportionment.has_economic_nexus is true and apportionment.state_code == "DC"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus is true and apportionment.state_code == "DC"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.state_code "DC" streq } over if
 </condition_postfix>
@@ -66,7 +66,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "DC" st
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - filing required</action_comment>
-<action_description>// Physical nexus established - filing required</action_description>
+<action_dsl>// Physical nexus established - filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="1" column_value="X"></action_column>
@@ -75,7 +75,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "DC" st
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established per Wayfair - filing required</action_comment>
-<action_description>// Economic nexus established per Wayfair - filing required</action_description>
+<action_dsl>// Economic nexus established per Wayfair - filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X"></action_column>
@@ -84,7 +84,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "DC" st
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required</action_comment>
-<action_description>// No nexus - no filing required; set apportionment.state_tax = 0.0; set result.dc_minimum_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_description>
+<action_dsl>// No nexus - no filing required; set apportionment.state_tax = 0.0; set result.dc_minimum_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_dsl>
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef 0.0 cvd /result.dc_minimum_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -115,7 +115,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "DC" st
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate adjustments</condition_comment>
-<condition_description>apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_description>
+<condition_dsl>apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -128,7 +128,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate DC state additions and subtractions</action_comment>
-<action_description>// Calculate DC state additions and subtractions; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_description>
+<action_dsl>// Calculate DC state additions and subtractions; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_dsl>
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -138,7 +138,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no adjustments</action_comment>
-<action_description>// No nexus - no adjustments; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_description>
+<action_dsl>// No nexus - no adjustments; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_dsl>
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -169,7 +169,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe tax</condition_comment>
-<condition_description>apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_description>
+<condition_dsl>apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -181,7 +181,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income > 0.0</condition_description>
+<condition_dsl>apportionment.state_taxable_income > 0.0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0.0 f>
 </condition_postfix>
@@ -195,7 +195,7 @@ apportionment.state_taxable_income 0.0 f>
 <action_details>
 <action_number>1</action_number>
 <action_comment>DC flat rate calculation (8.25%)</action_comment>
-<action_description>// DC uses 8.25% flat rate; set apportionment.state_tax = apportionment.state_taxable_income * apportionment.state_tax_rate - apportionment.state_credits;</action_description>
+<action_dsl>// DC uses 8.25% flat rate; set apportionment.state_tax = apportionment.state_taxable_income * apportionment.state_tax_rate - apportionment.state_credits;</action_dsl>
 <action_postfix>
 apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - 0.0 f> { apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - } { 0.0 } ifelse cvd /apportionment.state_tax xdef
 </action_postfix>
@@ -205,7 +205,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no tax liability</action_comment>
-<action_description>// No DC nexus - no tax liability; set apportionment.state_tax = 0.0; set result.dc_minimum_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_description>
+<action_dsl>// No DC nexus - no tax liability; set apportionment.state_tax = 0.0; set result.dc_minimum_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_dsl>
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef 0.0 cvd /result.dc_minimum_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -215,7 +215,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>3</action_number>
 <action_comment>Nexus but no taxable income - minimum tax applies</action_comment>
-<action_description>// No income-based tax, but minimum tax still applies; set apportionment.state_tax = 0.0;</action_description>
+<action_dsl>// No income-based tax, but minimum tax still applies; set apportionment.state_tax = 0.0;</action_dsl>
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef
 </action_postfix>
@@ -246,7 +246,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe minimum tax</condition_comment>
-<condition_description>apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_description>
+<condition_dsl>apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -258,7 +258,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>DC gross receipts exceed $1 million</condition_comment>
-<condition_description>result.dc_gross_receipts > 1000000.0</condition_description>
+<condition_dsl>result.dc_gross_receipts > 1000000.0</condition_dsl>
 <condition_postfix>
 result.dc_gross_receipts 1000000.0 f>
 </condition_postfix>
@@ -272,7 +272,7 @@ result.dc_gross_receipts 1000000.0 f>
 <action_details>
 <action_number>1</action_number>
 <action_comment>High gross receipts - $1,000 minimum</action_comment>
-<action_description>// Minimum tax: $1,000 for gross receipts > $1M; set result.dc_minimum_tax = 1000.0; set apportionment.state_tax = max(apportionment.state_tax, result.dc_minimum_tax); set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax;</action_description>
+<action_dsl>// Minimum tax: $1,000 for gross receipts > $1M; set result.dc_minimum_tax = 1000.0; set apportionment.state_tax = max(apportionment.state_tax, result.dc_minimum_tax); set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax;</action_dsl>
 <action_postfix>
 1000.0 cvd /result.dc_minimum_tax xdef apportionment.state_tax result.dc_minimum_tax f> { apportionment.state_tax } { result.dc_minimum_tax } ifelse cvd /apportionment.state_tax xdef apportionment.state_payments apportionment.state_tax - cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -282,7 +282,7 @@ result.dc_gross_receipts 1000000.0 f>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Low gross receipts - $250 minimum</action_comment>
-<action_description>// Minimum tax: $250 for gross receipts <= $1M; set result.dc_minimum_tax = 250.0; set apportionment.state_tax = max(apportionment.state_tax, result.dc_minimum_tax); set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax;</action_description>
+<action_dsl>// Minimum tax: $250 for gross receipts <= $1M; set result.dc_minimum_tax = 250.0; set apportionment.state_tax = max(apportionment.state_tax, result.dc_minimum_tax); set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax;</action_dsl>
 <action_postfix>
 250.0 cvd /result.dc_minimum_tax xdef apportionment.state_tax result.dc_minimum_tax f> { apportionment.state_tax } { result.dc_minimum_tax } ifelse cvd /apportionment.state_tax xdef apportionment.state_payments apportionment.state_tax - cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -292,7 +292,7 @@ result.dc_gross_receipts 1000000.0 f>
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no minimum tax</action_comment>
-<action_description>// No DC nexus - no minimum tax requirement; set result.dc_minimum_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_description>
+<action_dsl>// No DC nexus - no minimum tax requirement; set result.dc_minimum_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_dsl>
 <action_postfix>
 0.0 cvd /result.dc_minimum_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>

--- a/sampleprojects/CorporateTax/xml/states/DE_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/DE_corp_dt.xml
@@ -22,7 +22,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in DE (office, employees, property)</condition_comment>
-<condition_description>apportionment.has_physical_presence is true and apportionment.state_code == "DE"</condition_description>
+<condition_dsl>apportionment.has_physical_presence is true and apportionment.state_code == "DE"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true beq { pop apportionment.state_code "DE" streq } over if
 </condition_postfix>
@@ -34,7 +34,7 @@ apportionment.has_physical_presence true beq { pop apportionment.state_code "DE"
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets DE economic nexus threshold ($100,000 or 200 transactions)</condition_comment>
-<condition_description>apportionment.has_economic_nexus is true and apportionment.state_code == "DE"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus is true and apportionment.state_code == "DE"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.state_code "DE" streq } over if
 </condition_postfix>
@@ -48,7 +48,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "DE" st
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - filing required</action_comment>
-<action_description>// Physical nexus established - filing required</action_description>
+<action_dsl>// Physical nexus established - filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="1" column_value="X" />
@@ -57,7 +57,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "DE" st
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established per Wayfair - filing required</action_comment>
-<action_description>// Economic nexus established per Wayfair - filing required</action_description>
+<action_dsl>// Economic nexus established per Wayfair - filing required</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -66,7 +66,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "DE" st
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required; // No nexus - no filing required; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -97,7 +97,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "DE" st
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -110,7 +110,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Delaware state additions and subtractions; // Calculate Delaware state additions and subtractions; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -120,7 +120,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no adjustments; // No nexus - no adjustments; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -151,7 +151,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -163,7 +163,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0.0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0.0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0.0 f&gt;
 </condition_postfix>
@@ -177,7 +177,7 @@ apportionment.state_taxable_income 0.0 f&gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Delaware tax at 8.8% flat rate; // Delaware uses 8.8% flat rate; set apportionment.state_tax = apportionment.state_taxable_income * apportionment.state_tax_rate - apportionment.state_credits; set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - 0.0 f&gt; { apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - } { 0.0 } ifelse cvd /apportionment.state_tax xdef apportionment.state_payments apportionment.state_tax - cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -187,7 +187,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no tax liability; // No Delaware nexus - no tax liability; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -197,7 +197,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
 <action_details>
 <action_number>3</action_number>
 <action_comment>No taxable income - no tax liability; // No Delaware taxable income - no tax liability; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>

--- a/sampleprojects/CorporateTax/xml/states/FL_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/FL_corp_dt.xml
@@ -18,7 +18,7 @@
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in FL (office, employees, property)</condition_comment>
-        <condition_description>apportionment.has_physical_presence is true and apportionment.state_code == "FL"</condition_description>
+        <condition_dsl>apportionment.has_physical_presence is true and apportionment.state_code == "FL"</condition_dsl>
         <condition_postfix>
 apportionment.has_physical_presence true beq { pop apportionment.state_code "FL" streq } over if
 </condition_postfix>
@@ -29,7 +29,7 @@ apportionment.has_physical_presence true beq { pop apportionment.state_code "FL"
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets FL economic nexus threshold ($50K or 200 transactions)</condition_comment>
-        <condition_description>apportionment.has_economic_nexus is true and apportionment.state_code == "FL"</condition_description>
+        <condition_dsl>apportionment.has_economic_nexus is true and apportionment.state_code == "FL"</condition_dsl>
         <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.state_code "FL" streq } over if
 </condition_postfix>
@@ -42,7 +42,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "FL" st
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus established - filing required</action_comment>
-        <action_description>// Physical nexus established - filing required</action_description>
+        <action_dsl>// Physical nexus established - filing required</action_dsl>
         <action_postfix>
 </action_postfix>
         <action_column column_number="1" column_value="X" />
@@ -50,7 +50,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "FL" st
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus established per Wayfair - filing required</action_comment>
-        <action_description>// Economic nexus established per Wayfair - filing required</action_description>
+        <action_dsl>// Economic nexus established per Wayfair - filing required</action_dsl>
         <action_postfix>
 </action_postfix>
         <action_column column_number="2" column_value="X" />
@@ -58,7 +58,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "FL" st
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required; // No nexus - no filing required; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -93,7 +93,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "FL" st
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -105,7 +105,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Florida state additions and subtractions; // Calculate Florida state additions and subtractions - placeholder; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -114,7 +114,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no Florida state adjustments; // No nexus - no adjustments; set apportionment.state_additions = 0.0; set apportionment.state_subtractions = 0.0;</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 0.0 cvd /apportionment.state_additions xdef 0.0 cvd /apportionment.state_subtractions xdef
 </action_postfix>
@@ -146,7 +146,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus is true or apportionment.has_physical_presence is true</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true beq { pop apportionment.has_physical_presence true beq } over not if
 </condition_postfix>
@@ -157,7 +157,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive state taxable income</condition_comment>
-        <condition_description>apportionment.state_taxable_income &gt; 0.0</condition_description>
+        <condition_dsl>apportionment.state_taxable_income &gt; 0.0</condition_dsl>
         <condition_postfix>
 apportionment.state_taxable_income 0.0 f&gt;
 </condition_postfix>
@@ -170,7 +170,7 @@ apportionment.state_taxable_income 0.0 f&gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Florida 5.5% flat rate calculation; // Florida uses 5.5% flat rate; set apportionment.state_tax = apportionment.state_taxable_income * apportionment.state_tax_rate - apportionment.state_credits; set apportionment.state_refund_or_owed = apportionment.state_payments - apportionment.state_tax;</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - 0.0 f&gt; { apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionment.state_credits - } { 0.0 } ifelse cvd /apportionment.state_tax xdef apportionment.state_payments apportionment.state_tax - cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -179,7 +179,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no tax liability; // No nexus - no tax liability; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>
@@ -188,7 +188,7 @@ apportionment.state_taxable_income apportionment.state_tax_rate fmul apportionme
       <action_details>
         <action_number>3</action_number>
         <action_comment>No taxable income - no tax liability; // No taxable income - no tax liability; set apportionment.state_tax = 0.0; set apportionment.state_refund_or_owed = apportionment.state_payments;</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 0.0 cvd /apportionment.state_tax xdef apportionment.state_payments cvd /apportionment.state_refund_or_owed xdef
 </action_postfix>

--- a/sampleprojects/CorporateTax/xml/states/GA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/GA_corp_dt.xml
@@ -16,7 +16,7 @@
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in GA (office, employees, property)</condition_comment>
-        <condition_description>apportionment.has_physical_presence is equal to true and apportionment.state_code is equal to "GA"</condition_description>
+        <condition_dsl>apportionment.has_physical_presence is equal to true and apportionment.state_code is equal to "GA"</condition_dsl>
         <condition_postfix>
 apportionment.has_physical_presence true eq
 apportionment.state_code "GA" streq
@@ -29,7 +29,7 @@ apportionment.state_code "GA" streq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets GA economic nexus threshold</condition_comment>
-        <condition_description>apportionment.has_economic_nexus is equal to true and apportionment.state_code is equal to "GA"</condition_description>
+        <condition_dsl>apportionment.has_economic_nexus is equal to true and apportionment.state_code is equal to "GA"</condition_dsl>
         <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.state_code "GA" streq
@@ -44,7 +44,7 @@ apportionment.state_code "GA" streq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus established - filing required</action_comment>
-        <action_description>Apportionment will be calculated by tables 7000-7500</action_description>
+        <action_dsl>Apportionment will be calculated by tables 7000-7500</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 // Apportionment will be calculated by tables 7000-7500
@@ -55,7 +55,7 @@ apportionment.state_code "GA" streq
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus established per Wayfair; Filing required due to economic nexus. Threshold: $100,000 gross receipts OR 200 transactions.</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 // Apportionment will be calculated by tables 7000-7500
@@ -66,7 +66,7 @@ apportionment.state_code "GA" streq
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_description>
+        <action_dsl>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_dsl>
         <action_postfix>
 0.0 apportionment.state_tax xdef
 apportionment.state_payments apportionment.state_refund_or_owed xdef
@@ -92,7 +92,7 @@ apportionment.state_payments apportionment.state_refund_or_owed xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus is equal to true or apportionment.has_physical_presence is equal to true</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true eq
 { pop apportionment.has_physical_presence true eq } over not if
@@ -105,7 +105,7 @@ apportionment.has_economic_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate GA state additions and subtractions; Calculate Georgia state-specific income adjustments to federal taxable income per GA Form 600 Schedule 1.</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Georgia state additions
 0.0 /additions xdef
@@ -139,7 +139,7 @@ subtractions apportionment.state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no state adjustments</action_comment>
-        <action_description>apportionment.state_additions = 0.0; apportionment.state_subtractions = 0.0</action_description>
+        <action_dsl>apportionment.state_additions = 0.0; apportionment.state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 apportionment.state_additions xdef
 0.0 apportionment.state_subtractions xdef
@@ -165,7 +165,7 @@ subtractions apportionment.state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus is equal to true or apportionment.has_physical_presence is equal to true</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true eq
 { pop apportionment.has_physical_presence true eq } over not if
@@ -177,7 +177,7 @@ apportionment.has_economic_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive state taxable income; apportionment.state_taxable_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.state_taxable_income 0 &gt;
 </condition_postfix>
@@ -190,7 +190,7 @@ apportionment.state_taxable_income 0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate GA tax at 5.75% flat rate; Georgia state corporate income tax calculation: Apply 5.75% flat rate, subtract credits, calculate refund or amount owed.</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Georgia uses 5.75% flat rate
 apportionment.state_taxable_income apportionment.state_tax_rate mul /ga_tax xdef
@@ -209,7 +209,7 @@ apportionment.state_payments apportionment.state_tax sub apportionment.state_ref
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_description>
+        <action_dsl>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_dsl>
         <action_postfix>
 0.0 apportionment.state_tax xdef
 apportionment.state_payments apportionment.state_refund_or_owed xdef
@@ -220,7 +220,7 @@ apportionment.state_payments apportionment.state_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_description>
+        <action_dsl>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_dsl>
         <action_postfix>
 0.0 apportionment.state_tax xdef
 apportionment.state_payments apportionment.state_refund_or_owed xdef

--- a/sampleprojects/CorporateTax/xml/states/HI_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/HI_corp_dt.xml
@@ -16,7 +16,7 @@
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in HI (office, employees, property)</condition_comment>
-        <condition_description>apportionment.has_physical_presence is equal to true and apportionment.state_code is equal to "HI"</condition_description>
+        <condition_dsl>apportionment.has_physical_presence is equal to true and apportionment.state_code is equal to "HI"</condition_dsl>
         <condition_postfix>
 apportionment.has_physical_presence true eq
 { pop apportionment.state_code "HI" streq } over if
@@ -28,7 +28,7 @@ apportionment.has_physical_presence true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets HI economic nexus threshold</condition_comment>
-        <condition_description>apportionment.has_economic_nexus is equal to true and apportionment.state_code is equal to "HI"</condition_description>
+        <condition_dsl>apportionment.has_economic_nexus is equal to true and apportionment.state_code is equal to "HI"</condition_dsl>
         <condition_postfix>
 apportionment.has_economic_nexus true eq
 { pop apportionment.state_code "HI" streq } over if
@@ -42,7 +42,7 @@ apportionment.has_economic_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus established - filing required</action_comment>
-        <action_description>Apportionment will be calculated by tables 7000-7500</action_description>
+        <action_dsl>Apportionment will be calculated by tables 7000-7500</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 // Apportionment will be calculated by tables 7000-7500
@@ -52,7 +52,7 @@ apportionment.has_economic_nexus true eq
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus established per Wayfair - filing required; Threshold: $100,000 gross receipts OR 200 transactions</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 // Apportionment will be calculated by tables 7000-7500
@@ -62,7 +62,7 @@ apportionment.has_economic_nexus true eq
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_description>
+        <action_dsl>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 0.0 apportionment.state_tax xdef
@@ -102,7 +102,7 @@ apportionment.state_payments apportionment.state_refund_or_owed xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus is equal to true or apportionment.has_physical_presence is equal to true</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true eq
 { pop apportionment.has_physical_presence true eq } over not if
@@ -115,7 +115,7 @@ apportionment.has_economic_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate HI state additions and subtractions; Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate state additions (customize for Hawaii)
 0.0 /additions xdef
@@ -147,7 +147,7 @@ subtractions apportionment.state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no state adjustments</action_comment>
-        <action_description>apportionment.state_additions = 0.0; apportionment.state_subtractions = 0.0</action_description>
+        <action_dsl>apportionment.state_additions = 0.0; apportionment.state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 apportionment.state_additions xdef
 0.0 apportionment.state_subtractions xdef
@@ -182,7 +182,7 @@ subtractions apportionment.state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus is equal to true or apportionment.has_physical_presence is equal to true</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true eq
 { pop apportionment.has_physical_presence true eq } over not if
@@ -194,7 +194,7 @@ apportionment.has_economic_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive state taxable income; apportionment.state_taxable_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.state_taxable_income 0 &gt;
 </condition_postfix>
@@ -207,7 +207,7 @@ apportionment.state_taxable_income 0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Hawaii 6.4% flat rate calculation; Calculate HI tax using 6.4% flat rate</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Hawaii uses 6.4% flat rate
 apportionment.state_taxable_income apportionment.state_tax_rate mul
@@ -226,7 +226,7 @@ apportionment.state_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_description>
+        <action_dsl>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_dsl>
         <action_postfix>
 0.0 apportionment.state_tax xdef
 apportionment.state_payments apportionment.state_refund_or_owed xdef
@@ -236,7 +236,7 @@ apportionment.state_payments apportionment.state_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>Nexus but no taxable income - no tax liability</action_comment>
-        <action_description>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_description>
+        <action_dsl>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_dsl>
         <action_postfix>
 0.0 apportionment.state_tax xdef
 apportionment.state_payments apportionment.state_refund_or_owed xdef

--- a/sampleprojects/CorporateTax/xml/states/IA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/IA_corp_dt.xml
@@ -13,7 +13,7 @@
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Iowa filing requirement check</action_description>
+        <action_dsl>Initialize Iowa filing requirement check</action_dsl>
         <action_postfix>
 "Iowa Corporate Filing Requirement Check Started" job.audit_trail swap addto
 false result.ia_has_nexus xdef
@@ -24,7 +24,7 @@ false result.ia_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in Iowa</condition_comment>
-        <condition_description>result.has_physical_presence_ia is equal to true</condition_description>
+        <condition_dsl>result.has_physical_presence_ia is equal to true</condition_dsl>
         <condition_postfix>
 result.has_physical_presence_ia true eq
 </condition_postfix>
@@ -35,7 +35,7 @@ result.has_physical_presence_ia true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets economic nexus threshold ($100K gross receipts); result.ia_gross_receipts is greater than or equal to result.ia_economic_nexus_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.ia_gross_receipts result.ia_economic_nexus_threshold &gt;=
 </condition_postfix>
@@ -48,7 +48,7 @@ result.ia_gross_receipts result.ia_economic_nexus_threshold &gt;=
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus - filing required</action_comment>
-        <action_description>result.ia_has_nexus = true</action_description>
+        <action_dsl>result.ia_has_nexus = true</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 true result.ia_has_nexus xdef
@@ -59,7 +59,7 @@ true result.ia_has_nexus xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus - filing required (no transaction count as of 7/1/2023)</action_comment>
-        <action_description>result.ia_has_nexus = true</action_description>
+        <action_dsl>result.ia_has_nexus = true</action_dsl>
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 true result.ia_has_nexus xdef
@@ -70,7 +70,7 @@ true result.ia_has_nexus xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>result.ia_has_nexus = false; result.ia_tax_liability = 0.0</action_description>
+        <action_dsl>result.ia_has_nexus = false; result.ia_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 false result.ia_has_nexus xdef
@@ -94,7 +94,7 @@ false result.ia_has_nexus xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Iowa income adjustments</action_description>
+        <action_dsl>Initialize Iowa income adjustments</action_dsl>
         <action_postfix>
 "Iowa Corporate Income Adjustments Calculation Started" job.audit_trail swap addto
 0.0 result.ia_state_additions xdef
@@ -106,7 +106,7 @@ false result.ia_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Iowa nexus</condition_comment>
-        <condition_description>result.ia_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.ia_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.ia_has_nexus true eq
 </condition_postfix>
@@ -118,7 +118,7 @@ result.ia_has_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Iowa state additions and subtractions; Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Iowa state additions
 0.0 /ia_additions xdef
@@ -162,7 +162,7 @@ ia_subtractions result.ia_state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no adjustments</action_comment>
-        <action_description>result.ia_state_additions = 0.0; result.ia_state_subtractions = 0.0</action_description>
+        <action_dsl>result.ia_state_additions = 0.0; result.ia_state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 result.ia_state_additions xdef
 0.0 result.ia_state_subtractions xdef
@@ -185,7 +185,7 @@ ia_subtractions result.ia_state_subtractions xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Iowa tax calculation</action_description>
+        <action_dsl>Initialize Iowa tax calculation</action_dsl>
         <action_postfix>
 "Iowa Corporate Tax Calculation Started" job.audit_trail swap addto
 0.0 result.ia_taxable_income xdef
@@ -199,7 +199,7 @@ ia_subtractions result.ia_state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Iowa nexus</condition_comment>
-        <condition_description>result.ia_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.ia_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.ia_has_nexus true eq
 </condition_postfix>
@@ -211,7 +211,7 @@ result.ia_has_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive taxable income; result.ia_apportioned_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.ia_apportioned_income 0.0 &gt;
 </condition_postfix>
@@ -223,7 +223,7 @@ result.ia_apportioned_income 0.0 &gt;
       <condition_details>
         <condition_number>3</condition_number>
         <condition_comment>Income exceeds $100,000 bracket threshold; result.ia_taxable_income is greater than result.ia_tax_bracket_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.ia_taxable_income result.ia_tax_bracket_threshold &gt;
 </condition_postfix>
@@ -237,7 +237,7 @@ result.ia_taxable_income result.ia_tax_bracket_threshold &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Iowa tax with graduated rates - income over $100K; Apply graduated rates: 5.5% on first $100K, 7.1% on excess</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Iowa taxable income
 // Federal taxable income apportioned to IA + additions - subtractions
@@ -279,7 +279,7 @@ result.ia_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Calculate Iowa tax - income $100K or less (only 5.5% rate); Apply only 5.5% rate for income under $100K</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Iowa taxable income
 result.ia_apportioned_income
@@ -310,7 +310,7 @@ result.ia_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>result.ia_taxable_income = 0.0; result.ia_tax_liability = 0.0</action_description>
+        <action_dsl>result.ia_taxable_income = 0.0; result.ia_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No taxable income - no tax liability
 0.0 result.ia_taxable_income xdef
@@ -323,7 +323,7 @@ result.ia_estimated_payments result.ia_refund_or_owed xdef
       <action_details>
         <action_number>4</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>result.ia_taxable_income = 0.0; result.ia_tax_liability = 0.0</action_description>
+        <action_dsl>result.ia_taxable_income = 0.0; result.ia_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no tax liability
 0.0 result.ia_taxable_income xdef

--- a/sampleprojects/CorporateTax/xml/states/ID_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/ID_corp_dt.xml
@@ -13,7 +13,7 @@
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Idaho filing requirement check</action_description>
+        <action_dsl>Initialize Idaho filing requirement check</action_dsl>
         <action_postfix>
 "Idaho Corporate Filing Requirement Check Started" job.audit_trail swap addto
 false result.id_has_nexus xdef
@@ -24,7 +24,7 @@ false result.id_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in Idaho</condition_comment>
-        <condition_description>result.has_physical_presence_id is equal to true</condition_description>
+        <condition_dsl>result.has_physical_presence_id is equal to true</condition_dsl>
         <condition_postfix>
 result.has_physical_presence_id true eq
 </condition_postfix>
@@ -35,7 +35,7 @@ result.has_physical_presence_id true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets economic nexus or doing business threshold; result.id_gross_receipts is greater than or equal to result.id_economic_nexus_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.id_gross_receipts result.id_economic_nexus_threshold &gt;=
 </condition_postfix>
@@ -48,7 +48,7 @@ result.id_gross_receipts result.id_economic_nexus_threshold &gt;=
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus - filing required</action_comment>
-        <action_description>result.id_has_nexus = true</action_description>
+        <action_dsl>result.id_has_nexus = true</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 true result.id_has_nexus xdef
@@ -59,7 +59,7 @@ true result.id_has_nexus xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus or doing business - filing required</action_comment>
-        <action_description>result.id_has_nexus = true</action_description>
+        <action_dsl>result.id_has_nexus = true</action_dsl>
         <action_postfix>
 // Economic nexus or doing business established - filing required
 true result.id_has_nexus xdef
@@ -70,7 +70,7 @@ true result.id_has_nexus xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>result.id_has_nexus = false; result.id_tax_liability = 0.0</action_description>
+        <action_dsl>result.id_has_nexus = false; result.id_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 false result.id_has_nexus xdef
@@ -94,7 +94,7 @@ false result.id_has_nexus xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Idaho income adjustments</action_description>
+        <action_dsl>Initialize Idaho income adjustments</action_dsl>
         <action_postfix>
 "Idaho Corporate Income Adjustments Calculation Started" job.audit_trail swap addto
 0.0 result.id_state_additions xdef
@@ -106,7 +106,7 @@ false result.id_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Idaho nexus</condition_comment>
-        <condition_description>result.id_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.id_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.id_has_nexus true eq
 </condition_postfix>
@@ -118,7 +118,7 @@ result.id_has_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Idaho state additions and subtractions; Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Idaho state additions
 0.0 /id_additions xdef
@@ -161,7 +161,7 @@ id_subtractions result.id_state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no adjustments</action_comment>
-        <action_description>result.id_state_additions = 0.0; result.id_state_subtractions = 0.0</action_description>
+        <action_dsl>result.id_state_additions = 0.0; result.id_state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 result.id_state_additions xdef
 0.0 result.id_state_subtractions xdef
@@ -184,7 +184,7 @@ id_subtractions result.id_state_subtractions xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Idaho tax calculation</action_description>
+        <action_dsl>Initialize Idaho tax calculation</action_dsl>
         <action_postfix>
 "Idaho Corporate Tax Calculation Started" job.audit_trail swap addto
 0.0 result.id_taxable_income xdef
@@ -196,7 +196,7 @@ id_subtractions result.id_state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Idaho nexus</condition_comment>
-        <condition_description>result.id_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.id_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.id_has_nexus true eq
 </condition_postfix>
@@ -207,7 +207,7 @@ result.id_has_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive taxable income; result.id_apportioned_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.id_apportioned_income 0.0 &gt;
 </condition_postfix>
@@ -220,7 +220,7 @@ result.id_apportioned_income 0.0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Idaho corporate tax (flat rate 5.3%); Apply Idaho 5.3% flat rate</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Idaho taxable income
 // Federal taxable income apportioned to ID + additions - subtractions
@@ -250,7 +250,7 @@ result.id_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>result.id_taxable_income = 0.0; result.id_tax_liability = 0.0</action_description>
+        <action_dsl>result.id_taxable_income = 0.0; result.id_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No taxable income - no tax liability
 0.0 result.id_taxable_income xdef
@@ -263,7 +263,7 @@ result.id_estimated_payments result.id_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>result.id_taxable_income = 0.0; result.id_tax_liability = 0.0</action_description>
+        <action_dsl>result.id_taxable_income = 0.0; result.id_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no tax liability
 0.0 result.id_taxable_income xdef

--- a/sampleprojects/CorporateTax/xml/states/IL_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/IL_corp_dt.xml
@@ -16,7 +16,7 @@
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in IL (office, employees, property)</condition_comment>
-        <condition_description>apportionment.has_physical_presence is equal to true and apportionment.state_code is equal to "IL"</condition_description>
+        <condition_dsl>apportionment.has_physical_presence is equal to true and apportionment.state_code is equal to "IL"</condition_dsl>
         <condition_postfix>
 apportionment.has_physical_presence true eq
 { pop apportionment.state_code "IL" streq } over if
@@ -29,7 +29,7 @@ apportionment.has_physical_presence true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets IL economic nexus threshold ($100K)</condition_comment>
-        <condition_description>apportionment.has_economic_nexus is equal to true and apportionment.state_code is equal to "IL"</condition_description>
+        <condition_dsl>apportionment.has_economic_nexus is equal to true and apportionment.state_code is equal to "IL"</condition_dsl>
         <condition_postfix>
 apportionment.has_economic_nexus true eq
 { pop apportionment.state_code "IL" streq } over if
@@ -44,7 +44,7 @@ apportionment.has_economic_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus established - filing required</action_comment>
-        <action_description>Physical presence in IL requires filing</action_description>
+        <action_dsl>Physical presence in IL requires filing</action_dsl>
         <action_postfix>
 "IL filing required due to physical presence (office, employees, or property in state). Reference: IL Income Tax Act, 35 ILCS 5/201; IL Department of Revenue Publication 101; 86 Ill. Admin. Code § 100.9710" result.policy_statements swap addto
 </action_postfix>
@@ -53,7 +53,7 @@ apportionment.has_economic_nexus true eq
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus established per Wayfair - filing required</action_comment>
-        <action_description>Economic nexus requires filing</action_description>
+        <action_dsl>Economic nexus requires filing</action_dsl>
         <action_postfix>
 "IL filing required due to economic nexus (post-Wayfair). Threshold: $100,000 in IL gross receipts OR 200 transactions. Reference: South Dakota v. Wayfair, Inc., 138 S. Ct. 2080 (2018); 35 ILCS 5/1501(a)(1); IL Department of Revenue ST 19-0001-GIL" result.policy_statements swap addto
 </action_postfix>
@@ -62,7 +62,7 @@ apportionment.has_economic_nexus true eq
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_description>
+        <action_dsl>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_dsl>
         <action_postfix>
 0.0 apportionment.state_tax xdef
 apportionment.state_payments apportionment.state_refund_or_owed xdef
@@ -89,7 +89,7 @@ apportionment.state_payments apportionment.state_refund_or_owed xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus is equal to true or apportionment.has_physical_presence is equal to true</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true eq
 { pop apportionment.has_physical_presence true eq } over not if
@@ -102,7 +102,7 @@ apportionment.has_economic_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate IL state additions and subtractions; Calculate state-specific adjustments to federal taxable income</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 0.0 /additions xdef
 0.0 /subtractions xdef
@@ -115,7 +115,7 @@ subtractions apportionment.state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no state adjustments calculated</action_comment>
-        <action_description>apportionment.state_additions = 0.0; apportionment.state_subtractions = 0.0</action_description>
+        <action_dsl>apportionment.state_additions = 0.0; apportionment.state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 apportionment.state_additions xdef
 0.0 apportionment.state_subtractions xdef
@@ -141,7 +141,7 @@ subtractions apportionment.state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus is equal to true or apportionment.has_physical_presence is equal to true</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true eq
 { pop apportionment.has_physical_presence true eq } over not if
@@ -153,7 +153,7 @@ apportionment.has_economic_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive state taxable income; apportionment.state_taxable_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.state_taxable_income 0 &gt;
 </condition_postfix>
@@ -166,7 +166,7 @@ apportionment.state_taxable_income 0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate IL tax at 9.5% flat rate; Calculate IL state tax, apply credits, and calculate refund/owed</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 apportionment.state_taxable_income apportionment.state_tax_rate mul apportionment.state_tax xdef
 0.0 apportionment.state_tax apportionment.state_credits sub max apportionment.state_tax xdef
@@ -178,7 +178,7 @@ apportionment.state_payments apportionment.state_tax sub apportionment.state_ref
       <action_details>
         <action_number>2</action_number>
         <action_comment>No IL nexus - no tax liability</action_comment>
-        <action_description>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_description>
+        <action_dsl>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_dsl>
         <action_postfix>
 0.0 apportionment.state_tax xdef
 apportionment.state_payments apportionment.state_refund_or_owed xdef
@@ -189,7 +189,7 @@ apportionment.state_payments apportionment.state_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>Nexus but no taxable income - no tax liability</action_comment>
-        <action_description>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_description>
+        <action_dsl>apportionment.state_tax = 0.0; apportionment.state_refund_or_owed = apportionment.state_payments</action_dsl>
         <action_postfix>
 0.0 apportionment.state_tax xdef
 apportionment.state_payments apportionment.state_refund_or_owed xdef
@@ -215,7 +215,7 @@ apportionment.state_payments apportionment.state_refund_or_owed xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Must have IL nexus; apportionment.has_economic_nexus is equal to true or apportionment.has_physical_presence is equal to true</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true eq
 { pop apportionment.has_physical_presence true eq } over not if
@@ -227,7 +227,7 @@ apportionment.has_economic_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive tax base for replacement tax calculation; apportionment.state_taxable_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.state_taxable_income 0 &gt;
 </condition_postfix>
@@ -240,7 +240,7 @@ apportionment.state_taxable_income 0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate replacement tax at 2.5%; Calculate replacement tax, add to total state tax, recalculate refund/owed</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 apportionment.state_taxable_income result.il_replacement_tax_rate mul result.il_replacement_tax xdef
 apportionment.state_tax result.il_replacement_tax add apportionment.state_tax xdef
@@ -252,7 +252,7 @@ apportionment.state_payments apportionment.state_tax sub apportionment.state_ref
       <action_details>
         <action_number>2</action_number>
         <action_comment>No replacement tax - no IL nexus</action_comment>
-        <action_description>result.il_replacement_tax = 0.0</action_description>
+        <action_dsl>result.il_replacement_tax = 0.0</action_dsl>
         <action_postfix>
 0.0 result.il_replacement_tax xdef
 "No replacement tax - no IL nexus." result.policy_statements swap addto
@@ -262,7 +262,7 @@ apportionment.state_payments apportionment.state_tax sub apportionment.state_ref
       <action_details>
         <action_number>3</action_number>
         <action_comment>No replacement tax - no positive tax base</action_comment>
-        <action_description>result.il_replacement_tax = 0.0</action_description>
+        <action_dsl>result.il_replacement_tax = 0.0</action_dsl>
         <action_postfix>
 0.0 result.il_replacement_tax xdef
 "No replacement tax - no positive tax base." result.policy_statements swap addto

--- a/sampleprojects/CorporateTax/xml/states/IN_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/IN_corp_dt.xml
@@ -13,7 +13,7 @@
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Indiana filing requirement check</action_description>
+        <action_dsl>Initialize Indiana filing requirement check</action_dsl>
         <action_postfix>
 "Indiana Corporate Filing Requirement Check Started" job.audit_trail swap addto
 false result.in_has_nexus xdef
@@ -24,7 +24,7 @@ false result.in_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in Indiana</condition_comment>
-        <condition_description>result.has_physical_presence_in is equal to true</condition_description>
+        <condition_dsl>result.has_physical_presence_in is equal to true</condition_dsl>
         <condition_postfix>
 result.has_physical_presence_in true eq
 </condition_postfix>
@@ -35,7 +35,7 @@ result.has_physical_presence_in true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets economic nexus threshold ($100K gross receipts, no transaction count as of Jan 1, 2024); result.in_gross_receipts is greater than or equal to result.in_economic_nexus_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.in_gross_receipts result.in_economic_nexus_threshold &gt;=
 </condition_postfix>
@@ -48,7 +48,7 @@ result.in_gross_receipts result.in_economic_nexus_threshold &gt;=
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus - filing required</action_comment>
-        <action_description>result.in_has_nexus = true</action_description>
+        <action_dsl>result.in_has_nexus = true</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 true result.in_has_nexus xdef
@@ -59,7 +59,7 @@ true result.in_has_nexus xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus - filing required</action_comment>
-        <action_description>result.in_has_nexus = true</action_description>
+        <action_dsl>result.in_has_nexus = true</action_dsl>
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 true result.in_has_nexus xdef
@@ -70,7 +70,7 @@ true result.in_has_nexus xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>result.in_has_nexus = false; result.in_tax_liability = 0.0</action_description>
+        <action_dsl>result.in_has_nexus = false; result.in_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 false result.in_has_nexus xdef
@@ -94,7 +94,7 @@ false result.in_has_nexus xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Indiana income adjustments</action_description>
+        <action_dsl>Initialize Indiana income adjustments</action_dsl>
         <action_postfix>
 "Indiana Corporate Income Adjustments Calculation Started" job.audit_trail swap addto
 0.0 result.in_state_additions xdef
@@ -106,7 +106,7 @@ false result.in_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Indiana nexus</condition_comment>
-        <condition_description>result.in_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.in_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.in_has_nexus true eq
 </condition_postfix>
@@ -118,7 +118,7 @@ result.in_has_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Indiana state additions and subtractions; Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Indiana state additions
 0.0 /in_additions xdef
@@ -161,7 +161,7 @@ in_subtractions result.in_state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no adjustments</action_comment>
-        <action_description>result.in_state_additions = 0.0; result.in_state_subtractions = 0.0</action_description>
+        <action_dsl>result.in_state_additions = 0.0; result.in_state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 result.in_state_additions xdef
 0.0 result.in_state_subtractions xdef
@@ -184,7 +184,7 @@ in_subtractions result.in_state_subtractions xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Indiana tax calculation</action_description>
+        <action_dsl>Initialize Indiana tax calculation</action_dsl>
         <action_postfix>
 "Indiana Corporate Tax Calculation Started" job.audit_trail swap addto
 0.0 result.in_taxable_income xdef
@@ -196,7 +196,7 @@ in_subtractions result.in_state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Indiana nexus</condition_comment>
-        <condition_description>result.in_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.in_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.in_has_nexus true eq
 </condition_postfix>
@@ -207,7 +207,7 @@ result.in_has_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive taxable income; result.in_apportioned_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.in_apportioned_income 0.0 &gt;
 </condition_postfix>
@@ -220,7 +220,7 @@ result.in_apportioned_income 0.0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Indiana corporate tax (flat rate 4.9%); Apply Indiana 4.9% flat rate</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Indiana taxable income
 // Federal taxable income apportioned to IN + additions - subtractions
@@ -250,7 +250,7 @@ result.in_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>result.in_taxable_income = 0.0; result.in_tax_liability = 0.0</action_description>
+        <action_dsl>result.in_taxable_income = 0.0; result.in_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No taxable income - no tax liability
 0.0 result.in_taxable_income xdef
@@ -263,7 +263,7 @@ result.in_estimated_payments result.in_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>result.in_taxable_income = 0.0; result.in_tax_liability = 0.0</action_description>
+        <action_dsl>result.in_taxable_income = 0.0; result.in_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no tax liability
 0.0 result.in_taxable_income xdef

--- a/sampleprojects/CorporateTax/xml/states/KS_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/KS_corp_dt.xml
@@ -13,7 +13,7 @@
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Kansas filing requirement check</action_description>
+        <action_dsl>Initialize Kansas filing requirement check</action_dsl>
         <action_postfix>
 "Kansas Corporate Filing Requirement Check Started" job.audit_trail swap addto
 false result.ks_has_nexus xdef
@@ -24,7 +24,7 @@ false result.ks_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in Kansas</condition_comment>
-        <condition_description>result.has_physical_presence_ks is equal to true</condition_description>
+        <condition_dsl>result.has_physical_presence_ks is equal to true</condition_dsl>
         <condition_postfix>
 result.has_physical_presence_ks true eq
 </condition_postfix>
@@ -35,7 +35,7 @@ result.has_physical_presence_ks true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets economic nexus threshold ($100K gross receipts or 200 transactions); result.ks_gross_receipts is greater than or equal to result.ks_economic_nexus_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.ks_gross_receipts result.ks_economic_nexus_threshold &gt;=
 </condition_postfix>
@@ -48,7 +48,7 @@ result.ks_gross_receipts result.ks_economic_nexus_threshold &gt;=
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus - filing required</action_comment>
-        <action_description>result.ks_has_nexus = true</action_description>
+        <action_dsl>result.ks_has_nexus = true</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 true result.ks_has_nexus xdef
@@ -59,7 +59,7 @@ true result.ks_has_nexus xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus - filing required</action_comment>
-        <action_description>result.ks_has_nexus = true</action_description>
+        <action_dsl>result.ks_has_nexus = true</action_dsl>
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 true result.ks_has_nexus xdef
@@ -70,7 +70,7 @@ true result.ks_has_nexus xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>result.ks_has_nexus = false; result.ks_tax_liability = 0.0</action_description>
+        <action_dsl>result.ks_has_nexus = false; result.ks_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 false result.ks_has_nexus xdef
@@ -94,7 +94,7 @@ false result.ks_has_nexus xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Kansas income adjustments</action_description>
+        <action_dsl>Initialize Kansas income adjustments</action_dsl>
         <action_postfix>
 "Kansas Corporate Income Adjustments Calculation Started" job.audit_trail swap addto
 0.0 result.ks_state_additions xdef
@@ -106,7 +106,7 @@ false result.ks_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Kansas nexus</condition_comment>
-        <condition_description>result.ks_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.ks_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.ks_has_nexus true eq
 </condition_postfix>
@@ -118,7 +118,7 @@ result.ks_has_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Kansas state additions and subtractions; Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Kansas state additions
 0.0 /ks_additions xdef
@@ -167,7 +167,7 @@ ks_subtractions result.ks_state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no adjustments</action_comment>
-        <action_description>result.ks_state_additions = 0.0; result.ks_state_subtractions = 0.0</action_description>
+        <action_dsl>result.ks_state_additions = 0.0; result.ks_state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 result.ks_state_additions xdef
 0.0 result.ks_state_subtractions xdef
@@ -190,7 +190,7 @@ ks_subtractions result.ks_state_subtractions xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Kansas tax calculation</action_description>
+        <action_dsl>Initialize Kansas tax calculation</action_dsl>
         <action_postfix>
 "Kansas Corporate Tax Calculation Started" job.audit_trail swap addto
 0.0 result.ks_taxable_income xdef
@@ -204,7 +204,7 @@ ks_subtractions result.ks_state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Kansas nexus</condition_comment>
-        <condition_description>result.ks_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.ks_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.ks_has_nexus true eq
 </condition_postfix>
@@ -216,7 +216,7 @@ result.ks_has_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive taxable income; result.ks_apportioned_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.ks_apportioned_income 0.0 &gt;
 </condition_postfix>
@@ -228,7 +228,7 @@ result.ks_apportioned_income 0.0 &gt;
       <condition_details>
         <condition_number>3</condition_number>
         <condition_comment>Income exceeds $50,000 surtax threshold; result.ks_taxable_income is greater than result.ks_surtax_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.ks_taxable_income result.ks_surtax_threshold &gt;
 </condition_postfix>
@@ -242,7 +242,7 @@ result.ks_taxable_income result.ks_surtax_threshold &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Kansas tax with base rate + surtax (income over $50K); Apply 4.0% base + 3.0% surtax on income over $50K</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Kansas taxable income
 result.ks_apportioned_income
@@ -282,7 +282,7 @@ result.ks_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Calculate Kansas tax - income $50K or less (base rate only); Apply only 4.0% base rate</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Kansas taxable income
 result.ks_apportioned_income
@@ -313,7 +313,7 @@ result.ks_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>result.ks_taxable_income = 0.0; result.ks_tax_liability = 0.0</action_description>
+        <action_dsl>result.ks_taxable_income = 0.0; result.ks_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No taxable income - no tax liability
 0.0 result.ks_taxable_income xdef
@@ -326,7 +326,7 @@ result.ks_estimated_payments result.ks_refund_or_owed xdef
       <action_details>
         <action_number>4</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>result.ks_taxable_income = 0.0; result.ks_tax_liability = 0.0</action_description>
+        <action_dsl>result.ks_taxable_income = 0.0; result.ks_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no tax liability
 0.0 result.ks_taxable_income xdef

--- a/sampleprojects/CorporateTax/xml/states/KY_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/KY_corp_dt.xml
@@ -13,7 +13,7 @@
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Kentucky filing requirement check</action_description>
+        <action_dsl>Initialize Kentucky filing requirement check</action_dsl>
         <action_postfix>
 "Kentucky Corporate Filing Requirement Check Started" job.audit_trail swap addto
 false result.ky_has_nexus xdef
@@ -24,7 +24,7 @@ false result.ky_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in Kentucky</condition_comment>
-        <condition_description>result.has_physical_presence_ky is equal to true</condition_description>
+        <condition_dsl>result.has_physical_presence_ky is equal to true</condition_dsl>
         <condition_postfix>
 result.has_physical_presence_ky true eq
 </condition_postfix>
@@ -35,7 +35,7 @@ result.has_physical_presence_ky true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets economic nexus threshold ($100K gross receipts or 200 transactions); result.ky_gross_receipts is greater than or equal to result.ky_economic_nexus_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.ky_gross_receipts result.ky_economic_nexus_threshold &gt;=
 </condition_postfix>
@@ -48,7 +48,7 @@ result.ky_gross_receipts result.ky_economic_nexus_threshold &gt;=
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus - filing required</action_comment>
-        <action_description>result.ky_has_nexus = true</action_description>
+        <action_dsl>result.ky_has_nexus = true</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 true result.ky_has_nexus xdef
@@ -59,7 +59,7 @@ true result.ky_has_nexus xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus - filing required</action_comment>
-        <action_description>result.ky_has_nexus = true</action_description>
+        <action_dsl>result.ky_has_nexus = true</action_dsl>
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 true result.ky_has_nexus xdef
@@ -70,7 +70,7 @@ true result.ky_has_nexus xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>result.ky_has_nexus = false; result.ky_tax_liability = 0.0</action_description>
+        <action_dsl>result.ky_has_nexus = false; result.ky_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 false result.ky_has_nexus xdef
@@ -94,7 +94,7 @@ false result.ky_has_nexus xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Kentucky income adjustments</action_description>
+        <action_dsl>Initialize Kentucky income adjustments</action_dsl>
         <action_postfix>
 "Kentucky Corporate Income Adjustments Calculation Started" job.audit_trail swap addto
 0.0 result.ky_state_additions xdef
@@ -106,7 +106,7 @@ false result.ky_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Kentucky nexus</condition_comment>
-        <condition_description>result.ky_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.ky_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.ky_has_nexus true eq
 </condition_postfix>
@@ -118,7 +118,7 @@ result.ky_has_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Kentucky state additions and subtractions; Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Kentucky state additions
 0.0 /ky_additions xdef
@@ -161,7 +161,7 @@ ky_subtractions result.ky_state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no adjustments</action_comment>
-        <action_description>result.ky_state_additions = 0.0; result.ky_state_subtractions = 0.0</action_description>
+        <action_dsl>result.ky_state_additions = 0.0; result.ky_state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 result.ky_state_additions xdef
 0.0 result.ky_state_subtractions xdef
@@ -184,7 +184,7 @@ ky_subtractions result.ky_state_subtractions xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Kentucky tax calculation</action_description>
+        <action_dsl>Initialize Kentucky tax calculation</action_dsl>
         <action_postfix>
 "Kentucky Corporate Tax Calculation Started" job.audit_trail swap addto
 0.0 result.ky_taxable_income xdef
@@ -196,7 +196,7 @@ ky_subtractions result.ky_state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Kentucky nexus</condition_comment>
-        <condition_description>result.ky_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.ky_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.ky_has_nexus true eq
 </condition_postfix>
@@ -207,7 +207,7 @@ result.ky_has_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive taxable income; result.ky_apportioned_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.ky_apportioned_income 0.0 &gt;
 </condition_postfix>
@@ -220,7 +220,7 @@ result.ky_apportioned_income 0.0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Kentucky corporate tax (flat rate 4.5%); Apply Kentucky 4.5% flat rate</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Kentucky taxable income
 // Federal taxable income apportioned to KY + additions - subtractions
@@ -250,7 +250,7 @@ result.ky_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>result.ky_taxable_income = 0.0; result.ky_tax_liability = 0.0</action_description>
+        <action_dsl>result.ky_taxable_income = 0.0; result.ky_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No taxable income - no tax liability
 0.0 result.ky_taxable_income xdef
@@ -263,7 +263,7 @@ result.ky_estimated_payments result.ky_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>result.ky_taxable_income = 0.0; result.ky_tax_liability = 0.0</action_description>
+        <action_dsl>result.ky_taxable_income = 0.0; result.ky_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no tax liability
 0.0 result.ky_taxable_income xdef

--- a/sampleprojects/CorporateTax/xml/states/LA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/LA_corp_dt.xml
@@ -13,7 +13,7 @@
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Louisiana filing requirement check</action_description>
+        <action_dsl>Initialize Louisiana filing requirement check</action_dsl>
         <action_postfix>
 "Louisiana Corporate Filing Requirement Check Started" job.audit_trail swap addto
 false result.la_has_nexus xdef
@@ -24,7 +24,7 @@ false result.la_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in Louisiana</condition_comment>
-        <condition_description>result.has_physical_presence_la is equal to true</condition_description>
+        <condition_dsl>result.has_physical_presence_la is equal to true</condition_dsl>
         <condition_postfix>
 result.has_physical_presence_la true eq
 </condition_postfix>
@@ -35,7 +35,7 @@ result.has_physical_presence_la true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets economic nexus threshold ($100K gross receipts, no transaction count as of 2023); result.la_gross_receipts is greater than or equal to result.la_economic_nexus_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.la_gross_receipts result.la_economic_nexus_threshold &gt;=
 </condition_postfix>
@@ -48,7 +48,7 @@ result.la_gross_receipts result.la_economic_nexus_threshold &gt;=
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus - filing required</action_comment>
-        <action_description>result.la_has_nexus = true</action_description>
+        <action_dsl>result.la_has_nexus = true</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 true result.la_has_nexus xdef
@@ -59,7 +59,7 @@ true result.la_has_nexus xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus - filing required</action_comment>
-        <action_description>result.la_has_nexus = true</action_description>
+        <action_dsl>result.la_has_nexus = true</action_dsl>
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 true result.la_has_nexus xdef
@@ -70,7 +70,7 @@ true result.la_has_nexus xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>result.la_has_nexus = false; result.la_tax_liability = 0.0</action_description>
+        <action_dsl>result.la_has_nexus = false; result.la_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 false result.la_has_nexus xdef
@@ -94,7 +94,7 @@ false result.la_has_nexus xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Louisiana income adjustments</action_description>
+        <action_dsl>Initialize Louisiana income adjustments</action_dsl>
         <action_postfix>
 "Louisiana Corporate Income Adjustments Calculation Started" job.audit_trail swap addto
 0.0 result.la_state_additions xdef
@@ -106,7 +106,7 @@ false result.la_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Louisiana nexus</condition_comment>
-        <condition_description>result.la_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.la_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.la_has_nexus true eq
 </condition_postfix>
@@ -118,7 +118,7 @@ result.la_has_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Louisiana state additions and subtractions; Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Louisiana state additions
 0.0 /la_additions xdef
@@ -160,7 +160,7 @@ la_subtractions result.la_state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no adjustments</action_comment>
-        <action_description>result.la_state_additions = 0.0; result.la_state_subtractions = 0.0</action_description>
+        <action_dsl>result.la_state_additions = 0.0; result.la_state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 result.la_state_additions xdef
 0.0 result.la_state_subtractions xdef
@@ -183,7 +183,7 @@ la_subtractions result.la_state_subtractions xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Louisiana tax calculation</action_description>
+        <action_dsl>Initialize Louisiana tax calculation</action_dsl>
         <action_postfix>
 "Louisiana Corporate Tax Calculation Started" job.audit_trail swap addto
 0.0 result.la_taxable_income xdef
@@ -195,7 +195,7 @@ la_subtractions result.la_state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Louisiana nexus</condition_comment>
-        <condition_description>result.la_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.la_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.la_has_nexus true eq
 </condition_postfix>
@@ -206,7 +206,7 @@ result.la_has_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive taxable income; result.la_apportioned_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.la_apportioned_income 0.0 &gt;
 </condition_postfix>
@@ -219,7 +219,7 @@ result.la_apportioned_income 0.0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Louisiana corporate tax (flat rate 5.5% - NEW for 2025); Apply Louisiana 5.5% flat rate</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Louisiana taxable income
 // Federal taxable income apportioned to LA + additions - subtractions
@@ -249,7 +249,7 @@ result.la_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>result.la_taxable_income = 0.0; result.la_tax_liability = 0.0</action_description>
+        <action_dsl>result.la_taxable_income = 0.0; result.la_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No taxable income - no tax liability
 0.0 result.la_taxable_income xdef
@@ -262,7 +262,7 @@ result.la_estimated_payments result.la_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>result.la_taxable_income = 0.0; result.la_tax_liability = 0.0</action_description>
+        <action_dsl>result.la_taxable_income = 0.0; result.la_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no tax liability
 0.0 result.la_taxable_income xdef

--- a/sampleprojects/CorporateTax/xml/states/MA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/MA_corp_dt.xml
@@ -13,7 +13,7 @@
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Massachusetts filing requirement check</action_description>
+        <action_dsl>Initialize Massachusetts filing requirement check</action_dsl>
         <action_postfix>
 "Massachusetts Corporate Filing Requirement Check Started" job.audit_trail swap addto
 false result.ma_has_nexus xdef
@@ -24,7 +24,7 @@ false result.ma_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in Massachusetts</condition_comment>
-        <condition_description>result.has_physical_presence_ma is equal to true</condition_description>
+        <condition_dsl>result.has_physical_presence_ma is equal to true</condition_dsl>
         <condition_postfix>
 result.has_physical_presence_ma true eq
 </condition_postfix>
@@ -35,7 +35,7 @@ result.has_physical_presence_ma true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets economic nexus threshold ($500K gross receipts); result.ma_gross_receipts is greater than or equal to result.ma_economic_nexus_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.ma_gross_receipts result.ma_economic_nexus_threshold &gt;=
 </condition_postfix>
@@ -48,7 +48,7 @@ result.ma_gross_receipts result.ma_economic_nexus_threshold &gt;=
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus - filing required</action_comment>
-        <action_description>result.ma_has_nexus = true</action_description>
+        <action_dsl>result.ma_has_nexus = true</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 true result.ma_has_nexus xdef
@@ -59,7 +59,7 @@ true result.ma_has_nexus xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus - filing required</action_comment>
-        <action_description>result.ma_has_nexus = true</action_description>
+        <action_dsl>result.ma_has_nexus = true</action_dsl>
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 true result.ma_has_nexus xdef
@@ -70,7 +70,7 @@ true result.ma_has_nexus xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>result.ma_has_nexus = false; result.ma_tax_liability = 0.0</action_description>
+        <action_dsl>result.ma_has_nexus = false; result.ma_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 false result.ma_has_nexus xdef
@@ -94,7 +94,7 @@ false result.ma_has_nexus xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Massachusetts income adjustments</action_description>
+        <action_dsl>Initialize Massachusetts income adjustments</action_dsl>
         <action_postfix>
 "Massachusetts Corporate Income Adjustments Calculation Started" job.audit_trail swap addto
 0.0 result.ma_state_additions xdef
@@ -106,7 +106,7 @@ false result.ma_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Massachusetts nexus</condition_comment>
-        <condition_description>result.ma_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.ma_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.ma_has_nexus true eq
 </condition_postfix>
@@ -118,7 +118,7 @@ result.ma_has_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Massachusetts state additions and subtractions; Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Massachusetts state additions
 0.0 /ma_additions xdef
@@ -162,7 +162,7 @@ ma_subtractions result.ma_state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no adjustments</action_comment>
-        <action_description>result.ma_state_additions = 0.0; result.ma_state_subtractions = 0.0</action_description>
+        <action_dsl>result.ma_state_additions = 0.0; result.ma_state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 result.ma_state_additions xdef
 0.0 result.ma_state_subtractions xdef
@@ -185,7 +185,7 @@ ma_subtractions result.ma_state_subtractions xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Massachusetts tax calculation</action_description>
+        <action_dsl>Initialize Massachusetts tax calculation</action_dsl>
         <action_postfix>
 "Massachusetts Corporate Tax Calculation Started" job.audit_trail swap addto
 0.0 result.ma_taxable_income xdef
@@ -197,7 +197,7 @@ ma_subtractions result.ma_state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Massachusetts nexus</condition_comment>
-        <condition_description>result.ma_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.ma_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.ma_has_nexus true eq
 </condition_postfix>
@@ -208,7 +208,7 @@ result.ma_has_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive taxable income; result.ma_apportioned_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.ma_apportioned_income 0.0 &gt;
 </condition_postfix>
@@ -221,7 +221,7 @@ result.ma_apportioned_income 0.0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Massachusetts corporate tax (flat rate 8.0%); Apply Massachusetts 8.0% flat rate</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Massachusetts taxable income
 // Federal taxable income apportioned to MA + additions - subtractions
@@ -251,7 +251,7 @@ result.ma_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>result.ma_taxable_income = 0.0; result.ma_tax_liability = 0.0</action_description>
+        <action_dsl>result.ma_taxable_income = 0.0; result.ma_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No taxable income - no tax liability
 0.0 result.ma_taxable_income xdef
@@ -264,7 +264,7 @@ result.ma_estimated_payments result.ma_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>result.ma_taxable_income = 0.0; result.ma_tax_liability = 0.0</action_description>
+        <action_dsl>result.ma_taxable_income = 0.0; result.ma_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no tax liability
 0.0 result.ma_taxable_income xdef

--- a/sampleprojects/CorporateTax/xml/states/MD_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/MD_corp_dt.xml
@@ -13,7 +13,7 @@
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Maryland filing requirement check</action_description>
+        <action_dsl>Initialize Maryland filing requirement check</action_dsl>
         <action_postfix>
 "Maryland Corporate Filing Requirement Check Started" job.audit_trail swap addto
 false result.md_has_nexus xdef
@@ -24,7 +24,7 @@ false result.md_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in Maryland</condition_comment>
-        <condition_description>result.has_physical_presence_md is equal to true</condition_description>
+        <condition_dsl>result.has_physical_presence_md is equal to true</condition_dsl>
         <condition_postfix>
 result.has_physical_presence_md true eq
 </condition_postfix>
@@ -35,7 +35,7 @@ result.has_physical_presence_md true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets economic nexus threshold ($100K gross receipts); result.md_gross_receipts is greater than or equal to result.md_economic_nexus_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.md_gross_receipts result.md_economic_nexus_threshold &gt;=
 </condition_postfix>
@@ -48,7 +48,7 @@ result.md_gross_receipts result.md_economic_nexus_threshold &gt;=
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus - filing required</action_comment>
-        <action_description>result.md_has_nexus = true</action_description>
+        <action_dsl>result.md_has_nexus = true</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 true result.md_has_nexus xdef
@@ -59,7 +59,7 @@ true result.md_has_nexus xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus - filing required</action_comment>
-        <action_description>result.md_has_nexus = true</action_description>
+        <action_dsl>result.md_has_nexus = true</action_dsl>
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 true result.md_has_nexus xdef
@@ -70,7 +70,7 @@ true result.md_has_nexus xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>result.md_has_nexus = false; result.md_tax_liability = 0.0</action_description>
+        <action_dsl>result.md_has_nexus = false; result.md_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 false result.md_has_nexus xdef
@@ -94,7 +94,7 @@ false result.md_has_nexus xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Maryland income adjustments</action_description>
+        <action_dsl>Initialize Maryland income adjustments</action_dsl>
         <action_postfix>
 "Maryland Corporate Income Adjustments Calculation Started" job.audit_trail swap addto
 0.0 result.md_state_additions xdef
@@ -106,7 +106,7 @@ false result.md_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Maryland nexus</condition_comment>
-        <condition_description>result.md_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.md_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.md_has_nexus true eq
 </condition_postfix>
@@ -118,7 +118,7 @@ result.md_has_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Maryland state additions and subtractions; Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Maryland state additions
 0.0 /md_additions xdef
@@ -157,7 +157,7 @@ md_subtractions result.md_state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no adjustments</action_comment>
-        <action_description>result.md_state_additions = 0.0; result.md_state_subtractions = 0.0</action_description>
+        <action_dsl>result.md_state_additions = 0.0; result.md_state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 result.md_state_additions xdef
 0.0 result.md_state_subtractions xdef
@@ -180,7 +180,7 @@ md_subtractions result.md_state_subtractions xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Maryland tax calculation</action_description>
+        <action_dsl>Initialize Maryland tax calculation</action_dsl>
         <action_postfix>
 "Maryland Corporate Tax Calculation Started" job.audit_trail swap addto
 0.0 result.md_taxable_income xdef
@@ -192,7 +192,7 @@ md_subtractions result.md_state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Maryland nexus</condition_comment>
-        <condition_description>result.md_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.md_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.md_has_nexus true eq
 </condition_postfix>
@@ -203,7 +203,7 @@ result.md_has_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive taxable income; result.md_apportioned_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.md_apportioned_income 0.0 &gt;
 </condition_postfix>
@@ -216,7 +216,7 @@ result.md_apportioned_income 0.0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Maryland corporate tax (flat rate 8.25%); Apply Maryland 8.25% flat rate</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Maryland taxable income
 // Federal taxable income apportioned to MD + additions - subtractions
@@ -246,7 +246,7 @@ result.md_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>result.md_taxable_income = 0.0; result.md_tax_liability = 0.0</action_description>
+        <action_dsl>result.md_taxable_income = 0.0; result.md_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No taxable income - no tax liability
 0.0 result.md_taxable_income xdef
@@ -259,7 +259,7 @@ result.md_estimated_payments result.md_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>result.md_taxable_income = 0.0; result.md_tax_liability = 0.0</action_description>
+        <action_dsl>result.md_taxable_income = 0.0; result.md_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no tax liability
 0.0 result.md_taxable_income xdef

--- a/sampleprojects/CorporateTax/xml/states/ME_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/ME_corp_dt.xml
@@ -13,7 +13,7 @@
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Maine filing requirement check</action_description>
+        <action_dsl>Initialize Maine filing requirement check</action_dsl>
         <action_postfix>
 "Maine Corporate Filing Requirement Check Started" job.audit_trail swap addto
 false result.me_has_nexus xdef
@@ -24,7 +24,7 @@ false result.me_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in Maine</condition_comment>
-        <condition_description>result.has_physical_presence_me is equal to true</condition_description>
+        <condition_dsl>result.has_physical_presence_me is equal to true</condition_dsl>
         <condition_postfix>
 result.has_physical_presence_me true eq
 </condition_postfix>
@@ -35,7 +35,7 @@ result.has_physical_presence_me true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets economic nexus threshold (factor presence standards); result.me_gross_receipts is greater than or equal to result.me_economic_nexus_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.me_gross_receipts result.me_economic_nexus_threshold &gt;=
 </condition_postfix>
@@ -48,7 +48,7 @@ result.me_gross_receipts result.me_economic_nexus_threshold &gt;=
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus - filing required</action_comment>
-        <action_description>result.me_has_nexus = true</action_description>
+        <action_dsl>result.me_has_nexus = true</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 true result.me_has_nexus xdef
@@ -59,7 +59,7 @@ true result.me_has_nexus xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus - filing required</action_comment>
-        <action_description>result.me_has_nexus = true</action_description>
+        <action_dsl>result.me_has_nexus = true</action_dsl>
         <action_postfix>
 // Economic nexus established per factor presence standards - filing required
 true result.me_has_nexus xdef
@@ -70,7 +70,7 @@ true result.me_has_nexus xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>result.me_has_nexus = false; result.me_tax_liability = 0.0</action_description>
+        <action_dsl>result.me_has_nexus = false; result.me_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 false result.me_has_nexus xdef
@@ -94,7 +94,7 @@ false result.me_has_nexus xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Maine income adjustments</action_description>
+        <action_dsl>Initialize Maine income adjustments</action_dsl>
         <action_postfix>
 "Maine Corporate Income Adjustments Calculation Started" job.audit_trail swap addto
 0.0 result.me_state_additions xdef
@@ -106,7 +106,7 @@ false result.me_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Maine nexus</condition_comment>
-        <condition_description>result.me_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.me_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.me_has_nexus true eq
 </condition_postfix>
@@ -118,7 +118,7 @@ result.me_has_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Maine state additions and subtractions; Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Maine state additions
 0.0 /me_additions xdef
@@ -163,7 +163,7 @@ me_subtractions result.me_state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no adjustments</action_comment>
-        <action_description>result.me_state_additions = 0.0; result.me_state_subtractions = 0.0</action_description>
+        <action_dsl>result.me_state_additions = 0.0; result.me_state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 result.me_state_additions xdef
 0.0 result.me_state_subtractions xdef
@@ -186,7 +186,7 @@ me_subtractions result.me_state_subtractions xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Maine tax calculation</action_description>
+        <action_dsl>Initialize Maine tax calculation</action_dsl>
         <action_postfix>
 "Maine Corporate Tax Calculation Started" job.audit_trail swap addto
 0.0 result.me_taxable_income xdef
@@ -198,7 +198,7 @@ me_subtractions result.me_state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Maine nexus</condition_comment>
-        <condition_description>result.me_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.me_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.me_has_nexus true eq
 </condition_postfix>
@@ -209,7 +209,7 @@ result.me_has_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive taxable income; result.me_apportioned_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.me_apportioned_income 0.0 &gt;
 </condition_postfix>
@@ -222,7 +222,7 @@ result.me_apportioned_income 0.0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Maine corporate tax (graduated rates); Apply Maine graduated rates (3.5%, 7.5%, 8.3%, 8.93%)</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Maine taxable income
 // Federal taxable income apportioned to ME + additions - subtractions
@@ -283,7 +283,7 @@ result.me_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>result.me_taxable_income = 0.0; result.me_tax_liability = 0.0</action_description>
+        <action_dsl>result.me_taxable_income = 0.0; result.me_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No taxable income - no tax liability
 0.0 result.me_taxable_income xdef
@@ -296,7 +296,7 @@ result.me_estimated_payments result.me_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>result.me_taxable_income = 0.0; result.me_tax_liability = 0.0</action_description>
+        <action_dsl>result.me_taxable_income = 0.0; result.me_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no tax liability
 0.0 result.me_taxable_income xdef

--- a/sampleprojects/CorporateTax/xml/states/MI_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/MI_corp_dt.xml
@@ -13,7 +13,7 @@
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Michigan filing requirement check</action_description>
+        <action_dsl>Initialize Michigan filing requirement check</action_dsl>
         <action_postfix>
 "Michigan Corporate Filing Requirement Check Started" job.audit_trail swap addto
 false result.mi_has_nexus xdef
@@ -24,7 +24,7 @@ false result.mi_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in Michigan</condition_comment>
-        <condition_description>result.has_physical_presence_mi is equal to true</condition_description>
+        <condition_dsl>result.has_physical_presence_mi is equal to true</condition_dsl>
         <condition_postfix>
 result.has_physical_presence_mi true eq
 </condition_postfix>
@@ -35,7 +35,7 @@ result.has_physical_presence_mi true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets economic nexus threshold ($100K gross receipts); result.mi_gross_receipts is greater than or equal to result.mi_economic_nexus_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.mi_gross_receipts result.mi_economic_nexus_threshold &gt;=
 </condition_postfix>
@@ -48,7 +48,7 @@ result.mi_gross_receipts result.mi_economic_nexus_threshold &gt;=
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus - filing required</action_comment>
-        <action_description>result.mi_has_nexus = true</action_description>
+        <action_dsl>result.mi_has_nexus = true</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 true result.mi_has_nexus xdef
@@ -59,7 +59,7 @@ true result.mi_has_nexus xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus - filing required</action_comment>
-        <action_description>result.mi_has_nexus = true</action_description>
+        <action_dsl>result.mi_has_nexus = true</action_dsl>
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 true result.mi_has_nexus xdef
@@ -70,7 +70,7 @@ true result.mi_has_nexus xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>result.mi_has_nexus = false; result.mi_tax_liability = 0.0</action_description>
+        <action_dsl>result.mi_has_nexus = false; result.mi_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 false result.mi_has_nexus xdef
@@ -94,7 +94,7 @@ false result.mi_has_nexus xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Michigan income adjustments</action_description>
+        <action_dsl>Initialize Michigan income adjustments</action_dsl>
         <action_postfix>
 "Michigan Corporate Income Adjustments Calculation Started" job.audit_trail swap addto
 0.0 result.mi_state_additions xdef
@@ -106,7 +106,7 @@ false result.mi_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Michigan nexus</condition_comment>
-        <condition_description>result.mi_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.mi_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.mi_has_nexus true eq
 </condition_postfix>
@@ -118,7 +118,7 @@ result.mi_has_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Michigan state additions and subtractions; Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Michigan state additions
 0.0 /mi_additions xdef
@@ -156,7 +156,7 @@ mi_subtractions result.mi_state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no adjustments</action_comment>
-        <action_description>result.mi_state_additions = 0.0; result.mi_state_subtractions = 0.0</action_description>
+        <action_dsl>result.mi_state_additions = 0.0; result.mi_state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 result.mi_state_additions xdef
 0.0 result.mi_state_subtractions xdef
@@ -179,7 +179,7 @@ mi_subtractions result.mi_state_subtractions xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Michigan tax calculation</action_description>
+        <action_dsl>Initialize Michigan tax calculation</action_dsl>
         <action_postfix>
 "Michigan Corporate Tax Calculation Started" job.audit_trail swap addto
 0.0 result.mi_taxable_income xdef
@@ -191,7 +191,7 @@ mi_subtractions result.mi_state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Michigan nexus</condition_comment>
-        <condition_description>result.mi_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.mi_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.mi_has_nexus true eq
 </condition_postfix>
@@ -202,7 +202,7 @@ result.mi_has_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive taxable income; result.mi_apportioned_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.mi_apportioned_income 0.0 &gt;
 </condition_postfix>
@@ -215,7 +215,7 @@ result.mi_apportioned_income 0.0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Michigan corporate tax (flat rate 6.0%); Apply Michigan 6.0% flat rate</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Michigan taxable income
 // Federal taxable income apportioned to MI + additions - subtractions
@@ -245,7 +245,7 @@ result.mi_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>result.mi_taxable_income = 0.0; result.mi_tax_liability = 0.0</action_description>
+        <action_dsl>result.mi_taxable_income = 0.0; result.mi_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No taxable income - no tax liability
 0.0 result.mi_taxable_income xdef
@@ -258,7 +258,7 @@ result.mi_estimated_payments result.mi_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>result.mi_taxable_income = 0.0; result.mi_tax_liability = 0.0</action_description>
+        <action_dsl>result.mi_taxable_income = 0.0; result.mi_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no tax liability
 0.0 result.mi_taxable_income xdef

--- a/sampleprojects/CorporateTax/xml/states/MN_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/MN_corp_dt.xml
@@ -13,7 +13,7 @@
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Minnesota filing requirement check</action_description>
+        <action_dsl>Initialize Minnesota filing requirement check</action_dsl>
         <action_postfix>
 "Minnesota Corporate Filing Requirement Check Started" job.audit_trail swap addto
 false result.mn_has_nexus xdef
@@ -24,7 +24,7 @@ false result.mn_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in Minnesota</condition_comment>
-        <condition_description>result.has_physical_presence_mn is equal to true</condition_description>
+        <condition_dsl>result.has_physical_presence_mn is equal to true</condition_dsl>
         <condition_postfix>
 result.has_physical_presence_mn true eq
 </condition_postfix>
@@ -35,7 +35,7 @@ result.has_physical_presence_mn true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets economic nexus threshold ($100K gross receipts); result.mn_gross_receipts is greater than or equal to result.mn_economic_nexus_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.mn_gross_receipts result.mn_economic_nexus_threshold &gt;=
 </condition_postfix>
@@ -48,7 +48,7 @@ result.mn_gross_receipts result.mn_economic_nexus_threshold &gt;=
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus - filing required</action_comment>
-        <action_description>result.mn_has_nexus = true</action_description>
+        <action_dsl>result.mn_has_nexus = true</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 true result.mn_has_nexus xdef
@@ -59,7 +59,7 @@ true result.mn_has_nexus xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus - filing required</action_comment>
-        <action_description>result.mn_has_nexus = true</action_description>
+        <action_dsl>result.mn_has_nexus = true</action_dsl>
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 true result.mn_has_nexus xdef
@@ -70,7 +70,7 @@ true result.mn_has_nexus xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>result.mn_has_nexus = false; result.mn_tax_liability = 0.0</action_description>
+        <action_dsl>result.mn_has_nexus = false; result.mn_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 false result.mn_has_nexus xdef
@@ -94,7 +94,7 @@ false result.mn_has_nexus xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Minnesota income adjustments</action_description>
+        <action_dsl>Initialize Minnesota income adjustments</action_dsl>
         <action_postfix>
 "Minnesota Corporate Income Adjustments Calculation Started" job.audit_trail swap addto
 0.0 result.mn_state_additions xdef
@@ -106,7 +106,7 @@ false result.mn_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Minnesota nexus</condition_comment>
-        <condition_description>result.mn_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.mn_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.mn_has_nexus true eq
 </condition_postfix>
@@ -118,7 +118,7 @@ result.mn_has_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Minnesota state additions and subtractions; Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Minnesota state additions
 0.0 /mn_additions xdef
@@ -155,7 +155,7 @@ mn_subtractions result.mn_state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no adjustments</action_comment>
-        <action_description>result.mn_state_additions = 0.0; result.mn_state_subtractions = 0.0</action_description>
+        <action_dsl>result.mn_state_additions = 0.0; result.mn_state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 result.mn_state_additions xdef
 0.0 result.mn_state_subtractions xdef
@@ -178,7 +178,7 @@ mn_subtractions result.mn_state_subtractions xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Minnesota tax calculation</action_description>
+        <action_dsl>Initialize Minnesota tax calculation</action_dsl>
         <action_postfix>
 "Minnesota Corporate Tax Calculation Started" job.audit_trail swap addto
 0.0 result.mn_taxable_income xdef
@@ -190,7 +190,7 @@ mn_subtractions result.mn_state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Minnesota nexus</condition_comment>
-        <condition_description>result.mn_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.mn_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.mn_has_nexus true eq
 </condition_postfix>
@@ -201,7 +201,7 @@ result.mn_has_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive taxable income; result.mn_apportioned_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.mn_apportioned_income 0.0 &gt;
 </condition_postfix>
@@ -214,7 +214,7 @@ result.mn_apportioned_income 0.0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Minnesota corporate tax (flat rate 9.5%); Apply Minnesota 9.5% flat rate</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Minnesota taxable income
 // Federal taxable income apportioned to MN + additions - subtractions
@@ -244,7 +244,7 @@ result.mn_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>result.mn_taxable_income = 0.0; result.mn_tax_liability = 0.0</action_description>
+        <action_dsl>result.mn_taxable_income = 0.0; result.mn_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No taxable income - no tax liability
 0.0 result.mn_taxable_income xdef
@@ -257,7 +257,7 @@ result.mn_estimated_payments result.mn_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>result.mn_taxable_income = 0.0; result.mn_tax_liability = 0.0</action_description>
+        <action_dsl>result.mn_taxable_income = 0.0; result.mn_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no tax liability
 0.0 result.mn_taxable_income xdef

--- a/sampleprojects/CorporateTax/xml/states/MO_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/MO_corp_dt.xml
@@ -13,7 +13,7 @@
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Missouri filing requirement check</action_description>
+        <action_dsl>Initialize Missouri filing requirement check</action_dsl>
         <action_postfix>
 "Missouri Corporate Filing Requirement Check Started" job.audit_trail swap addto
 false result.mo_has_nexus xdef
@@ -24,7 +24,7 @@ false result.mo_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in Missouri</condition_comment>
-        <condition_description>result.has_physical_presence_mo is equal to true</condition_description>
+        <condition_dsl>result.has_physical_presence_mo is equal to true</condition_dsl>
         <condition_postfix>
 result.has_physical_presence_mo true eq
 </condition_postfix>
@@ -35,7 +35,7 @@ result.has_physical_presence_mo true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets economic nexus threshold ($100K gross receipts); result.mo_gross_receipts is greater than or equal to result.mo_economic_nexus_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.mo_gross_receipts result.mo_economic_nexus_threshold &gt;=
 </condition_postfix>
@@ -48,7 +48,7 @@ result.mo_gross_receipts result.mo_economic_nexus_threshold &gt;=
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus - filing required</action_comment>
-        <action_description>result.mo_has_nexus = true</action_description>
+        <action_dsl>result.mo_has_nexus = true</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 true result.mo_has_nexus xdef
@@ -59,7 +59,7 @@ true result.mo_has_nexus xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus - filing required</action_comment>
-        <action_description>result.mo_has_nexus = true</action_description>
+        <action_dsl>result.mo_has_nexus = true</action_dsl>
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 true result.mo_has_nexus xdef
@@ -70,7 +70,7 @@ true result.mo_has_nexus xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>result.mo_has_nexus = false; result.mo_tax_liability = 0.0</action_description>
+        <action_dsl>result.mo_has_nexus = false; result.mo_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 false result.mo_has_nexus xdef
@@ -94,7 +94,7 @@ false result.mo_has_nexus xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Missouri income adjustments</action_description>
+        <action_dsl>Initialize Missouri income adjustments</action_dsl>
         <action_postfix>
 "Missouri Corporate Income Adjustments Calculation Started" job.audit_trail swap addto
 0.0 result.mo_state_additions xdef
@@ -106,7 +106,7 @@ false result.mo_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Missouri nexus</condition_comment>
-        <condition_description>result.mo_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.mo_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.mo_has_nexus true eq
 </condition_postfix>
@@ -118,7 +118,7 @@ result.mo_has_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Missouri state additions and subtractions (including 50% federal tax deduction); Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Missouri state additions
 0.0 /mo_additions xdef
@@ -163,7 +163,7 @@ mo_subtractions result.mo_state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no adjustments</action_comment>
-        <action_description>result.mo_state_additions = 0.0; result.mo_state_subtractions = 0.0</action_description>
+        <action_dsl>result.mo_state_additions = 0.0; result.mo_state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 result.mo_state_additions xdef
 0.0 result.mo_state_subtractions xdef
@@ -186,7 +186,7 @@ mo_subtractions result.mo_state_subtractions xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Missouri tax calculation</action_description>
+        <action_dsl>Initialize Missouri tax calculation</action_dsl>
         <action_postfix>
 "Missouri Corporate Tax Calculation Started" job.audit_trail swap addto
 0.0 result.mo_taxable_income xdef
@@ -198,7 +198,7 @@ mo_subtractions result.mo_state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Missouri nexus</condition_comment>
-        <condition_description>result.mo_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.mo_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.mo_has_nexus true eq
 </condition_postfix>
@@ -209,7 +209,7 @@ result.mo_has_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive taxable income; result.mo_apportioned_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.mo_apportioned_income 0.0 &gt;
 </condition_postfix>
@@ -222,7 +222,7 @@ result.mo_apportioned_income 0.0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Missouri corporate tax (flat rate 4.0%); Apply Missouri 4.0% flat rate</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Missouri taxable income
 // Federal taxable income apportioned to MO + additions - subtractions
@@ -253,7 +253,7 @@ result.mo_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>result.mo_taxable_income = 0.0; result.mo_tax_liability = 0.0</action_description>
+        <action_dsl>result.mo_taxable_income = 0.0; result.mo_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No taxable income - no tax liability
 // 50% federal tax deduction may create zero/negative MO income
@@ -267,7 +267,7 @@ result.mo_estimated_payments result.mo_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>result.mo_taxable_income = 0.0; result.mo_tax_liability = 0.0</action_description>
+        <action_dsl>result.mo_taxable_income = 0.0; result.mo_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no tax liability
 0.0 result.mo_taxable_income xdef

--- a/sampleprojects/CorporateTax/xml/states/MS_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/MS_corp_dt.xml
@@ -13,7 +13,7 @@
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Mississippi filing requirement check</action_description>
+        <action_dsl>Initialize Mississippi filing requirement check</action_dsl>
         <action_postfix>
 "Mississippi Corporate Filing Requirement Check Started" job.audit_trail swap addto
 false result.ms_has_nexus xdef
@@ -24,7 +24,7 @@ false result.ms_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in Mississippi</condition_comment>
-        <condition_description>result.has_physical_presence_ms is equal to true</condition_description>
+        <condition_dsl>result.has_physical_presence_ms is equal to true</condition_dsl>
         <condition_postfix>
 result.has_physical_presence_ms true eq
 </condition_postfix>
@@ -35,7 +35,7 @@ result.has_physical_presence_ms true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets economic nexus threshold ($250K gross receipts); result.ms_gross_receipts is greater than or equal to result.ms_economic_nexus_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.ms_gross_receipts result.ms_economic_nexus_threshold &gt;=
 </condition_postfix>
@@ -48,7 +48,7 @@ result.ms_gross_receipts result.ms_economic_nexus_threshold &gt;=
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus - filing required</action_comment>
-        <action_description>result.ms_has_nexus = true</action_description>
+        <action_dsl>result.ms_has_nexus = true</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 true result.ms_has_nexus xdef
@@ -59,7 +59,7 @@ true result.ms_has_nexus xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus - filing required</action_comment>
-        <action_description>result.ms_has_nexus = true</action_description>
+        <action_dsl>result.ms_has_nexus = true</action_dsl>
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 true result.ms_has_nexus xdef
@@ -70,7 +70,7 @@ true result.ms_has_nexus xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>result.ms_has_nexus = false; result.ms_tax_liability = 0.0</action_description>
+        <action_dsl>result.ms_has_nexus = false; result.ms_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 false result.ms_has_nexus xdef
@@ -94,7 +94,7 @@ false result.ms_has_nexus xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Mississippi income adjustments</action_description>
+        <action_dsl>Initialize Mississippi income adjustments</action_dsl>
         <action_postfix>
 "Mississippi Corporate Income Adjustments Calculation Started" job.audit_trail swap addto
 0.0 result.ms_state_additions xdef
@@ -106,7 +106,7 @@ false result.ms_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Mississippi nexus</condition_comment>
-        <condition_description>result.ms_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.ms_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.ms_has_nexus true eq
 </condition_postfix>
@@ -118,7 +118,7 @@ result.ms_has_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Mississippi state additions and subtractions; Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Mississippi state additions
 0.0 /ms_additions xdef
@@ -157,7 +157,7 @@ ms_subtractions result.ms_state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no adjustments</action_comment>
-        <action_description>result.ms_state_additions = 0.0; result.ms_state_subtractions = 0.0</action_description>
+        <action_dsl>result.ms_state_additions = 0.0; result.ms_state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 result.ms_state_additions xdef
 0.0 result.ms_state_subtractions xdef
@@ -180,7 +180,7 @@ ms_subtractions result.ms_state_subtractions xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Mississippi tax calculation</action_description>
+        <action_dsl>Initialize Mississippi tax calculation</action_dsl>
         <action_postfix>
 "Mississippi Corporate Tax Calculation Started" job.audit_trail swap addto
 0.0 result.ms_taxable_income xdef
@@ -192,7 +192,7 @@ ms_subtractions result.ms_state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Mississippi nexus</condition_comment>
-        <condition_description>result.ms_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.ms_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.ms_has_nexus true eq
 </condition_postfix>
@@ -203,7 +203,7 @@ result.ms_has_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive taxable income; result.ms_apportioned_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.ms_apportioned_income 0.0 &gt;
 </condition_postfix>
@@ -216,7 +216,7 @@ result.ms_apportioned_income 0.0 &gt;
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Mississippi corporate tax (graduated rates 3%, 4%, 5%); Apply Mississippi graduated rates</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Mississippi taxable income
 // Federal taxable income apportioned to MS + additions - subtractions
@@ -268,7 +268,7 @@ result.ms_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>result.ms_taxable_income = 0.0; result.ms_tax_liability = 0.0</action_description>
+        <action_dsl>result.ms_taxable_income = 0.0; result.ms_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No taxable income - no tax liability
 0.0 result.ms_taxable_income xdef
@@ -281,7 +281,7 @@ result.ms_estimated_payments result.ms_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>result.ms_taxable_income = 0.0; result.ms_tax_liability = 0.0</action_description>
+        <action_dsl>result.ms_taxable_income = 0.0; result.ms_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no tax liability
 0.0 result.ms_taxable_income xdef

--- a/sampleprojects/CorporateTax/xml/states/MT_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/MT_corp_dt.xml
@@ -13,7 +13,7 @@
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Montana filing requirement check</action_description>
+        <action_dsl>Initialize Montana filing requirement check</action_dsl>
         <action_postfix>
 "Montana Corporate Filing Requirement Check Started" job.audit_trail swap addto
 false result.mt_has_nexus xdef
@@ -24,7 +24,7 @@ false result.mt_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in Montana</condition_comment>
-        <condition_description>result.has_physical_presence_mt is equal to true</condition_description>
+        <condition_dsl>result.has_physical_presence_mt is equal to true</condition_dsl>
         <condition_postfix>
 result.has_physical_presence_mt true eq
 </condition_postfix>
@@ -35,7 +35,7 @@ result.has_physical_presence_mt true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets economic nexus threshold ($100K gross receipts or 200 transactions); result.mt_gross_receipts is greater than or equal to result.mt_economic_nexus_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.mt_gross_receipts result.mt_economic_nexus_threshold &gt;=
 </condition_postfix>
@@ -48,7 +48,7 @@ result.mt_gross_receipts result.mt_economic_nexus_threshold &gt;=
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus - filing required</action_comment>
-        <action_description>result.mt_has_nexus = true</action_description>
+        <action_dsl>result.mt_has_nexus = true</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 true result.mt_has_nexus xdef
@@ -59,7 +59,7 @@ true result.mt_has_nexus xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus - filing required</action_comment>
-        <action_description>result.mt_has_nexus = true</action_description>
+        <action_dsl>result.mt_has_nexus = true</action_dsl>
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 true result.mt_has_nexus xdef
@@ -70,7 +70,7 @@ true result.mt_has_nexus xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required</action_comment>
-        <action_description>result.mt_has_nexus = false; result.mt_tax_liability = 0.0</action_description>
+        <action_dsl>result.mt_has_nexus = false; result.mt_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no filing required
 false result.mt_has_nexus xdef
@@ -94,7 +94,7 @@ false result.mt_has_nexus xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Montana income adjustments</action_description>
+        <action_dsl>Initialize Montana income adjustments</action_dsl>
         <action_postfix>
 "Montana Corporate Income Adjustments Calculation Started" job.audit_trail swap addto
 0.0 result.mt_state_additions xdef
@@ -106,7 +106,7 @@ false result.mt_has_nexus xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Montana nexus</condition_comment>
-        <condition_description>result.mt_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.mt_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.mt_has_nexus true eq
 </condition_postfix>
@@ -118,7 +118,7 @@ result.mt_has_nexus true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Montana state additions and subtractions; Calculate state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Montana state additions
 0.0 /mt_additions xdef
@@ -158,7 +158,7 @@ mt_subtractions result.mt_state_subtractions xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no adjustments</action_comment>
-        <action_description>result.mt_state_additions = 0.0; result.mt_state_subtractions = 0.0</action_description>
+        <action_dsl>result.mt_state_additions = 0.0; result.mt_state_subtractions = 0.0</action_dsl>
         <action_postfix>
 0.0 result.mt_state_additions xdef
 0.0 result.mt_state_subtractions xdef
@@ -181,7 +181,7 @@ mt_subtractions result.mt_state_subtractions xdef
     <contexts />
     <initial_actions>
       <initial_action>
-        <action_description>Initialize Montana tax calculation</action_description>
+        <action_dsl>Initialize Montana tax calculation</action_dsl>
         <action_postfix>
 "Montana Corporate Tax Calculation Started" job.audit_trail swap addto
 0.0 result.mt_taxable_income xdef
@@ -193,7 +193,7 @@ mt_subtractions result.mt_state_subtractions xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has Montana nexus</condition_comment>
-        <condition_description>result.mt_has_nexus is equal to true</condition_description>
+        <condition_dsl>result.mt_has_nexus is equal to true</condition_dsl>
         <condition_postfix>
 result.mt_has_nexus true eq
 </condition_postfix>
@@ -205,7 +205,7 @@ result.mt_has_nexus true eq
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive taxable income; result.mt_apportioned_income is greater than 0</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.mt_apportioned_income 0.0 &gt;
 </condition_postfix>
@@ -217,7 +217,7 @@ result.mt_apportioned_income 0.0 &gt;
       <condition_details>
         <condition_number>3</condition_number>
         <condition_comment>Made water's edge election</condition_comment>
-        <condition_description>result.mt_waters_edge_election is equal to true</condition_description>
+        <condition_dsl>result.mt_waters_edge_election is equal to true</condition_dsl>
         <condition_postfix>
 result.mt_waters_edge_election true eq
 </condition_postfix>
@@ -231,7 +231,7 @@ result.mt_waters_edge_election true eq
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate Montana corporate tax (standard rate 6.75%); Apply Montana 6.75% flat rate</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Montana taxable income
 // Federal taxable income apportioned to MT + additions - subtractions
@@ -261,7 +261,7 @@ result.mt_refund_or_owed xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>Calculate Montana corporate tax (water's edge rate 7.0%); Apply Montana 7.0% water's edge rate</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate Montana taxable income
 // Federal taxable income apportioned to MT + additions - subtractions
@@ -291,7 +291,7 @@ result.mt_refund_or_owed xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No taxable income - no tax liability</action_comment>
-        <action_description>result.mt_taxable_income = 0.0; result.mt_tax_liability = 0.0</action_description>
+        <action_dsl>result.mt_taxable_income = 0.0; result.mt_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No taxable income - no tax liability
 0.0 result.mt_taxable_income xdef
@@ -304,7 +304,7 @@ result.mt_estimated_payments result.mt_refund_or_owed xdef
       <action_details>
         <action_number>4</action_number>
         <action_comment>No nexus - no tax liability</action_comment>
-        <action_description>result.mt_taxable_income = 0.0; result.mt_tax_liability = 0.0</action_description>
+        <action_dsl>result.mt_taxable_income = 0.0; result.mt_tax_liability = 0.0</action_dsl>
         <action_postfix>
 // No nexus - no tax liability
 0.0 result.mt_taxable_income xdef

--- a/sampleprojects/CorporateTax/xml/states/NC_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NC_corp_dt.xml
@@ -19,7 +19,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in NC</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "NC"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "NC"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true eq
 apportionment.state_code "NC" streq
@@ -30,7 +30,7 @@ and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has economic nexus in NC</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "NC"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "NC"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.state_code "NC" streq
@@ -44,7 +44,7 @@ and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - filing required; Log NC filing requirement due to physical presence</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Physical nexus established - filing required
 // Apportionment will be calculated by tables 7000-7500
@@ -54,7 +54,7 @@ and
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established - filing required; Log NC filing requirement due to economic nexus</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Economic nexus established per Wayfair - filing required
 // Apportionment will be calculated by tables 7000-7500
@@ -64,7 +64,7 @@ and
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required</action_comment>
-<action_description>Set state tax to zero and refund any payments</action_description>
+<action_dsl>Set state tax to zero and refund any payments</action_dsl>
 <action_postfix>
 // No nexus - no filing required
 apportionment.state_tax 0.0 xdef
@@ -93,7 +93,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has NC nexus (physical or economic); apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -107,7 +107,7 @@ or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate NC state additions and subtractions; Calculate NC state-specific income adjustments to federal taxable income</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Calculate NC state additions and subtractions
 0.0 /additions xdef
@@ -121,7 +121,7 @@ apportionment.state_subtractions subtractions xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - zero adjustments; Set state additions and subtractions to zero</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // No nexus - no state adjustments
 apportionment.state_additions 0.0 xdef
@@ -150,7 +150,7 @@ apportionment.state_subtractions 0.0 xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has NC nexus (physical or economic); apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -163,7 +163,7 @@ or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive NC taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0 gt
 </condition_postfix>
@@ -175,7 +175,7 @@ apportionment.state_taxable_income 0 gt
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate NC tax at 2.5% flat rate (LOWEST in nation); Calculate NC state tax using 2.5% flat rate, apply credits, calculate refund or owed</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // NC uses 2.5% flat rate (LOWEST STATE RATE IN THE NATION)
 apportionment.state_taxable_income apportionment.state_tax_rate mul
@@ -195,7 +195,7 @@ apportionment.state_payments apportionment.state_tax sub
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no tax liability</action_comment>
-<action_description>Set state tax to zero and refund any payments</action_description>
+<action_dsl>Set state tax to zero and refund any payments</action_dsl>
 <action_postfix>
 // No nexus - no tax liability
 apportionment.state_tax 0.0 xdef
@@ -206,7 +206,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Nexus but no taxable income - no tax liability</action_comment>
-<action_description>Set state tax to zero and refund any payments</action_description>
+<action_dsl>Set state tax to zero and refund any payments</action_dsl>
 <action_postfix>
 // Nexus but no taxable income - no tax liability
 apportionment.state_tax 0.0 xdef

--- a/sampleprojects/CorporateTax/xml/states/ND_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/ND_corp_dt.xml
@@ -34,7 +34,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in ND</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "ND"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "ND"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true eq
 apportionment.state_code "ND" streq
@@ -48,7 +48,7 @@ and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has economic nexus in ND</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "ND"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "ND"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.state_code "ND" streq
@@ -122,7 +122,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has ND nexus</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true || apportionment.has_physical_presence == true</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true || apportionment.has_physical_presence == true</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -184,7 +184,7 @@ apportionment.state_subtractions 0.0 xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has ND nexus</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true || apportionment.has_physical_presence == true</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true || apportionment.has_physical_presence == true</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -198,7 +198,7 @@ or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income > 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income > 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0 gt
 </condition_postfix>

--- a/sampleprojects/CorporateTax/xml/states/NE_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NE_corp_dt.xml
@@ -36,7 +36,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in NE</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "NE"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "NE"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true eq
 apportionment.state_code "NE" streq
@@ -50,7 +50,7 @@ and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has economic nexus in NE</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "NE"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "NE"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.state_code "NE" streq
@@ -124,7 +124,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has NE nexus</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true || apportionment.has_physical_presence == true</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true || apportionment.has_physical_presence == true</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -186,7 +186,7 @@ apportionment.state_subtractions 0.0 xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has NE nexus</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true || apportionment.has_physical_presence == true</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true || apportionment.has_physical_presence == true</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -200,7 +200,7 @@ or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income > 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income > 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0 gt
 </condition_postfix>

--- a/sampleprojects/CorporateTax/xml/states/NH_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NH_corp_dt.xml
@@ -22,7 +22,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in NH</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "NH"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "NH"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true eq
 apportionment.state_code "NH" streq
@@ -36,7 +36,7 @@ and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has economic nexus in NH</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "NH"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "NH"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.state_code "NH" streq
@@ -104,7 +104,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus with NH; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -164,7 +164,7 @@ apportionment.state_subtractions 0.0 xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus with NH; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -178,7 +178,7 @@ or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0 gt
 </condition_postfix>

--- a/sampleprojects/CorporateTax/xml/states/NJ_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NJ_corp_dt.xml
@@ -16,7 +16,7 @@
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Has physical presence in NJ (office, employees, property)</condition_comment>
-        <condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "NJ"</condition_description>
+        <condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "NJ"</condition_dsl>
         <condition_postfix>
 apportionment.has_physical_presence true eq
 apportionment.state_code "NJ" streq
@@ -29,7 +29,7 @@ and
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Meets NJ economic nexus threshold ($100K)</condition_comment>
-        <condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "NJ"</condition_description>
+        <condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "NJ"</condition_dsl>
         <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.state_code "NJ" streq
@@ -44,7 +44,7 @@ and
       <action_details>
         <action_number>1</action_number>
         <action_comment>Physical nexus established - filing required</action_comment>
-        <action_description>Physical nexus established - apportionment calculated by tables 7000-7500</action_description>
+        <action_dsl>Physical nexus established - apportionment calculated by tables 7000-7500</action_dsl>
         <action_postfix>
 // Physical nexus established - filing required
 // Apportionment will be calculated by tables 7000-7500
@@ -54,7 +54,7 @@ and
       <action_details>
         <action_number>2</action_number>
         <action_comment>Economic nexus established - filing required</action_comment>
-        <action_description>Economic nexus established per Wayfair - filing required</action_description>
+        <action_dsl>Economic nexus established per Wayfair - filing required</action_dsl>
         <action_postfix>
 // Economic nexus established per Wayfair - filing required
 // Apportionment will be calculated by tables 7000-7500
@@ -64,7 +64,7 @@ and
       <action_details>
         <action_number>3</action_number>
         <action_comment>No nexus - no filing required; No nexus - zero tax and refund payments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // No nexus - no filing required
 apportionment.state_tax 0.0 xdef
@@ -104,7 +104,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -118,7 +118,7 @@ or
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate NJ state additions and subtractions; Calculate NJ state-specific income adjustments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Calculate NJ state additions and subtractions
 0.0 /additions xdef
@@ -134,7 +134,7 @@ result.nj_entire_net_income apportionment.state_taxable_income xdef
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - zero adjustments; No nexus - no state adjustments calculated</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // No nexus - no state adjustments
 apportionment.state_additions 0.0 xdef
@@ -171,7 +171,7 @@ result.nj_entire_net_income 0.0 xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -184,7 +184,7 @@ or
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Has positive state taxable income</condition_comment>
-        <condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+        <condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
         <condition_postfix>
 apportionment.state_taxable_income 0 gt
         </condition_postfix>
@@ -197,7 +197,7 @@ apportionment.state_taxable_income 0 gt
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate NJ tax at 9% base rate; Calculate NJ state tax at 9% base rate, subtract credits</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // NJ uses 9% base rate
 apportionment.state_taxable_income apportionment.state_tax_rate mul
@@ -217,7 +217,7 @@ apportionment.state_payments apportionment.state_tax sub
       <action_details>
         <action_number>2</action_number>
         <action_comment>No nexus - no tax; No NJ nexus - zero tax and refund payments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // No nexus - no tax liability
 apportionment.state_tax 0.0 xdef
@@ -228,7 +228,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>Nexus but no taxable income; No NJ taxable income - zero tax and refund payments</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // Nexus but no taxable income - no tax liability
 apportionment.state_tax 0.0 xdef
@@ -268,7 +268,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
       <condition_details>
         <condition_number>1</condition_number>
         <condition_comment>Must have NJ nexus; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -282,7 +282,7 @@ or
       <condition_details>
         <condition_number>2</condition_number>
         <condition_comment>Entire net income exceeds $1,000,000 surtax threshold; result.nj_entire_net_income &gt; result.nj_surtax_threshold</condition_comment>
-        <condition_description />
+        <condition_dsl />
         <condition_postfix>
 result.nj_entire_net_income result.nj_surtax_threshold gt
         </condition_postfix>
@@ -294,7 +294,7 @@ result.nj_entire_net_income result.nj_surtax_threshold gt
       <condition_details>
         <condition_number>3</condition_number>
         <condition_comment>Has positive tax base for surtax calculation</condition_comment>
-        <condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+        <condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
         <condition_postfix>
 apportionment.state_taxable_income 0 gt
         </condition_postfix>
@@ -308,7 +308,7 @@ apportionment.state_taxable_income 0 gt
       <action_details>
         <action_number>1</action_number>
         <action_comment>Calculate NJ surtax for large corporations; Calculate NJ surtax at 2.5% for income &gt; $1M</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // NJ surtax is 2.5% of entire net income for income &gt; $1M
 result.nj_entire_net_income result.nj_surtax_rate mul
@@ -327,7 +327,7 @@ apportionment.state_payments apportionment.state_tax sub
       <action_details>
         <action_number>2</action_number>
         <action_comment>No surtax - below threshold; No NJ surtax - income below threshold</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // No surtax - below threshold
 result.nj_surtax 0.0 xdef
@@ -337,7 +337,7 @@ result.nj_surtax 0.0 xdef
       <action_details>
         <action_number>3</action_number>
         <action_comment>No surtax - no nexus; No NJ surtax - no NJ nexus</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // No surtax
 result.nj_surtax 0.0 xdef
@@ -347,7 +347,7 @@ result.nj_surtax 0.0 xdef
       <action_details>
         <action_number>4</action_number>
         <action_comment>No surtax - no positive tax base; No NJ surtax - no positive tax base</action_comment>
-        <action_description />
+        <action_dsl />
         <action_postfix>
 // No surtax
 result.nj_surtax 0.0 xdef

--- a/sampleprojects/CorporateTax/xml/states/NM_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NM_corp_dt.xml
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in NM</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "NM"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "NM"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true eq
 apportionment.state_code "NM" streq
@@ -37,7 +37,7 @@ and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has economic nexus in NM</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "NM"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "NM"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.state_code "NM" streq
@@ -106,7 +106,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus with NM; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -167,7 +167,7 @@ apportionment.state_subtractions 0.0 xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus with NM; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -181,7 +181,7 @@ or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0 gt
 </condition_postfix>

--- a/sampleprojects/CorporateTax/xml/states/NV_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NV_corp_dt.xml
@@ -18,7 +18,7 @@
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize Nevada filing requirement check</action_description>
+<action_dsl>Initialize Nevada filing requirement check</action_dsl>
 <action_postfix>
 // Initialize Nevada Commerce Tax
 result.nv_qualifies_for_exemption false xdef
@@ -31,7 +31,7 @@ result.nv_commerce_tax 0.0 xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in Nevada; has_physical_presence == true AND below threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.has_physical_presence_nv result.nv_gross_revenue result.nv_commerce_tax_threshold lt and
 </condition_postfix>
@@ -44,7 +44,7 @@ result.has_physical_presence_nv result.nv_gross_revenue result.nv_commerce_tax_t
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has physical presence and exceeds threshold; has_physical_presence == true AND exceeds threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.has_physical_presence_nv result.nv_gross_revenue result.nv_commerce_tax_threshold ge and
 </condition_postfix>
@@ -57,7 +57,7 @@ result.has_physical_presence_nv result.nv_gross_revenue result.nv_commerce_tax_t
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Has economic nexus and exceeds threshold; has_economic_nexus == true AND exceeds threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.nv_gross_revenue result.nv_economic_nexus_threshold ge result.nv_gross_revenue result.nv_commerce_tax_threshold ge and
 </condition_postfix>
@@ -134,7 +134,7 @@ result.state_refund_or_owed result.state_payments xdef
 
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Nevada has NO corporate income tax
 result.state_tax_rate 0.0 xdef
@@ -148,7 +148,7 @@ result.state_subtractions 0.0 xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus with Nevada; has_economic_nexus == true OR has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.has_physical_presence_nv result.nv_gross_revenue result.nv_economic_nexus_threshold ge or
 </condition_postfix>
@@ -202,7 +202,7 @@ result.state_subtractions 0.0 xdef
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize Nevada business classification determination</action_description>
+<action_dsl>Initialize Nevada business classification determination</action_dsl>
 <action_postfix>
 // Default to Other Services rate
 result.nv_commerce_tax_rate result.nv_other_rate xdef
@@ -214,7 +214,7 @@ result.nv_commerce_tax_rate result.nv_other_rate xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Financial Services (NAICS 52)</condition_comment>
-<condition_description>business classification is financial</condition_description>
+<condition_dsl>business classification is financial</condition_dsl>
 <condition_postfix>
 result.nv_business_classification financial streq
 </condition_postfix>
@@ -231,7 +231,7 @@ result.nv_business_classification financial streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Mining (NAICS 21)</condition_comment>
-<condition_description>business classification is mining</condition_description>
+<condition_dsl>business classification is mining</condition_dsl>
 <condition_postfix>
 result.nv_business_classification mining streq
 </condition_postfix>
@@ -248,7 +248,7 @@ result.nv_business_classification mining streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Utilities (NAICS 22)</condition_comment>
-<condition_description>business classification is utilities</condition_description>
+<condition_dsl>business classification is utilities</condition_dsl>
 <condition_postfix>
 result.nv_business_classification utilities streq
 </condition_postfix>
@@ -265,7 +265,7 @@ result.nv_business_classification utilities streq
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Professional Services (NAICS 54)</condition_comment>
-<condition_description>business classification is professional</condition_description>
+<condition_dsl>business classification is professional</condition_dsl>
 <condition_postfix>
 result.nv_business_classification professional streq
 </condition_postfix>
@@ -282,7 +282,7 @@ result.nv_business_classification professional streq
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>Retail Trade (NAICS 44-45)</condition_comment>
-<condition_description>business classification is retail</condition_description>
+<condition_dsl>business classification is retail</condition_dsl>
 <condition_postfix>
 result.nv_business_classification retail streq
 </condition_postfix>
@@ -299,7 +299,7 @@ result.nv_business_classification retail streq
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>Manufacturing (NAICS 31-33)</condition_comment>
-<condition_description>business classification is manufacturing</condition_description>
+<condition_dsl>business classification is manufacturing</condition_dsl>
 <condition_postfix>
 result.nv_business_classification manufacturing streq
 </condition_postfix>
@@ -316,7 +316,7 @@ result.nv_business_classification manufacturing streq
 <condition_details>
 <condition_number>7</condition_number>
 <condition_comment>Wholesale Trade (NAICS 42)</condition_comment>
-<condition_description>business classification is wholesale</condition_description>
+<condition_dsl>business classification is wholesale</condition_dsl>
 <condition_postfix>
 result.nv_business_classification wholesale streq
 </condition_postfix>
@@ -432,7 +432,7 @@ result.nv_commerce_tax_rate result.nv_other_rate xdef
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize Nevada sitused revenue calculation</action_description>
+<action_dsl>Initialize Nevada sitused revenue calculation</action_dsl>
 <action_postfix>
 // Initialize sitused revenue
 result.nv_sitused_revenue 0.0 xdef
@@ -445,7 +445,7 @@ result.nv_gross_revenue 0.0 xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus and has apportionment percentage</condition_comment>
-<condition_description>has_nexus AND apportionment_percentage &gt; 0</condition_description>
+<condition_dsl>has_nexus AND apportionment_percentage &gt; 0</condition_dsl>
 <condition_postfix>
 result.has_physical_presence_nv result.nv_gross_receipts result.nv_economic_nexus_threshold ge or
 result.apportionment_percentage 0 gt and
@@ -458,7 +458,7 @@ result.apportionment_percentage 0 gt and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has nexus but no apportionment percentage</condition_comment>
-<condition_description>has_nexus AND apportionment_percentage = 0</condition_description>
+<condition_dsl>has_nexus AND apportionment_percentage = 0</condition_dsl>
 <condition_postfix>
 result.has_physical_presence_nv result.nv_gross_receipts result.nv_economic_nexus_threshold ge or
 result.apportionment_percentage 0 eq and
@@ -524,7 +524,7 @@ result.nv_gross_revenue 0.0 xdef
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize Nevada Commerce Tax calculation</action_description>
+<action_dsl>Initialize Nevada Commerce Tax calculation</action_dsl>
 <action_postfix>
 // Initialize Commerce Tax
 result.nv_taxable_revenue 0.0 xdef
@@ -537,7 +537,7 @@ result.nv_commerce_tax 0.0 xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus and exceeds $4M threshold; has_nexus AND gross_revenue &gt;= threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.has_physical_presence_nv result.nv_gross_revenue result.nv_economic_nexus_threshold ge or
 result.nv_gross_revenue result.nv_commerce_tax_threshold ge and
@@ -550,7 +550,7 @@ result.nv_gross_revenue result.nv_commerce_tax_threshold ge and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has nexus but below threshold; has_nexus AND gross_revenue &lt; threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.has_physical_presence_nv result.nv_gross_revenue result.nv_economic_nexus_threshold ge or
 result.nv_gross_revenue result.nv_commerce_tax_threshold lt and

--- a/sampleprojects/CorporateTax/xml/states/NY_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NY_corp_dt.xml
@@ -16,7 +16,7 @@
   <condition_details>
   <condition_number>1</condition_number>
   <condition_comment>Has physical presence in NY (office, employees, property)</condition_comment>
-  <condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "NY"</condition_description>
+  <condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "NY"</condition_dsl>
   <condition_postfix>
 apportionment.has_physical_presence true eq
 apportionment.state_code "NY" streq
@@ -29,7 +29,7 @@ and
   <condition_details>
   <condition_number>2</condition_number>
   <condition_comment>Meets NY economic nexus threshold ($1M)</condition_comment>
-  <condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "NY"</condition_description>
+  <condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "NY"</condition_dsl>
   <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.state_code "NY" streq
@@ -44,7 +44,7 @@ and
   <action_details>
   <action_number>1</action_number>
   <action_comment>Physical nexus established - filing required</action_comment>
-  <action_description>Apportionment will be calculated by tables 7000-7500</action_description>
+  <action_dsl>Apportionment will be calculated by tables 7000-7500</action_dsl>
   <action_postfix>
 // Physical nexus established - filing required
 // Apportionment will be calculated by tables 7000-7500
@@ -54,7 +54,7 @@ and
   <action_details>
   <action_number>2</action_number>
   <action_comment>Economic nexus established per Wayfair - filing required</action_comment>
-  <action_description>Apportionment will be calculated by tables 7000-7500</action_description>
+  <action_dsl>Apportionment will be calculated by tables 7000-7500</action_dsl>
   <action_postfix>
 // Economic nexus established per Wayfair - filing required
 // Apportionment will be calculated by tables 7000-7500
@@ -64,7 +64,7 @@ and
   <action_details>
   <action_number>3</action_number>
   <action_comment>No nexus - no filing required; No NY nexus - any estimated payments would be refunded</action_comment>
-  <action_description />
+  <action_dsl />
   <action_postfix>
 // No nexus - no filing required
 apportionment.state_tax 0.0 xdef
@@ -90,7 +90,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
   <condition_details>
   <condition_number>1</condition_number>
   <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-  <condition_description />
+  <condition_dsl />
   <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -104,7 +104,7 @@ or
   <action_details>
   <action_number>1</action_number>
   <action_comment>Calculate NY state additions and subtractions; Calculate state additions (federal bond interest, IRC 199A addback, depreciation) and subtractions (NY municipal interest, QETC deductions)</action_comment>
-  <action_description />
+  <action_dsl />
   <action_postfix>
 // Calculate NY state additions and subtractions
 0.0 /additions xdef
@@ -117,7 +117,7 @@ apportionment.state_subtractions subtractions xdef
   <action_details>
   <action_number>2</action_number>
   <action_comment>No nexus - no state adjustments; No nexus - no state adjustments calculated</action_comment>
-  <action_description />
+  <action_dsl />
   <action_postfix>
 // No nexus - no state adjustments
 apportionment.state_additions 0.0 xdef
@@ -143,7 +143,7 @@ apportionment.state_subtractions 0.0 xdef
   <condition_details>
   <condition_number>1</condition_number>
   <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-  <condition_description />
+  <condition_dsl />
   <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -156,7 +156,7 @@ or
   <condition_details>
   <condition_number>2</condition_number>
   <condition_comment>Has positive state taxable income</condition_comment>
-  <condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+  <condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
   <condition_postfix>
 apportionment.state_taxable_income 0 gt
   </condition_postfix>
@@ -169,7 +169,7 @@ apportionment.state_taxable_income 0 gt
   <action_details>
   <action_number>1</action_number>
   <action_comment>Calculate NY tax at 6.5% flat rate; NY uses flat 6.5% rate (Tax Law § 209), subtract credits, calculate refund/owed</action_comment>
-  <action_description />
+  <action_dsl />
   <action_postfix>
 // NY uses 6.5% flat rate
 apportionment.state_taxable_income apportionment.state_tax_rate mul
@@ -189,7 +189,7 @@ apportionment.state_payments apportionment.state_tax sub
   <action_details>
   <action_number>2</action_number>
   <action_comment>No nexus - no tax liability; No NY nexus - any estimated payments are refunded</action_comment>
-  <action_description />
+  <action_dsl />
   <action_postfix>
 // No nexus - no tax liability
 apportionment.state_tax 0.0 xdef
@@ -200,7 +200,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
   <action_details>
   <action_number>3</action_number>
   <action_comment>Nexus but no taxable income - no tax liability; No NY taxable income - NY NOL rules may apply (not implemented)</action_comment>
-  <action_description />
+  <action_dsl />
   <action_postfix>
 // Nexus but no taxable income - no tax liability
 apportionment.state_tax 0.0 xdef
@@ -226,7 +226,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
   <condition_details>
   <condition_number>1</condition_number>
   <condition_comment>Must have NY nexus; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-  <condition_description />
+  <condition_dsl />
   <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -240,7 +240,7 @@ or
   <condition_details>
   <condition_number>2</condition_number>
   <condition_comment>Business operates in MTA region</condition_comment>
-  <condition_description>result.ny_in_mta_region == true</condition_description>
+  <condition_dsl>result.ny_in_mta_region == true</condition_dsl>
   <condition_postfix>
 result.ny_in_mta_region true eq
   </condition_postfix>
@@ -252,7 +252,7 @@ result.ny_in_mta_region true eq
   <condition_details>
   <condition_number>3</condition_number>
   <condition_comment>Has positive tax base for surcharge calculation</condition_comment>
-  <condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+  <condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
   <condition_postfix>
 apportionment.state_taxable_income 0 gt
   </condition_postfix>
@@ -266,7 +266,7 @@ apportionment.state_taxable_income 0 gt
   <action_details>
   <action_number>1</action_number>
   <action_comment>Calculate MTA surcharge at 0.34%; MTA surcharge is 0.34% of business income base, add to total state tax, recalculate refund/owed</action_comment>
-  <action_description />
+  <action_dsl />
   <action_postfix>
 // MTA surcharge is 0.34% of business income base
 apportionment.state_taxable_income result.ny_mta_surcharge_rate mul
@@ -285,7 +285,7 @@ apportionment.state_payments apportionment.state_tax sub
   <action_details>
   <action_number>2</action_number>
   <action_comment>No MTA surcharge - not in MTA region</action_comment>
-  <action_description>State tax and refund/owed already calculated in table 50180</action_description>
+  <action_dsl>State tax and refund/owed already calculated in table 50180</action_dsl>
   <action_postfix>
   // No MTA surcharge
 result.ny_mta_surcharge 0.0 xdef
@@ -295,7 +295,7 @@ result.ny_mta_surcharge 0.0 xdef
   <action_details>
   <action_number>3</action_number>
   <action_comment>No MTA surcharge - no nexus; No MTA surcharge - no NY nexus or no taxable income</action_comment>
-  <action_description />
+  <action_dsl />
   <action_postfix>
   // No MTA surcharge - no nexus
 result.ny_mta_surcharge 0.0 xdef
@@ -305,7 +305,7 @@ result.ny_mta_surcharge 0.0 xdef
   <action_details>
   <action_number>4</action_number>
   <action_comment>No MTA surcharge - no positive tax base; No positive tax base for surcharge calculation</action_comment>
-  <action_description />
+  <action_dsl />
   <action_postfix>
   // No MTA surcharge - no positive tax base
 result.ny_mta_surcharge 0.0 xdef

--- a/sampleprojects/CorporateTax/xml/states/OH_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/OH_corp_dt.xml
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in Ohio (bright-line presence)</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == 'OH'</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == 'OH'</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true eq
 apportionment.state_code "OH" streq
@@ -38,7 +38,7 @@ and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets Ohio economic nexus threshold ($500K Ohio receipts)</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == 'OH'</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == 'OH'</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.state_code "OH" streq
@@ -53,7 +53,7 @@ and
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Ohio receipts below $150K exclusion threshold; result.oh_taxable_gross_receipts &lt; result.oh_cat_exclusion_threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.oh_taxable_gross_receipts result.oh_cat_exclusion_threshold lt
 </condition_postfix>
@@ -68,7 +68,7 @@ result.oh_taxable_gross_receipts result.oh_cat_exclusion_threshold lt
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical presence but below exclusion threshold - no tax due; Set no CAT due and zero tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Physical presence but below threshold - no CAT due
 result.oh_qualifies_for_no_cat true xdef
@@ -84,7 +84,7 @@ apportionment.state_tax 0.0 xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Physical nexus established - CAT calculation required; Mark CAT as due and log bright-line presence</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Physical nexus - CAT calculation required
 result.oh_qualifies_for_no_cat false xdef
@@ -98,7 +98,7 @@ result.oh_qualifies_for_no_cat false xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Economic nexus established - CAT calculation required; Mark CAT as due and log economic nexus</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Economic nexus - CAT calculation required
 result.oh_qualifies_for_no_cat false xdef
@@ -112,7 +112,7 @@ result.oh_qualifies_for_no_cat false xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>No nexus - no filing required; Set no CAT due, zero tax, and refund any payments</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // No nexus - no filing required
 result.oh_qualifies_for_no_cat true xdef
@@ -150,7 +150,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus and above exclusion threshold; result.oh_qualifies_for_no_cat == false</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.oh_qualifies_for_no_cat false eq
 </condition_postfix>
@@ -162,7 +162,7 @@ result.oh_qualifies_for_no_cat false eq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has receipts excluded from CAT calculation</condition_comment>
-<condition_description>result.oh_cat_excluded_receipts &gt; 0</condition_description>
+<condition_dsl>result.oh_cat_excluded_receipts &gt; 0</condition_dsl>
 <condition_postfix>
 result.oh_cat_excluded_receipts 0 gt
 </condition_postfix>
@@ -176,7 +176,7 @@ result.oh_cat_excluded_receipts 0 gt
 <action_details>
 <action_number>1</action_number>
 <action_comment>No nexus or below threshold - no calculation needed</action_comment>
-<action_description>Set taxable receipts to zero</action_description>
+<action_dsl>Set taxable receipts to zero</action_dsl>
 <action_postfix>
 // No nexus or below threshold - no calculation needed
 result.oh_taxable_gross_receipts 0.0 xdef
@@ -189,7 +189,7 @@ result.oh_taxable_gross_receipts 0.0 xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate gross receipts after exclusions; Apply exclusions to Ohio-sourced receipts</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Calculate gross receipts after exclusions
 result.oh_taxable_gross_receipts result.oh_cat_excluded_receipts sub
@@ -204,7 +204,7 @@ result.oh_taxable_gross_receipts result.oh_cat_excluded_receipts sub
 <action_details>
 <action_number>3</action_number>
 <action_comment>Use Ohio-sourced gross receipts (no exclusions); Log CAT basis and situsing</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Use Ohio-sourced gross receipts (no exclusions)
 </action_postfix>
@@ -237,7 +237,7 @@ result.oh_taxable_gross_receipts result.oh_cat_excluded_receipts sub
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus and above exclusion threshold; result.oh_qualifies_for_no_cat == false</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.oh_qualifies_for_no_cat false eq
 </condition_postfix>
@@ -250,7 +250,7 @@ result.oh_qualifies_for_no_cat false eq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive Ohio-sourced gross receipts</condition_comment>
-<condition_description>result.oh_taxable_gross_receipts &gt; 0</condition_description>
+<condition_dsl>result.oh_taxable_gross_receipts &gt; 0</condition_dsl>
 <condition_postfix>
 result.oh_taxable_gross_receipts 0 gt
 </condition_postfix>
@@ -263,7 +263,7 @@ result.oh_taxable_gross_receipts 0 gt
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Ohio receipts at or above $1M (subject to percentage tax); result.oh_taxable_gross_receipts &gt;= result.oh_cat_minimum_threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.oh_taxable_gross_receipts result.oh_cat_minimum_threshold ge
 </condition_postfix>
@@ -278,7 +278,7 @@ result.oh_taxable_gross_receipts result.oh_cat_minimum_threshold ge
 <action_details>
 <action_number>1</action_number>
 <action_comment>No nexus or below exclusion threshold - no CAT</action_comment>
-<action_description>Set zero tax and refund payments</action_description>
+<action_dsl>Set zero tax and refund payments</action_dsl>
 <action_postfix>
 // No nexus or below exclusion threshold - no CAT
 result.oh_cat_tax 0.0 xdef
@@ -294,7 +294,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Receipts over $1M - calculate percentage tax + minimum; CAT = $150 + (Receipts - $1M) × 0.26%</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Receipts over $1M - CAT = $150 + (Receipts - $1M) x 0.26%
 result.oh_taxable_gross_receipts result.oh_cat_minimum_threshold sub
@@ -315,7 +315,7 @@ apportionment.state_payments apportionment.state_tax sub
 <action_details>
 <action_number>3</action_number>
 <action_comment>Receipts between $150K and $1M - minimum tax only</action_comment>
-<action_description>CAT = $150 flat minimum</action_description>
+<action_dsl>CAT = $150 flat minimum</action_dsl>
 <action_postfix>
 // Receipts between $150K and $1M - minimum tax only ($150)
 result.oh_cat_tax result.oh_cat_minimum_tax xdef
@@ -332,7 +332,7 @@ apportionment.state_payments apportionment.state_tax sub
 <action_details>
 <action_number>4</action_number>
 <action_comment>No taxable receipts - no CAT</action_comment>
-<action_description>Set zero tax and refund payments</action_description>
+<action_dsl>Set zero tax and refund payments</action_dsl>
 <action_postfix>
 // No taxable receipts - no CAT
 result.oh_cat_tax 0.0 xdef

--- a/sampleprojects/CorporateTax/xml/states/OK_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/OK_corp_dt.xml
@@ -33,7 +33,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in OK</condition_comment>
-<condition_description>apportionment.has_physical_presence == true &amp;&amp; apportionment.state_code == 'OK'</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true &amp;&amp; apportionment.state_code == 'OK'</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true eq
 apportionment.state_code "OK" streq
@@ -47,7 +47,7 @@ and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has economic nexus in OK</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true &amp;&amp; apportionment.state_code == 'OK'</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true &amp;&amp; apportionment.state_code == 'OK'</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.state_code "OK" streq
@@ -114,7 +114,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus with OK</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true || apportionment.has_physical_presence == true</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true || apportionment.has_physical_presence == true</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -173,7 +173,7 @@ apportionment.state_subtractions 0.0 xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus with OK</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true || apportionment.has_physical_presence == true</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true || apportionment.has_physical_presence == true</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -187,7 +187,7 @@ or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income > 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income > 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0 gt
 </condition_postfix>

--- a/sampleprojects/CorporateTax/xml/states/OR_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/OR_corp_dt.xml
@@ -24,7 +24,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in OR</condition_comment>
-<condition_description>apportionment.has_physical_presence == true and state_code == 'OR'</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true and state_code == 'OR'</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence true eq
 apportionment.state_code "OR" streq
@@ -38,7 +38,7 @@ and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has economic nexus in OR</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true and state_code == 'OR'</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true and state_code == 'OR'</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.state_code "OR" streq
@@ -54,7 +54,7 @@ and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus - filing required</action_comment>
-<action_description>Physical nexus established - filing required. Apportionment will be calculated by tables 7000-7500</action_description>
+<action_dsl>Physical nexus established - filing required. Apportionment will be calculated by tables 7000-7500</action_dsl>
 <action_postfix>
 // Physical nexus established - filing required
 </action_postfix>
@@ -64,7 +64,7 @@ and
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus - filing required; Economic nexus established per Wayfair - filing required. OR threshold: $750,000 in sales</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Economic nexus established per Wayfair - filing required
 </action_postfix>
@@ -74,7 +74,7 @@ and
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required; No nexus - no filing required</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // No nexus - no filing required
 apportionment.state_tax 0.0 xdef
@@ -132,7 +132,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus; Must have nexus to calculate adjustments</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -147,7 +147,7 @@ or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate OR state additions and subtractions; Calculate OR state additions and subtractions to federal taxable income</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Calculate OR state additions and subtractions
 apportionment.state_additions 0.0 xdef
@@ -159,7 +159,7 @@ apportionment.state_subtractions 0.0 xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no adjustments; No nexus - no state adjustments calculated</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // No nexus - no state adjustments
 apportionment.state_additions 0.0 xdef
@@ -210,7 +210,7 @@ apportionment.state_subtractions 0.0 xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus</condition_comment>
-<condition_description>Must have nexus to owe tax</condition_description>
+<condition_dsl>Must have nexus to owe tax</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus true eq
 apportionment.has_physical_presence true eq
@@ -225,7 +225,7 @@ or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>Has positive state taxable income</condition_description>
+<condition_dsl>Has positive state taxable income</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income 0 gt
 </condition_postfix>
@@ -238,7 +238,7 @@ apportionment.state_taxable_income 0 gt
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Is financial institution; Is financial institution subject to 7.6% rate</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.or_is_financial_institution true eq
 </condition_postfix>
@@ -253,7 +253,7 @@ result.or_is_financial_institution true eq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate OR tax for financial institutions (7.6% rate); Financial institutions use 7.6% rate instead of 6.6%</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Financial institutions use 7.6% rate
 apportionment.state_tax apportionment.state_taxable_income result.or_financial_institution_rate mul xdef
@@ -272,7 +272,7 @@ apportionment.state_refund_or_owed apportionment.state_payments apportionment.st
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate OR tax for regular corporations (6.6% rate); Regular corporations use 6.6% flat rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Regular corporations use 6.6% flat rate
 apportionment.state_tax apportionment.state_taxable_income apportionment.state_tax_rate mul xdef
@@ -291,7 +291,7 @@ apportionment.state_refund_or_owed apportionment.state_payments apportionment.st
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no tax liability; No nexus - no tax liability</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // No nexus - no tax liability
 apportionment.state_tax 0.0 xdef
@@ -304,7 +304,7 @@ apportionment.state_refund_or_owed apportionment.state_payments xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Nexus but no taxable income (still owe minimum tax!); No excise tax, but MINIMUM TAX STILL APPLIES</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 // Nexus but no taxable income - minimum tax still applies
 // Minimum tax calculated by separate table

--- a/sampleprojects/CorporateTax/xml/states/PA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/PA_corp_dt.xml
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in PA (office, employees, property)</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "PA"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "PA"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence get true eq
 apportionment.state_code get "PA" streq and
@@ -36,7 +36,7 @@ apportionment.state_code get "PA" streq and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets PA economic nexus threshold ($500,000)</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "PA"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "PA"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.state_code get "PA" streq and
@@ -51,7 +51,7 @@ apportionment.state_code get "PA" streq and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - PA CNIT filing required</action_comment>
-<action_description>PA filing required due to physical presence</action_description>
+<action_dsl>PA filing required due to physical presence</action_dsl>
 <action_postfix>
 "PA CNIT filing required due to physical presence. Reference: PA Code Title 72 7401(3)2.(a)(15)" job.audit_trail swap addto
 </action_postfix>
@@ -61,7 +61,7 @@ apportionment.state_code get "PA" streq and
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established - PA CNIT filing required; PA filing required due to economic nexus ($500K threshold)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "PA CNIT filing required due to economic nexus. PA threshold: $500,000 (higher than typical $100K). Reference: PA Code Title 72 7401(3)2.(a)(15)(C)" job.audit_trail swap addto
 </action_postfix>
@@ -71,7 +71,7 @@ apportionment.state_code get "PA" streq and
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no PA filing required; No PA nexus - no filing requirement</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef
@@ -105,7 +105,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate PA adjustments; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -119,7 +119,7 @@ apportionment.has_physical_presence get true eq or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate PA state additions and subtractions; Calculate PA-specific income adjustments</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_additions xdef
 0.0 /apportionment.state_subtractions xdef
@@ -131,7 +131,7 @@ apportionment.has_physical_presence get true eq or
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no PA state adjustments; No PA nexus - no adjustments calculated</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_additions xdef
 0.0 /apportionment.state_subtractions xdef
@@ -165,7 +165,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe PA tax; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -178,7 +178,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive PA taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income get 0 gt
 </condition_postfix>
@@ -192,7 +192,7 @@ apportionment.state_taxable_income get 0 gt
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate PA tax (8.99% flat rate); PA CNIT at 8.99% flat rate (one of highest state corporate rates)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 apportionment.state_taxable_income get apportionment.state_tax_rate get mul /apportionment.state_tax xdef
 apportionment.state_tax get apportionment.state_credits get sub 0.0 max /apportionment.state_tax xdef
@@ -205,7 +205,7 @@ apportionment.state_payments get apportionment.state_tax get sub /apportionment.
 <action_details>
 <action_number>2</action_number>
 <action_comment>No PA nexus - no tax liability; No PA nexus - no tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef
@@ -217,7 +217,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>No PA taxable income (loss year); No PA taxable income - no tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef

--- a/sampleprojects/CorporateTax/xml/states/RI_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/RI_corp_dt.xml
@@ -18,7 +18,7 @@
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize RI filing requirement check</action_description>
+<action_dsl>Initialize RI filing requirement check</action_dsl>
 <action_postfix>
 "RI Filing Requirement Check Started" job.audit_trail swap addto
 </action_postfix>
@@ -29,7 +29,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in RI</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "RI"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "RI"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence get true eq
 apportionment.state_code get "RI" streq and
@@ -42,7 +42,7 @@ apportionment.state_code get "RI" streq and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has economic nexus in RI</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "RI"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "RI"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.state_code get "RI" streq and
@@ -116,7 +116,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize RI income adjustments</action_description>
+<action_dsl>Initialize RI income adjustments</action_dsl>
 <action_postfix>
 "RI Income Adjustments Calculation Started" job.audit_trail swap addto
 </action_postfix>
@@ -127,7 +127,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus with RI; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -181,7 +181,7 @@ apportionment.has_physical_presence get true eq or
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize RI state tax calculation</action_description>
+<action_dsl>Initialize RI state tax calculation</action_dsl>
 <action_postfix>
 "RI State Tax Calculation Started" job.audit_trail swap addto
 </action_postfix>
@@ -192,7 +192,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus with RI; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -205,7 +205,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income get 0 gt
 </condition_postfix>

--- a/sampleprojects/CorporateTax/xml/states/SC_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/SC_corp_dt.xml
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in SC (office, employees, property)</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "SC"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "SC"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence get true eq
 apportionment.state_code get "SC" streq and
@@ -36,7 +36,7 @@ apportionment.state_code get "SC" streq and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets SC economic nexus threshold ($100K or 200 transactions)</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "SC"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "SC"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.state_code get "SC" streq and
@@ -51,7 +51,7 @@ apportionment.state_code get "SC" streq and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - filing required</action_comment>
-<action_description>SC filing required due to physical presence</action_description>
+<action_dsl>SC filing required due to physical presence</action_dsl>
 <action_postfix>
 "SC filing required due to physical presence. Reference: SC Code 12-6-2320" job.audit_trail swap addto
 </action_postfix>
@@ -61,7 +61,7 @@ apportionment.state_code get "SC" streq and
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established per Wayfair - filing required</action_comment>
-<action_description>SC filing required due to economic nexus</action_description>
+<action_dsl>SC filing required due to economic nexus</action_dsl>
 <action_postfix>
 "SC filing required due to economic nexus. Threshold: $100K OR 200 transactions. Reference: SC Code 12-36-2691" job.audit_trail swap addto
 </action_postfix>
@@ -71,7 +71,7 @@ apportionment.state_code get "SC" streq and
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required; No SC nexus - no filing requirement</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef
@@ -105,7 +105,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -119,7 +119,7 @@ apportionment.has_physical_presence get true eq or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate SC state additions and subtractions; Calculate SC-specific income adjustments</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_additions xdef
 0.0 /apportionment.state_subtractions xdef
@@ -131,7 +131,7 @@ apportionment.has_physical_presence get true eq or
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no state adjustments; No SC nexus - no adjustments calculated</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_additions xdef
 0.0 /apportionment.state_subtractions xdef
@@ -165,7 +165,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -178,7 +178,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income get 0 gt
 </condition_postfix>
@@ -192,7 +192,7 @@ apportionment.state_taxable_income get 0 gt
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate SC tax at 5% flat rate; SC income tax at 5% plus license fee</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 apportionment.state_taxable_income get apportionment.state_tax_rate get mul /apportionment.state_tax xdef
 apportionment.state_tax get apportionment.state_credits get sub 0.0 max /apportionment.state_tax xdef
@@ -207,7 +207,7 @@ apportionment.state_payments get apportionment.state_tax get sub /apportionment.
 <action_details>
 <action_number>2</action_number>
 <action_comment>No SC nexus - no tax liability; No SC nexus - no tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef
@@ -219,7 +219,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Nexus but no taxable income - license fee only; No SC taxable income but license fee applies</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 apportionment.license_fee_minimum get /apportionment.state_tax xdef
 apportionment.state_payments get apportionment.state_tax get sub /apportionment.state_refund_or_owed xdef

--- a/sampleprojects/CorporateTax/xml/states/SD_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/SD_corp_dt.xml
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>General business corporation (not financial institution or insurance company)</condition_comment>
-<condition_description>result.sd_is_financial_institution == false AND result.sd_is_insurance_company == false</condition_description>
+<condition_dsl>result.sd_is_financial_institution == false AND result.sd_is_insurance_company == false</condition_dsl>
 <condition_postfix>
 result.sd_is_financial_institution get false eq
 result.sd_is_insurance_company get false eq and
@@ -36,7 +36,7 @@ result.sd_is_insurance_company get false eq and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Financial institution subject to Bank Franchise Tax</condition_comment>
-<condition_description>result.sd_is_financial_institution == true</condition_description>
+<condition_dsl>result.sd_is_financial_institution == true</condition_dsl>
 <condition_postfix>
 result.sd_is_financial_institution get true eq
 </condition_postfix>
@@ -48,7 +48,7 @@ result.sd_is_financial_institution get true eq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Insurance company subject to Insurance Premium Tax</condition_comment>
-<condition_description>result.sd_is_insurance_company == true</condition_description>
+<condition_dsl>result.sd_is_insurance_company == true</condition_dsl>
 <condition_postfix>
 result.sd_is_insurance_company get true eq
 </condition_postfix>
@@ -62,7 +62,7 @@ result.sd_is_insurance_company get true eq
 <action_details>
 <action_number>1</action_number>
 <action_comment>General corporation - no corporate income tax; South Dakota has NO corporate income tax for general corporations</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 true /result.sd_no_corporate_tax xdef
 0.0 /apportionment.state_tax xdef
@@ -76,7 +76,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Financial institution - Bank Franchise Tax (NOT income tax); Financial institutions pay Bank Franchise Tax (separate from general corporate taxation)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.sd_bank_franchise_tax get /apportionment.state_tax xdef
 0.0 /apportionment.state_tax_rate xdef
@@ -88,7 +88,7 @@ result.sd_bank_franchise_tax get /apportionment.state_tax xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Insurance company - Insurance Premium Tax (NOT income tax); Insurance companies pay Insurance Premium Tax (separate from general corporate taxation)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.sd_insurance_premium_tax get /apportionment.state_tax xdef
 0.0 /apportionment.state_tax_rate xdef
@@ -122,7 +122,7 @@ result.sd_insurance_premium_tax get /apportionment.state_tax xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>General business corporation</condition_comment>
-<condition_description>result.sd_is_financial_institution == false AND result.sd_is_insurance_company == false</condition_description>
+<condition_dsl>result.sd_is_financial_institution == false AND result.sd_is_insurance_company == false</condition_dsl>
 <condition_postfix>
 result.sd_is_financial_institution get false eq
 result.sd_is_insurance_company get false eq and
@@ -136,7 +136,7 @@ result.sd_is_insurance_company get false eq and
 <action_details>
 <action_number>1</action_number>
 <action_comment>General corporation - no income tax adjustments; South Dakota has NO corporate income tax - no adjustments</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax_rate xdef
 0.0 /apportionment.state_additions xdef
@@ -150,7 +150,7 @@ result.sd_is_insurance_company get false eq and
 <action_details>
 <action_number>2</action_number>
 <action_comment>Specialized entity - no income adjustments; Financial institution or insurance company - no income tax adjustments</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_additions xdef
 0.0 /apportionment.state_subtractions xdef
@@ -184,7 +184,7 @@ result.sd_is_insurance_company get false eq and
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>General business corporation</condition_comment>
-<condition_description>result.sd_is_financial_institution == false AND result.sd_is_insurance_company == false</condition_description>
+<condition_dsl>result.sd_is_financial_institution == false AND result.sd_is_insurance_company == false</condition_dsl>
 <condition_postfix>
 result.sd_is_financial_institution get false eq
 result.sd_is_insurance_company get false eq and
@@ -198,7 +198,7 @@ result.sd_is_insurance_company get false eq and
 <action_details>
 <action_number>1</action_number>
 <action_comment>General corporation - $0 tax; South Dakota has NO corporate income tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 0.0 /apportionment.state_tax_rate xdef
@@ -212,7 +212,7 @@ true /result.sd_no_corporate_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Specialized entity - tax already calculated; Financial institution or insurance company - tax calculated in table 54500</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "Specialized entity tax (Bank Franchise or Insurance Premium) calculated separately." job.audit_trail swap addto
 </action_postfix>

--- a/sampleprojects/CorporateTax/xml/states/TN_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/TN_corp_dt.xml
@@ -18,7 +18,7 @@
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize Tennessee filing requirement check</action_description>
+<action_dsl>Initialize Tennessee filing requirement check</action_dsl>
 <action_postfix>
 "Tennessee Filing Requirement Check Started" job.audit_trail swap addto
 </action_postfix>
@@ -29,7 +29,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in TN (office, employees, property)</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "TN"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "TN"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence get true eq
 apportionment.state_code get "TN" streq and
@@ -42,7 +42,7 @@ apportionment.state_code get "TN" streq and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets TN economic nexus threshold ($100K or 200 transactions)</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "TN"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "TN"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.state_code get "TN" streq and
@@ -112,7 +112,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize Tennessee income adjustments</action_description>
+<action_dsl>Initialize Tennessee income adjustments</action_dsl>
 <action_postfix>
 "Tennessee Income Adjustments Started" job.audit_trail swap addto
 </action_postfix>
@@ -123,7 +123,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -223,7 +223,7 @@ subtractions /apportionment.state_subtractions xdef
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize Tennessee franchise tax calculation</action_description>
+<action_dsl>Initialize Tennessee franchise tax calculation</action_dsl>
 <action_postfix>
 "Tennessee Franchise Tax Calculation Started" job.audit_trail swap addto
 </action_postfix>
@@ -234,7 +234,7 @@ subtractions /apportionment.state_subtractions xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe franchise tax; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -247,7 +247,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive net worth in TN</condition_comment>
-<condition_description>result.tn_net_worth &gt; 0</condition_description>
+<condition_dsl>result.tn_net_worth &gt; 0</condition_dsl>
 <condition_postfix>
 result.tn_net_worth get 0 gt
 </condition_postfix>
@@ -310,7 +310,7 @@ result.tn_net_worth get result.tn_franchise_tax_rate get mul /result.tn_franchis
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize Tennessee excise tax calculation</action_description>
+<action_dsl>Initialize Tennessee excise tax calculation</action_dsl>
 <action_postfix>
 "Tennessee Excise Tax Calculation Started" job.audit_trail swap addto
 </action_postfix>
@@ -321,7 +321,7 @@ result.tn_net_worth get result.tn_franchise_tax_rate get mul /result.tn_franchis
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe excise tax; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -334,7 +334,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive apportioned taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income get 0 gt
 </condition_postfix>

--- a/sampleprojects/CorporateTax/xml/states/TX_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/TX_corp_dt.xml
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in Texas</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "TX"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "TX"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence get true eq
 apportionment.state_code get "TX" streq and
@@ -37,7 +37,7 @@ apportionment.state_code get "TX" streq and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets Texas economic nexus threshold ($500K Texas receipts)</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "TX"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "TX"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.state_code get "TX" streq and
@@ -51,7 +51,7 @@ apportionment.state_code get "TX" streq and
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Total revenue below $1.23M no-tax-due threshold; result.tx_total_revenue &lt; result.tx_no_tax_due_threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.tx_total_revenue get result.tx_no_tax_due_threshold get lt
 </condition_postfix>
@@ -66,7 +66,7 @@ result.tx_total_revenue get result.tx_no_tax_due_threshold get lt
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical presence but below threshold - no tax due; No tax due - total revenue below $1.23M threshold</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 true /result.tx_qualifies_for_no_tax_due xdef
 0.0 /result.tx_franchise_tax xdef
@@ -79,7 +79,7 @@ true /result.tx_qualifies_for_no_tax_due xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Physical nexus established - franchise tax calculation required</action_comment>
-<action_description>TX franchise tax filing required due to physical presence</action_description>
+<action_dsl>TX franchise tax filing required due to physical presence</action_dsl>
 <action_postfix>
 false /result.tx_qualifies_for_no_tax_due xdef
 "TX franchise tax filing required due to physical presence. Reference: TX Tax Code 171.001" job.audit_trail swap addto
@@ -90,7 +90,7 @@ false /result.tx_qualifies_for_no_tax_due xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Economic nexus established - franchise tax calculation required; TX franchise tax filing required due to economic nexus ($500K threshold)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 false /result.tx_qualifies_for_no_tax_due xdef
 "TX franchise tax filing required due to economic nexus ($500K TX receipts). Reference: TX Tax Code 171.0001(a)(1)" job.audit_trail swap addto
@@ -101,7 +101,7 @@ false /result.tx_qualifies_for_no_tax_due xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>No nexus - no filing required; No Texas nexus - no filing requirement</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 true /result.tx_qualifies_for_no_tax_due xdef
 0.0 /result.tx_franchise_tax xdef
@@ -137,7 +137,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus and above no-tax-due threshold; result.tx_qualifies_for_no_tax_due == false</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.tx_qualifies_for_no_tax_due get false eq
 </condition_postfix>
@@ -150,7 +150,7 @@ result.tx_qualifies_for_no_tax_due get false eq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>COGS is greater than compensation</condition_comment>
-<condition_description>result.tx_cogs &gt; result.tx_compensation</condition_description>
+<condition_dsl>result.tx_cogs &gt; result.tx_compensation</condition_dsl>
 <condition_postfix>
 result.tx_cogs get result.tx_compensation get gt
 </condition_postfix>
@@ -165,7 +165,7 @@ result.tx_cogs get result.tx_compensation get gt
 <action_details>
 <action_number>1</action_number>
 <action_comment>No nexus or below threshold - deduction method not applicable; No franchise tax due - deduction method not applicable</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "none" /result.tx_deduction_method xdef
 0.0 /result.tx_margin_deduction xdef
@@ -177,7 +177,7 @@ result.tx_cogs get result.tx_compensation get gt
 <action_details>
 <action_number>2</action_number>
 <action_comment>Use 70% of revenue deduction; 70% of revenue provides largest deduction (simplified method)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "70_percent" /result.tx_deduction_method xdef
 result.tx_total_revenue get 0.70 mul /result.tx_margin_deduction xdef
@@ -189,7 +189,7 @@ result.tx_total_revenue get 0.70 mul /result.tx_margin_deduction xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Use COGS deduction</action_comment>
-<action_description>COGS provides larger deduction than compensation</action_description>
+<action_dsl>COGS provides larger deduction than compensation</action_dsl>
 <action_postfix>
 "cogs" /result.tx_deduction_method xdef
 result.tx_cogs get /result.tx_margin_deduction xdef
@@ -201,7 +201,7 @@ result.tx_cogs get /result.tx_margin_deduction xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Use compensation deduction</action_comment>
-<action_description>Compensation provides larger deduction than COGS</action_description>
+<action_dsl>Compensation provides larger deduction than COGS</action_dsl>
 <action_postfix>
 "compensation" /result.tx_deduction_method xdef
 result.tx_compensation get /result.tx_margin_deduction xdef
@@ -235,7 +235,7 @@ result.tx_compensation get /result.tx_margin_deduction xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus and above no-tax-due threshold; result.tx_qualifies_for_no_tax_due == false</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.tx_qualifies_for_no_tax_due get false eq
 </condition_postfix>
@@ -247,7 +247,7 @@ result.tx_qualifies_for_no_tax_due get false eq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Qualifies for E-Z computation ($20M or less in revenue)</condition_comment>
-<condition_description>result.tx_total_revenue &lt;= 20000000.0</condition_description>
+<condition_dsl>result.tx_total_revenue &lt;= 20000000.0</condition_dsl>
 <condition_postfix>
 result.tx_total_revenue get 20000000.0 le
 </condition_postfix>
@@ -261,7 +261,7 @@ result.tx_total_revenue get 20000000.0 le
 <action_details>
 <action_number>1</action_number>
 <action_comment>No nexus or below threshold - no margin calculation; No franchise tax due - margin calculation not applicable</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.tx_taxable_margin xdef
 0.0 /result.tx_apportioned_margin xdef
@@ -273,7 +273,7 @@ result.tx_total_revenue get 20000000.0 le
 <action_details>
 <action_number>2</action_number>
 <action_comment>E-Z Computation option available; Calculate margin - E-Z computation available ($20M or less)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 true /result.tx_qualifies_for_ez_computation xdef
 result.tx_total_revenue get result.tx_margin_deduction get sub 0.0 max /result.tx_taxable_margin xdef
@@ -286,7 +286,7 @@ result.tx_taxable_margin get apportionment.apportionment_factor get mul /result.
 <action_details>
 <action_number>3</action_number>
 <action_comment>Standard margin calculation (no E-Z); Calculate margin - standard method (revenue exceeds $20M)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 false /result.tx_qualifies_for_ez_computation xdef
 result.tx_total_revenue get result.tx_margin_deduction get sub 0.0 max /result.tx_taxable_margin xdef
@@ -321,7 +321,7 @@ result.tx_taxable_margin get apportionment.apportionment_factor get mul /result.
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has nexus and above no-tax-due threshold; result.tx_qualifies_for_no_tax_due == false</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.tx_qualifies_for_no_tax_due get false eq
 </condition_postfix>
@@ -335,7 +335,7 @@ result.tx_qualifies_for_no_tax_due get false eq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive apportioned margin</condition_comment>
-<condition_description>result.tx_apportioned_margin &gt; 0</condition_description>
+<condition_dsl>result.tx_apportioned_margin &gt; 0</condition_dsl>
 <condition_postfix>
 result.tx_apportioned_margin get 0 gt
 </condition_postfix>
@@ -349,7 +349,7 @@ result.tx_apportioned_margin get 0 gt
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Elects to use E-Z computation method; result.tx_qualifies_for_ez_computation == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.tx_qualifies_for_ez_computation get true eq
 </condition_postfix>
@@ -363,7 +363,7 @@ result.tx_qualifies_for_ez_computation get true eq
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Primarily engaged in retail or wholesale trade</condition_comment>
-<condition_description>result.tx_is_retail_wholesale == true</condition_description>
+<condition_dsl>result.tx_is_retail_wholesale == true</condition_dsl>
 <condition_postfix>
 result.tx_is_retail_wholesale get true eq
 </condition_postfix>
@@ -379,7 +379,7 @@ result.tx_is_retail_wholesale get true eq
 <action_details>
 <action_number>1</action_number>
 <action_comment>No nexus or below threshold - no franchise tax; No Texas franchise tax due</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.tx_franchise_tax xdef
 0.0 /apportionment.state_tax xdef
@@ -392,7 +392,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>E-Z Computation (simplified method); TX franchise tax using E-Z computation (0.575%)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.tx_total_revenue get result.tx_no_tax_due_threshold get sub 0.0 max /taxable_revenue xdef
 taxable_revenue get result.tx_ez_computation_rate get mul apportionment.apportionment_factor get mul /result.tx_franchise_tax xdef
@@ -407,7 +407,7 @@ apportionment.state_payments get apportionment.state_tax get sub /apportionment.
 <action_details>
 <action_number>3</action_number>
 <action_comment>Retail/wholesale reduced rate (0.375%); TX franchise tax at reduced retail/wholesale rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.00375 /result.tx_margin_tax_rate xdef
 result.tx_apportioned_margin get result.tx_margin_tax_rate get mul /result.tx_franchise_tax xdef
@@ -422,7 +422,7 @@ apportionment.state_payments get apportionment.state_tax get sub /apportionment.
 <action_details>
 <action_number>4</action_number>
 <action_comment>Standard rate (0.75%); TX franchise tax at standard rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0075 /result.tx_margin_tax_rate xdef
 result.tx_apportioned_margin get result.tx_margin_tax_rate get mul /result.tx_franchise_tax xdef
@@ -437,7 +437,7 @@ apportionment.state_payments get apportionment.state_tax get sub /apportionment.
 <action_details>
 <action_number>5</action_number>
 <action_comment>No apportioned margin - no franchise tax; No TX franchise tax due - zero or negative margin</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.tx_franchise_tax xdef
 0.0 /apportionment.state_tax xdef

--- a/sampleprojects/CorporateTax/xml/states/UT_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/UT_corp_dt.xml
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in UT (office, employees, property)</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "UT"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "UT"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence get true eq
 apportionment.state_code get "UT" streq and
@@ -36,7 +36,7 @@ apportionment.state_code get "UT" streq and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets UT economic nexus threshold ($100K)</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "UT"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "UT"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.state_code get "UT" streq and
@@ -51,7 +51,7 @@ apportionment.state_code get "UT" streq and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - filing required</action_comment>
-<action_description>UT filing required due to physical presence</action_description>
+<action_dsl>UT filing required due to physical presence</action_dsl>
 <action_postfix>
 "UT filing required due to physical presence. Reference: UT Code 59-7-102" job.audit_trail swap addto
 </action_postfix>
@@ -61,7 +61,7 @@ apportionment.state_code get "UT" streq and
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established - filing required; UT filing required due to economic nexus ($100K threshold)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "UT filing required due to economic nexus. $100K threshold (200-transaction threshold removed per S.B. 47). Reference: UT Code 59-7-102" job.audit_trail swap addto
 </action_postfix>
@@ -71,7 +71,7 @@ apportionment.state_code get "UT" streq and
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required; No UT nexus - no filing requirement</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef
@@ -105,7 +105,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -119,7 +119,7 @@ apportionment.has_physical_presence get true eq or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate UT state additions and subtractions; Calculate UT-specific income adjustments</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_additions xdef
 0.0 /apportionment.state_subtractions xdef
@@ -131,7 +131,7 @@ apportionment.has_physical_presence get true eq or
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no state adjustments; No UT nexus - no adjustments calculated</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_additions xdef
 0.0 /apportionment.state_subtractions xdef
@@ -165,7 +165,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -178,7 +178,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income get 0 gt
 </condition_postfix>
@@ -192,7 +192,7 @@ apportionment.state_taxable_income get 0 gt
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate UT tax at 4.50% flat rate; UT income tax at 4.50% (reduced from 4.55% in 2025)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 apportionment.state_taxable_income get apportionment.state_tax_rate get mul /apportionment.state_tax xdef
 apportionment.state_tax get apportionment.state_credits get sub 0.0 max /apportionment.state_tax xdef
@@ -205,7 +205,7 @@ apportionment.state_payments get apportionment.state_tax get sub /apportionment.
 <action_details>
 <action_number>2</action_number>
 <action_comment>No UT nexus - no tax liability; No UT nexus - no tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef
@@ -217,7 +217,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Nexus but no taxable income; No UT taxable income - no tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef

--- a/sampleprojects/CorporateTax/xml/states/VA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/VA_corp_dt.xml
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in VA (office, employees, property)</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "VA"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "VA"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence get true eq
 apportionment.state_code get "VA" streq and
@@ -36,7 +36,7 @@ apportionment.state_code get "VA" streq and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets VA economic nexus threshold ($100K or 200 transactions)</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "VA"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "VA"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.state_code get "VA" streq and
@@ -51,7 +51,7 @@ apportionment.state_code get "VA" streq and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - filing required</action_comment>
-<action_description>VA filing required due to physical presence</action_description>
+<action_dsl>VA filing required due to physical presence</action_dsl>
 <action_postfix>
 "VA filing required due to physical presence. Reference: VA Code 58.1-400" job.audit_trail swap addto
 </action_postfix>
@@ -61,7 +61,7 @@ apportionment.state_code get "VA" streq and
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established per Wayfair - filing required</action_comment>
-<action_description>VA filing required due to economic nexus</action_description>
+<action_dsl>VA filing required due to economic nexus</action_dsl>
 <action_postfix>
 "VA filing required due to economic nexus. Threshold: $100K OR 200 transactions. Reference: VA Code 58.1-612" job.audit_trail swap addto
 </action_postfix>
@@ -71,7 +71,7 @@ apportionment.state_code get "VA" streq and
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required; No VA nexus - no filing requirement</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef
@@ -105,7 +105,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -119,7 +119,7 @@ apportionment.has_physical_presence get true eq or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate VA state additions and subtractions; Calculate VA-specific income adjustments</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_additions xdef
 0.0 /apportionment.state_subtractions xdef
@@ -131,7 +131,7 @@ apportionment.has_physical_presence get true eq or
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no state adjustments; No VA nexus - no adjustments calculated</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_additions xdef
 0.0 /apportionment.state_subtractions xdef
@@ -165,7 +165,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -178,7 +178,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income get 0 gt
 </condition_postfix>
@@ -192,7 +192,7 @@ apportionment.state_taxable_income get 0 gt
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate VA tax at 6% flat rate; VA income tax at 6% flat rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 apportionment.state_taxable_income get apportionment.state_tax_rate get mul /apportionment.state_tax xdef
 apportionment.state_tax get apportionment.state_credits get sub 0.0 max /apportionment.state_tax xdef
@@ -205,7 +205,7 @@ apportionment.state_payments get apportionment.state_tax get sub /apportionment.
 <action_details>
 <action_number>2</action_number>
 <action_comment>No VA nexus - no tax liability; No VA nexus - no tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef
@@ -217,7 +217,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Nexus but no taxable income; No VA taxable income - no tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef

--- a/sampleprojects/CorporateTax/xml/states/VT_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/VT_corp_dt.xml
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in VT (office, employees, property)</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "VT"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "VT"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence get true eq
 apportionment.state_code get "VT" streq and
@@ -36,7 +36,7 @@ apportionment.state_code get "VT" streq and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets VT economic nexus ("doing business" standard)</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "VT"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "VT"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.state_code get "VT" streq and
@@ -51,7 +51,7 @@ apportionment.state_code get "VT" streq and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - filing required</action_comment>
-<action_description>VT filing required due to physical presence</action_description>
+<action_dsl>VT filing required due to physical presence</action_dsl>
 <action_postfix>
 "VT filing required due to physical presence. Reference: 32 V.S.A. 5833" job.audit_trail swap addto
 </action_postfix>
@@ -61,7 +61,7 @@ apportionment.state_code get "VT" streq and
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established - filing required; VT filing required due to economic nexus ("doing business" standard)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "VT filing required due to economic nexus (doing business standard). Reference: 32 V.S.A. 5833" job.audit_trail swap addto
 </action_postfix>
@@ -71,7 +71,7 @@ apportionment.state_code get "VT" streq and
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required; No VT nexus - no filing requirement</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef
@@ -105,7 +105,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -119,7 +119,7 @@ apportionment.has_physical_presence get true eq or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate VT state additions and subtractions; Calculate VT-specific income adjustments</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_additions xdef
 0.0 /apportionment.state_subtractions xdef
@@ -131,7 +131,7 @@ apportionment.has_physical_presence get true eq or
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no state adjustments; No VT nexus - no adjustments calculated</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_additions xdef
 0.0 /apportionment.state_subtractions xdef
@@ -165,7 +165,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -178,7 +178,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income get 0 gt
 </condition_postfix>
@@ -192,7 +192,7 @@ apportionment.state_taxable_income get 0 gt
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate VT tax using graduated brackets (6%, 7%, 8.5%); VT income tax using graduated rates: 6% up to $10K, 7% $10K-$25K, 8.5% over $25K</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 apportionment.state_taxable_income get /taxable_income xdef
 0.0 /calculated_tax xdef
@@ -223,7 +223,7 @@ apportionment.state_payments get apportionment.state_tax get sub /apportionment.
 <action_details>
 <action_number>2</action_number>
 <action_comment>No VT nexus - no tax liability; No VT nexus - no tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 0.0 /apportionment.vt_calculated_tax xdef
@@ -236,7 +236,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Nexus but no taxable income; No VT taxable income - no tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 0.0 /apportionment.vt_calculated_tax xdef

--- a/sampleprojects/CorporateTax/xml/states/WA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/WA_corp_dt.xml
@@ -19,7 +19,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in Washington</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "WA"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "WA"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence get true eq
 apportionment.state_code get "WA" streq and
@@ -29,7 +29,7 @@ apportionment.state_code get "WA" streq and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets Washington economic nexus threshold</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "WA"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "WA"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.state_code get "WA" streq and
@@ -42,7 +42,7 @@ apportionment.state_code get "WA" streq and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus - B&amp;O tax filing required; Physical nexus established - B&amp;O tax filing required (calculated by table 51080)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "Washington B&amp;O tax filing required due to physical presence. Physical presence includes: office/business in WA, employees in WA, tangible property in WA, inventory in WA, or regular solicitation in WA. References: RCW 82.04.067 (Nexus), WAC 458-20-193 (Interstate Sales), WAC 458-20-19401 (Economic Nexus)" job.audit_trail swap addto
 </action_postfix>
@@ -51,7 +51,7 @@ apportionment.state_code get "WA" streq and
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus - B&amp;O tax filing required</action_comment>
-<action_description>Economic nexus established per Wayfair - filing required</action_description>
+<action_dsl>Economic nexus established per Wayfair - filing required</action_dsl>
 <action_postfix>
 "Washington B&amp;O tax filing required due to economic nexus. Economic nexus threshold (either): $100,000 or more in Washington receipts (gross revenue), OR 200 or more separate transactions in Washington. Washington adopted economic nexus following South Dakota v. Wayfair (2018). References: RCW 82.04.067 (Economic Nexus), WAC 458-20-19401 (Economic Nexus Rules), South Dakota v. Wayfair, Inc., 138 S. Ct. 2080 (2018)" job.audit_trail swap addto
 </action_postfix>
@@ -60,7 +60,7 @@ apportionment.state_code get "WA" streq and
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required; No Washington nexus - no B&amp;O tax filing requirement</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.wa_bo_tax xdef
 0.0 /apportionment.state_tax xdef
@@ -91,7 +91,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate WA gross receipts; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -103,7 +103,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has calculated apportionment percentage to Washington</condition_comment>
-<condition_description>apportionment.apportionment_percentage &gt; 0</condition_description>
+<condition_dsl>apportionment.apportionment_percentage &gt; 0</condition_dsl>
 <condition_postfix>
 apportionment.apportionment_percentage get 0 gt
 </condition_postfix>
@@ -115,7 +115,7 @@ apportionment.apportionment_percentage get 0 gt
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate WA gross receipts using apportionment; Calculate WA-sourced gross receipts using apportionment percentage</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 revenue.total_revenue get apportionment.apportionment_percentage get mul /result.wa_gross_receipts xdef
 "Washington gross receipts calculation for B&amp;O tax using market-based sourcing. Reference: RCW 82.04.460" job.audit_trail swap addto
@@ -125,7 +125,7 @@ revenue.total_revenue get apportionment.apportionment_percentage get mul /result
 <action_details>
 <action_number>2</action_number>
 <action_comment>No apportionment - assume 100% WA; No apportionment calculated - treating all receipts as Washington-sourced</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 revenue.total_revenue get /result.wa_gross_receipts xdef
 "No apportionment percentage - treating all receipts as Washington-sourced." job.audit_trail swap addto
@@ -135,7 +135,7 @@ revenue.total_revenue get /result.wa_gross_receipts xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no WA gross receipts; No Washington nexus - no gross receipts attributed to Washington</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.wa_gross_receipts xdef
 "No Washington nexus - no gross receipts attributed to Washington." job.audit_trail swap addto
@@ -164,7 +164,7 @@ revenue.total_revenue get /result.wa_gross_receipts xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Business classification code</condition_comment>
-<condition_description>result.wa_business_classification</condition_description>
+<condition_dsl>result.wa_business_classification</condition_dsl>
 <condition_postfix>
 result.wa_business_classification
 </condition_postfix>
@@ -180,7 +180,7 @@ result.wa_business_classification
 <action_details>
 <action_number>1</action_number>
 <action_comment>Retailing B&amp;O rate: 0.471%; Set retailing B&amp;O tax rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.wa_retailing_rate /result.wa_bo_tax_rate xdef
 "Washington B&amp;O tax - Retailing classification: 0.471%. Retailing includes sales of tangible personal property to consumers for consumption or use (not for resale). References: RCW 82.04.250 (Retailing), RCW 82.04.470 (Retailing B&amp;O Tax Rate)" job.audit_trail swap addto
@@ -190,7 +190,7 @@ result.wa_retailing_rate /result.wa_bo_tax_rate xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Wholesaling B&amp;O rate: 0.484%; Set wholesaling B&amp;O tax rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.wa_wholesaling_rate /result.wa_bo_tax_rate xdef
 "Washington B&amp;O tax - Wholesaling classification: 0.484%. Wholesaling includes sales of tangible personal property to persons for purpose of resale. References: RCW 82.04.060 (Wholesaling), RCW 82.04.270 (Wholesaling B&amp;O Tax)" job.audit_trail swap addto
@@ -200,7 +200,7 @@ result.wa_wholesaling_rate /result.wa_bo_tax_rate xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Manufacturing B&amp;O rate: 0.484%; Set manufacturing B&amp;O tax rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.wa_manufacturing_rate /result.wa_bo_tax_rate xdef
 "Washington B&amp;O tax - Manufacturing classification: 0.484%. Manufacturing includes production of articles for sale from raw materials, including processing, fabricating, assembling, extracting. Note: Certain manufacturers may qualify for preferential rates or exemptions. References: RCW 82.04.240 (Manufacturing), RCW 82.04.440 (Manufacturing B&amp;O Tax)" job.audit_trail swap addto
@@ -210,7 +210,7 @@ result.wa_manufacturing_rate /result.wa_bo_tax_rate xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Financial Business B&amp;O rate: 1.5%; Set financial business B&amp;O tax rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.wa_financial_rate /result.wa_bo_tax_rate xdef
 "Washington B&amp;O tax - Financial Business classification: 1.5% (highest rate). Financial business includes banks, savings and loan associations, credit unions, finance companies, insurance companies, and similar institutions. Reference: RCW 82.04.290 (Financial Business)" job.audit_trail swap addto
@@ -220,7 +220,7 @@ result.wa_financial_rate /result.wa_bo_tax_rate xdef
 <action_details>
 <action_number>5</action_number>
 <action_comment>Professional Services B&amp;O rate: 0.484%; Set professional services B&amp;O tax rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.wa_professional_rate /result.wa_bo_tax_rate xdef
 "Washington B&amp;O tax - Professional Services classification: 0.484%. Professional services include legal, accounting, engineering, consulting, and other professional activities. Reference: RCW 82.04.290 (Service and Other Activities)" job.audit_trail swap addto
@@ -230,7 +230,7 @@ result.wa_professional_rate /result.wa_bo_tax_rate xdef
 <action_details>
 <action_number>6</action_number>
 <action_comment>Service and Other Activities B&amp;O rate: 0.484%; Set service and other activities B&amp;O tax rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.wa_service_rate /result.wa_bo_tax_rate xdef
 "Washington B&amp;O tax - Service and Other Activities classification: 0.484%. This is the catch-all classification for business activities not specifically classified elsewhere. Reference: RCW 82.04.290 (Service and Other Activities)" job.audit_trail swap addto
@@ -259,7 +259,7 @@ result.wa_service_rate /result.wa_bo_tax_rate xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Total revenue below $250K small business threshold; revenue.total_revenue &lt; result.wa_small_business_credit_threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 revenue.total_revenue get result.wa_small_business_credit_threshold get lt
 </condition_postfix>
@@ -270,7 +270,7 @@ revenue.total_revenue get result.wa_small_business_credit_threshold get lt
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has Washington gross receipts subject to B&amp;O tax</condition_comment>
-<condition_description>result.wa_gross_receipts &gt; 0</condition_description>
+<condition_dsl>result.wa_gross_receipts &gt; 0</condition_dsl>
 <condition_postfix>
 result.wa_gross_receipts get 0 gt
 </condition_postfix>
@@ -282,7 +282,7 @@ result.wa_gross_receipts get 0 gt
 <action_details>
 <action_number>1</action_number>
 <action_comment>Qualifies for small business B&amp;O credit; Calculate small business credit (phases out as revenue approaches $250K)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 true /result.wa_qualifies_for_small_business_credit xdef
 1.0 revenue.total_revenue get result.wa_small_business_credit_threshold get div sub /credit_percentage xdef
@@ -295,7 +295,7 @@ max_annual_credit get credit_percentage get mul /result.wa_small_business_credit
 <action_details>
 <action_number>2</action_number>
 <action_comment>No credit - revenue exceeds threshold; No small business credit - gross revenue exceeds $250,000 threshold</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 false /result.wa_qualifies_for_small_business_credit xdef
 0.0 /result.wa_small_business_credit xdef
@@ -306,7 +306,7 @@ false /result.wa_qualifies_for_small_business_credit xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>No credit - no WA gross receipts; No small business credit - no Washington gross receipts to apply credit against</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 false /result.wa_qualifies_for_small_business_credit xdef
 0.0 /result.wa_small_business_credit xdef
@@ -336,7 +336,7 @@ false /result.wa_qualifies_for_small_business_credit xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe B&amp;O tax; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -348,7 +348,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive Washington gross receipts</condition_comment>
-<condition_description>result.wa_gross_receipts &gt; 0</condition_description>
+<condition_dsl>result.wa_gross_receipts &gt; 0</condition_dsl>
 <condition_postfix>
 result.wa_gross_receipts get 0 gt
 </condition_postfix>
@@ -360,7 +360,7 @@ result.wa_gross_receipts get 0 gt
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate B&amp;O tax with all credits; Calculate Washington B&amp;O tax on gross receipts and apply all credits</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.wa_gross_receipts get result.wa_bo_tax_rate get mul /result.wa_bo_tax xdef
 result.wa_bo_tax get result.wa_small_business_credit get sub 0.0 max /result.wa_bo_tax xdef
@@ -376,7 +376,7 @@ apportionment.state_payments get apportionment.state_tax get sub /apportionment.
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no B&amp;O tax; No Washington nexus - no B&amp;O tax liability</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.wa_bo_tax xdef
 0.0 /apportionment.state_tax xdef
@@ -388,7 +388,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>No WA gross receipts - no B&amp;O tax; No Washington gross receipts - no B&amp;O tax liability</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.wa_bo_tax xdef
 0.0 /apportionment.state_tax xdef

--- a/sampleprojects/CorporateTax/xml/states/WI_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/WI_corp_dt.xml
@@ -18,7 +18,7 @@
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize Wisconsin filing requirement determination</action_description>
+<action_dsl>Initialize Wisconsin filing requirement determination</action_dsl>
 <action_postfix>
 "Wisconsin Filing Requirement Check Started" job.audit_trail swap addto
 </action_postfix>
@@ -29,7 +29,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in Wisconsin</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "WI"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "WI"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence get true eq
 apportionment.state_code get "WI" streq and
@@ -42,7 +42,7 @@ apportionment.state_code get "WI" streq and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets Wisconsin economic nexus threshold</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "WI"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "WI"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.state_code get "WI" streq and
@@ -116,7 +116,7 @@ apportionment.state_payments /apportionment.state_refund_or_owed xdef
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize Wisconsin income adjustments calculation</action_description>
+<action_dsl>Initialize Wisconsin income adjustments calculation</action_dsl>
 <action_postfix>
 "Wisconsin Income Adjustments Calculation Started" job.audit_trail swap addto
 </action_postfix>
@@ -127,7 +127,7 @@ apportionment.state_payments /apportionment.state_refund_or_owed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -212,7 +212,7 @@ subtractions /apportionment.state_subtractions xdef
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize Wisconsin state tax calculation</action_description>
+<action_dsl>Initialize Wisconsin state tax calculation</action_dsl>
 <action_postfix>
 "Wisconsin State Tax Calculation Started" job.audit_trail swap addto
 </action_postfix>
@@ -223,7 +223,7 @@ subtractions /apportionment.state_subtractions xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -236,7 +236,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income get 0 gt
 </condition_postfix>

--- a/sampleprojects/CorporateTax/xml/states/WV_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/WV_corp_dt.xml
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has physical presence in WV (office, employees, property)</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "WV"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "WV"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence get true eq
 apportionment.state_code get "WV" streq and
@@ -36,7 +36,7 @@ apportionment.state_code get "WV" streq and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets WV economic nexus threshold ($100K or 200 transactions)</condition_comment>
-<condition_description>apportionment.has_economic_nexus == true AND apportionment.state_code == "WV"</condition_description>
+<condition_dsl>apportionment.has_economic_nexus == true AND apportionment.state_code == "WV"</condition_dsl>
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.state_code get "WV" streq and
@@ -51,7 +51,7 @@ apportionment.state_code get "WV" streq and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Physical nexus established - filing required</action_comment>
-<action_description>WV filing required due to physical presence</action_description>
+<action_dsl>WV filing required due to physical presence</action_dsl>
 <action_postfix>
 "WV filing required due to physical presence. Reference: WV Code 11-24-7" job.audit_trail swap addto
 </action_postfix>
@@ -61,7 +61,7 @@ apportionment.state_code get "WV" streq and
 <action_details>
 <action_number>2</action_number>
 <action_comment>Economic nexus established per Wayfair - filing required</action_comment>
-<action_description>WV filing required due to economic nexus</action_description>
+<action_dsl>WV filing required due to economic nexus</action_dsl>
 <action_postfix>
 "WV filing required due to economic nexus. Threshold: $100K OR 200 transactions. Reference: WV Code 11-24-7" job.audit_trail swap addto
 </action_postfix>
@@ -71,7 +71,7 @@ apportionment.state_code get "WV" streq and
 <action_details>
 <action_number>3</action_number>
 <action_comment>No nexus - no filing required; No WV nexus - no filing requirement</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef
@@ -105,7 +105,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to calculate adjustments; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -119,7 +119,7 @@ apportionment.has_physical_presence get true eq or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate WV state additions and subtractions; Calculate WV-specific income adjustments</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_additions xdef
 0.0 /apportionment.state_subtractions xdef
@@ -131,7 +131,7 @@ apportionment.has_physical_presence get true eq or
 <action_details>
 <action_number>2</action_number>
 <action_comment>No nexus - no state adjustments; No WV nexus - no adjustments calculated</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_additions xdef
 0.0 /apportionment.state_subtractions xdef
@@ -165,7 +165,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Must have nexus to owe tax; apportionment.has_economic_nexus == true OR apportionment.has_physical_presence == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 apportionment.has_economic_nexus get true eq
 apportionment.has_physical_presence get true eq or
@@ -178,7 +178,7 @@ apportionment.has_physical_presence get true eq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has positive state taxable income</condition_comment>
-<condition_description>apportionment.state_taxable_income &gt; 0</condition_description>
+<condition_dsl>apportionment.state_taxable_income &gt; 0</condition_dsl>
 <condition_postfix>
 apportionment.state_taxable_income get 0 gt
 </condition_postfix>
@@ -192,7 +192,7 @@ apportionment.state_taxable_income get 0 gt
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate WV tax at 6.5% flat rate; WV income tax at 6.5% flat rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 apportionment.state_taxable_income get apportionment.state_tax_rate get mul /apportionment.state_tax xdef
 apportionment.state_tax get apportionment.state_credits get sub 0.0 max /apportionment.state_tax xdef
@@ -205,7 +205,7 @@ apportionment.state_payments get apportionment.state_tax get sub /apportionment.
 <action_details>
 <action_number>2</action_number>
 <action_comment>No WV nexus - no tax liability; No WV nexus - no tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef
@@ -217,7 +217,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Nexus but no taxable income; No WV taxable income - no tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax xdef
 apportionment.state_payments get /apportionment.state_refund_or_owed xdef

--- a/sampleprojects/CorporateTax/xml/states/WY_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/WY_corp_dt.xml
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has presence in Wyoming (incorporated or registered)</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "WY"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "WY"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence get true eq
 apportionment.state_code get "WY" streq and
@@ -36,7 +36,7 @@ apportionment.state_code get "WY" streq and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Corporation incorporated in Wyoming (domestic)</condition_comment>
-<condition_description>corporation.state_of_incorporation == "WY"</condition_description>
+<condition_dsl>corporation.state_of_incorporation == "WY"</condition_dsl>
 <condition_postfix>
 corporation.state_of_incorporation get "WY" streq
 </condition_postfix>
@@ -50,7 +50,7 @@ corporation.state_of_incorporation get "WY" streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Wyoming domestic corporation - annual report required ($60); Wyoming has NO corporate income tax - only annual report ($60)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.wy_annual_report_fee_domestic get /result.wy_annual_report_fee xdef
 0.0 /result.wy_state_tax xdef
@@ -63,7 +63,7 @@ result.wy_annual_report_fee_domestic get /result.wy_annual_report_fee xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Wyoming foreign corporation - annual report required ($120); Wyoming has NO corporate income tax - only annual report ($120 foreign)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.wy_annual_report_fee_foreign get /result.wy_annual_report_fee xdef
 0.0 /result.wy_state_tax xdef
@@ -76,7 +76,7 @@ result.wy_annual_report_fee_foreign get /result.wy_annual_report_fee xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>No Wyoming presence - no filing requirement; No Wyoming presence - no filing requirement</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.wy_annual_report_fee xdef
 0.0 /result.wy_state_tax xdef
@@ -112,7 +112,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has presence in Wyoming</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "WY"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "WY"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence get true eq
 apportionment.state_code get "WY" streq and
@@ -126,7 +126,7 @@ apportionment.state_code get "WY" streq and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Wyoming - no income tax adjustments; Wyoming has NO corporate income tax - no adjustments</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax_rate xdef
 0.0 /apportionment.state_additions xdef
@@ -142,7 +142,7 @@ true /result.wy_no_franchise_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No Wyoming presence - no adjustments; No Wyoming presence - no adjustments</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /apportionment.state_tax_rate xdef
 0.0 /apportionment.state_additions xdef
@@ -180,7 +180,7 @@ true /result.wy_no_franchise_tax xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has presence in Wyoming (incorporated or registered)</condition_comment>
-<condition_description>apportionment.has_physical_presence == true AND apportionment.state_code == "WY"</condition_description>
+<condition_dsl>apportionment.has_physical_presence == true AND apportionment.state_code == "WY"</condition_dsl>
 <condition_postfix>
 apportionment.has_physical_presence get true eq
 apportionment.state_code get "WY" streq and
@@ -194,7 +194,7 @@ apportionment.state_code get "WY" streq and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Wyoming - $0 corporate tax; Wyoming has NO corporate income tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.wy_state_tax xdef
 0.0 /apportionment.state_tax xdef
@@ -207,7 +207,7 @@ apportionment.state_payments get /apportionment.state_refund_or_owed xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No Wyoming presence - $0 tax; No Wyoming presence - $0 tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.wy_state_tax xdef
 0.0 /apportionment.state_tax xdef

--- a/sampleprojects/DTEligibility/xml/eligibility_dt.xml
+++ b/sampleprojects/DTEligibility/xml/eligibility_dt.xml
@@ -16,7 +16,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Always run</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>otherwise</condition_postfix>
 <condition_column column_number="1" column_value="*" /></condition_details>
 </conditions>
@@ -25,56 +25,56 @@
 <action_number>1</action_number>
 <action_comment>Calculate income for all; For each member, calculate their income</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>household.members { person entitypush Calculate_Individual_Income entitypop } forall</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Determine adults</action_comment>
 <action_requirement />
-<action_description>Determine who is an adult</action_description>
+<action_dsl>Determine who is an adult</action_dsl>
 <action_postfix>household.members { person entitypush Determine_Adult_Status entitypop } forall</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate household totals; Calculate household income totals</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>Calculate_Household_Totals</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>4</action_number>
 <action_comment>Determine heads</action_comment>
 <action_requirement />
-<action_description>Determine who can be head of household</action_description>
+<action_dsl>Determine who can be head of household</action_dsl>
 <action_postfix>Determine_Head_of_Household</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>5</action_number>
 <action_comment>Create EDGs; Create eligibility groups for each potential head</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>Create_Eligibility_Groups</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>6</action_number>
 <action_comment>Non-EDG programs; Evaluate programs that dont use EDGs (Medicare, Disability)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>household.members { person entitypush Evaluate_Non_EDG_Programs entitypop } forall</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>7</action_number>
 <action_comment>EDG programs</action_comment>
 <action_requirement />
-<action_description>Evaluate means-tested programs using EDGs</action_description>
+<action_dsl>Evaluate means-tested programs using EDGs</action_dsl>
 <action_postfix>Evaluate_EDG_Programs</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>8</action_number>
 <action_comment>Vehicle assistance</action_comment>
 <action_requirement />
-<action_description>Evaluate vehicle assistance program</action_description>
+<action_dsl>Evaluate vehicle assistance program</action_dsl>
 <action_postfix>Evaluate_Vehicle_Assistance</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 </actions>
@@ -96,7 +96,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Has income sources</condition_comment>
 <condition_requirement />
-<condition_description>Person has income array</condition_description>
+<condition_dsl>Person has income array</condition_dsl>
 <condition_postfix>person.incomes notempty</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" /></condition_details>
@@ -106,7 +106,7 @@
 <action_number>1</action_number>
 <action_comment>Sum earned income; Calculate total earned income</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>0 person.incomes { income entitypush income.is_earned { income.amount + } if entitypop } forall person /earned_income exch def</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="" /></action_details>
@@ -114,7 +114,7 @@
 <action_number>2</action_number>
 <action_comment>Sum unearned income; Calculate total unearned income</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>0 person.incomes { income entitypush income.is_earned not { income.amount + } if entitypop } forall person /unearned_income exch def</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="" /></action_details>
@@ -122,7 +122,7 @@
 <action_number>3</action_number>
 <action_comment>Calculate total</action_comment>
 <action_requirement />
-<action_description>Set total income</action_description>
+<action_dsl>Set total income</action_dsl>
 <action_postfix>person.earned_income person.unearned_income + person /total_income exch def</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="" /></action_details>
@@ -130,7 +130,7 @@
 <action_number>4</action_number>
 <action_comment>No income</action_comment>
 <action_requirement />
-<action_description>Set income to zero</action_description>
+<action_dsl>Set income to zero</action_dsl>
 <action_postfix>0 person /total_income exch def 0 person /earned_income exch def 0 person /unearned_income exch def</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" /></action_details>
@@ -153,7 +153,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Age 18+; Person is 18 or older</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>person.age constants.adult_age ge</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -164,7 +164,7 @@
 <condition_number>2</condition_number>
 <condition_comment>Is parent</condition_comment>
 <condition_requirement />
-<condition_description>Person is a parent of someone in household</condition_description>
+<condition_dsl>Person is a parent of someone in household</condition_dsl>
 <condition_postfix>person.is_parent</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -175,7 +175,7 @@
 <condition_number>3</condition_number>
 <condition_comment>Is married</condition_comment>
 <condition_requirement />
-<condition_description>Person is married</condition_description>
+<condition_dsl>Person is married</condition_dsl>
 <condition_postfix>person.relationship_to_head "SPOUSE" streq</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="-" />
@@ -186,7 +186,7 @@
 <condition_number>4</condition_number>
 <condition_comment>Is elderly; Person is 65 or older</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>person.age constants.elderly_age ge</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="-" />
@@ -199,7 +199,7 @@
 <action_number>1</action_number>
 <action_comment>Mark as adult</action_comment>
 <action_requirement />
-<action_description>Set is_adult to true</action_description>
+<action_dsl>Set is_adult to true</action_dsl>
 <action_postfix>true person /is_adult exch def false person /is_child exch def</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="X" />
@@ -210,7 +210,7 @@
 <action_number>2</action_number>
 <action_comment>Mark as child</action_comment>
 <action_requirement />
-<action_description>Set is_child to true</action_description>
+<action_dsl>Set is_child to true</action_dsl>
 <action_postfix>false person /is_adult exch def true person /is_child exch def</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="" />
@@ -221,7 +221,7 @@
 <action_number>3</action_number>
 <action_comment>Mark elderly; Set is_elderly based on age</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>person.age constants.elderly_age ge person /is_elderly exch def</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="X" />
@@ -232,7 +232,7 @@
 <action_number>4</action_number>
 <action_comment>Add note for minor parent</action_comment>
 <action_requirement />
-<action_description>Note that minor is treated as adult due to parental status</action_description>
+<action_dsl>Note that minor is treated as adult due to parental status</action_dsl>
 <action_postfix>"Minor treated as adult due to parental status" person.notes addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -258,7 +258,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Always run</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>otherwise</condition_postfix>
 <condition_column column_number="1" column_value="*" /></condition_details>
 </conditions>
@@ -267,35 +267,35 @@
 <action_number>1</action_number>
 <action_comment>Calculate total income</action_comment>
 <action_requirement />
-<action_description>Sum all member incomes</action_description>
+<action_dsl>Sum all member incomes</action_dsl>
 <action_postfix>0 household.members { person entitypush person.total_income + entitypop } forall household /total_household_income exch def</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate earned income</action_comment>
 <action_requirement />
-<action_description>Sum all earned income</action_description>
+<action_dsl>Sum all earned income</action_dsl>
 <action_postfix>0 household.members { person entitypush person.earned_income + entitypop } forall household /total_earned_income exch def</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate unearned income</action_comment>
 <action_requirement />
-<action_description>Sum all unearned income</action_description>
+<action_dsl>Sum all unearned income</action_dsl>
 <action_postfix>0 household.members { person entitypush person.unearned_income + entitypop } forall household /total_unearned_income exch def</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>4</action_number>
 <action_comment>Count members</action_comment>
 <action_requirement />
-<action_description>Count household size</action_description>
+<action_dsl>Count household size</action_dsl>
 <action_postfix>household.members length household /household_size exch def</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>5</action_number>
 <action_comment>Find primary earner</action_comment>
 <action_requirement />
-<action_description>Find person with highest income</action_description>
+<action_dsl>Find person with highest income</action_dsl>
 <action_postfix>Determine_Primary_Earner</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 </actions>
@@ -317,7 +317,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Always</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>otherwise</condition_postfix>
 <condition_column column_number="1" column_value="*" /></condition_details>
 </conditions>
@@ -326,14 +326,14 @@
 <action_number>1</action_number>
 <action_comment>Find max earner</action_comment>
 <action_requirement />
-<action_description>Find person with highest earned income among adults</action_description>
+<action_dsl>Find person with highest earned income among adults</action_dsl>
 <action_postfix>null 0 household.members { person entitypush person.is_adult { person.earned_income 2 index gt { pop pop person person.earned_income } if } if entitypop } forall pop household /primary_earner exch def</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Mark primary earner</action_comment>
 <action_requirement />
-<action_description>Set is_primary_earner flag on the person</action_description>
+<action_dsl>Set is_primary_earner flag on the person</action_dsl>
 <action_postfix>household.primary_earner null ne { true household.primary_earner /is_primary_earner exch def } if</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 </actions>
@@ -355,7 +355,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Always</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>otherwise</condition_postfix>
 <condition_column column_number="1" column_value="*" /></condition_details>
 </conditions>
@@ -364,14 +364,14 @@
 <action_number>1</action_number>
 <action_comment>Evaluate each member</action_comment>
 <action_requirement />
-<action_description>Check if each adult can be head</action_description>
+<action_dsl>Check if each adult can be head</action_dsl>
 <action_postfix>household.members { person entitypush Evaluate_Can_Be_Head entitypop } forall</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Select primary head</action_comment>
 <action_requirement />
-<action_description>Select the primary head of household</action_description>
+<action_dsl>Select the primary head of household</action_dsl>
 <action_postfix>Select_Primary_Head</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 </actions>
@@ -393,7 +393,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Is adult</condition_comment>
 <condition_requirement />
-<condition_description>Person must be an adult</condition_description>
+<condition_dsl>Person must be an adult</condition_dsl>
 <condition_postfix>person.is_adult</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="Y" />
@@ -403,7 +403,7 @@
 <condition_number>2</condition_number>
 <condition_comment>US citizen or qualified; Must be US citizen or qualified immigrant</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>person.is_us_citizen person.immigration_status "QUALIFIED" streq or</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="Y" />
@@ -413,7 +413,7 @@
 <condition_number>3</condition_number>
 <condition_comment>Has income or disabled; Has income or is disabled</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>person.total_income 0 gt person.is_disabled or</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -425,7 +425,7 @@
 <action_number>1</action_number>
 <action_comment>Can be head</action_comment>
 <action_requirement />
-<action_description>Mark person as eligible to be head</action_description>
+<action_dsl>Mark person as eligible to be head</action_dsl>
 <action_postfix>true person /can_be_head exch def</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="" />
@@ -435,7 +435,7 @@
 <action_number>2</action_number>
 <action_comment>Cannot be head</action_comment>
 <action_requirement />
-<action_description>Mark person as not eligible to be head</action_description>
+<action_dsl>Mark person as not eligible to be head</action_dsl>
 <action_postfix>false person /can_be_head exch def</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -445,7 +445,7 @@
 <action_number>3</action_number>
 <action_comment>Note no income; Add note about no income</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>"Cannot be head - no income and not disabled" person.notes addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -455,7 +455,7 @@
 <action_number>4</action_number>
 <action_comment>Note citizenship</action_comment>
 <action_requirement />
-<action_description>Add note about citizenship</action_description>
+<action_dsl>Add note about citizenship</action_dsl>
 <action_postfix>"Cannot be head - citizenship requirement not met" person.notes addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="" />
@@ -480,7 +480,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Primary earner can be head</condition_comment>
 <condition_requirement />
-<condition_description>Primary earner is eligible to be head</condition_description>
+<condition_dsl>Primary earner is eligible to be head</condition_dsl>
 <condition_postfix>household.primary_earner null ne { household.primary_earner entitypush person.can_be_head entitypop } { false } ifelse</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -489,7 +489,7 @@
 <condition_number>2</condition_number>
 <condition_comment>Any adult can be head; At least one adult can be head</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>false household.members { person entitypush person.can_be_head { pop true } if entitypop } forall</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -500,7 +500,7 @@
 <action_number>1</action_number>
 <action_comment>Primary earner is head</action_comment>
 <action_requirement />
-<action_description>Set primary earner as head of household</action_description>
+<action_dsl>Set primary earner as head of household</action_dsl>
 <action_postfix>household.primary_earner household /head_of_household exch def</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="" />
@@ -509,7 +509,7 @@
 <action_number>2</action_number>
 <action_comment>First eligible adult</action_comment>
 <action_requirement />
-<action_description>Select first eligible adult as head</action_description>
+<action_dsl>Select first eligible adult as head</action_dsl>
 <action_postfix>household.members { person entitypush person.can_be_head { person household /head_of_household exch def exit } if entitypop } forall</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -518,7 +518,7 @@
 <action_number>3</action_number>
 <action_comment>No eligible head; Add error - no eligible head</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>"ERROR: No eligible head of household found" job.errors addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="" />
@@ -542,7 +542,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Always</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>otherwise</condition_postfix>
 <condition_column column_number="1" column_value="*" /></condition_details>
 </conditions>
@@ -551,14 +551,14 @@
 <action_number>1</action_number>
 <action_comment>Clear existing EDGs</action_comment>
 <action_requirement />
-<action_description>Clear any existing eligibility groups</action_description>
+<action_dsl>Clear any existing eligibility groups</action_dsl>
 <action_postfix>newarray household /eligibility_groups exch def</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Create EDG for each head; For each person who can be head, create an EDG</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>household.members { person entitypush person.can_be_head { Build_EDG_For_Head } if entitypop } forall</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 </actions>
@@ -580,7 +580,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Always</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>otherwise</condition_postfix>
 <condition_column column_number="1" column_value="*" /></condition_details>
 </conditions>
@@ -589,56 +589,56 @@
 <action_number>1</action_number>
 <action_comment>Create EDG entity</action_comment>
 <action_requirement />
-<action_description>Create new eligibility group entity</action_description>
+<action_dsl>Create new eligibility group entity</action_dsl>
 <action_postfix>eligibility_group createentity</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Set head</action_comment>
 <action_requirement />
-<action_description>Set the head of this EDG</action_description>
+<action_dsl>Set the head of this EDG</action_dsl>
 <action_postfix>person eligibility_group /head exch def</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment>Set group ID</action_comment>
 <action_requirement />
-<action_description>Create unique group ID using head person ID</action_description>
+<action_dsl>Create unique group ID using head person ID</action_dsl>
 <action_postfix>"EDG-" person.person_id strconcat eligibility_group /group_id exch def</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>4</action_number>
 <action_comment>Initialize members</action_comment>
 <action_requirement />
-<action_description>Create empty members array and add head</action_description>
+<action_dsl>Create empty members array and add head</action_dsl>
 <action_postfix>newarray eligibility_group /members exch def person eligibility_group.members addto</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>5</action_number>
 <action_comment>Add group members</action_comment>
 <action_requirement />
-<action_description>Add related members to this EDG</action_description>
+<action_dsl>Add related members to this EDG</action_dsl>
 <action_postfix>Calculate_EDG_Members</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate group totals; Calculate group size and income</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>Calculate_EDG_Totals</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>7</action_number>
 <action_comment>Calculate group FPL; Calculate FPL percentage for this EDG</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>Calculate_EDG_FPL</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>8</action_number>
 <action_comment>Add to household</action_comment>
 <action_requirement />
-<action_description>Add this EDG to household list</action_description>
+<action_dsl>Add this EDG to household list</action_dsl>
 <action_postfix>eligibility_group household.eligibility_groups addto</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 </actions>
@@ -660,7 +660,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Always</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>otherwise</condition_postfix>
 <condition_column column_number="1" column_value="*" /></condition_details>
 </conditions>
@@ -669,7 +669,7 @@
 <action_number>1</action_number>
 <action_comment>Add related members; For each household member, check if they belong in this EDG</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>household.members { dup eligibility_group.head ne { dup entitypush Check_EDG_Membership entitypop } { pop } ifelse } forall</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 </actions>
@@ -691,7 +691,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Is spouse of head</condition_comment>
 <condition_requirement />
-<condition_description>Person is the spouse of the EDG head</condition_description>
+<condition_dsl>Person is the spouse of the EDG head</condition_dsl>
 <condition_postfix>person.relationship_to_head "SPOUSE" streq eligibility_group.head entitypush person.relationship_to_head entitypop "SPOUSE" streq and</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -702,7 +702,7 @@
 <condition_number>2</condition_number>
 <condition_comment>Head is parent of person</condition_comment>
 <condition_requirement />
-<condition_description>The EDG head is a parent of this person</condition_description>
+<condition_dsl>The EDG head is a parent of this person</condition_dsl>
 <condition_postfix>eligibility_group.head entitypush person.is_mother person.is_father or entitypop</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -713,7 +713,7 @@
 <condition_number>3</condition_number>
 <condition_comment>Person is parent of head; This person is a parent of the EDG head (if head is child)</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>person.is_mother person.is_father or eligibility_group.head entitypush person.is_child entitypop and</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="-" />
@@ -724,7 +724,7 @@
 <condition_number>4</condition_number>
 <condition_comment>Minor sibling</condition_comment>
 <condition_requirement />
-<condition_description>Person is under 18 and shares a parent with head</condition_description>
+<condition_dsl>Person is under 18 and shares a parent with head</condition_dsl>
 <condition_postfix>person.is_child person.relationship_to_head "SIBLING" streq and</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="-" />
@@ -737,7 +737,7 @@
 <action_number>1</action_number>
 <action_comment>Add to EDG</action_comment>
 <action_requirement />
-<action_description>Add this person to the EDG members</action_description>
+<action_dsl>Add this person to the EDG members</action_dsl>
 <action_postfix>person eligibility_group.members addto</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="X" />
@@ -763,7 +763,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Always</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>otherwise</condition_postfix>
 <condition_column column_number="1" column_value="*" /></condition_details>
 </conditions>
@@ -772,14 +772,14 @@
 <action_number>1</action_number>
 <action_comment>Count members</action_comment>
 <action_requirement />
-<action_description>Set group size</action_description>
+<action_dsl>Set group size</action_dsl>
 <action_postfix>eligibility_group.members length eligibility_group /group_size exch def</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Sum income; Calculate total group income from adult members only</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>0 eligibility_group.members { dup entitypush dup is_adult { total_income + } { pop } ifelse entitypop } forall eligibility_group /group_income exch def</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 </actions>
@@ -801,7 +801,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Size 1</condition_comment>
 <condition_requirement />
-<condition_description>EDG has 1 member</condition_description>
+<condition_dsl>EDG has 1 member</condition_dsl>
 <condition_postfix>eligibility_group.group_size 1 eq</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -812,7 +812,7 @@
 <condition_number>2</condition_number>
 <condition_comment>Size 2</condition_comment>
 <condition_requirement />
-<condition_description>EDG has 2 members</condition_description>
+<condition_dsl>EDG has 2 members</condition_dsl>
 <condition_postfix>eligibility_group.group_size 2 eq</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -823,7 +823,7 @@
 <condition_number>3</condition_number>
 <condition_comment>Size 3</condition_comment>
 <condition_requirement />
-<condition_description>EDG has 3 members</condition_description>
+<condition_dsl>EDG has 3 members</condition_dsl>
 <condition_postfix>eligibility_group.group_size 3 eq</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="-" />
@@ -834,7 +834,7 @@
 <condition_number>4</condition_number>
 <condition_comment>Size 4</condition_comment>
 <condition_requirement />
-<condition_description>EDG has 4 members</condition_description>
+<condition_dsl>EDG has 4 members</condition_dsl>
 <condition_postfix>eligibility_group.group_size 4 eq</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="-" />
@@ -847,7 +847,7 @@
 <action_number>1</action_number>
 <action_comment>FPL for 1; Calculate FPL percentage for 1 person</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>eligibility_group.group_income 100 * constants.fpl_base_1 / eligibility_group /group_fpl exch def</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="" />
@@ -858,7 +858,7 @@
 <action_number>2</action_number>
 <action_comment>FPL for 2; Calculate FPL percentage for 2 people</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>eligibility_group.group_income 100 * constants.fpl_base_2 / eligibility_group /group_fpl exch def</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -869,7 +869,7 @@
 <action_number>3</action_number>
 <action_comment>FPL for 3; Calculate FPL percentage for 3 people</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>eligibility_group.group_income 100 * constants.fpl_base_3 / eligibility_group /group_fpl exch def</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="" />
@@ -880,7 +880,7 @@
 <action_number>4</action_number>
 <action_comment>FPL for 4; Calculate FPL percentage for 4 people</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>eligibility_group.group_income 100 * constants.fpl_base_4 / eligibility_group /group_fpl exch def</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="" />
@@ -891,7 +891,7 @@
 <action_number>5</action_number>
 <action_comment>FPL for 5+; Calculate FPL for 5+ people</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>constants.fpl_base_4 eligibility_group.group_size 4 - constants.fpl_per_additional * + eligibility_group.group_income 100 * exch / eligibility_group /group_fpl exch def</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="" />
@@ -917,7 +917,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Always</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>otherwise</condition_postfix>
 <condition_column column_number="1" column_value="*" /></condition_details>
 </conditions>
@@ -926,14 +926,14 @@
 <action_number>1</action_number>
 <action_comment>Medicare; Evaluate Medicare eligibility (age/disability based)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>Evaluate_Medicare_Eligibility</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Disability; Evaluate disability programs (status based)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>Evaluate_Disability_Programs</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 </actions>
@@ -955,7 +955,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Has EDGs</condition_comment>
 <condition_requirement />
-<condition_description>Household has eligibility groups</condition_description>
+<condition_dsl>Household has eligibility groups</condition_dsl>
 <condition_postfix>household.eligibility_groups notempty</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" /></condition_details>
@@ -965,7 +965,7 @@
 <action_number>1</action_number>
 <action_comment>Evaluate each person by EDG; For each person, evaluate programs under each applicable EDG</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>household.members { person entitypush Evaluate_Person_By_All_EDGs entitypop } forall</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="" /></action_details>
@@ -973,7 +973,7 @@
 <action_number>2</action_number>
 <action_comment>No EDGs warning; Add warning that no EDGs exist</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>"WARNING: No eligibility groups created - cannot evaluate means-tested programs" job.warnings addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" /></action_details>
@@ -996,7 +996,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Always</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>otherwise</condition_postfix>
 <condition_column column_number="1" column_value="*" /></condition_details>
 </conditions>
@@ -1005,7 +1005,7 @@
 <action_number>1</action_number>
 <action_comment>Check each EDG; For each EDG this person belongs to, evaluate programs</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>household.eligibility_groups { eligibility_group entitypush Check_Person_In_EDG entitypop } forall</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 </actions>
@@ -1027,7 +1027,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Person in EDG</condition_comment>
 <condition_requirement />
-<condition_description>Check if person is a member of this EDG</condition_description>
+<condition_dsl>Check if person is a member of this EDG</condition_dsl>
 <condition_postfix>false eligibility_group.members { person eq { pop true } if } forall</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" /></condition_details>
@@ -1037,7 +1037,7 @@
 <action_number>1</action_number>
 <action_comment>Evaluate programs</action_comment>
 <action_requirement />
-<action_description>Evaluate all EDG-based programs for this person using this EDG</action_description>
+<action_dsl>Evaluate all EDG-based programs for this person using this EDG</action_dsl>
 <action_postfix>Evaluate_Programs_For_EDG</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="" /></action_details>
@@ -1060,7 +1060,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Always</condition_comment>
 <condition_requirement />
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>otherwise</condition_postfix>
 <condition_column column_number="1" column_value="*" /></condition_details>
 </conditions>
@@ -1069,35 +1069,35 @@
 <action_number>1</action_number>
 <action_comment>CHIP</action_comment>
 <action_requirement />
-<action_description>Evaluate CHIP using EDG FPL</action_description>
+<action_dsl>Evaluate CHIP using EDG FPL</action_dsl>
 <action_postfix>Evaluate_CHIP_For_EDG</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Medicaid</action_comment>
 <action_requirement />
-<action_description>Evaluate Medicaid using EDG FPL</action_description>
+<action_dsl>Evaluate Medicaid using EDG FPL</action_dsl>
 <action_postfix>Evaluate_Medicaid_For_EDG</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment>SNAP</action_comment>
 <action_requirement />
-<action_description>Evaluate SNAP using EDG FPL</action_description>
+<action_dsl>Evaluate SNAP using EDG FPL</action_dsl>
 <action_postfix>Evaluate_SNAP_For_EDG</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>4</action_number>
 <action_comment>TANF</action_comment>
 <action_requirement />
-<action_description>Evaluate TANF using EDG FPL</action_description>
+<action_dsl>Evaluate TANF using EDG FPL</action_dsl>
 <action_postfix>Evaluate_TANF_For_EDG</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 <action_details>
 <action_number>5</action_number>
 <action_comment>LIHEAP</action_comment>
 <action_requirement />
-<action_description>Evaluate LIHEAP using EDG FPL</action_description>
+<action_dsl>Evaluate LIHEAP using EDG FPL</action_dsl>
 <action_postfix>Evaluate_LIHEAP_For_EDG</action_postfix>
 <action_column column_number="1" column_value="X" /></action_details>
 </actions>
@@ -1119,7 +1119,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Already eligible</condition_comment>
 <condition_requirement />
-<condition_description>Person already eligible for CHIP from another EDG</condition_description>
+<condition_dsl>Person already eligible for CHIP from another EDG</condition_dsl>
 <condition_postfix>false person.eligible_programs { "CHIP" streq { pop true } if } forall</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -1131,7 +1131,7 @@
 <condition_number>2</condition_number>
 <condition_comment>Under age limit</condition_comment>
 <condition_requirement />
-<condition_description>Person is under CHIP age limit</condition_description>
+<condition_dsl>Person is under CHIP age limit</condition_dsl>
 <condition_postfix>person.age constants.chip_max_age lt</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -1143,7 +1143,7 @@
 <condition_number>3</condition_number>
 <condition_comment>No insurance; Does not have health insurance</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>person.has_health_insurance not</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -1155,7 +1155,7 @@
 <condition_number>4</condition_number>
 <condition_comment>Citizen; US citizen or qualified immigrant</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>person.is_us_citizen person.immigration_status "QUALIFIED" streq or</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -1167,7 +1167,7 @@
 <condition_number>5</condition_number>
 <condition_comment>Income limit</condition_comment>
 <condition_requirement />
-<condition_description>EDG FPL is within CHIP limit</condition_description>
+<condition_dsl>EDG FPL is within CHIP limit</condition_dsl>
 <condition_postfix>eligibility_group.group_fpl constants.chip_max_fpl le</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -1181,7 +1181,7 @@
 <action_number>1</action_number>
 <action_comment>Eligible</action_comment>
 <action_requirement />
-<action_description>Mark eligible for CHIP via this EDG</action_description>
+<action_dsl>Mark eligible for CHIP via this EDG</action_dsl>
 <action_postfix>"CHIP" person.eligible_programs addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -1193,7 +1193,7 @@
 <action_number>2</action_number>
 <action_comment>Record EDG used</action_comment>
 <action_requirement />
-<action_description>Note which EDG made person eligible</action_description>
+<action_dsl>Note which EDG made person eligible</action_dsl>
 <action_postfix>"CHIP eligible via EDG: " eligibility_group.group_id strconcat person.notes addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -1220,7 +1220,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Already eligible</condition_comment>
 <condition_requirement />
-<condition_description>Person already eligible for Medicaid</condition_description>
+<condition_dsl>Person already eligible for Medicaid</condition_dsl>
 <condition_postfix>false person.eligible_programs { "MEDICAID" streq { pop true } if } forall</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -1231,7 +1231,7 @@
 <condition_number>2</condition_number>
 <condition_comment>Citizen; US citizen or qualified immigrant</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>person.is_us_citizen person.immigration_status "QUALIFIED" streq or</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -1242,7 +1242,7 @@
 <condition_number>3</condition_number>
 <condition_comment>Income limit</condition_comment>
 <condition_requirement />
-<condition_description>EDG FPL within Medicaid limit</condition_description>
+<condition_dsl>EDG FPL within Medicaid limit</condition_dsl>
 <condition_postfix>eligibility_group.group_fpl constants.medicaid_max_fpl le</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -1253,7 +1253,7 @@
 <condition_number>4</condition_number>
 <condition_comment>Pregnant or disabled; Is pregnant or disabled (higher income allowed)</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>person.is_pregnant person.is_disabled or</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="-" />
@@ -1266,7 +1266,7 @@
 <action_number>1</action_number>
 <action_comment>Eligible</action_comment>
 <action_requirement />
-<action_description>Mark eligible for Medicaid</action_description>
+<action_dsl>Mark eligible for Medicaid</action_dsl>
 <action_postfix>"MEDICAID" person.eligible_programs addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -1277,7 +1277,7 @@
 <action_number>2</action_number>
 <action_comment>Record EDG</action_comment>
 <action_requirement />
-<action_description>Note which EDG made person eligible</action_description>
+<action_dsl>Note which EDG made person eligible</action_dsl>
 <action_postfix>"MEDICAID eligible via EDG: " eligibility_group.group_id strconcat person.notes addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -1303,7 +1303,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Already eligible</condition_comment>
 <condition_requirement />
-<condition_description>Person already eligible for SNAP</condition_description>
+<condition_dsl>Person already eligible for SNAP</condition_dsl>
 <condition_postfix>false person.eligible_programs { "SNAP" streq { pop true } if } forall</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -1313,7 +1313,7 @@
 <condition_number>2</condition_number>
 <condition_comment>Citizen; US citizen or qualified immigrant</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>person.is_us_citizen person.immigration_status "QUALIFIED" streq or</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -1323,7 +1323,7 @@
 <condition_number>3</condition_number>
 <condition_comment>Income limit</condition_comment>
 <condition_requirement />
-<condition_description>EDG FPL within SNAP gross limit</condition_description>
+<condition_dsl>EDG FPL within SNAP gross limit</condition_dsl>
 <condition_postfix>eligibility_group.group_fpl constants.snap_max_fpl le</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -1335,7 +1335,7 @@
 <action_number>1</action_number>
 <action_comment>Eligible</action_comment>
 <action_requirement />
-<action_description>Mark eligible for SNAP</action_description>
+<action_dsl>Mark eligible for SNAP</action_dsl>
 <action_postfix>"SNAP" person.eligible_programs addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -1345,7 +1345,7 @@
 <action_number>2</action_number>
 <action_comment>Record EDG</action_comment>
 <action_requirement />
-<action_description>Note which EDG made person eligible</action_description>
+<action_dsl>Note which EDG made person eligible</action_dsl>
 <action_postfix>"SNAP eligible via EDG: " eligibility_group.group_id strconcat person.notes addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -1370,7 +1370,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Already eligible</condition_comment>
 <condition_requirement />
-<condition_description>Person already eligible for TANF</condition_description>
+<condition_dsl>Person already eligible for TANF</condition_dsl>
 <condition_postfix>false person.eligible_programs { "TANF" streq { pop true } if } forall</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -1381,7 +1381,7 @@
 <condition_number>2</condition_number>
 <condition_comment>Citizen; US citizen or qualified immigrant</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>person.is_us_citizen person.immigration_status "QUALIFIED" streq or</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -1392,7 +1392,7 @@
 <condition_number>3</condition_number>
 <condition_comment>Income limit</condition_comment>
 <condition_requirement />
-<condition_description>EDG FPL within TANF limit</condition_description>
+<condition_dsl>EDG FPL within TANF limit</condition_dsl>
 <condition_postfix>eligibility_group.group_fpl constants.tanf_max_fpl le</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -1403,7 +1403,7 @@
 <condition_number>4</condition_number>
 <condition_comment>Has children or pregnant; Person is child, has children, or is pregnant</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>person.is_child person.is_parent or person.is_pregnant or</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -1416,7 +1416,7 @@
 <action_number>1</action_number>
 <action_comment>Eligible</action_comment>
 <action_requirement />
-<action_description>Mark eligible for TANF</action_description>
+<action_dsl>Mark eligible for TANF</action_dsl>
 <action_postfix>"TANF" person.eligible_programs addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -1427,7 +1427,7 @@
 <action_number>2</action_number>
 <action_comment>Record EDG</action_comment>
 <action_requirement />
-<action_description>Note which EDG made person eligible</action_description>
+<action_dsl>Note which EDG made person eligible</action_dsl>
 <action_postfix>"TANF eligible via EDG: " eligibility_group.group_id strconcat person.notes addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -1453,7 +1453,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Already eligible</condition_comment>
 <condition_requirement />
-<condition_description>Person already eligible for LIHEAP</condition_description>
+<condition_dsl>Person already eligible for LIHEAP</condition_dsl>
 <condition_postfix>false person.eligible_programs { "LIHEAP" streq { pop true } if } forall</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -1462,7 +1462,7 @@
 <condition_number>2</condition_number>
 <condition_comment>Income limit</condition_comment>
 <condition_requirement />
-<condition_description>EDG FPL within LIHEAP limit</condition_description>
+<condition_dsl>EDG FPL within LIHEAP limit</condition_dsl>
 <condition_postfix>eligibility_group.group_fpl constants.liheap_max_fpl le</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -1473,7 +1473,7 @@
 <action_number>1</action_number>
 <action_comment>Eligible</action_comment>
 <action_requirement />
-<action_description>Mark eligible for LIHEAP</action_description>
+<action_dsl>Mark eligible for LIHEAP</action_dsl>
 <action_postfix>"LIHEAP" person.eligible_programs addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -1482,7 +1482,7 @@
 <action_number>2</action_number>
 <action_comment>Record EDG</action_comment>
 <action_requirement />
-<action_description>Note which EDG made person eligible</action_description>
+<action_dsl>Note which EDG made person eligible</action_dsl>
 <action_postfix>"LIHEAP eligible via EDG: " eligibility_group.group_id strconcat person.notes addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -1506,7 +1506,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Age 65+; Person is 65 or older</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>person.is_elderly</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -1515,7 +1515,7 @@
 <condition_number>2</condition_number>
 <condition_comment>Disabled and receiving SSDI</condition_comment>
 <condition_requirement />
-<condition_description>Person is disabled and receives SSDI</condition_description>
+<condition_dsl>Person is disabled and receives SSDI</condition_dsl>
 <condition_postfix>person.is_disabled person.receives_ssdi and</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -1526,7 +1526,7 @@
 <action_number>1</action_number>
 <action_comment>Eligible</action_comment>
 <action_requirement />
-<action_description>Mark eligible for Medicare</action_description>
+<action_dsl>Mark eligible for Medicare</action_dsl>
 <action_postfix>"MEDICARE" person.eligible_programs addto</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="X" />
@@ -1535,7 +1535,7 @@
 <action_number>2</action_number>
 <action_comment>Age note</action_comment>
 <action_requirement />
-<action_description>Add note for age-based eligibility</action_description>
+<action_dsl>Add note for age-based eligibility</action_dsl>
 <action_postfix>"MEDICARE: Eligible due to age 65+" person.notes addto</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="" />
@@ -1544,7 +1544,7 @@
 <action_number>3</action_number>
 <action_comment>Disability note</action_comment>
 <action_requirement />
-<action_description>Add note for disability-based eligibility</action_description>
+<action_dsl>Add note for disability-based eligibility</action_dsl>
 <action_postfix>"MEDICARE: Eligible due to disability + SSDI" person.notes addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -1568,7 +1568,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Is disabled</condition_comment>
 <condition_requirement />
-<condition_description>Person has a disability</condition_description>
+<condition_dsl>Person has a disability</condition_dsl>
 <condition_postfix>person.is_disabled</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="Y" />
@@ -1577,7 +1577,7 @@
 <condition_number>2</condition_number>
 <condition_comment>Already receiving benefits; Already receives SSI or SSDI</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>person.receives_ssi person.receives_ssdi or</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -1588,7 +1588,7 @@
 <action_number>1</action_number>
 <action_comment>Note current benefits</action_comment>
 <action_requirement />
-<action_description>Note existing disability benefits</action_description>
+<action_dsl>Note existing disability benefits</action_dsl>
 <action_postfix>"DISABILITY: Already receiving SSI/SSDI benefits" person.notes addto</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="" />
@@ -1597,7 +1597,7 @@
 <action_number>2</action_number>
 <action_comment>May qualify</action_comment>
 <action_requirement />
-<action_description>Person disabled but not receiving - may qualify</action_description>
+<action_dsl>Person disabled but not receiving - may qualify</action_dsl>
 <action_postfix>"DISABILITY_REVIEW" person.eligible_programs addto "DISABILITY: Disabled but not receiving benefits - review for SSI/SSDI" person.notes addto</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="X" />
@@ -1621,7 +1621,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Has vehicles</condition_comment>
 <condition_requirement />
-<condition_description>Household has vehicles to evaluate</condition_description>
+<condition_dsl>Household has vehicles to evaluate</condition_dsl>
 <condition_postfix>household.vehicles notempty</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" /></condition_details>
@@ -1631,7 +1631,7 @@
 <action_number>1</action_number>
 <action_comment>Evaluate each vehicle</action_comment>
 <action_requirement />
-<action_description>Check each vehicle for assistance eligibility</action_description>
+<action_dsl>Check each vehicle for assistance eligibility</action_dsl>
 <action_postfix>household.vehicles { vehicle entitypush Evaluate_Vehicle_For_Assistance entitypop } forall</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="" /></action_details>
@@ -1654,7 +1654,7 @@
 <condition_number>1</condition_number>
 <condition_comment>Used for work</condition_comment>
 <condition_requirement />
-<condition_description>Vehicle is used to commute to work</condition_description>
+<condition_dsl>Vehicle is used to commute to work</condition_dsl>
 <condition_postfix>vehicle.used_for_work</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -1664,7 +1664,7 @@
 <condition_number>2</condition_number>
 <condition_comment>Used for medical</condition_comment>
 <condition_requirement />
-<condition_description>Vehicle is used for medical transport</condition_description>
+<condition_dsl>Vehicle is used for medical transport</condition_dsl>
 <condition_postfix>vehicle.used_for_medical</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -1674,7 +1674,7 @@
 <condition_number>3</condition_number>
 <condition_comment>Adapted for disability</condition_comment>
 <condition_requirement />
-<condition_description>Vehicle is adapted for disability</condition_description>
+<condition_dsl>Vehicle is adapted for disability</condition_dsl>
 <condition_postfix>vehicle.is_adapted_for_disability</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="-" />
@@ -1686,7 +1686,7 @@
 <action_number>1</action_number>
 <action_comment>Exempt from assets</action_comment>
 <action_requirement />
-<action_description>Mark vehicle as exempt from asset test</action_description>
+<action_dsl>Mark vehicle as exempt from asset test</action_dsl>
 <action_postfix>true vehicle /is_exempt_from_asset_test exch def</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="X" />
@@ -1696,7 +1696,7 @@
 <action_number>2</action_number>
 <action_comment>Not exempt</action_comment>
 <action_requirement />
-<action_description>Vehicle counts as asset</action_description>
+<action_dsl>Vehicle counts as asset</action_dsl>
 <action_postfix>false vehicle /is_exempt_from_asset_test exch def</action_postfix>
 <action_column column_number="1" column_value="" />
 <action_column column_number="2" column_value="" />

--- a/sampleprojects/KidAid/repository/xml/kidaid_dt.xml
+++ b/sampleprojects/KidAid/repository/xml/kidaid_dt.xml
@@ -14,7 +14,7 @@
 <condition_number>1</condition_number>
 <condition_comment>KidAid</condition_comment>
 <condition_requirement />
-<condition_description>job.program == KidAid</condition_description>
+<condition_dsl>job.program == KidAid</condition_dsl>
 <condition_postfix>
 job.program KidAid streq 
 </condition_postfix>
@@ -23,7 +23,7 @@ job.program KidAid streq
 <condition_number>2</condition_number>
 <condition_comment>MEDICAID</condition_comment>
 <condition_requirement />
-<condition_description>job.program == MEDICAID</condition_description>
+<condition_dsl>job.program == MEDICAID</condition_dsl>
 <condition_postfix>
 job.program MEDICAID streq 
 </condition_postfix>
@@ -32,7 +32,7 @@ job.program MEDICAID streq
 <condition_number>3</condition_number>
 <condition_comment>FOODSTAMPS</condition_comment>
 <condition_requirement />
-<condition_description>job.program == FOODSTAMPS</condition_description>
+<condition_dsl>job.program == FOODSTAMPS</condition_dsl>
 <condition_postfix>
 job.program FOODSTAMPS streq 
 </condition_postfix>
@@ -41,7 +41,7 @@ job.program FOODSTAMPS streq
 <condition_number>4</condition_number>
 <condition_comment>If Not Any of these programs, Report Results Anyway</condition_comment>
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -51,7 +51,7 @@ true
 <action_number>1</action_number>
 <action_comment>Calculate the Individual Incomes</action_comment>
 <initial_action_requirement />
-<action_description>Perform Calculate_Individual_Income</action_description>
+<action_dsl>Perform Calculate_Individual_Income</action_dsl>
 <action_postfix>
 Calculate_Individual_Income 
 </action_postfix>
@@ -62,7 +62,7 @@ Calculate_Individual_Income
 <action_number>2</action_number>
 <action_comment>Get the Group Size for each individual</action_comment>
 <initial_action_requirement />
-<action_description>Perform Calculate_Group_Size</action_description>
+<action_dsl>Perform Calculate_Group_Size</action_dsl>
 <action_postfix>
 Calculate_Group_Size 
 </action_postfix>
@@ -73,7 +73,7 @@ Calculate_Group_Size
 <action_number>3</action_number>
 <action_comment>Evaluate for KidAid</action_comment>
 <initial_action_requirement />
-<action_description>Perform Evaluate_KidAid_Eligibility</action_description>
+<action_dsl>Perform Evaluate_KidAid_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_KidAid_Eligibility 
 </action_postfix>
@@ -82,7 +82,7 @@ Evaluate_KidAid_Eligibility
 <action_number>4</action_number>
 <action_comment>Evaluate for MEDICAID</action_comment>
 <initial_action_requirement />
-<action_description>Perform Evaluate_MEDICAID_Eligibility</action_description>
+<action_dsl>Perform Evaluate_MEDICAID_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_MEDICAID_Eligibility 
 </action_postfix>
@@ -91,7 +91,7 @@ Evaluate_MEDICAID_Eligibility
 <action_number>5</action_number>
 <action_comment>Evaluate for FOODSTAMPS</action_comment>
 <initial_action_requirement />
-<action_description>Perform Evaluate_FOODSTAMPS_Eligibility</action_description>
+<action_dsl>Perform Evaluate_FOODSTAMPS_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_FOODSTAMPS_Eligibility 
 </action_postfix>
@@ -100,7 +100,7 @@ Evaluate_FOODSTAMPS_Eligibility
 <action_number>6</action_number>
 <action_comment>Build a set of Result Objects to report to the caller</action_comment>
 <initial_action_requirement />
-<action_description>Perform Evaluate_Results</action_description>
+<action_dsl>Perform Evaluate_Results</action_dsl>
 <action_postfix>
 Evaluate_Results 
 </action_postfix>
@@ -132,14 +132,14 @@ Evaluate_Results
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment />
-<context_description>for all incomes</context_description>
+<context_dsl>for all incomes</context_dsl>
 <context_postfix>
 dup incomes forall pop 
 </context_postfix></context_details></contexts>
@@ -149,7 +149,7 @@ dup incomes forall pop
 <condition_number>1</condition_number>
 <condition_comment>We include all earned income</condition_comment>
 <condition_requirement />
-<condition_description>income.earned == true</condition_description>
+<condition_dsl>income.earned == true</condition_dsl>
 <condition_postfix>
 income.earned true beq 
 </condition_postfix>
@@ -159,7 +159,7 @@ income.earned true beq
 <condition_number>2</condition_number>
 <condition_comment>We don't include all unearned income types</condition_comment>
 <condition_requirement />
-<condition_description>ExcludedIncomeTypes includes the string income.type</condition_description>
+<condition_dsl>ExcludedIncomeTypes includes the string income.type</condition_dsl>
 <condition_postfix>
 ExcludedIncomeTypes income.type memberof 
 </condition_postfix>
@@ -169,7 +169,7 @@ ExcludedIncomeTypes income.type memberof
 <action_number>1</action_number>
 <action_comment>Add this income to the total income for this client</action_comment>
 <initial_action_requirement />
-<action_description>add income.amount to the client.totalIncome</action_description>
+<action_dsl>add income.amount to the client.totalIncome</action_dsl>
 <action_postfix>
 income.amount  client.totalIncome + /client.totalIncome xdef 
 </action_postfix>
@@ -196,21 +196,21 @@ income.amount  client.totalIncome + /client.totalIncome xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>For each client in the group, we need to calculate a group size (we only need to do this for applying clients)</context_comment>
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>We want to compare a client against every other client in the case, so we set up a local variable to point to ThisClient</context_comment>
-<context_description>local entity ThisClient = client</context_description>
+<context_dsl>local entity ThisClient = client</context_dsl>
 <context_postfix>
 client cve allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment>Now consider the client in respect to all the other clients in the case (We need to consider all clients in the case, even if not applying)</context_comment>
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -219,7 +219,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Are we consider the client themselves?</condition_comment>
 <condition_requirement />
-<condition_description>ThisClient == client</condition_description>
+<condition_dsl>ThisClient == client</condition_dsl>
 <condition_postfix>
 0 local@  client req  
 </condition_postfix>
@@ -230,7 +230,7 @@ dup clients forall pop
 <condition_number>2</condition_number>
 <condition_comment>Include ThisClient's parents</condition_comment>
 <condition_requirement />
-<condition_description>the client is the parent of ThisClient</condition_description>
+<condition_dsl>the client is the parent of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type parent relationships findmatch swap pop
 </condition_postfix>
@@ -241,7 +241,7 @@ dup clients forall pop
 <condition_number>3</condition_number>
 <condition_comment>Include ThisClient's siblings</condition_comment>
 <condition_requirement />
-<condition_description>the client is the sibling of ThisClient</condition_description>
+<condition_dsl>the client is the sibling of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type sibling relationships findmatch swap pop
 </condition_postfix>
@@ -252,7 +252,7 @@ dup clients forall pop
 <condition_number>4</condition_number>
 <condition_comment>Include ThisClient's children</condition_comment>
 <condition_requirement />
-<condition_description>the client is the child of ThisClient</condition_description>
+<condition_dsl>the client is the child of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type child relationships findmatch swap pop
 </condition_postfix>
@@ -262,7 +262,7 @@ dup clients forall pop
 <condition_number>5</condition_number>
 <condition_comment>Include the unborn children in some cases</condition_comment>
 <condition_requirement />
-<condition_description>the client.pregnant == true</condition_description>
+<condition_dsl>the client.pregnant == true</condition_dsl>
 <condition_postfix>
 client.pregnant true beq 
 </condition_postfix>
@@ -276,7 +276,7 @@ client.pregnant true beq
 <condition_number>6</condition_number>
 <condition_comment>Is this client older than 18</condition_comment>
 <condition_requirement />
-<condition_description>client.age &gt; 18</condition_description>
+<condition_dsl>client.age &gt; 18</condition_dsl>
 <condition_postfix>
 client.age 18 &gt; 
 </condition_postfix>
@@ -289,7 +289,7 @@ client.age 18 &gt;
 <action_number>1</action_number>
 <action_comment>Count the Client himself and particular relatives</action_comment>
 <initial_action_requirement />
-<action_description>add 1 to ThisClient's IncomeGroupCount</action_description>
+<action_dsl>add 1 to ThisClient's IncomeGroupCount</action_dsl>
 <action_postfix>
 1  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -304,7 +304,7 @@ client.age 18 &gt;
 <action_number>2</action_number>
 <action_comment>Add 1 for each of the expected babies for a pregnant person</action_comment>
 <initial_action_requirement />
-<action_description>add expectedChildren to ThisClient's IncomeGroupCount</action_description>
+<action_dsl>add expectedChildren to ThisClient's IncomeGroupCount</action_dsl>
 <action_postfix>
 expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -315,7 +315,7 @@ expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef
 <action_number>3</action_number>
 <action_comment>Add this person's Income to the ThisPerson's total group income</action_comment>
 <initial_action_requirement />
-<action_description>add the client.totalIncome to ThisClient's totalGroupIncome</action_description>
+<action_dsl>add the client.totalIncome to ThisClient's totalGroupIncome</action_dsl>
 <action_postfix>
 client.totalIncome  0 local@  entitypush totalGroupIncome + /totalGroupIncome xdef entitypop 
 </action_postfix>
@@ -371,56 +371,56 @@ client.totalIncome  0 local@  entitypush totalGroupIncome + /totalGroupIncome xd
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>FPL = the Federal Poverty Limit calculated for the number of people in this client's Income Group.</context_comment>
-<context_description>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_description>
+<context_dsl>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_dsl>
 <context_postfix>
 FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment>FPL125 = 125 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL125 = FPL * 1.25</context_description>
+<context_dsl>local int FPL125 = FPL * 1.25</context_dsl>
 <context_postfix>
 0 local@  1.25 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment>FPL150 = 150 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL150 = FPL * 1.5</context_description>
+<context_dsl>local int FPL150 = FPL * 1.5</context_dsl>
 <context_postfix>
 0 local@  1.5 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>5</context_number>
 <context_comment>FPL175 = 175 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL175 = FPL * 1.75</context_description>
+<context_dsl>local int FPL175 = FPL * 1.75</context_dsl>
 <context_postfix>
 0 local@  1.75 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>6</context_number>
 <context_comment>FPL200 = 200 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL200 = FPL * 2</context_description>
+<context_dsl>local int FPL200 = FPL * 2</context_dsl>
 <context_postfix>
 0 local@  2 *  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>7</context_number>
 <context_comment>FPL250 = 250 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL250 = FPL * 2.5</context_description>
+<context_dsl>local int FPL250 = FPL * 2.5</context_dsl>
 <context_postfix>
 0 local@  2.5 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>8</context_number>
 <context_comment>FPL300 = 300 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL300 = FPL * 3</context_description>
+<context_dsl>local int FPL300 = FPL * 3</context_dsl>
 <context_postfix>
 0 local@  3 *  cvi allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -429,7 +429,7 @@ FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate 
 <condition_number>1</condition_number>
 <condition_comment>You have to be a Citizen</condition_comment>
 <condition_requirement />
-<condition_description>validatedCitizenship</condition_description>
+<condition_dsl>validatedCitizenship</condition_dsl>
 <condition_postfix>
 validatedCitizenship 
 </condition_postfix>
@@ -447,7 +447,7 @@ validatedCitizenship
 <condition_number>2</condition_number>
 <condition_comment>Make sure this case is in the appropriate county</condition_comment>
 <condition_requirement />
-<condition_description>The CoveredCounties includes the string case.county_Cd</condition_description>
+<condition_dsl>The CoveredCounties includes the string case.county_Cd</condition_dsl>
 <condition_postfix>
 CoveredCounties case.county_Cd memberof 
 </condition_postfix>
@@ -465,7 +465,7 @@ CoveredCounties case.county_Cd memberof
 <condition_number>3</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>client.age &lt; 1</condition_description>
+<condition_dsl>client.age &lt; 1</condition_dsl>
 <condition_postfix>
 client.age 1 &lt; 
 </condition_postfix>
@@ -479,7 +479,7 @@ client.age 1 &lt;
 <condition_number>4</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>client.age &lt; 6</condition_description>
+<condition_dsl>client.age &lt; 6</condition_dsl>
 <condition_postfix>
 client.age 6 &lt; 
 </condition_postfix>
@@ -491,7 +491,7 @@ client.age 6 &lt;
 <condition_number>5</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>client.age &lt;= 18</condition_description>
+<condition_dsl>client.age &lt;= 18</condition_dsl>
 <condition_postfix>
 client.age 18 &lt;= 
 </condition_postfix>
@@ -504,7 +504,7 @@ client.age 18 &lt;=
 <condition_number>6</condition_number>
 <condition_comment>Exclude under the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL</condition_dsl>
 <condition_postfix>
 totalGroupIncome 0 local@  &gt; 
 </condition_postfix>
@@ -513,7 +513,7 @@ totalGroupIncome 0 local@  &gt;
 <condition_number>7</condition_number>
 <condition_comment>Exclude under 125 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL125</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL125</condition_dsl>
 <condition_postfix>
 totalGroupIncome 1 local@  &gt; 
 </condition_postfix>
@@ -522,7 +522,7 @@ totalGroupIncome 1 local@  &gt;
 <condition_number>8</condition_number>
 <condition_comment>Exclude under 150 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL150</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL150</condition_dsl>
 <condition_postfix>
 totalGroupIncome 2 local@  &gt; 
 </condition_postfix>
@@ -531,7 +531,7 @@ totalGroupIncome 2 local@  &gt;
 <condition_number>9</condition_number>
 <condition_comment>Exclude under 175 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL175</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL175</condition_dsl>
 <condition_postfix>
 totalGroupIncome 3 local@  &gt; 
 </condition_postfix>
@@ -542,7 +542,7 @@ totalGroupIncome 3 local@  &gt;
 <condition_number>10</condition_number>
 <condition_comment>Exclude under 200 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL200</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL200</condition_dsl>
 <condition_postfix>
 totalGroupIncome 4 local@  &gt; 
 </condition_postfix></condition_details>
@@ -550,7 +550,7 @@ totalGroupIncome 4 local@  &gt;
 <condition_number>11</condition_number>
 <condition_comment>Exclude under 250 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL250</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL250</condition_dsl>
 <condition_postfix>
 totalGroupIncome 5 local@  &gt; 
 </condition_postfix></condition_details>
@@ -558,7 +558,7 @@ totalGroupIncome 5 local@  &gt;
 <condition_number>12</condition_number>
 <condition_comment>Include if not excluded and under 175 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL175</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL175</condition_dsl>
 <condition_postfix>
 totalGroupIncome 3 local@  &lt;= 
 </condition_postfix>
@@ -569,7 +569,7 @@ totalGroupIncome 3 local@  &lt;=
 <condition_number>13</condition_number>
 <condition_comment>Include if not excluded and under 200 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL200</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL200</condition_dsl>
 <condition_postfix>
 totalGroupIncome 4 local@  &lt;= 
 </condition_postfix>
@@ -579,7 +579,7 @@ totalGroupIncome 4 local@  &lt;=
 <condition_number>14</condition_number>
 <condition_comment>Include if not excluded and under 250 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL250</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL250</condition_dsl>
 <condition_postfix>
 totalGroupIncome 5 local@  &lt;= 
 </condition_postfix>
@@ -588,7 +588,7 @@ totalGroupIncome 5 local@  &lt;=
 <condition_number>15</condition_number>
 <condition_comment>Include if not excluded and under 300 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL300</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL300</condition_dsl>
 <condition_postfix>
 totalGroupIncome 6 local@  &lt;= 
 </condition_postfix>
@@ -598,7 +598,7 @@ totalGroupIncome 6 local@  &lt;=
 <action_number>1</action_number>
 <action_comment>set the program Level</action_comment>
 <initial_action_requirement />
-<action_description>set client.programLevel = FreeCoverage</action_description>
+<action_dsl>set client.programLevel = FreeCoverage</action_dsl>
 <action_postfix>
 FreeCoverage cvs /client.programLevel xdef  
 </action_postfix>
@@ -609,7 +609,7 @@ FreeCoverage cvs /client.programLevel xdef
 <action_number>2</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set client.programLevel = LowCostCoverage</action_description>
+<action_dsl>set client.programLevel = LowCostCoverage</action_dsl>
 <action_postfix>
 LowCostCoverage cvs /client.programLevel xdef  
 </action_postfix>
@@ -620,7 +620,7 @@ LowCostCoverage cvs /client.programLevel xdef
 <action_number>3</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set client.programLevel = AtCostCoverage</action_description>
+<action_dsl>set client.programLevel = AtCostCoverage</action_dsl>
 <action_postfix>
 AtCostCoverage cvs /client.programLevel xdef  
 </action_postfix>
@@ -629,7 +629,7 @@ AtCostCoverage cvs /client.programLevel xdef
 <action_number>4</action_number>
 <action_comment>Provide reasons for rejection</action_comment>
 <initial_action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -641,7 +641,7 @@ false cvb /client.eligible xdef
 <action_number>5</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>Add "Client is eligible for Medicaid, so cannot enroll in KidAid" to client.notes</action_description>
+<action_dsl>Add "Client is eligible for Medicaid, so cannot enroll in KidAid" to client.notes</action_dsl>
 <action_postfix>
 "Client is eligible for Medicaid, so cannot enroll in KidAid" client.notes swap addto 
 </action_postfix>
@@ -650,7 +650,7 @@ false cvb /client.eligible xdef
 <action_number>6</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>Add "Must Provide Validation of Citizenship" to client.notes</action_description>
+<action_dsl>Add "Must Provide Validation of Citizenship" to client.notes</action_dsl>
 <action_postfix>
 "Must Provide Validation of Citizenship" client.notes swap addto 
 </action_postfix>
@@ -660,7 +660,7 @@ false cvb /client.eligible xdef
 <action_number>7</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>Add "Case must be within a KidAid County" to client.notes</action_description>
+<action_dsl>Add "Case must be within a KidAid County" to client.notes</action_dsl>
 <action_postfix>
 "Case must be within a KidAid County" client.notes swap addto 
 </action_postfix>
@@ -670,7 +670,7 @@ false cvb /client.eligible xdef
 <action_number>8</action_number>
 <action_comment>Add "Must be 18 or younger to qualify for KidAid" to client.notes</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "Must be 18 or younger to qualify for KidAid" client.notes swap addto 
 </action_postfix>
@@ -679,7 +679,7 @@ false cvb /client.eligible xdef
 <action_number>9</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set client_fpl = (100.0 * totalGroupIncome) / FPL</action_description>
+<action_dsl>set client_fpl = (100.0 * totalGroupIncome) / FPL</action_dsl>
 <action_postfix>
 100.0 totalGroupIncome fmul 0 local@  fdiv  cvi /client_fpl xdef  
 </action_postfix>
@@ -707,7 +707,7 @@ false cvb /client.eligible xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -717,7 +717,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
 <condition_requirement />
-<condition_description>client.applying == true</condition_description>
+<condition_dsl>client.applying == true</condition_dsl>
 <condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -727,7 +727,7 @@ client.applying true beq
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
 <initial_action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -736,7 +736,7 @@ false cvb /client.eligible xdef
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Medicaid Applications" to client.notes</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "The System does not yet support Medicaid Applications" client.notes swap addto 
 </action_postfix>
@@ -753,7 +753,7 @@ false cvb /client.eligible xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -763,7 +763,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
 <condition_requirement />
-<condition_description>client.applying == true</condition_description>
+<condition_dsl>client.applying == true</condition_dsl>
 <condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -773,7 +773,7 @@ client.applying true beq
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
 <initial_action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -782,7 +782,7 @@ false cvb /client.eligible xdef
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Food Stamp Applications" to client.notes</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "The System does not yet support Food Stamp Applications" client.notes swap addto 
 </action_postfix>
@@ -802,7 +802,7 @@ in this table, and update the test code to get the data from the client object.<
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details></contexts>
@@ -812,7 +812,7 @@ in this table, and update the test code to get the data from the client object.<
 <condition_number>1</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called 
 </condition_postfix>
@@ -822,7 +822,7 @@ perform when called
 <action_number>1</action_number>
 <action_comment>Create a Result Record</action_comment>
 <initial_action_requirement />
-<action_description>add a new Result entity to the context of this table</action_description>
+<action_dsl>add a new Result entity to the context of this table</action_dsl>
 <action_postfix>
 /Result createentity entitypush 
 </action_postfix>
@@ -831,7 +831,7 @@ perform when called
 <action_number>2</action_number>
 <action_comment>Add the record to the list on the job</action_comment>
 <initial_action_requirement />
-<action_description>add the result to the job.results</action_description>
+<action_dsl>add the result to the job.results</action_dsl>
 <action_postfix>
 result job.results swap addto 
 </action_postfix>
@@ -840,7 +840,7 @@ result job.results swap addto
 <action_number>3</action_number>
 <action_comment>Add the case notes to the result notes</action_comment>
 <initial_action_requirement />
-<action_description>Add the case.notes to the Result.notes</action_description>
+<action_dsl>Add the case.notes to the Result.notes</action_dsl>
 <action_postfix>
 case.notes Result.notes true  addarray 
 </action_postfix>
@@ -849,7 +849,7 @@ case.notes Result.notes true  addarray
 <action_number>4</action_number>
 <action_comment>Add the client notes to the result notes</action_comment>
 <initial_action_requirement />
-<action_description>Add the client.notes to the Result.notes</action_description>
+<action_dsl>Add the client.notes to the Result.notes</action_dsl>
 <action_postfix>
 client.notes Result.notes true  addarray 
 </action_postfix>
@@ -858,7 +858,7 @@ client.notes Result.notes true  addarray
 <action_number>5</action_number>
 <action_comment>Copy the client ID</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.client_id = client.client_id</action_description>
+<action_dsl>Set Result.client_id = client.client_id</action_dsl>
 <action_postfix>
 client.client_id cvs /Result.client_id xdef  
 </action_postfix>
@@ -867,7 +867,7 @@ client.client_id cvs /Result.client_id xdef
 <action_number>6</action_number>
 <action_comment>Point the Result to the client</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.client = client.client</action_description>
+<action_dsl>Set Result.client = client.client</action_dsl>
 <action_postfix>
 client.client cve /Result.client xdef  
 </action_postfix>
@@ -876,7 +876,7 @@ client.client cve /Result.client xdef
 <action_number>7</action_number>
 <action_comment>Set the Result to the program we processed</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.program = job.program</action_description>
+<action_dsl>Set Result.program = job.program</action_dsl>
 <action_postfix>
 job.program cvs /Result.program xdef  
 </action_postfix>
@@ -885,7 +885,7 @@ job.program cvs /Result.program xdef
 <action_number>8</action_number>
 <action_comment>Set the Result programLevel to that recorded on the client</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.programLevel = client.programLevel</action_description>
+<action_dsl>Set Result.programLevel = client.programLevel</action_dsl>
 <action_postfix>
 client.programLevel cvs /Result.programLevel xdef  
 </action_postfix>
@@ -894,7 +894,7 @@ client.programLevel cvs /Result.programLevel xdef
 <action_number>9</action_number>
 <action_comment>Set the Result eligible flag to that recorded on the client</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.eligible = client.eligible</action_description>
+<action_dsl>Set Result.eligible = client.eligible</action_dsl>
 <action_postfix>
 client.eligible cvb /Result.eligible xdef  
 </action_postfix>
@@ -903,7 +903,7 @@ client.eligible cvb /Result.eligible xdef
 <action_number>10</action_number>
 <action_comment>Set the Result Federal Poverty Level to the client's</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.client_fpl = client.client_fpl</action_description>
+<action_dsl>Set Result.client_fpl = client.client_fpl</action_dsl>
 <action_postfix>
 client.client_fpl  cvi /Result.client_fpl xdef  
 </action_postfix>
@@ -912,7 +912,7 @@ client.client_fpl  cvi /Result.client_fpl xdef
 <action_number>11</action_number>
 <action_comment>Set the Result's totalGroupIncome to the clients.</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.totalGroupIncome = client.totalGroupIncome</action_description>
+<action_dsl>Set Result.totalGroupIncome = client.totalGroupIncome</action_dsl>
 <action_postfix>
 client.totalGroupIncome  cvi /Result.totalGroupIncome xdef  
 </action_postfix>

--- a/sampleprojects/KidAid/xml/kidaid_dt.xml
+++ b/sampleprojects/KidAid/xml/kidaid_dt.xml
@@ -14,7 +14,7 @@
 <condition_number>1</condition_number>
 <condition_comment>KidAid</condition_comment>
 <condition_requirement />
-<condition_description>job.program == KidAid</condition_description>
+<condition_dsl>job.program == KidAid</condition_dsl>
 <condition_postfix>
 job.program KidAid streq 
 </condition_postfix>
@@ -23,7 +23,7 @@ job.program KidAid streq
 <condition_number>2</condition_number>
 <condition_comment>MEDICAID</condition_comment>
 <condition_requirement />
-<condition_description>job.program == MEDICAID</condition_description>
+<condition_dsl>job.program == MEDICAID</condition_dsl>
 <condition_postfix>
 job.program MEDICAID streq 
 </condition_postfix>
@@ -32,7 +32,7 @@ job.program MEDICAID streq
 <condition_number>3</condition_number>
 <condition_comment>FOODSTAMPS</condition_comment>
 <condition_requirement />
-<condition_description>job.program == FOODSTAMPS</condition_description>
+<condition_dsl>job.program == FOODSTAMPS</condition_dsl>
 <condition_postfix>
 job.program FOODSTAMPS streq 
 </condition_postfix>
@@ -41,7 +41,7 @@ job.program FOODSTAMPS streq
 <condition_number>4</condition_number>
 <condition_comment>If Not Any of these programs, Report Results Anyway</condition_comment>
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -51,7 +51,7 @@ true
 <action_number>1</action_number>
 <action_comment>Calculate the Individual Incomes</action_comment>
 <action_requirement />
-<action_description>Perform Calculate_Individual_Income</action_description>
+<action_dsl>Perform Calculate_Individual_Income</action_dsl>
 <action_postfix>
 Calculate_Individual_Income 
 </action_postfix>
@@ -62,7 +62,7 @@ Calculate_Individual_Income
 <action_number>2</action_number>
 <action_comment>Get the Group Size for each individual</action_comment>
 <action_requirement />
-<action_description>Perform Calculate_Group_Size</action_description>
+<action_dsl>Perform Calculate_Group_Size</action_dsl>
 <action_postfix>
 Calculate_Group_Size 
 </action_postfix>
@@ -73,7 +73,7 @@ Calculate_Group_Size
 <action_number>3</action_number>
 <action_comment>Evaluate for KidAid</action_comment>
 <action_requirement />
-<action_description>Perform Evaluate_KidAid_Eligibility</action_description>
+<action_dsl>Perform Evaluate_KidAid_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_KidAid_Eligibility 
 </action_postfix>
@@ -82,7 +82,7 @@ Evaluate_KidAid_Eligibility
 <action_number>4</action_number>
 <action_comment>Evaluate for MEDICAID</action_comment>
 <action_requirement />
-<action_description>Perform Evaluate_MEDICAID_Eligibility</action_description>
+<action_dsl>Perform Evaluate_MEDICAID_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_MEDICAID_Eligibility 
 </action_postfix>
@@ -91,7 +91,7 @@ Evaluate_MEDICAID_Eligibility
 <action_number>5</action_number>
 <action_comment>Evaluate for FOODSTAMPS</action_comment>
 <action_requirement />
-<action_description>Perform Evaluate_FOODSTAMPS_Eligibility</action_description>
+<action_dsl>Perform Evaluate_FOODSTAMPS_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_FOODSTAMPS_Eligibility 
 </action_postfix>
@@ -100,7 +100,7 @@ Evaluate_FOODSTAMPS_Eligibility
 <action_number>6</action_number>
 <action_comment>Build a set of Result Objects to report to the caller</action_comment>
 <action_requirement />
-<action_description>Perform Evaluate_Results</action_description>
+<action_dsl>Perform Evaluate_Results</action_dsl>
 <action_postfix>
 Evaluate_Results 
 </action_postfix>
@@ -132,14 +132,14 @@ Evaluate_Results
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment />
-<context_description>for all incomes</context_description>
+<context_dsl>for all incomes</context_dsl>
 <context_postfix>
 dup incomes forall pop 
 </context_postfix></context_details></contexts>
@@ -149,7 +149,7 @@ dup incomes forall pop
 <condition_number>1</condition_number>
 <condition_comment>We include all earned income</condition_comment>
 <condition_requirement />
-<condition_description>income.earned == true</condition_description>
+<condition_dsl>income.earned == true</condition_dsl>
 <condition_postfix>
 income.earned true beq 
 </condition_postfix>
@@ -159,7 +159,7 @@ income.earned true beq
 <condition_number>2</condition_number>
 <condition_comment>We don't include all unearned income types</condition_comment>
 <condition_requirement />
-<condition_description>ExcludedIncomeTypes includes the string income.type</condition_description>
+<condition_dsl>ExcludedIncomeTypes includes the string income.type</condition_dsl>
 <condition_postfix>
 ExcludedIncomeTypes income.type memberof 
 </condition_postfix>
@@ -169,7 +169,7 @@ ExcludedIncomeTypes income.type memberof
 <action_number>1</action_number>
 <action_comment>Add this income to the total income for this client</action_comment>
 <action_requirement />
-<action_description>add income.amount to the client.totalIncome</action_description>
+<action_dsl>add income.amount to the client.totalIncome</action_dsl>
 <action_postfix>
 income.amount  client.totalIncome + /client.totalIncome xdef 
 </action_postfix>
@@ -196,21 +196,21 @@ income.amount  client.totalIncome + /client.totalIncome xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>For each client in the group, we need to calculate a group size (we only need to do this for applying clients)</context_comment>
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>We want to compare a client against every other client in the case, so we set up a local variable to point to ThisClient</context_comment>
-<context_description>local entity ThisClient = client</context_description>
+<context_dsl>local entity ThisClient = client</context_dsl>
 <context_postfix>
 client cve allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment>Now consider the client in respect to all the other clients in the case (We need to consider all clients in the case, even if not applying)</context_comment>
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -219,7 +219,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Are we consider the client themselves?</condition_comment>
 <condition_requirement />
-<condition_description>ThisClient == client</condition_description>
+<condition_dsl>ThisClient == client</condition_dsl>
 <condition_postfix>
 0 local@  client req  
 </condition_postfix>
@@ -230,7 +230,7 @@ dup clients forall pop
 <condition_number>2</condition_number>
 <condition_comment>Include ThisClient's parents</condition_comment>
 <condition_requirement />
-<condition_description>the client is the parent of ThisClient</condition_description>
+<condition_dsl>the client is the parent of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type parent relationships findmatch swap pop
 </condition_postfix>
@@ -241,7 +241,7 @@ dup clients forall pop
 <condition_number>3</condition_number>
 <condition_comment>Include ThisClient's siblings</condition_comment>
 <condition_requirement />
-<condition_description>the client is the sibling of ThisClient</condition_description>
+<condition_dsl>the client is the sibling of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type sibling relationships findmatch swap pop
 </condition_postfix>
@@ -252,7 +252,7 @@ dup clients forall pop
 <condition_number>4</condition_number>
 <condition_comment>Include ThisClient's children</condition_comment>
 <condition_requirement />
-<condition_description>the client is the child of ThisClient</condition_description>
+<condition_dsl>the client is the child of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type child relationships findmatch swap pop
 </condition_postfix>
@@ -262,7 +262,7 @@ dup clients forall pop
 <condition_number>5</condition_number>
 <condition_comment>Include the unborn children in some cases</condition_comment>
 <condition_requirement />
-<condition_description>the client.pregnant == true</condition_description>
+<condition_dsl>the client.pregnant == true</condition_dsl>
 <condition_postfix>
 client.pregnant true beq 
 </condition_postfix>
@@ -276,7 +276,7 @@ client.pregnant true beq
 <condition_number>6</condition_number>
 <condition_comment>Is this client older than 18</condition_comment>
 <condition_requirement />
-<condition_description>client.age &gt; 18</condition_description>
+<condition_dsl>client.age &gt; 18</condition_dsl>
 <condition_postfix>
 client.age 18 &gt; 
 </condition_postfix>
@@ -289,7 +289,7 @@ client.age 18 &gt;
 <action_number>1</action_number>
 <action_comment>Count the Client himself and particular relatives</action_comment>
 <action_requirement />
-<action_description>add 1 to ThisClient's IncomeGroupCount</action_description>
+<action_dsl>add 1 to ThisClient's IncomeGroupCount</action_dsl>
 <action_postfix>
 1  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -304,7 +304,7 @@ client.age 18 &gt;
 <action_number>2</action_number>
 <action_comment>Add 1 for each of the expected babies for a pregnant person</action_comment>
 <action_requirement />
-<action_description>add expectedChildren to ThisClient's IncomeGroupCount</action_description>
+<action_dsl>add expectedChildren to ThisClient's IncomeGroupCount</action_dsl>
 <action_postfix>
 expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -315,7 +315,7 @@ expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef
 <action_number>3</action_number>
 <action_comment>Add this person's Income to the ThisPerson's total group income</action_comment>
 <action_requirement />
-<action_description>add the client.totalIncome to ThisClient's totalGroupIncome</action_description>
+<action_dsl>add the client.totalIncome to ThisClient's totalGroupIncome</action_dsl>
 <action_postfix>
 client.totalIncome  0 local@  entitypush totalGroupIncome + /totalGroupIncome xdef entitypop 
 </action_postfix>
@@ -371,56 +371,56 @@ client.totalIncome  0 local@  entitypush totalGroupIncome + /totalGroupIncome xd
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>FPL = the Federal Poverty Limit calculated for the number of people in this client's Income Group.</context_comment>
-<context_description>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_description>
+<context_dsl>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_dsl>
 <context_postfix>
 FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment>FPL125 = 125 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL125 = FPL * 1.25</context_description>
+<context_dsl>local int FPL125 = FPL * 1.25</context_dsl>
 <context_postfix>
 0 local@  1.25 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment>FPL150 = 150 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL150 = FPL * 1.5</context_description>
+<context_dsl>local int FPL150 = FPL * 1.5</context_dsl>
 <context_postfix>
 0 local@  1.5 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>5</context_number>
 <context_comment>FPL175 = 175 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL175 = FPL * 1.75</context_description>
+<context_dsl>local int FPL175 = FPL * 1.75</context_dsl>
 <context_postfix>
 0 local@  1.75 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>6</context_number>
 <context_comment>FPL200 = 200 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL200 = FPL * 2</context_description>
+<context_dsl>local int FPL200 = FPL * 2</context_dsl>
 <context_postfix>
 0 local@  2 *  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>7</context_number>
 <context_comment>FPL250 = 250 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL250 = FPL * 2.5</context_description>
+<context_dsl>local int FPL250 = FPL * 2.5</context_dsl>
 <context_postfix>
 0 local@  2.5 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>8</context_number>
 <context_comment>FPL300 = 300 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL300 = FPL * 3</context_description>
+<context_dsl>local int FPL300 = FPL * 3</context_dsl>
 <context_postfix>
 0 local@  3 *  cvi allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -429,7 +429,7 @@ FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate 
 <condition_number>1</condition_number>
 <condition_comment>You have to be a Citizen</condition_comment>
 <condition_requirement />
-<condition_description>validatedCitizenship</condition_description>
+<condition_dsl>validatedCitizenship</condition_dsl>
 <condition_postfix>
 validatedCitizenship 
 </condition_postfix>
@@ -447,7 +447,7 @@ validatedCitizenship
 <condition_number>2</condition_number>
 <condition_comment>Make sure this case is in the appropriate county</condition_comment>
 <condition_requirement />
-<condition_description>The CoveredCounties includes the string case.county_Cd</condition_description>
+<condition_dsl>The CoveredCounties includes the string case.county_Cd</condition_dsl>
 <condition_postfix>
 CoveredCounties case.county_Cd memberof 
 </condition_postfix>
@@ -465,7 +465,7 @@ CoveredCounties case.county_Cd memberof
 <condition_number>3</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>client.age &lt; 1</condition_description>
+<condition_dsl>client.age &lt; 1</condition_dsl>
 <condition_postfix>
 client.age 1 &lt; 
 </condition_postfix>
@@ -479,7 +479,7 @@ client.age 1 &lt;
 <condition_number>4</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>client.age &lt; 6</condition_description>
+<condition_dsl>client.age &lt; 6</condition_dsl>
 <condition_postfix>
 client.age 6 &lt; 
 </condition_postfix>
@@ -491,7 +491,7 @@ client.age 6 &lt;
 <condition_number>5</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>client.age &lt;= 18</condition_description>
+<condition_dsl>client.age &lt;= 18</condition_dsl>
 <condition_postfix>
 client.age 18 &lt;= 
 </condition_postfix>
@@ -504,7 +504,7 @@ client.age 18 &lt;=
 <condition_number>6</condition_number>
 <condition_comment>Exclude under the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL</condition_dsl>
 <condition_postfix>
 totalGroupIncome 0 local@  &gt; 
 </condition_postfix>
@@ -513,7 +513,7 @@ totalGroupIncome 0 local@  &gt;
 <condition_number>7</condition_number>
 <condition_comment>Exclude under 125 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL125</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL125</condition_dsl>
 <condition_postfix>
 totalGroupIncome 1 local@  &gt; 
 </condition_postfix>
@@ -522,7 +522,7 @@ totalGroupIncome 1 local@  &gt;
 <condition_number>8</condition_number>
 <condition_comment>Exclude under 150 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL150</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL150</condition_dsl>
 <condition_postfix>
 totalGroupIncome 2 local@  &gt; 
 </condition_postfix>
@@ -531,7 +531,7 @@ totalGroupIncome 2 local@  &gt;
 <condition_number>9</condition_number>
 <condition_comment>Exclude under 175 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL175</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL175</condition_dsl>
 <condition_postfix>
 totalGroupIncome 3 local@  &gt; 
 </condition_postfix>
@@ -542,7 +542,7 @@ totalGroupIncome 3 local@  &gt;
 <condition_number>10</condition_number>
 <condition_comment>Exclude under 200 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL200</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL200</condition_dsl>
 <condition_postfix>
 totalGroupIncome 4 local@  &gt; 
 </condition_postfix></condition_details>
@@ -550,7 +550,7 @@ totalGroupIncome 4 local@  &gt;
 <condition_number>11</condition_number>
 <condition_comment>Exclude under 250 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL250</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL250</condition_dsl>
 <condition_postfix>
 totalGroupIncome 5 local@  &gt; 
 </condition_postfix></condition_details>
@@ -558,7 +558,7 @@ totalGroupIncome 5 local@  &gt;
 <condition_number>12</condition_number>
 <condition_comment>Include if not excluded and under 175 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL175</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL175</condition_dsl>
 <condition_postfix>
 totalGroupIncome 3 local@  &lt;= 
 </condition_postfix>
@@ -569,7 +569,7 @@ totalGroupIncome 3 local@  &lt;=
 <condition_number>13</condition_number>
 <condition_comment>Include if not excluded and under 200 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL200</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL200</condition_dsl>
 <condition_postfix>
 totalGroupIncome 4 local@  &lt;= 
 </condition_postfix>
@@ -579,7 +579,7 @@ totalGroupIncome 4 local@  &lt;=
 <condition_number>14</condition_number>
 <condition_comment>Include if not excluded and under 250 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL250</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL250</condition_dsl>
 <condition_postfix>
 totalGroupIncome 5 local@  &lt;= 
 </condition_postfix>
@@ -588,7 +588,7 @@ totalGroupIncome 5 local@  &lt;=
 <condition_number>15</condition_number>
 <condition_comment>Include if not excluded and under 300 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL300</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL300</condition_dsl>
 <condition_postfix>
 totalGroupIncome 6 local@  &lt;= 
 </condition_postfix>
@@ -598,7 +598,7 @@ totalGroupIncome 6 local@  &lt;=
 <action_number>1</action_number>
 <action_comment>set the program Level</action_comment>
 <action_requirement />
-<action_description>set client.programLevel = FreeCoverage</action_description>
+<action_dsl>set client.programLevel = FreeCoverage</action_dsl>
 <action_postfix>
 FreeCoverage cvs /client.programLevel xdef  
 </action_postfix>
@@ -609,7 +609,7 @@ FreeCoverage cvs /client.programLevel xdef
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set client.programLevel = LowCostCoverage</action_description>
+<action_dsl>set client.programLevel = LowCostCoverage</action_dsl>
 <action_postfix>
 LowCostCoverage cvs /client.programLevel xdef  
 </action_postfix>
@@ -620,7 +620,7 @@ LowCostCoverage cvs /client.programLevel xdef
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set client.programLevel = AtCostCoverage</action_description>
+<action_dsl>set client.programLevel = AtCostCoverage</action_dsl>
 <action_postfix>
 AtCostCoverage cvs /client.programLevel xdef  
 </action_postfix>
@@ -629,7 +629,7 @@ AtCostCoverage cvs /client.programLevel xdef
 <action_number>4</action_number>
 <action_comment>Provide reasons for rejection</action_comment>
 <action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -641,7 +641,7 @@ false cvb /client.eligible xdef
 <action_number>5</action_number>
 <action_comment />
 <action_requirement />
-<action_description>Add "Client is eligible for Medicaid, so cannot enroll in KidAid" to client.notes</action_description>
+<action_dsl>Add "Client is eligible for Medicaid, so cannot enroll in KidAid" to client.notes</action_dsl>
 <action_postfix>
 "Client is eligible for Medicaid, so cannot enroll in KidAid" client.notes swap addto 
 </action_postfix>
@@ -650,7 +650,7 @@ false cvb /client.eligible xdef
 <action_number>6</action_number>
 <action_comment />
 <action_requirement />
-<action_description>Add "Must Provide Validation of Citizenship" to client.notes</action_description>
+<action_dsl>Add "Must Provide Validation of Citizenship" to client.notes</action_dsl>
 <action_postfix>
 "Must Provide Validation of Citizenship" client.notes swap addto 
 </action_postfix>
@@ -660,7 +660,7 @@ false cvb /client.eligible xdef
 <action_number>7</action_number>
 <action_comment />
 <action_requirement />
-<action_description>Add "Case must be within a KidAid County" to client.notes</action_description>
+<action_dsl>Add "Case must be within a KidAid County" to client.notes</action_dsl>
 <action_postfix>
 "Case must be within a KidAid County" client.notes swap addto 
 </action_postfix>
@@ -670,7 +670,7 @@ false cvb /client.eligible xdef
 <action_number>8</action_number>
 <action_comment>Add "Must be 18 or younger to qualify for KidAid" to client.notes</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "Must be 18 or younger to qualify for KidAid" client.notes swap addto 
 </action_postfix>
@@ -679,7 +679,7 @@ false cvb /client.eligible xdef
 <action_number>9</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set client_fpl = (100.0 * totalGroupIncome) / FPL</action_description>
+<action_dsl>set client_fpl = (100.0 * totalGroupIncome) / FPL</action_dsl>
 <action_postfix>
 100.0 totalGroupIncome fmul 0 local@  fdiv  cvi /client_fpl xdef  
 </action_postfix>
@@ -707,7 +707,7 @@ false cvb /client.eligible xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -717,7 +717,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
 <condition_requirement />
-<condition_description>client.applying == true</condition_description>
+<condition_dsl>client.applying == true</condition_dsl>
 <condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -727,7 +727,7 @@ client.applying true beq
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
 <action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -736,7 +736,7 @@ false cvb /client.eligible xdef
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Medicaid Applications" to client.notes</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "The System does not yet support Medicaid Applications" client.notes swap addto 
 </action_postfix>
@@ -753,7 +753,7 @@ false cvb /client.eligible xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -763,7 +763,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
 <condition_requirement />
-<condition_description>client.applying == true</condition_description>
+<condition_dsl>client.applying == true</condition_dsl>
 <condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -773,7 +773,7 @@ client.applying true beq
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
 <action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -782,7 +782,7 @@ false cvb /client.eligible xdef
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Food Stamp Applications" to client.notes</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "The System does not yet support Food Stamp Applications" client.notes swap addto 
 </action_postfix>
@@ -802,7 +802,7 @@ in this table, and update the test code to get the data from the client object.<
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details></contexts>
@@ -812,7 +812,7 @@ in this table, and update the test code to get the data from the client object.<
 <condition_number>1</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called 
 </condition_postfix>
@@ -822,7 +822,7 @@ perform when called
 <action_number>1</action_number>
 <action_comment>Create a Result Record</action_comment>
 <action_requirement />
-<action_description>add a new Result entity to the context of this table</action_description>
+<action_dsl>add a new Result entity to the context of this table</action_dsl>
 <action_postfix>
 /Result createentity entitypush 
 </action_postfix>
@@ -831,7 +831,7 @@ perform when called
 <action_number>2</action_number>
 <action_comment>Add the record to the list on the job</action_comment>
 <action_requirement />
-<action_description>add the result to the job.results</action_description>
+<action_dsl>add the result to the job.results</action_dsl>
 <action_postfix>
 result job.results swap addto 
 </action_postfix>
@@ -840,7 +840,7 @@ result job.results swap addto
 <action_number>3</action_number>
 <action_comment>Add the case notes to the result notes</action_comment>
 <action_requirement />
-<action_description>Add the case.notes to the Result.notes</action_description>
+<action_dsl>Add the case.notes to the Result.notes</action_dsl>
 <action_postfix>
 case.notes Result.notes true  addarray 
 </action_postfix>
@@ -849,7 +849,7 @@ case.notes Result.notes true  addarray
 <action_number>4</action_number>
 <action_comment>Add the client notes to the result notes</action_comment>
 <action_requirement />
-<action_description>Add the client.notes to the Result.notes</action_description>
+<action_dsl>Add the client.notes to the Result.notes</action_dsl>
 <action_postfix>
 client.notes Result.notes true  addarray 
 </action_postfix>
@@ -858,7 +858,7 @@ client.notes Result.notes true  addarray
 <action_number>5</action_number>
 <action_comment>Copy the client ID</action_comment>
 <action_requirement />
-<action_description>Set Result.client_id = client.client_id</action_description>
+<action_dsl>Set Result.client_id = client.client_id</action_dsl>
 <action_postfix>
 client.client_id cvs /Result.client_id xdef  
 </action_postfix>
@@ -867,7 +867,7 @@ client.client_id cvs /Result.client_id xdef
 <action_number>6</action_number>
 <action_comment>Point the Result to the client</action_comment>
 <action_requirement />
-<action_description>Set Result.client = client.client</action_description>
+<action_dsl>Set Result.client = client.client</action_dsl>
 <action_postfix>
 client.client cve /Result.client xdef  
 </action_postfix>
@@ -876,7 +876,7 @@ client.client cve /Result.client xdef
 <action_number>7</action_number>
 <action_comment>Set the Result to the program we processed</action_comment>
 <action_requirement />
-<action_description>Set Result.program = job.program</action_description>
+<action_dsl>Set Result.program = job.program</action_dsl>
 <action_postfix>
 job.program cvs /Result.program xdef  
 </action_postfix>
@@ -885,7 +885,7 @@ job.program cvs /Result.program xdef
 <action_number>8</action_number>
 <action_comment>Set the Result programLevel to that recorded on the client</action_comment>
 <action_requirement />
-<action_description>Set Result.programLevel = client.programLevel</action_description>
+<action_dsl>Set Result.programLevel = client.programLevel</action_dsl>
 <action_postfix>
 client.programLevel cvs /Result.programLevel xdef  
 </action_postfix>
@@ -894,7 +894,7 @@ client.programLevel cvs /Result.programLevel xdef
 <action_number>9</action_number>
 <action_comment>Set the Result eligible flag to that recorded on the client</action_comment>
 <action_requirement />
-<action_description>Set Result.eligible = client.eligible</action_description>
+<action_dsl>Set Result.eligible = client.eligible</action_dsl>
 <action_postfix>
 client.eligible cvb /Result.eligible xdef  
 </action_postfix>
@@ -903,7 +903,7 @@ client.eligible cvb /Result.eligible xdef
 <action_number>10</action_number>
 <action_comment>Set the Result Federal Poverty Level to the client's</action_comment>
 <action_requirement />
-<action_description>Set Result.client_fpl = client.client_fpl</action_description>
+<action_dsl>Set Result.client_fpl = client.client_fpl</action_dsl>
 <action_postfix>
 client.client_fpl  cvi /Result.client_fpl xdef  
 </action_postfix>
@@ -912,7 +912,7 @@ client.client_fpl  cvi /Result.client_fpl xdef
 <action_number>11</action_number>
 <action_comment>Set the Result's totalGroupIncome to the clients.</action_comment>
 <action_requirement />
-<action_description>Set Result.totalGroupIncome = client.totalGroupIncome</action_description>
+<action_dsl>Set Result.totalGroupIncome = client.totalGroupIncome</action_dsl>
 <action_postfix>
 client.totalGroupIncome  cvi /Result.totalGroupIncome xdef  
 </action_postfix>

--- a/sampleprojects/KidAid_Application/repository/xml/kidaid_dt.xml
+++ b/sampleprojects/KidAid_Application/repository/xml/kidaid_dt.xml
@@ -14,7 +14,7 @@
 <condition_number>1</condition_number>
 <condition_comment>KidAid</condition_comment>
 <condition_requirement />
-<condition_description>job.program == KidAid</condition_description>
+<condition_dsl>job.program == KidAid</condition_dsl>
 <condition_postfix>
 job.program KidAid streq 
 </condition_postfix>
@@ -23,7 +23,7 @@ job.program KidAid streq
 <condition_number>2</condition_number>
 <condition_comment>MEDICAID</condition_comment>
 <condition_requirement />
-<condition_description>job.program == MEDICAID</condition_description>
+<condition_dsl>job.program == MEDICAID</condition_dsl>
 <condition_postfix>
 job.program MEDICAID streq 
 </condition_postfix>
@@ -32,7 +32,7 @@ job.program MEDICAID streq
 <condition_number>3</condition_number>
 <condition_comment>FOODSTAMPS</condition_comment>
 <condition_requirement />
-<condition_description>job.program == FOODSTAMPS</condition_description>
+<condition_dsl>job.program == FOODSTAMPS</condition_dsl>
 <condition_postfix>
 job.program FOODSTAMPS streq 
 </condition_postfix>
@@ -41,7 +41,7 @@ job.program FOODSTAMPS streq
 <condition_number>4</condition_number>
 <condition_comment>If Not Any of these programs, Report Results Anyway</condition_comment>
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -51,7 +51,7 @@ true
 <action_number>1</action_number>
 <action_comment>Calculate the Individual Incomes</action_comment>
 <action_requirement />
-<action_description>Perform Calculate_Individual_Income</action_description>
+<action_dsl>Perform Calculate_Individual_Income</action_dsl>
 <action_postfix>
 Calculate_Individual_Income 
 </action_postfix>
@@ -62,7 +62,7 @@ Calculate_Individual_Income
 <action_number>2</action_number>
 <action_comment>Get the Group Size for each individual</action_comment>
 <action_requirement />
-<action_description>Perform Calculate_Group_Size</action_description>
+<action_dsl>Perform Calculate_Group_Size</action_dsl>
 <action_postfix>
 Calculate_Group_Size 
 </action_postfix>
@@ -73,7 +73,7 @@ Calculate_Group_Size
 <action_number>3</action_number>
 <action_comment>Evaluate for KidAid</action_comment>
 <action_requirement />
-<action_description>Perform Evaluate_KidAid_Eligibility</action_description>
+<action_dsl>Perform Evaluate_KidAid_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_KidAid_Eligibility 
 </action_postfix>
@@ -82,7 +82,7 @@ Evaluate_KidAid_Eligibility
 <action_number>4</action_number>
 <action_comment>Evaluate for MEDICAID</action_comment>
 <action_requirement />
-<action_description>Perform Evaluate_MEDICAID_Eligibility</action_description>
+<action_dsl>Perform Evaluate_MEDICAID_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_MEDICAID_Eligibility 
 </action_postfix>
@@ -91,7 +91,7 @@ Evaluate_MEDICAID_Eligibility
 <action_number>5</action_number>
 <action_comment>Evaluate for FOODSTAMPS</action_comment>
 <action_requirement />
-<action_description>Perform Evaluate_FOODSTAMPS_Eligibility</action_description>
+<action_dsl>Perform Evaluate_FOODSTAMPS_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_FOODSTAMPS_Eligibility 
 </action_postfix>
@@ -100,7 +100,7 @@ Evaluate_FOODSTAMPS_Eligibility
 <action_number>6</action_number>
 <action_comment>Build a set of Result Objects to report to the caller</action_comment>
 <action_requirement />
-<action_description>Perform Evaluate_Results</action_description>
+<action_dsl>Perform Evaluate_Results</action_dsl>
 <action_postfix>
 Evaluate_Results 
 </action_postfix>
@@ -132,14 +132,14 @@ Evaluate_Results
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment />
-<context_description>for all incomes</context_description>
+<context_dsl>for all incomes</context_dsl>
 <context_postfix>
 dup incomes forall pop 
 </context_postfix></context_details></contexts>
@@ -149,7 +149,7 @@ dup incomes forall pop
 <condition_number>1</condition_number>
 <condition_comment>We include all earned income</condition_comment>
 <condition_requirement />
-<condition_description>income.earned == true</condition_description>
+<condition_dsl>income.earned == true</condition_dsl>
 <condition_postfix>
 income.earned true beq 
 </condition_postfix>
@@ -159,7 +159,7 @@ income.earned true beq
 <condition_number>2</condition_number>
 <condition_comment>We don't include all unearned income types</condition_comment>
 <condition_requirement />
-<condition_description>ExcludedIncomeTypes includes the string income.type</condition_description>
+<condition_dsl>ExcludedIncomeTypes includes the string income.type</condition_dsl>
 <condition_postfix>
 ExcludedIncomeTypes income.type memberof 
 </condition_postfix>
@@ -169,7 +169,7 @@ ExcludedIncomeTypes income.type memberof
 <action_number>1</action_number>
 <action_comment>Add this income to the total income for this client</action_comment>
 <action_requirement />
-<action_description>add income.amount to the client.totalIncome</action_description>
+<action_dsl>add income.amount to the client.totalIncome</action_dsl>
 <action_postfix>
 income.amount  client.totalIncome + /client.totalIncome xdef 
 </action_postfix>
@@ -196,21 +196,21 @@ income.amount  client.totalIncome + /client.totalIncome xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>For each client in the group, we need to calculate a group size (we only need to do this for applying clients)</context_comment>
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>We want to compare a client against every other client in the case, so we set up a local variable to point to ThisClient</context_comment>
-<context_description>local entity ThisClient = client</context_description>
+<context_dsl>local entity ThisClient = client</context_dsl>
 <context_postfix>
 client cve allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment>Now consider the client in respect to all the other clients in the case (We need to consider all clients in the case, even if not applying)</context_comment>
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -219,7 +219,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Are we consider the client themselves?</condition_comment>
 <condition_requirement />
-<condition_description>ThisClient == client</condition_description>
+<condition_dsl>ThisClient == client</condition_dsl>
 <condition_postfix>
 0 local@  client req  
 </condition_postfix>
@@ -230,7 +230,7 @@ dup clients forall pop
 <condition_number>2</condition_number>
 <condition_comment>Include ThisClient's parents</condition_comment>
 <condition_requirement />
-<condition_description>the client is the parent of ThisClient</condition_description>
+<condition_dsl>the client is the parent of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type parent relationships findmatch swap pop
 </condition_postfix>
@@ -241,7 +241,7 @@ dup clients forall pop
 <condition_number>3</condition_number>
 <condition_comment>Include ThisClient's siblings</condition_comment>
 <condition_requirement />
-<condition_description>the client is the sibling of ThisClient</condition_description>
+<condition_dsl>the client is the sibling of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type sibling relationships findmatch swap pop
 </condition_postfix>
@@ -252,7 +252,7 @@ dup clients forall pop
 <condition_number>4</condition_number>
 <condition_comment>Include ThisClient's children</condition_comment>
 <condition_requirement />
-<condition_description>the client is the child of ThisClient</condition_description>
+<condition_dsl>the client is the child of ThisClient</condition_dsl>
 <condition_postfix>
 /source client /target 0 local@  /type child relationships findmatch swap pop
 </condition_postfix>
@@ -262,7 +262,7 @@ dup clients forall pop
 <condition_number>5</condition_number>
 <condition_comment>Include the unborn children in some cases</condition_comment>
 <condition_requirement />
-<condition_description>the client.pregnant == true</condition_description>
+<condition_dsl>the client.pregnant == true</condition_dsl>
 <condition_postfix>
 client.pregnant true beq 
 </condition_postfix>
@@ -276,7 +276,7 @@ client.pregnant true beq
 <condition_number>6</condition_number>
 <condition_comment>Is this client older than 18</condition_comment>
 <condition_requirement />
-<condition_description>client.age &gt; 18</condition_description>
+<condition_dsl>client.age &gt; 18</condition_dsl>
 <condition_postfix>
 client.age 18 &gt; 
 </condition_postfix>
@@ -289,7 +289,7 @@ client.age 18 &gt;
 <action_number>1</action_number>
 <action_comment>Count the Client himself and particular relatives</action_comment>
 <action_requirement />
-<action_description>add 1 to ThisClient's IncomeGroupCount</action_description>
+<action_dsl>add 1 to ThisClient's IncomeGroupCount</action_dsl>
 <action_postfix>
 1  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -304,7 +304,7 @@ client.age 18 &gt;
 <action_number>2</action_number>
 <action_comment>Add 1 for each of the expected babies for a pregnant person</action_comment>
 <action_requirement />
-<action_description>add expectedChildren to ThisClient's IncomeGroupCount</action_description>
+<action_dsl>add expectedChildren to ThisClient's IncomeGroupCount</action_dsl>
 <action_postfix>
 expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -315,7 +315,7 @@ expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef
 <action_number>3</action_number>
 <action_comment>Add this person's Income to the ThisPerson's total group income</action_comment>
 <action_requirement />
-<action_description>add the client.totalIncome to ThisClient's totalGroupIncome</action_description>
+<action_dsl>add the client.totalIncome to ThisClient's totalGroupIncome</action_dsl>
 <action_postfix>
 client.totalIncome  0 local@  entitypush totalGroupIncome + /totalGroupIncome xdef entitypop 
 </action_postfix>
@@ -371,56 +371,56 @@ client.totalIncome  0 local@  entitypush totalGroupIncome + /totalGroupIncome xd
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>FPL = the Federal Poverty Limit calculated for the number of people in this client's Income Group.</context_comment>
-<context_description>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_description>
+<context_dsl>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_dsl>
 <context_postfix>
 FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment>FPL125 = 125 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL125 = FPL * 1.25</context_description>
+<context_dsl>local int FPL125 = FPL * 1.25</context_dsl>
 <context_postfix>
 0 local@  1.25 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment>FPL150 = 150 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL150 = FPL * 1.5</context_description>
+<context_dsl>local int FPL150 = FPL * 1.5</context_dsl>
 <context_postfix>
 0 local@  1.5 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>5</context_number>
 <context_comment>FPL175 = 175 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL175 = FPL * 1.75</context_description>
+<context_dsl>local int FPL175 = FPL * 1.75</context_dsl>
 <context_postfix>
 0 local@  1.75 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>6</context_number>
 <context_comment>FPL200 = 200 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL200 = FPL * 2</context_description>
+<context_dsl>local int FPL200 = FPL * 2</context_dsl>
 <context_postfix>
 0 local@  2 *  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>7</context_number>
 <context_comment>FPL250 = 250 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL250 = FPL * 2.5</context_description>
+<context_dsl>local int FPL250 = FPL * 2.5</context_dsl>
 <context_postfix>
 0 local@  2.5 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>8</context_number>
 <context_comment>FPL300 = 300 percent of the Federal Poverty Limit</context_comment>
-<context_description>local int FPL300 = FPL * 3</context_description>
+<context_dsl>local int FPL300 = FPL * 3</context_dsl>
 <context_postfix>
 0 local@  3 *  cvi allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -429,7 +429,7 @@ FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate 
 <condition_number>1</condition_number>
 <condition_comment>You have to be a Citizen</condition_comment>
 <condition_requirement />
-<condition_description>validatedCitizenship</condition_description>
+<condition_dsl>validatedCitizenship</condition_dsl>
 <condition_postfix>
 validatedCitizenship 
 </condition_postfix>
@@ -447,7 +447,7 @@ validatedCitizenship
 <condition_number>2</condition_number>
 <condition_comment>Make sure this case is in the appropriate county</condition_comment>
 <condition_requirement />
-<condition_description>The CoveredCounties includes the string case.county_Cd</condition_description>
+<condition_dsl>The CoveredCounties includes the string case.county_Cd</condition_dsl>
 <condition_postfix>
 CoveredCounties case.county_Cd memberof 
 </condition_postfix>
@@ -465,7 +465,7 @@ CoveredCounties case.county_Cd memberof
 <condition_number>3</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>client.age &lt; 1</condition_description>
+<condition_dsl>client.age &lt; 1</condition_dsl>
 <condition_postfix>
 client.age 1 &lt; 
 </condition_postfix>
@@ -479,7 +479,7 @@ client.age 1 &lt;
 <condition_number>4</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>client.age &lt; 6</condition_description>
+<condition_dsl>client.age &lt; 6</condition_dsl>
 <condition_postfix>
 client.age 6 &lt; 
 </condition_postfix>
@@ -491,7 +491,7 @@ client.age 6 &lt;
 <condition_number>5</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>client.age &lt;= 18</condition_description>
+<condition_dsl>client.age &lt;= 18</condition_dsl>
 <condition_postfix>
 client.age 18 &lt;= 
 </condition_postfix>
@@ -504,7 +504,7 @@ client.age 18 &lt;=
 <condition_number>6</condition_number>
 <condition_comment>Exclude under the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL</condition_dsl>
 <condition_postfix>
 totalGroupIncome 0 local@  &gt; 
 </condition_postfix>
@@ -513,7 +513,7 @@ totalGroupIncome 0 local@  &gt;
 <condition_number>7</condition_number>
 <condition_comment>Exclude under 125 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL125</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL125</condition_dsl>
 <condition_postfix>
 totalGroupIncome 1 local@  &gt; 
 </condition_postfix>
@@ -522,7 +522,7 @@ totalGroupIncome 1 local@  &gt;
 <condition_number>8</condition_number>
 <condition_comment>Exclude under 150 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL150</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL150</condition_dsl>
 <condition_postfix>
 totalGroupIncome 2 local@  &gt; 
 </condition_postfix>
@@ -531,7 +531,7 @@ totalGroupIncome 2 local@  &gt;
 <condition_number>9</condition_number>
 <condition_comment>Exclude under 175 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL175</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL175</condition_dsl>
 <condition_postfix>
 totalGroupIncome 3 local@  &gt; 
 </condition_postfix>
@@ -542,7 +542,7 @@ totalGroupIncome 3 local@  &gt;
 <condition_number>10</condition_number>
 <condition_comment>Exclude under 200 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL200</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL200</condition_dsl>
 <condition_postfix>
 totalGroupIncome 4 local@  &gt; 
 </condition_postfix></condition_details>
@@ -550,7 +550,7 @@ totalGroupIncome 4 local@  &gt;
 <condition_number>11</condition_number>
 <condition_comment>Exclude under 250 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL250</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL250</condition_dsl>
 <condition_postfix>
 totalGroupIncome 5 local@  &gt; 
 </condition_postfix></condition_details>
@@ -558,7 +558,7 @@ totalGroupIncome 5 local@  &gt;
 <condition_number>12</condition_number>
 <condition_comment>Include if not excluded and under 175 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL175</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL175</condition_dsl>
 <condition_postfix>
 totalGroupIncome 3 local@  &lt;= 
 </condition_postfix>
@@ -569,7 +569,7 @@ totalGroupIncome 3 local@  &lt;=
 <condition_number>13</condition_number>
 <condition_comment>Include if not excluded and under 200 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL200</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL200</condition_dsl>
 <condition_postfix>
 totalGroupIncome 4 local@  &lt;= 
 </condition_postfix>
@@ -579,7 +579,7 @@ totalGroupIncome 4 local@  &lt;=
 <condition_number>14</condition_number>
 <condition_comment>Include if not excluded and under 250 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL250</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL250</condition_dsl>
 <condition_postfix>
 totalGroupIncome 5 local@  &lt;= 
 </condition_postfix>
@@ -588,7 +588,7 @@ totalGroupIncome 5 local@  &lt;=
 <condition_number>15</condition_number>
 <condition_comment>Include if not excluded and under 300 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL300</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL300</condition_dsl>
 <condition_postfix>
 totalGroupIncome 6 local@  &lt;= 
 </condition_postfix>
@@ -598,7 +598,7 @@ totalGroupIncome 6 local@  &lt;=
 <action_number>1</action_number>
 <action_comment>set the program Level</action_comment>
 <action_requirement />
-<action_description>set client.programLevel = FreeCoverage</action_description>
+<action_dsl>set client.programLevel = FreeCoverage</action_dsl>
 <action_postfix>
 FreeCoverage cvs /client.programLevel xdef  
 </action_postfix>
@@ -609,7 +609,7 @@ FreeCoverage cvs /client.programLevel xdef
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set client.programLevel = LowCostCoverage</action_description>
+<action_dsl>set client.programLevel = LowCostCoverage</action_dsl>
 <action_postfix>
 LowCostCoverage cvs /client.programLevel xdef  
 </action_postfix>
@@ -620,7 +620,7 @@ LowCostCoverage cvs /client.programLevel xdef
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set client.programLevel = AtCostCoverage</action_description>
+<action_dsl>set client.programLevel = AtCostCoverage</action_dsl>
 <action_postfix>
 AtCostCoverage cvs /client.programLevel xdef  
 </action_postfix>
@@ -629,7 +629,7 @@ AtCostCoverage cvs /client.programLevel xdef
 <action_number>4</action_number>
 <action_comment>Provide reasons for rejection</action_comment>
 <action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -641,7 +641,7 @@ false cvb /client.eligible xdef
 <action_number>5</action_number>
 <action_comment />
 <action_requirement />
-<action_description>Add "Client is eligible for Medicaid, so cannot enroll in KidAid" to client.notes</action_description>
+<action_dsl>Add "Client is eligible for Medicaid, so cannot enroll in KidAid" to client.notes</action_dsl>
 <action_postfix>
 "Client is eligible for Medicaid, so cannot enroll in KidAid" client.notes swap addto 
 </action_postfix>
@@ -650,7 +650,7 @@ false cvb /client.eligible xdef
 <action_number>6</action_number>
 <action_comment />
 <action_requirement />
-<action_description>Add "Must Provide Validation of Citizenship" to client.notes</action_description>
+<action_dsl>Add "Must Provide Validation of Citizenship" to client.notes</action_dsl>
 <action_postfix>
 "Must Provide Validation of Citizenship" client.notes swap addto 
 </action_postfix>
@@ -660,7 +660,7 @@ false cvb /client.eligible xdef
 <action_number>7</action_number>
 <action_comment />
 <action_requirement />
-<action_description>Add "Case must be within a KidAid County" to client.notes</action_description>
+<action_dsl>Add "Case must be within a KidAid County" to client.notes</action_dsl>
 <action_postfix>
 "Case must be within a KidAid County" client.notes swap addto 
 </action_postfix>
@@ -670,7 +670,7 @@ false cvb /client.eligible xdef
 <action_number>8</action_number>
 <action_comment>Add "Must be 18 or younger to qualify for KidAid" to client.notes</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "Must be 18 or younger to qualify for KidAid" client.notes swap addto 
 </action_postfix>
@@ -679,7 +679,7 @@ false cvb /client.eligible xdef
 <action_number>9</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set client_fpl = (100.0 * totalGroupIncome) / FPL</action_description>
+<action_dsl>set client_fpl = (100.0 * totalGroupIncome) / FPL</action_dsl>
 <action_postfix>
 100.0 totalGroupIncome fmul 0 local@  fdiv  cvi /client_fpl xdef  
 </action_postfix>
@@ -707,7 +707,7 @@ false cvb /client.eligible xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -717,7 +717,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
 <condition_requirement />
-<condition_description>client.applying == true</condition_description>
+<condition_dsl>client.applying == true</condition_dsl>
 <condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -727,7 +727,7 @@ client.applying true beq
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
 <action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -736,7 +736,7 @@ false cvb /client.eligible xdef
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Medicaid Applications" to client.notes</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "The System does not yet support Medicaid Applications" client.notes swap addto 
 </action_postfix>
@@ -753,7 +753,7 @@ false cvb /client.eligible xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -763,7 +763,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
 <condition_requirement />
-<condition_description>client.applying == true</condition_description>
+<condition_dsl>client.applying == true</condition_dsl>
 <condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -773,7 +773,7 @@ client.applying true beq
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
 <action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -782,7 +782,7 @@ false cvb /client.eligible xdef
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Food Stamp Applications" to client.notes</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "The System does not yet support Food Stamp Applications" client.notes swap addto 
 </action_postfix>
@@ -802,7 +802,7 @@ in this table, and update the test code to get the data from the client object.<
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details></contexts>
@@ -812,7 +812,7 @@ in this table, and update the test code to get the data from the client object.<
 <condition_number>1</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called 
 </condition_postfix>
@@ -822,7 +822,7 @@ perform when called
 <action_number>1</action_number>
 <action_comment>Create a Result Record</action_comment>
 <action_requirement />
-<action_description>add a new Result entity to the context of this table</action_description>
+<action_dsl>add a new Result entity to the context of this table</action_dsl>
 <action_postfix>
 /Result createentity entitypush 
 </action_postfix>
@@ -831,7 +831,7 @@ perform when called
 <action_number>2</action_number>
 <action_comment>Add the record to the list on the job</action_comment>
 <action_requirement />
-<action_description>add the result to the job.results</action_description>
+<action_dsl>add the result to the job.results</action_dsl>
 <action_postfix>
 result job.results swap addto 
 </action_postfix>
@@ -840,7 +840,7 @@ result job.results swap addto
 <action_number>3</action_number>
 <action_comment>Add the case notes to the result notes</action_comment>
 <action_requirement />
-<action_description>Add the case.notes to the Result.notes</action_description>
+<action_dsl>Add the case.notes to the Result.notes</action_dsl>
 <action_postfix>
 case.notes Result.notes true  addarray 
 </action_postfix>
@@ -849,7 +849,7 @@ case.notes Result.notes true  addarray
 <action_number>4</action_number>
 <action_comment>Add the client notes to the result notes</action_comment>
 <action_requirement />
-<action_description>Add the client.notes to the Result.notes</action_description>
+<action_dsl>Add the client.notes to the Result.notes</action_dsl>
 <action_postfix>
 client.notes Result.notes true  addarray 
 </action_postfix>
@@ -858,7 +858,7 @@ client.notes Result.notes true  addarray
 <action_number>5</action_number>
 <action_comment>Copy the client ID</action_comment>
 <action_requirement />
-<action_description>Set Result.client_id = client.client_id</action_description>
+<action_dsl>Set Result.client_id = client.client_id</action_dsl>
 <action_postfix>
 client.client_id cvs /Result.client_id xdef  
 </action_postfix>
@@ -867,7 +867,7 @@ client.client_id cvs /Result.client_id xdef
 <action_number>6</action_number>
 <action_comment>Point the Result to the client</action_comment>
 <action_requirement />
-<action_description>Set Result.client = client.client</action_description>
+<action_dsl>Set Result.client = client.client</action_dsl>
 <action_postfix>
 client.client cve /Result.client xdef  
 </action_postfix>
@@ -876,7 +876,7 @@ client.client cve /Result.client xdef
 <action_number>7</action_number>
 <action_comment>Set the Result to the program we processed</action_comment>
 <action_requirement />
-<action_description>Set Result.program = job.program</action_description>
+<action_dsl>Set Result.program = job.program</action_dsl>
 <action_postfix>
 job.program cvs /Result.program xdef  
 </action_postfix>
@@ -885,7 +885,7 @@ job.program cvs /Result.program xdef
 <action_number>8</action_number>
 <action_comment>Set the Result programLevel to that recorded on the client</action_comment>
 <action_requirement />
-<action_description>Set Result.programLevel = client.programLevel</action_description>
+<action_dsl>Set Result.programLevel = client.programLevel</action_dsl>
 <action_postfix>
 client.programLevel cvs /Result.programLevel xdef  
 </action_postfix>
@@ -894,7 +894,7 @@ client.programLevel cvs /Result.programLevel xdef
 <action_number>9</action_number>
 <action_comment>Set the Result eligible flag to that recorded on the client</action_comment>
 <action_requirement />
-<action_description>Set Result.eligible = client.eligible</action_description>
+<action_dsl>Set Result.eligible = client.eligible</action_dsl>
 <action_postfix>
 client.eligible cvb /Result.eligible xdef  
 </action_postfix>
@@ -903,7 +903,7 @@ client.eligible cvb /Result.eligible xdef
 <action_number>10</action_number>
 <action_comment>Set the Result Federal Poverty Level to the client's</action_comment>
 <action_requirement />
-<action_description>Set Result.client_fpl = client.client_fpl</action_description>
+<action_dsl>Set Result.client_fpl = client.client_fpl</action_dsl>
 <action_postfix>
 client.client_fpl  cvi /Result.client_fpl xdef  
 </action_postfix>
@@ -912,7 +912,7 @@ client.client_fpl  cvi /Result.client_fpl xdef
 <action_number>11</action_number>
 <action_comment>Set the Result's totalGroupIncome to the clients.</action_comment>
 <action_requirement />
-<action_description>Set Result.totalGroupIncome = client.totalGroupIncome</action_description>
+<action_dsl>Set Result.totalGroupIncome = client.totalGroupIncome</action_dsl>
 <action_postfix>
 client.totalGroupIncome  cvi /Result.totalGroupIncome xdef  
 </action_postfix>

--- a/sampleprojects/KidAid_Application/repository/xml/sp2_dt.xml
+++ b/sampleprojects/KidAid_Application/repository/xml/sp2_dt.xml
@@ -14,7 +14,7 @@
 <condition_number>1</condition_number>
 <condition_comment>KidAid</condition_comment>
 <condition_requirement />
-<condition_description>job.program == KidAid</condition_description>
+<condition_dsl>job.program == KidAid</condition_dsl>
 <condition_postfix>
 job.program KidAid streq 
 </condition_postfix>
@@ -38,7 +38,7 @@ job.program KidAid streq
 <condition_number>2</condition_number>
 <condition_comment>MEDICAID</condition_comment>
 <condition_requirement />
-<condition_description>job.program == MEDICAID</condition_description>
+<condition_dsl>job.program == MEDICAID</condition_dsl>
 <condition_postfix>
 job.program MEDICAID streq 
 </condition_postfix>
@@ -62,7 +62,7 @@ job.program MEDICAID streq
 <condition_number>3</condition_number>
 <condition_comment>FOODSTAMPS</condition_comment>
 <condition_requirement />
-<condition_description>job.program == FOODSTAMPS</condition_description>
+<condition_dsl>job.program == FOODSTAMPS</condition_dsl>
 <condition_postfix>
 job.program FOODSTAMPS streq 
 </condition_postfix>
@@ -86,7 +86,7 @@ job.program FOODSTAMPS streq
 <condition_number>4</condition_number>
 <condition_comment>If Not Any of these programs, Report Results Anyway</condition_comment>
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -111,7 +111,7 @@ true
 <action_number>1</action_number>
 <action_comment>Calculate the Individual Incomes</action_comment>
 <initial_action_requirement />
-<action_description>Perform Calculate_Individual_Income</action_description>
+<action_dsl>Perform Calculate_Individual_Income</action_dsl>
 <action_postfix>
 Calculate_Individual_Income 
 </action_postfix>
@@ -122,7 +122,7 @@ Calculate_Individual_Income
 <action_number>2</action_number>
 <action_comment>Get the Group Size for each individual</action_comment>
 <initial_action_requirement />
-<action_description>Perform Calculate_Group_Size</action_description>
+<action_dsl>Perform Calculate_Group_Size</action_dsl>
 <action_postfix>
 Calculate_Group_Size 
 </action_postfix>
@@ -133,7 +133,7 @@ Calculate_Group_Size
 <action_number>3</action_number>
 <action_comment>Evaluate for KidAid</action_comment>
 <initial_action_requirement />
-<action_description>Perform Evaluate_KidAid_Eligibility</action_description>
+<action_dsl>Perform Evaluate_KidAid_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_KidAid_Eligibility 
 </action_postfix>
@@ -142,7 +142,7 @@ Evaluate_KidAid_Eligibility
 <action_number>4</action_number>
 <action_comment>Evaluate for MEDICAID</action_comment>
 <initial_action_requirement />
-<action_description>Perform Evaluate_MEDICAID_Eligibility</action_description>
+<action_dsl>Perform Evaluate_MEDICAID_Eligibility</action_dsl>
 <action_postfix>
 Evaluate_MEDICAID_Eligibility 
 </action_postfix>
@@ -151,7 +151,7 @@ Evaluate_MEDICAID_Eligibility
 <action_number>5</action_number>
 <action_comment>Evaluate for FOODSTAMPS</action_comment>
 <initial_action_requirement />
-<action_description>Perform Evaluate_FOODSTAMPS_Eligibilty</action_description>
+<action_dsl>Perform Evaluate_FOODSTAMPS_Eligibilty</action_dsl>
 <action_postfix>
 Evaluate_FOODSTAMPS_Eligibilty 
 </action_postfix>
@@ -160,7 +160,7 @@ Evaluate_FOODSTAMPS_Eligibilty
 <action_number>6</action_number>
 <action_comment>Build a set of Result Objects to report to the caller</action_comment>
 <initial_action_requirement />
-<action_description>Perform Evaluate_Results</action_description>
+<action_dsl>Perform Evaluate_Results</action_dsl>
 <action_postfix>
 Evaluate_Results 
 </action_postfix>
@@ -178,13 +178,13 @@ Evaluate_Results
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
-<context_description>for all incomes</context_description>
+<context_dsl>for all incomes</context_dsl>
 <context_postfix>
 dup incomes forall pop 
 </context_postfix></context_details></contexts>
@@ -194,7 +194,7 @@ dup incomes forall pop
 <condition_number>1</condition_number>
 <condition_comment>We include all earned income</condition_comment>
 <condition_requirement />
-<condition_description>income.earned == true</condition_description>
+<condition_dsl>income.earned == true</condition_dsl>
 <condition_postfix>
 income.earned true beq 
 </condition_postfix>
@@ -218,7 +218,7 @@ income.earned true beq
 <condition_number>2</condition_number>
 <condition_comment>We don't include all unearned income types</condition_comment>
 <condition_requirement />
-<condition_description>ExcludedIncomeTypes includes the string income.type</condition_description>
+<condition_dsl>ExcludedIncomeTypes includes the string income.type</condition_dsl>
 <condition_postfix>
 ExcludedIncomeTypes income.type memberof 
 </condition_postfix>
@@ -243,7 +243,7 @@ ExcludedIncomeTypes income.type memberof
 <action_number>1</action_number>
 <action_comment>Add this income to the total income for this client</action_comment>
 <initial_action_requirement />
-<action_description>add income.amount to the client.totalIncome</action_description>
+<action_dsl>add income.amount to the client.totalIncome</action_dsl>
 <action_postfix>
 income.amount  client.totalIncome + /client.totalIncome xdef 
 </action_postfix>
@@ -259,19 +259,19 @@ income.amount  client.totalIncome + /client.totalIncome xdef
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
-<context_description>local entity ThisClient = client</context_description>
+<context_dsl>local entity ThisClient = client</context_dsl>
 <context_postfix>
 client cve allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -280,7 +280,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Are we consider the client themselves?</condition_comment>
 <condition_requirement />
-<condition_description>ThisClient == client</condition_description>
+<condition_dsl>ThisClient == client</condition_dsl>
 <condition_postfix>
 0 local@  client req  
 </condition_postfix>
@@ -304,7 +304,7 @@ dup clients forall pop
 <condition_number>2</condition_number>
 <condition_comment>Include ThisClient's parents</condition_comment>
 <condition_requirement />
-<condition_description>the client is the parent of ThisClient</condition_description>
+<condition_dsl>the client is the parent of ThisClient</condition_dsl>
 <condition_postfix>
 parent { pop true } { pop false } { dup type streq source client  req and target 0 local@   req and }  relationships forfirstelse 
 </condition_postfix>
@@ -328,7 +328,7 @@ parent { pop true } { pop false } { dup type streq source client  req and target
 <condition_number>3</condition_number>
 <condition_comment>Include ThisClient's siblings</condition_comment>
 <condition_requirement />
-<condition_description>the client is the sibling of ThisClient</condition_description>
+<condition_dsl>the client is the sibling of ThisClient</condition_dsl>
 <condition_postfix>
 sibling { pop true } { pop false } { dup type streq source client  req and target 0 local@   req and }  relationships forfirstelse 
 </condition_postfix>
@@ -352,7 +352,7 @@ sibling { pop true } { pop false } { dup type streq source client  req and targe
 <condition_number>4</condition_number>
 <condition_comment>Include ThisClient's children</condition_comment>
 <condition_requirement />
-<condition_description>the client is the child of ThisClient</condition_description>
+<condition_dsl>the client is the child of ThisClient</condition_dsl>
 <condition_postfix>
 child { pop true } { pop false } { dup type streq source client  req and target 0 local@   req and }  relationships forfirstelse 
 </condition_postfix>
@@ -376,7 +376,7 @@ child { pop true } { pop false } { dup type streq source client  req and target 
 <condition_number>5</condition_number>
 <condition_comment>Include the unborn children in some cases</condition_comment>
 <condition_requirement />
-<condition_description>the client.pregnant == true</condition_description>
+<condition_dsl>the client.pregnant == true</condition_dsl>
 <condition_postfix>
 client.pregnant true beq 
 </condition_postfix>
@@ -400,7 +400,7 @@ client.pregnant true beq
 <condition_number>6</condition_number>
 <condition_comment>Is this client older than 18</condition_comment>
 <condition_requirement />
-<condition_description>client.age &gt; 18</condition_description>
+<condition_dsl>client.age &gt; 18</condition_dsl>
 <condition_postfix>
 client.age 18 &gt; 
 </condition_postfix>
@@ -425,7 +425,7 @@ client.age 18 &gt;
 <action_number>1</action_number>
 <action_comment>Count the Client himself and particular relatives</action_comment>
 <initial_action_requirement />
-<action_description>add 1 to ThisClient's IncomeGroupCount</action_description>
+<action_dsl>add 1 to ThisClient's IncomeGroupCount</action_dsl>
 <action_postfix>
 1  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -440,7 +440,7 @@ client.age 18 &gt;
 <action_number>2</action_number>
 <action_comment>Add 1 for each of the expected babies for a pregnant person</action_comment>
 <initial_action_requirement />
-<action_description>add expectedChildren to ThisClient's IncomeGroupCount</action_description>
+<action_dsl>add expectedChildren to ThisClient's IncomeGroupCount</action_dsl>
 <action_postfix>
 expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop 
 </action_postfix>
@@ -451,7 +451,7 @@ expectedChildren  0 local@  entitypush IncomeGroupCount + /IncomeGroupCount xdef
 <action_number>3</action_number>
 <action_comment>Add this person's Income to the ThisPerson's total group income</action_comment>
 <initial_action_requirement />
-<action_description>add the client.totalIncome to ThisClient's totalGroupIncome</action_description>
+<action_dsl>add the client.totalIncome to ThisClient's totalGroupIncome</action_dsl>
 <action_postfix>
 client.totalIncome  0 local@  entitypush totalGroupIncome + /totalGroupIncome xdef entitypop 
 </action_postfix>
@@ -469,49 +469,49 @@ client.totalIncome  0 local@  entitypush totalGroupIncome + /totalGroupIncome xd
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
-<context_description>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_description>
+<context_dsl>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_dsl>
 <context_postfix>
 FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
-<context_description>local int FPL125 = FPL * 1.25</context_description>
+<context_dsl>local int FPL125 = FPL * 1.25</context_dsl>
 <context_postfix>
 0 local@  1.25 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
-<context_description>local int FPL150 = FPL * 1.5</context_description>
+<context_dsl>local int FPL150 = FPL * 1.5</context_dsl>
 <context_postfix>
 0 local@  1.5 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>5</context_number>
-<context_description>local int FPL175 = FPL * 1.75</context_description>
+<context_dsl>local int FPL175 = FPL * 1.75</context_dsl>
 <context_postfix>
 0 local@  1.75 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>6</context_number>
-<context_description>local int FPL200 = FPL * 2</context_description>
+<context_dsl>local int FPL200 = FPL * 2</context_dsl>
 <context_postfix>
 0 local@  2 *  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>7</context_number>
-<context_description>local int FPL250 = FPL * 2.5</context_description>
+<context_dsl>local int FPL250 = FPL * 2.5</context_dsl>
 <context_postfix>
 0 local@  2.5 fmul  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>8</context_number>
-<context_description>local int FPL300 = FPL * 3</context_description>
+<context_dsl>local int FPL300 = FPL * 3</context_dsl>
 <context_postfix>
 0 local@  3 *  cvi allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -520,7 +520,7 @@ FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 -  * +  cvi allocate 
 <condition_number>1</condition_number>
 <condition_comment>You have to be a Citizen</condition_comment>
 <condition_requirement />
-<condition_description>validatedCitizenship</condition_description>
+<condition_dsl>validatedCitizenship</condition_dsl>
 <condition_postfix>
 validatedCitizenship 
 </condition_postfix>
@@ -544,7 +544,7 @@ validatedCitizenship
 <condition_number>2</condition_number>
 <condition_comment>Make sure this case is in the appropriate county</condition_comment>
 <condition_requirement />
-<condition_description>The CoveredCounties includes the string case.county_Cd</condition_description>
+<condition_dsl>The CoveredCounties includes the string case.county_Cd</condition_dsl>
 <condition_postfix>
 CoveredCounties case.county_Cd memberof 
 </condition_postfix>
@@ -568,7 +568,7 @@ CoveredCounties case.county_Cd memberof
 <condition_number>3</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>client.age &lt; 1</condition_description>
+<condition_dsl>client.age &lt; 1</condition_dsl>
 <condition_postfix>
 client.age 1 &lt; 
 </condition_postfix>
@@ -592,7 +592,7 @@ client.age 1 &lt;
 <condition_number>4</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>client.age &lt; 6</condition_description>
+<condition_dsl>client.age &lt; 6</condition_dsl>
 <condition_postfix>
 client.age 6 &lt; 
 </condition_postfix>
@@ -616,7 +616,7 @@ client.age 6 &lt;
 <condition_number>5</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>client.age &lt;= 18</condition_description>
+<condition_dsl>client.age &lt;= 18</condition_dsl>
 <condition_postfix>
 client.age 18 &lt;= 
 </condition_postfix>
@@ -640,7 +640,7 @@ client.age 18 &lt;=
 <condition_number>6</condition_number>
 <condition_comment>Exclude under the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL</condition_dsl>
 <condition_postfix>
 totalGroupIncome 0 local@  &gt; 
 </condition_postfix>
@@ -664,7 +664,7 @@ totalGroupIncome 0 local@  &gt;
 <condition_number>7</condition_number>
 <condition_comment>Exclude under 125 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL125</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL125</condition_dsl>
 <condition_postfix>
 totalGroupIncome 1 local@  &gt; 
 </condition_postfix>
@@ -688,7 +688,7 @@ totalGroupIncome 1 local@  &gt;
 <condition_number>8</condition_number>
 <condition_comment>Exclude under 150 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL150</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL150</condition_dsl>
 <condition_postfix>
 totalGroupIncome 2 local@  &gt; 
 </condition_postfix>
@@ -712,7 +712,7 @@ totalGroupIncome 2 local@  &gt;
 <condition_number>9</condition_number>
 <condition_comment>Exclude under 175 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL175</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL175</condition_dsl>
 <condition_postfix>
 totalGroupIncome 3 local@  &gt; 
 </condition_postfix>
@@ -736,7 +736,7 @@ totalGroupIncome 3 local@  &gt;
 <condition_number>10</condition_number>
 <condition_comment>Exclude under 200 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL200</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL200</condition_dsl>
 <condition_postfix>
 totalGroupIncome 4 local@  &gt; 
 </condition_postfix>
@@ -760,7 +760,7 @@ totalGroupIncome 4 local@  &gt;
 <condition_number>11</condition_number>
 <condition_comment>Exclude under 250 percent of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &gt; FPL250</condition_description>
+<condition_dsl>totalGroupIncome &gt; FPL250</condition_dsl>
 <condition_postfix>
 totalGroupIncome 5 local@  &gt; 
 </condition_postfix>
@@ -784,7 +784,7 @@ totalGroupIncome 5 local@  &gt;
 <condition_number>12</condition_number>
 <condition_comment>Include if not excluded and under 175 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL175</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL175</condition_dsl>
 <condition_postfix>
 totalGroupIncome 3 local@  &lt;= 
 </condition_postfix>
@@ -808,7 +808,7 @@ totalGroupIncome 3 local@  &lt;=
 <condition_number>13</condition_number>
 <condition_comment>Include if not excluded and under 200 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL200</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL200</condition_dsl>
 <condition_postfix>
 totalGroupIncome 4 local@  &lt;= 
 </condition_postfix>
@@ -832,7 +832,7 @@ totalGroupIncome 4 local@  &lt;=
 <condition_number>14</condition_number>
 <condition_comment>Include if not excluded and under 250 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL250</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL250</condition_dsl>
 <condition_postfix>
 totalGroupIncome 5 local@  &lt;= 
 </condition_postfix>
@@ -856,7 +856,7 @@ totalGroupIncome 5 local@  &lt;=
 <condition_number>15</condition_number>
 <condition_comment>Include if not excluded and under 300 of the FPL</condition_comment>
 <condition_requirement />
-<condition_description>totalGroupIncome &lt;= FPL300</condition_description>
+<condition_dsl>totalGroupIncome &lt;= FPL300</condition_dsl>
 <condition_postfix>
 totalGroupIncome 6 local@  &lt;= 
 </condition_postfix>
@@ -881,7 +881,7 @@ totalGroupIncome 6 local@  &lt;=
 <action_number>1</action_number>
 <action_comment>set the program Level</action_comment>
 <initial_action_requirement />
-<action_description>set client.programLevel = FreeCoverage</action_description>
+<action_dsl>set client.programLevel = FreeCoverage</action_dsl>
 <action_postfix>
 FreeCoverage cvs /client.programLevel xdef  
 </action_postfix>
@@ -892,7 +892,7 @@ FreeCoverage cvs /client.programLevel xdef
 <action_number>2</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set client.programLevel = LowCostCoverage</action_description>
+<action_dsl>set client.programLevel = LowCostCoverage</action_dsl>
 <action_postfix>
 LowCostCoverage cvs /client.programLevel xdef  
 </action_postfix>
@@ -903,7 +903,7 @@ LowCostCoverage cvs /client.programLevel xdef
 <action_number>3</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set client.programLevel = AtCostCoverage</action_description>
+<action_dsl>set client.programLevel = AtCostCoverage</action_dsl>
 <action_postfix>
 AtCostCoverage cvs /client.programLevel xdef  
 </action_postfix>
@@ -912,7 +912,7 @@ AtCostCoverage cvs /client.programLevel xdef
 <action_number>4</action_number>
 <action_comment>Provide reasons for rejection</action_comment>
 <initial_action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -924,7 +924,7 @@ false cvb /client.eligible xdef
 <action_number>5</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>Add "Client is eligible for Medicaid, so cannot enroll in KidAid" to client.notes</action_description>
+<action_dsl>Add "Client is eligible for Medicaid, so cannot enroll in KidAid" to client.notes</action_dsl>
 <action_postfix>
 "Client is eligible for Medicaid, so cannot enroll in KidAid" client.notes swap addto 
 </action_postfix>
@@ -933,7 +933,7 @@ false cvb /client.eligible xdef
 <action_number>6</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>Add "Must Provide Validation of Citizenship" to client.notes</action_description>
+<action_dsl>Add "Must Provide Validation of Citizenship" to client.notes</action_dsl>
 <action_postfix>
 "Must Provide Validation of Citizenship" client.notes swap addto 
 </action_postfix>
@@ -943,7 +943,7 @@ false cvb /client.eligible xdef
 <action_number>7</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>Add "Case must be within a KidAid County" to client.notes</action_description>
+<action_dsl>Add "Case must be within a KidAid County" to client.notes</action_dsl>
 <action_postfix>
 "Case must be within a KidAid County" client.notes swap addto 
 </action_postfix>
@@ -953,7 +953,7 @@ false cvb /client.eligible xdef
 <action_number>8</action_number>
 <action_comment>Add "Must be 18 or younger to qualify for KidAid" to client.notes</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "Must be 18 or younger to qualify for KidAid" client.notes swap addto 
 </action_postfix>
@@ -962,7 +962,7 @@ false cvb /client.eligible xdef
 <action_number>9</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set client_fpl = (100.0 * totalGroupIncome) / FPL</action_description>
+<action_dsl>set client_fpl = (100.0 * totalGroupIncome) / FPL</action_dsl>
 <action_postfix>
 100.0 totalGroupIncome fmul 0 local@  fdiv  cvi /client_fpl xdef  
 </action_postfix>
@@ -988,7 +988,7 @@ false cvb /client.eligible xdef
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -998,7 +998,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
 <condition_requirement />
-<condition_description>client.applying == true</condition_description>
+<condition_dsl>client.applying == true</condition_dsl>
 <condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -1023,7 +1023,7 @@ client.applying true beq
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
 <initial_action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -1032,7 +1032,7 @@ false cvb /client.eligible xdef
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Medicaid Applications" to client.notes</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "The System does not yet support Medicaid Applications" client.notes swap addto 
 </action_postfix>
@@ -1047,7 +1047,7 @@ false cvb /client.eligible xdef
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -1057,7 +1057,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
 <condition_requirement />
-<condition_description>client.applying == true</condition_description>
+<condition_dsl>client.applying == true</condition_dsl>
 <condition_postfix>
 client.applying true beq 
 </condition_postfix>
@@ -1082,7 +1082,7 @@ client.applying true beq
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
 <initial_action_requirement />
-<action_description>set client.eligible = false</action_description>
+<action_dsl>set client.eligible = false</action_dsl>
 <action_postfix>
 false cvb /client.eligible xdef  
 </action_postfix>
@@ -1091,7 +1091,7 @@ false cvb /client.eligible xdef
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Food Stamp Applications" to client.notes</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 "The System does not yet support Food Stamp Applications" client.notes swap addto 
 </action_postfix>
@@ -1109,7 +1109,7 @@ in this table, and update the test code to get the data from the client object.<
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_description>for all clients whose applying == true</context_description>
+<context_dsl>for all clients whose applying == true</context_dsl>
 <context_postfix>
 { dup applying true beq if } clients forall pop 
 </context_postfix></context_details></contexts>
@@ -1119,7 +1119,7 @@ in this table, and update the test code to get the data from the client object.<
 <condition_number>1</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called 
 </condition_postfix>
@@ -1144,7 +1144,7 @@ perform when called
 <action_number>1</action_number>
 <action_comment>Create a Result Record</action_comment>
 <initial_action_requirement />
-<action_description>add a new Result entity to the context of this table</action_description>
+<action_dsl>add a new Result entity to the context of this table</action_dsl>
 <action_postfix>
 /Result createentity entitypush 
 </action_postfix>
@@ -1153,7 +1153,7 @@ perform when called
 <action_number>2</action_number>
 <action_comment>Add the record to the list on the job</action_comment>
 <initial_action_requirement />
-<action_description>add the result to the job.results</action_description>
+<action_dsl>add the result to the job.results</action_dsl>
 <action_postfix>
 result job.results swap addto 
 </action_postfix>
@@ -1162,7 +1162,7 @@ result job.results swap addto
 <action_number>3</action_number>
 <action_comment>Point the Result notes to the Client notes</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.notes = client.notes</action_description>
+<action_dsl>Set Result.notes = client.notes</action_dsl>
 <action_postfix>
 client.notes /Result.notes xdef 
 </action_postfix>
@@ -1171,7 +1171,7 @@ client.notes /Result.notes xdef
 <action_number>4</action_number>
 <action_comment>Copy the client ID</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.client_id = client.client_id</action_description>
+<action_dsl>Set Result.client_id = client.client_id</action_dsl>
 <action_postfix>
 client.client_id cvs /Result.client_id xdef  
 </action_postfix>
@@ -1180,7 +1180,7 @@ client.client_id cvs /Result.client_id xdef
 <action_number>5</action_number>
 <action_comment>Point the Result to the client</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.client = client.client</action_description>
+<action_dsl>Set Result.client = client.client</action_dsl>
 <action_postfix>
 client.client cve /Result.client xdef  
 </action_postfix>
@@ -1189,7 +1189,7 @@ client.client cve /Result.client xdef
 <action_number>6</action_number>
 <action_comment>Set the Result to the program we processed</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.program = job.program</action_description>
+<action_dsl>Set Result.program = job.program</action_dsl>
 <action_postfix>
 job.program cvs /Result.program xdef  
 </action_postfix>
@@ -1198,7 +1198,7 @@ job.program cvs /Result.program xdef
 <action_number>7</action_number>
 <action_comment>Set the Result programLevel to that recorded on the client</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.programLevel = client.programLevel</action_description>
+<action_dsl>Set Result.programLevel = client.programLevel</action_dsl>
 <action_postfix>
 client.programLevel cvs /Result.programLevel xdef  
 </action_postfix>
@@ -1207,7 +1207,7 @@ client.programLevel cvs /Result.programLevel xdef
 <action_number>8</action_number>
 <action_comment>Set the Result eligible flag to that recorded on the client</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.eligible = client.eligible</action_description>
+<action_dsl>Set Result.eligible = client.eligible</action_dsl>
 <action_postfix>
 client.eligible cvb /Result.eligible xdef  
 </action_postfix>
@@ -1216,7 +1216,7 @@ client.eligible cvb /Result.eligible xdef
 <action_number>9</action_number>
 <action_comment>Set the Result Federal Poverty Level to the client's</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.client_fpl = client.client_fpl</action_description>
+<action_dsl>Set Result.client_fpl = client.client_fpl</action_dsl>
 <action_postfix>
 client.client_fpl  cvi /Result.client_fpl xdef  
 </action_postfix>
@@ -1225,7 +1225,7 @@ client.client_fpl  cvi /Result.client_fpl xdef
 <action_number>10</action_number>
 <action_comment>Set the Result's totalGroupIncome to the clients.</action_comment>
 <initial_action_requirement />
-<action_description>Set Result.totalGroupIncome = client.totalGroupIncome</action_description>
+<action_dsl>Set Result.totalGroupIncome = client.totalGroupIncome</action_dsl>
 <action_postfix>
 client.totalGroupIncome  cvi /Result.totalGroupIncome xdef  
 </action_postfix>

--- a/sampleprojects/StateTax/repository/xml/StateTax_dt.xml
+++ b/sampleprojects/StateTax/repository/xml/StateTax_dt.xml
@@ -14,7 +14,7 @@
 <condition_number>1</condition_number>
 <condition_comment>State has no income tax (AK, FL, NV, NH, SD, TN, TX, WA, WY)</condition_comment>
 <condition_requirement />
-<condition_description>state_config.tax_type == "none"</condition_description>
+<condition_dsl>state_config.tax_type == "none"</condition_dsl>
 <condition_postfix>
 state_config.tax_type "none" streq
 </condition_postfix>
@@ -23,7 +23,7 @@ state_config.tax_type "none" streq
 <condition_number>2</condition_number>
 <condition_comment>Flat tax state (IL, PA, CO, etc.)</condition_comment>
 <condition_requirement />
-<condition_description>state_config.tax_type == "flat"</condition_description>
+<condition_dsl>state_config.tax_type == "flat"</condition_dsl>
 <condition_postfix>
 state_config.tax_type "flat" streq
 </condition_postfix>
@@ -32,7 +32,7 @@ state_config.tax_type "flat" streq
 <condition_number>3</condition_number>
 <condition_comment>Progressive bracket state (CA, NY, etc.)</condition_comment>
 <condition_requirement />
-<condition_description>state_config.tax_type == "progressive"</condition_description>
+<condition_dsl>state_config.tax_type == "progressive"</condition_dsl>
 <condition_postfix>
 state_config.tax_type "progressive" streq
 </condition_postfix>
@@ -41,7 +41,7 @@ state_config.tax_type "progressive" streq
 <condition_number>4</condition_number>
 <condition_comment>Unknown tax type catch-all</condition_comment>
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -51,7 +51,7 @@ true
 <action_number>1</action_number>
 <action_comment>Sum all income sources</action_comment>
 <action_requirement />
-<action_description>Perform Calculate_Gross_Income</action_description>
+<action_dsl>Perform Calculate_Gross_Income</action_dsl>
 <action_postfix>
 Calculate_Gross_Income
 </action_postfix>
@@ -61,7 +61,7 @@ Calculate_Gross_Income
 <action_number>2</action_number>
 <action_comment>Initialize AGI to gross income</action_comment>
 <action_requirement />
-<action_description>set taxpayer.agi = taxpayer.grossIncome</action_description>
+<action_dsl>set taxpayer.agi = taxpayer.grossIncome</action_dsl>
 <action_postfix>
 taxpayer.grossIncome cvi /taxpayer.agi xdef
 </action_postfix>
@@ -71,7 +71,7 @@ taxpayer.grossIncome cvi /taxpayer.agi xdef
 <action_number>3</action_number>
 <action_comment>Subtract above-the-line adjustments</action_comment>
 <action_requirement />
-<action_description>Perform Apply_Adjustments</action_description>
+<action_dsl>Perform Apply_Adjustments</action_dsl>
 <action_postfix>
 Apply_Adjustments
 </action_postfix>
@@ -81,7 +81,7 @@ Apply_Adjustments
 <action_number>4</action_number>
 <action_comment>Set deduction and exemptions from state_config</action_comment>
 <action_requirement />
-<action_description>Perform Determine_Filing_Details</action_description>
+<action_dsl>Perform Determine_Filing_Details</action_dsl>
 <action_postfix>
 Determine_Filing_Details
 </action_postfix>
@@ -91,7 +91,7 @@ Determine_Filing_Details
 <action_number>5</action_number>
 <action_comment>Compute taxable income</action_comment>
 <action_requirement />
-<action_description>Perform Calculate_Taxable_Income</action_description>
+<action_dsl>Perform Calculate_Taxable_Income</action_dsl>
 <action_postfix>
 Calculate_Taxable_Income
 </action_postfix>
@@ -101,7 +101,7 @@ Calculate_Taxable_Income
 <action_number>6</action_number>
 <action_comment>Apply flat tax rate</action_comment>
 <action_requirement />
-<action_description>Perform Apply_Flat_Tax</action_description>
+<action_dsl>Perform Apply_Flat_Tax</action_dsl>
 <action_postfix>
 Apply_Flat_Tax
 </action_postfix>
@@ -110,7 +110,7 @@ Apply_Flat_Tax
 <action_number>7</action_number>
 <action_comment>Select brackets for filing status and apply progressive rates; Perform Select_And_Apply_Brackets</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 Select_And_Apply_Brackets
 </action_postfix>
@@ -119,7 +119,7 @@ Select_And_Apply_Brackets
 <action_number>8</action_number>
 <action_comment>Build result entity</action_comment>
 <action_requirement />
-<action_description>Perform Evaluate_Results</action_description>
+<action_dsl>Perform Evaluate_Results</action_dsl>
 <action_postfix>
 Evaluate_Results
 </action_postfix>
@@ -151,7 +151,7 @@ Evaluate_Results
 <context_details>
 <context_number>1</context_number>
 <context_comment>Iterate over all income entries</context_comment>
-<context_description>for all incomes</context_description>
+<context_dsl>for all incomes</context_dsl>
 <context_postfix>
 dup incomes forall pop
 </context_postfix></context_details></contexts>
@@ -161,7 +161,7 @@ dup incomes forall pop
 <condition_number>1</condition_number>
 <condition_comment>Include all income types</condition_comment>
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -171,7 +171,7 @@ true
 <action_number>1</action_number>
 <action_comment>Add income to gross total</action_comment>
 <action_requirement />
-<action_description>add income.amount to taxpayer.grossIncome</action_description>
+<action_dsl>add income.amount to taxpayer.grossIncome</action_dsl>
 <action_postfix>
 income.amount taxpayer.grossIncome + /taxpayer.grossIncome xdef
 </action_postfix>
@@ -191,7 +191,7 @@ income.amount taxpayer.grossIncome + /taxpayer.grossIncome xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Iterate over all adjustments</context_comment>
-<context_description>for all adjustments</context_description>
+<context_dsl>for all adjustments</context_dsl>
 <context_postfix>
 dup adjustments forall pop
 </context_postfix></context_details></contexts>
@@ -201,7 +201,7 @@ dup adjustments forall pop
 <condition_number>1</condition_number>
 <condition_comment>Apply all adjustments</condition_comment>
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -211,7 +211,7 @@ true
 <action_number>1</action_number>
 <action_comment>Subtract adjustment from AGI</action_comment>
 <action_requirement />
-<action_description>set taxpayer.agi = taxpayer.agi - adjustment.amount</action_description>
+<action_dsl>set taxpayer.agi = taxpayer.agi - adjustment.amount</action_dsl>
 <action_postfix>
 taxpayer.agi adjustment.amount - cvi /taxpayer.agi xdef
 </action_postfix>
@@ -234,7 +234,7 @@ taxpayer.agi adjustment.amount - cvi /taxpayer.agi xdef
 <condition_number>1</condition_number>
 <condition_comment>Single filer</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.filing_status == "SINGLE"</condition_description>
+<condition_dsl>taxpayer.filing_status == "SINGLE"</condition_dsl>
 <condition_postfix>
 taxpayer.filing_status "SINGLE" streq
 </condition_postfix>
@@ -243,7 +243,7 @@ taxpayer.filing_status "SINGLE" streq
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.filing_status == "MFJ"</condition_description>
+<condition_dsl>taxpayer.filing_status == "MFJ"</condition_dsl>
 <condition_postfix>
 taxpayer.filing_status "MFJ" streq
 </condition_postfix>
@@ -252,7 +252,7 @@ taxpayer.filing_status "MFJ" streq
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.filing_status == "HOH"</condition_description>
+<condition_dsl>taxpayer.filing_status == "HOH"</condition_dsl>
 <condition_postfix>
 taxpayer.filing_status "HOH" streq
 </condition_postfix>
@@ -261,7 +261,7 @@ taxpayer.filing_status "HOH" streq
 <condition_number>4</condition_number>
 <condition_comment>Default to Single</condition_comment>
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -271,7 +271,7 @@ true
 <action_number>1</action_number>
 <action_comment>Deduction for Single</action_comment>
 <action_requirement />
-<action_description>set taxpayer.deduction = state_config.standard_deduction_single</action_description>
+<action_dsl>set taxpayer.deduction = state_config.standard_deduction_single</action_dsl>
 <action_postfix>
 state_config.standard_deduction_single cvi /taxpayer.deduction xdef
 </action_postfix>
@@ -281,7 +281,7 @@ state_config.standard_deduction_single cvi /taxpayer.deduction xdef
 <action_number>2</action_number>
 <action_comment>Deduction for MFJ</action_comment>
 <action_requirement />
-<action_description>set taxpayer.deduction = state_config.standard_deduction_mfj</action_description>
+<action_dsl>set taxpayer.deduction = state_config.standard_deduction_mfj</action_dsl>
 <action_postfix>
 state_config.standard_deduction_mfj cvi /taxpayer.deduction xdef
 </action_postfix>
@@ -290,7 +290,7 @@ state_config.standard_deduction_mfj cvi /taxpayer.deduction xdef
 <action_number>3</action_number>
 <action_comment>Deduction for HOH</action_comment>
 <action_requirement />
-<action_description>set taxpayer.deduction = state_config.standard_deduction_hoh</action_description>
+<action_dsl>set taxpayer.deduction = state_config.standard_deduction_hoh</action_dsl>
 <action_postfix>
 state_config.standard_deduction_hoh cvi /taxpayer.deduction xdef
 </action_postfix>
@@ -299,7 +299,7 @@ state_config.standard_deduction_hoh cvi /taxpayer.deduction xdef
 <action_number>4</action_number>
 <action_comment>Exemptions: self only; set taxpayer.exemptions = taxpayer.num_dependents + 1</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.num_dependents 1 + cvi /taxpayer.exemptions xdef
 </action_postfix>
@@ -310,7 +310,7 @@ taxpayer.num_dependents 1 + cvi /taxpayer.exemptions xdef
 <action_number>5</action_number>
 <action_comment>Exemptions: self + spouse; set taxpayer.exemptions = taxpayer.num_dependents + 2</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.num_dependents 2 + cvi /taxpayer.exemptions xdef
 </action_postfix>
@@ -342,7 +342,7 @@ taxpayer.num_dependents 2 + cvi /taxpayer.exemptions xdef
 <condition_number>1</condition_number>
 <condition_comment>Check if taxable income is positive; taxpayer.agi - taxpayer.deduction - (taxpayer.exemptions * state_config.exemption_amount) &gt; 0</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 taxpayer.agi cvi taxpayer.deduction cvi - taxpayer.exemptions cvi state_config.exemption_amount cvi * - 0 &gt;
 </condition_postfix>
@@ -353,7 +353,7 @@ taxpayer.agi cvi taxpayer.deduction cvi - taxpayer.exemptions cvi state_config.e
 <action_number>1</action_number>
 <action_comment>Compute positive taxable income; set taxpayer.taxableIncome = taxpayer.agi - taxpayer.deduction - (taxpayer.exemptions * state_config.exemption_amount)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.agi cvi taxpayer.deduction cvi - taxpayer.exemptions cvi state_config.exemption_amount cvi * - /taxpayer.taxableIncome xdef
 </action_postfix>
@@ -362,7 +362,7 @@ taxpayer.agi cvi taxpayer.deduction cvi - taxpayer.exemptions cvi state_config.e
 <action_number>2</action_number>
 <action_comment>Floor at zero</action_comment>
 <action_requirement />
-<action_description>set taxpayer.taxableIncome = 0</action_description>
+<action_dsl>set taxpayer.taxableIncome = 0</action_dsl>
 <action_postfix>
 0 cvi /taxpayer.taxableIncome xdef
 </action_postfix>
@@ -388,7 +388,7 @@ taxpayer.agi cvi taxpayer.deduction cvi - taxpayer.exemptions cvi state_config.e
 <condition_number>1</condition_number>
 <condition_comment>Always apply</condition_comment>
 <condition_requirement />
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -398,7 +398,7 @@ perform when called
 <action_number>1</action_number>
 <action_comment>Compute flat tax: taxableIncome * flat_rate_bps / 10000; set taxpayer.taxOwed = taxpayer.taxableIncome * (state_config.flat_rate_bps / 10000.0)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.taxableIncome state_config.flat_rate_bps 10000.0 fdiv fmul cvi /taxpayer.taxOwed xdef
 </action_postfix>
@@ -418,7 +418,7 @@ taxpayer.taxableIncome state_config.flat_rate_bps 10000.0 fdiv fmul cvi /taxpaye
 <condition_number>1</condition_number>
 <condition_comment>No taxable income</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.taxableIncome &lt;= 0</condition_description>
+<condition_dsl>taxpayer.taxableIncome &lt;= 0</condition_dsl>
 <condition_postfix>
 taxpayer.taxableIncome 0 &lt;=
 </condition_postfix>
@@ -427,7 +427,7 @@ taxpayer.taxableIncome 0 &lt;=
 <condition_number>2</condition_number>
 <condition_comment>Single filer</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.filing_status == "SINGLE"</condition_description>
+<condition_dsl>taxpayer.filing_status == "SINGLE"</condition_dsl>
 <condition_postfix>
 taxpayer.filing_status "SINGLE" streq
 </condition_postfix>
@@ -436,7 +436,7 @@ taxpayer.filing_status "SINGLE" streq
 <condition_number>3</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.filing_status == "MFJ"</condition_description>
+<condition_dsl>taxpayer.filing_status == "MFJ"</condition_dsl>
 <condition_postfix>
 taxpayer.filing_status "MFJ" streq
 </condition_postfix>
@@ -445,7 +445,7 @@ taxpayer.filing_status "MFJ" streq
 <condition_number>4</condition_number>
 <condition_comment>HOH or default</condition_comment>
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -455,7 +455,7 @@ true
 <action_number>1</action_number>
 <action_comment>No tax on zero income</action_comment>
 <action_requirement />
-<action_description>set taxpayer.taxOwed = 0</action_description>
+<action_dsl>set taxpayer.taxOwed = 0</action_dsl>
 <action_postfix>
 0 cvi /taxpayer.taxOwed xdef
 </action_postfix>
@@ -464,7 +464,7 @@ true
 <action_number>2</action_number>
 <action_comment>Use single brackets; set taxpayer.active_brackets = state_config.brackets_single; set taxpayer.bracket_applied = false; Perform Apply_Bracket_Iteration</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 state_config.brackets_single /taxpayer.active_brackets xdef false cvb /taxpayer.bracket_applied xdef Apply_Bracket_Iteration
 </action_postfix>
@@ -473,7 +473,7 @@ state_config.brackets_single /taxpayer.active_brackets xdef false cvb /taxpayer.
 <action_number>3</action_number>
 <action_comment>Use MFJ brackets; set taxpayer.active_brackets = state_config.brackets_mfj; set taxpayer.bracket_applied = false; Perform Apply_Bracket_Iteration</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 state_config.brackets_mfj /taxpayer.active_brackets xdef false cvb /taxpayer.bracket_applied xdef Apply_Bracket_Iteration
 </action_postfix>
@@ -482,7 +482,7 @@ state_config.brackets_mfj /taxpayer.active_brackets xdef false cvb /taxpayer.bra
 <action_number>4</action_number>
 <action_comment>Use HOH brackets (default); set taxpayer.active_brackets = state_config.brackets_hoh; set taxpayer.bracket_applied = false; Perform Apply_Bracket_Iteration</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 state_config.brackets_hoh /taxpayer.active_brackets xdef false cvb /taxpayer.bracket_applied xdef Apply_Bracket_Iteration
 </action_postfix>
@@ -499,7 +499,7 @@ state_config.brackets_hoh /taxpayer.active_brackets xdef false cvb /taxpayer.bra
 <context_details>
 <context_number>1</context_number>
 <context_comment>Iterate over active bracket array</context_comment>
-<context_description>for all active_brackets</context_description>
+<context_dsl>for all active_brackets</context_dsl>
 <context_postfix>
 dup active_brackets forall pop
 </context_postfix></context_details></contexts>
@@ -509,7 +509,7 @@ dup active_brackets forall pop
 <condition_number>1</condition_number>
 <condition_comment>Guard: only apply one bracket</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.bracket_applied == false</condition_description>
+<condition_dsl>taxpayer.bracket_applied == false</condition_dsl>
 <condition_postfix>
 taxpayer.bracket_applied false beq
 </condition_postfix>
@@ -518,7 +518,7 @@ taxpayer.bracket_applied false beq
 <condition_number>2</condition_number>
 <condition_comment>Income falls within this bracket</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.taxableIncome &lt;= bracket.ceiling</condition_description>
+<condition_dsl>taxpayer.taxableIncome &lt;= bracket.ceiling</condition_dsl>
 <condition_postfix>
 taxpayer.taxableIncome bracket.ceiling &lt;=
 </condition_postfix>
@@ -528,7 +528,7 @@ taxpayer.taxableIncome bracket.ceiling &lt;=
 <action_number>1</action_number>
 <action_comment>Compute tax: base_tax + (taxableIncome - floor) * rate_bps / 10000; set taxpayer.taxOwed = bracket.base_tax + (taxpayer.taxableIncome - bracket.floor) * (bracket.rate_bps / 10000.0)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 bracket.base_tax taxpayer.taxableIncome bracket.floor - bracket.rate_bps 10000.0 fdiv fmul + cvi /taxpayer.taxOwed xdef
 </action_postfix>
@@ -537,7 +537,7 @@ bracket.base_tax taxpayer.taxableIncome bracket.floor - bracket.rate_bps 10000.0
 <action_number>2</action_number>
 <action_comment>Set guard to prevent further bracket application</action_comment>
 <action_requirement />
-<action_description>set taxpayer.bracket_applied = true</action_description>
+<action_dsl>set taxpayer.bracket_applied = true</action_dsl>
 <action_postfix>
 true cvb /taxpayer.bracket_applied xdef
 </action_postfix>
@@ -557,7 +557,7 @@ true cvb /taxpayer.bracket_applied xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Create result entity for this table's context</context_comment>
-<context_description>add a new result entity to the context of this table</context_description>
+<context_dsl>add a new result entity to the context of this table</context_dsl>
 <context_postfix>
 /result createentity entitypush
 </context_postfix></context_details></contexts>
@@ -567,7 +567,7 @@ true cvb /taxpayer.bracket_applied xdef
 <condition_number>1</condition_number>
 <condition_comment>Always execute</condition_comment>
 <condition_requirement />
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -577,7 +577,7 @@ perform when called
 <action_number>1</action_number>
 <action_comment>Add to job results</action_comment>
 <action_requirement />
-<action_description>add result to job.results</action_description>
+<action_dsl>add result to job.results</action_dsl>
 <action_postfix>
 result job.results swap addto
 </action_postfix>
@@ -586,7 +586,7 @@ result job.results swap addto
 <action_number>2</action_number>
 <action_comment>Copy state code</action_comment>
 <action_requirement />
-<action_description>set result.state_code = state_config.state_code</action_description>
+<action_dsl>set result.state_code = state_config.state_code</action_dsl>
 <action_postfix>
 state_config.state_code cvs /result.state_code xdef
 </action_postfix>
@@ -595,7 +595,7 @@ state_config.state_code cvs /result.state_code xdef
 <action_number>3</action_number>
 <action_comment>Copy taxpayer ID</action_comment>
 <action_requirement />
-<action_description>set result.taxpayer_ID = taxpayer.taxpayer_ID</action_description>
+<action_dsl>set result.taxpayer_ID = taxpayer.taxpayer_ID</action_dsl>
 <action_postfix>
 taxpayer.taxpayer_ID cvs /result.taxpayer_ID xdef
 </action_postfix>
@@ -604,7 +604,7 @@ taxpayer.taxpayer_ID cvs /result.taxpayer_ID xdef
 <action_number>4</action_number>
 <action_comment>Copy taxpayer reference</action_comment>
 <action_requirement />
-<action_description>set result.taxpayer = taxpayer.taxpayer</action_description>
+<action_dsl>set result.taxpayer = taxpayer.taxpayer</action_dsl>
 <action_postfix>
 taxpayer.taxpayer cve /result.taxpayer xdef
 </action_postfix>
@@ -613,7 +613,7 @@ taxpayer.taxpayer cve /result.taxpayer xdef
 <action_number>5</action_number>
 <action_comment>Copy filing status</action_comment>
 <action_requirement />
-<action_description>set result.filing_status = taxpayer.filing_status</action_description>
+<action_dsl>set result.filing_status = taxpayer.filing_status</action_dsl>
 <action_postfix>
 taxpayer.filing_status cvs /result.filing_status xdef
 </action_postfix>
@@ -622,7 +622,7 @@ taxpayer.filing_status cvs /result.filing_status xdef
 <action_number>6</action_number>
 <action_comment>Copy gross income</action_comment>
 <action_requirement />
-<action_description>set result.grossIncome = taxpayer.grossIncome</action_description>
+<action_dsl>set result.grossIncome = taxpayer.grossIncome</action_dsl>
 <action_postfix>
 taxpayer.grossIncome cvi /result.grossIncome xdef
 </action_postfix>
@@ -631,7 +631,7 @@ taxpayer.grossIncome cvi /result.grossIncome xdef
 <action_number>7</action_number>
 <action_comment>Copy AGI</action_comment>
 <action_requirement />
-<action_description>set result.agi = taxpayer.agi</action_description>
+<action_dsl>set result.agi = taxpayer.agi</action_dsl>
 <action_postfix>
 taxpayer.agi cvi /result.agi xdef
 </action_postfix>
@@ -640,7 +640,7 @@ taxpayer.agi cvi /result.agi xdef
 <action_number>8</action_number>
 <action_comment>Copy deduction</action_comment>
 <action_requirement />
-<action_description>set result.deduction = taxpayer.deduction</action_description>
+<action_dsl>set result.deduction = taxpayer.deduction</action_dsl>
 <action_postfix>
 taxpayer.deduction cvi /result.deduction xdef
 </action_postfix>
@@ -649,7 +649,7 @@ taxpayer.deduction cvi /result.deduction xdef
 <action_number>9</action_number>
 <action_comment>Copy exemptions; set result.exemptions = taxpayer.exemptions</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.exemptions cvi /result.exemptions xdef
 </action_postfix>
@@ -658,7 +658,7 @@ taxpayer.exemptions cvi /result.exemptions xdef
 <action_number>10</action_number>
 <action_comment>Copy taxable income</action_comment>
 <action_requirement />
-<action_description>set result.taxableIncome = taxpayer.taxableIncome</action_description>
+<action_dsl>set result.taxableIncome = taxpayer.taxableIncome</action_dsl>
 <action_postfix>
 taxpayer.taxableIncome cvi /result.taxableIncome xdef
 </action_postfix>
@@ -667,7 +667,7 @@ taxpayer.taxableIncome cvi /result.taxableIncome xdef
 <action_number>11</action_number>
 <action_comment>Copy tax owed</action_comment>
 <action_requirement />
-<action_description>set result.taxOwed = taxpayer.taxOwed</action_description>
+<action_dsl>set result.taxOwed = taxpayer.taxOwed</action_dsl>
 <action_postfix>
 taxpayer.taxOwed cvi /result.taxOwed xdef
 </action_postfix>
@@ -676,7 +676,7 @@ taxpayer.taxOwed cvi /result.taxOwed xdef
 <action_number>12</action_number>
 <action_comment>Copy notes</action_comment>
 <action_requirement />
-<action_description>add the taxpayer.notes to the result.notes</action_description>
+<action_dsl>add the taxpayer.notes to the result.notes</action_dsl>
 <action_postfix>
 taxpayer.notes result.notes true addarray
 </action_postfix>

--- a/sampleprojects/StateTax/xml/StateTax_dt.xml
+++ b/sampleprojects/StateTax/xml/StateTax_dt.xml
@@ -14,7 +14,7 @@
 <condition_number>1</condition_number>
 <condition_comment>State has no income tax (AK, FL, NV, NH, SD, TN, TX, WA, WY)</condition_comment>
 <condition_requirement />
-<condition_description>state_config.tax_type == "none"</condition_description>
+<condition_dsl>state_config.tax_type == "none"</condition_dsl>
 <condition_postfix>
 state_config.tax_type "none" streq
 </condition_postfix>
@@ -23,7 +23,7 @@ state_config.tax_type "none" streq
 <condition_number>2</condition_number>
 <condition_comment>Flat tax state (IL, PA, CO, etc.)</condition_comment>
 <condition_requirement />
-<condition_description>state_config.tax_type == "flat"</condition_description>
+<condition_dsl>state_config.tax_type == "flat"</condition_dsl>
 <condition_postfix>
 state_config.tax_type "flat" streq
 </condition_postfix>
@@ -32,7 +32,7 @@ state_config.tax_type "flat" streq
 <condition_number>3</condition_number>
 <condition_comment>Progressive bracket state (CA, NY, etc.)</condition_comment>
 <condition_requirement />
-<condition_description>state_config.tax_type == "progressive"</condition_description>
+<condition_dsl>state_config.tax_type == "progressive"</condition_dsl>
 <condition_postfix>
 state_config.tax_type "progressive" streq
 </condition_postfix>
@@ -41,7 +41,7 @@ state_config.tax_type "progressive" streq
 <condition_number>4</condition_number>
 <condition_comment>Unknown tax type catch-all</condition_comment>
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -51,7 +51,7 @@ true
 <action_number>1</action_number>
 <action_comment>Sum all income sources</action_comment>
 <action_requirement />
-<action_description>Perform Calculate_Gross_Income</action_description>
+<action_dsl>Perform Calculate_Gross_Income</action_dsl>
 <action_postfix>
 Calculate_Gross_Income
 </action_postfix>
@@ -61,7 +61,7 @@ Calculate_Gross_Income
 <action_number>2</action_number>
 <action_comment>Initialize AGI to gross income</action_comment>
 <action_requirement />
-<action_description>set taxpayer.agi = taxpayer.grossIncome</action_description>
+<action_dsl>set taxpayer.agi = taxpayer.grossIncome</action_dsl>
 <action_postfix>
 taxpayer.grossIncome cvi /taxpayer.agi xdef
 </action_postfix>
@@ -71,7 +71,7 @@ taxpayer.grossIncome cvi /taxpayer.agi xdef
 <action_number>3</action_number>
 <action_comment>Subtract above-the-line adjustments</action_comment>
 <action_requirement />
-<action_description>Perform Apply_Adjustments</action_description>
+<action_dsl>Perform Apply_Adjustments</action_dsl>
 <action_postfix>
 Apply_Adjustments
 </action_postfix>
@@ -81,7 +81,7 @@ Apply_Adjustments
 <action_number>4</action_number>
 <action_comment>Set deduction and exemptions from state_config</action_comment>
 <action_requirement />
-<action_description>Perform Determine_Filing_Details</action_description>
+<action_dsl>Perform Determine_Filing_Details</action_dsl>
 <action_postfix>
 Determine_Filing_Details
 </action_postfix>
@@ -91,7 +91,7 @@ Determine_Filing_Details
 <action_number>5</action_number>
 <action_comment>Compute taxable income</action_comment>
 <action_requirement />
-<action_description>Perform Calculate_Taxable_Income</action_description>
+<action_dsl>Perform Calculate_Taxable_Income</action_dsl>
 <action_postfix>
 Calculate_Taxable_Income
 </action_postfix>
@@ -101,7 +101,7 @@ Calculate_Taxable_Income
 <action_number>6</action_number>
 <action_comment>Apply flat tax rate</action_comment>
 <action_requirement />
-<action_description>Perform Apply_Flat_Tax</action_description>
+<action_dsl>Perform Apply_Flat_Tax</action_dsl>
 <action_postfix>
 Apply_Flat_Tax
 </action_postfix>
@@ -110,7 +110,7 @@ Apply_Flat_Tax
 <action_number>7</action_number>
 <action_comment>Select brackets for filing status and apply progressive rates; Perform Select_And_Apply_Brackets</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 Select_And_Apply_Brackets
 </action_postfix>
@@ -119,7 +119,7 @@ Select_And_Apply_Brackets
 <action_number>8</action_number>
 <action_comment>Build result entity</action_comment>
 <action_requirement />
-<action_description>Perform Evaluate_Results</action_description>
+<action_dsl>Perform Evaluate_Results</action_dsl>
 <action_postfix>
 Evaluate_Results
 </action_postfix>
@@ -151,7 +151,7 @@ Evaluate_Results
 <context_details>
 <context_number>1</context_number>
 <context_comment>Iterate over all income entries</context_comment>
-<context_description>for all incomes</context_description>
+<context_dsl>for all incomes</context_dsl>
 <context_postfix>
 dup incomes forall pop
 </context_postfix></context_details></contexts>
@@ -161,7 +161,7 @@ dup incomes forall pop
 <condition_number>1</condition_number>
 <condition_comment>Include all income types</condition_comment>
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -171,7 +171,7 @@ true
 <action_number>1</action_number>
 <action_comment>Add income to gross total</action_comment>
 <action_requirement />
-<action_description>add income.amount to taxpayer.grossIncome</action_description>
+<action_dsl>add income.amount to taxpayer.grossIncome</action_dsl>
 <action_postfix>
 income.amount taxpayer.grossIncome + /taxpayer.grossIncome xdef
 </action_postfix>
@@ -191,7 +191,7 @@ income.amount taxpayer.grossIncome + /taxpayer.grossIncome xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Iterate over all adjustments</context_comment>
-<context_description>for all adjustments</context_description>
+<context_dsl>for all adjustments</context_dsl>
 <context_postfix>
 dup adjustments forall pop
 </context_postfix></context_details></contexts>
@@ -201,7 +201,7 @@ dup adjustments forall pop
 <condition_number>1</condition_number>
 <condition_comment>Apply all adjustments</condition_comment>
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -211,7 +211,7 @@ true
 <action_number>1</action_number>
 <action_comment>Subtract adjustment from AGI</action_comment>
 <action_requirement />
-<action_description>subtract adjustment.amount from taxpayer.agi</action_description>
+<action_dsl>subtract adjustment.amount from taxpayer.agi</action_dsl>
 <action_postfix>
 taxpayer.agi adjustment.amount - /taxpayer.agi xdef
 </action_postfix>
@@ -234,7 +234,7 @@ taxpayer.agi adjustment.amount - /taxpayer.agi xdef
 <condition_number>1</condition_number>
 <condition_comment>Single filer</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.filing_status == SINGLE</condition_description>
+<condition_dsl>taxpayer.filing_status == SINGLE</condition_dsl>
 <condition_postfix>
 taxpayer.filing_status "SINGLE" streq
 </condition_postfix>
@@ -243,7 +243,7 @@ taxpayer.filing_status "SINGLE" streq
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.filing_status == MFJ</condition_description>
+<condition_dsl>taxpayer.filing_status == MFJ</condition_dsl>
 <condition_postfix>
 taxpayer.filing_status "MFJ" streq
 </condition_postfix>
@@ -252,7 +252,7 @@ taxpayer.filing_status "MFJ" streq
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.filing_status == HOH</condition_description>
+<condition_dsl>taxpayer.filing_status == HOH</condition_dsl>
 <condition_postfix>
 taxpayer.filing_status "HOH" streq
 </condition_postfix>
@@ -261,7 +261,7 @@ taxpayer.filing_status "HOH" streq
 <condition_number>4</condition_number>
 <condition_comment>Default to Single</condition_comment>
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -271,7 +271,7 @@ true
 <action_number>1</action_number>
 <action_comment>Deduction for Single</action_comment>
 <action_requirement />
-<action_description>set deduction from state_config.standard_deduction_single</action_description>
+<action_dsl>set deduction from state_config.standard_deduction_single</action_dsl>
 <action_postfix>
 state_config.standard_deduction_single cvi /taxpayer.deduction xdef
 </action_postfix>
@@ -281,7 +281,7 @@ state_config.standard_deduction_single cvi /taxpayer.deduction xdef
 <action_number>2</action_number>
 <action_comment>Deduction for MFJ</action_comment>
 <action_requirement />
-<action_description>set deduction from state_config.standard_deduction_mfj</action_description>
+<action_dsl>set deduction from state_config.standard_deduction_mfj</action_dsl>
 <action_postfix>
 state_config.standard_deduction_mfj cvi /taxpayer.deduction xdef
 </action_postfix>
@@ -290,7 +290,7 @@ state_config.standard_deduction_mfj cvi /taxpayer.deduction xdef
 <action_number>3</action_number>
 <action_comment>Deduction for HOH</action_comment>
 <action_requirement />
-<action_description>set deduction from state_config.standard_deduction_hoh</action_description>
+<action_dsl>set deduction from state_config.standard_deduction_hoh</action_dsl>
 <action_postfix>
 state_config.standard_deduction_hoh cvi /taxpayer.deduction xdef
 </action_postfix>
@@ -299,7 +299,7 @@ state_config.standard_deduction_hoh cvi /taxpayer.deduction xdef
 <action_number>4</action_number>
 <action_comment>Exemptions: self only; set exemptions = num_dependents + 1</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.num_dependents 1 + /taxpayer.exemptions xdef
 </action_postfix>
@@ -310,7 +310,7 @@ taxpayer.num_dependents 1 + /taxpayer.exemptions xdef
 <action_number>5</action_number>
 <action_comment>Exemptions: self + spouse; set exemptions = num_dependents + 2</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.num_dependents 2 + /taxpayer.exemptions xdef
 </action_postfix>
@@ -342,7 +342,7 @@ taxpayer.num_dependents 2 + /taxpayer.exemptions xdef
 <condition_number>1</condition_number>
 <condition_comment>Check if taxable income is positive; AGI - deduction - (exemptions * exemption_amount) &gt; 0</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 taxpayer.agi cvi taxpayer.deduction cvi - taxpayer.exemptions cvi state_config.exemption_amount cvi * - 0 &gt;
 </condition_postfix>
@@ -353,7 +353,7 @@ taxpayer.agi cvi taxpayer.deduction cvi - taxpayer.exemptions cvi state_config.e
 <action_number>1</action_number>
 <action_comment>Compute positive taxable income; taxableIncome = AGI - deduction - (exemptions * exemption_amount)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.agi cvi taxpayer.deduction cvi - taxpayer.exemptions cvi state_config.exemption_amount cvi * - /taxpayer.taxableIncome xdef
 </action_postfix>
@@ -362,7 +362,7 @@ taxpayer.agi cvi taxpayer.deduction cvi - taxpayer.exemptions cvi state_config.e
 <action_number>2</action_number>
 <action_comment>Floor at zero</action_comment>
 <action_requirement />
-<action_description>set taxableIncome = 0</action_description>
+<action_dsl>set taxableIncome = 0</action_dsl>
 <action_postfix>
 0 /taxpayer.taxableIncome xdef
 </action_postfix>
@@ -388,7 +388,7 @@ taxpayer.agi cvi taxpayer.deduction cvi - taxpayer.exemptions cvi state_config.e
 <condition_number>1</condition_number>
 <condition_comment>Always apply</condition_comment>
 <condition_requirement />
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -398,7 +398,7 @@ perform when called
 <action_number>1</action_number>
 <action_comment>Compute flat tax: taxableIncome * flat_rate_bps / 10000</action_comment>
 <action_requirement />
-<action_description>taxOwed = taxableIncome * flat_rate / 10000</action_description>
+<action_dsl>taxOwed = taxableIncome * flat_rate / 10000</action_dsl>
 <action_postfix>
 taxpayer.taxableIncome cvi state_config.flat_rate_bps cvi 10000.0 fdiv fmul cvi /taxpayer.taxOwed xdef
 </action_postfix>
@@ -418,7 +418,7 @@ taxpayer.taxableIncome cvi state_config.flat_rate_bps cvi 10000.0 fdiv fmul cvi 
 <condition_number>1</condition_number>
 <condition_comment>No taxable income</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.taxableIncome &lt;= 0</condition_description>
+<condition_dsl>taxpayer.taxableIncome &lt;= 0</condition_dsl>
 <condition_postfix>
 taxpayer.taxableIncome 0 &lt;=
 </condition_postfix>
@@ -427,7 +427,7 @@ taxpayer.taxableIncome 0 &lt;=
 <condition_number>2</condition_number>
 <condition_comment>Single filer</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.filing_status == SINGLE</condition_description>
+<condition_dsl>taxpayer.filing_status == SINGLE</condition_dsl>
 <condition_postfix>
 taxpayer.filing_status "SINGLE" streq
 </condition_postfix>
@@ -436,7 +436,7 @@ taxpayer.filing_status "SINGLE" streq
 <condition_number>3</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.filing_status == MFJ</condition_description>
+<condition_dsl>taxpayer.filing_status == MFJ</condition_dsl>
 <condition_postfix>
 taxpayer.filing_status "MFJ" streq
 </condition_postfix>
@@ -445,7 +445,7 @@ taxpayer.filing_status "MFJ" streq
 <condition_number>4</condition_number>
 <condition_comment>HOH or default</condition_comment>
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -455,7 +455,7 @@ true
 <action_number>1</action_number>
 <action_comment>No tax on zero income</action_comment>
 <action_requirement />
-<action_description>set taxOwed = 0</action_description>
+<action_dsl>set taxOwed = 0</action_dsl>
 <action_postfix>
 0 /taxpayer.taxOwed xdef
 </action_postfix>
@@ -464,7 +464,7 @@ true
 <action_number>2</action_number>
 <action_comment>Use single brackets; set active_brackets = brackets_single, reset guard, apply</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 state_config.brackets_single /taxpayer.active_brackets xdef false cvb /taxpayer.bracket_applied xdef Apply_Bracket_Iteration
 </action_postfix>
@@ -473,7 +473,7 @@ state_config.brackets_single /taxpayer.active_brackets xdef false cvb /taxpayer.
 <action_number>3</action_number>
 <action_comment>Use MFJ brackets; set active_brackets = brackets_mfj, reset guard, apply</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 state_config.brackets_mfj /taxpayer.active_brackets xdef false cvb /taxpayer.bracket_applied xdef Apply_Bracket_Iteration
 </action_postfix>
@@ -482,7 +482,7 @@ state_config.brackets_mfj /taxpayer.active_brackets xdef false cvb /taxpayer.bra
 <action_number>4</action_number>
 <action_comment>Use HOH brackets (default); set active_brackets = brackets_hoh, reset guard, apply</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 state_config.brackets_hoh /taxpayer.active_brackets xdef false cvb /taxpayer.bracket_applied xdef Apply_Bracket_Iteration
 </action_postfix>
@@ -499,7 +499,7 @@ state_config.brackets_hoh /taxpayer.active_brackets xdef false cvb /taxpayer.bra
 <context_details>
 <context_number>1</context_number>
 <context_comment>Iterate over active bracket array</context_comment>
-<context_description>for all active_brackets</context_description>
+<context_dsl>for all active_brackets</context_dsl>
 <context_postfix>
 dup active_brackets forall pop
 </context_postfix></context_details></contexts>
@@ -509,7 +509,7 @@ dup active_brackets forall pop
 <condition_number>1</condition_number>
 <condition_comment>Guard: only apply one bracket</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.bracket_applied == false</condition_description>
+<condition_dsl>taxpayer.bracket_applied == false</condition_dsl>
 <condition_postfix>
 taxpayer.bracket_applied false beq
 </condition_postfix>
@@ -518,7 +518,7 @@ taxpayer.bracket_applied false beq
 <condition_number>2</condition_number>
 <condition_comment>Income falls within this bracket</condition_comment>
 <condition_requirement />
-<condition_description>taxpayer.taxableIncome &lt;= bracket.ceiling</condition_description>
+<condition_dsl>taxpayer.taxableIncome &lt;= bracket.ceiling</condition_dsl>
 <condition_postfix>
 taxpayer.taxableIncome cvi bracket.ceiling cvi &lt;=
 </condition_postfix>
@@ -528,7 +528,7 @@ taxpayer.taxableIncome cvi bracket.ceiling cvi &lt;=
 <action_number>1</action_number>
 <action_comment>Compute tax: base_tax + (taxableIncome - floor) * rate_bps / 10000</action_comment>
 <action_requirement />
-<action_description>taxOwed = base_tax + marginal tax for this bracket</action_description>
+<action_dsl>taxOwed = base_tax + marginal tax for this bracket</action_dsl>
 <action_postfix>
 bracket.base_tax cvi taxpayer.taxableIncome cvi bracket.floor cvi - bracket.rate_bps cvi 10000.0 fdiv fmul cvi + /taxpayer.taxOwed xdef
 </action_postfix>
@@ -537,7 +537,7 @@ bracket.base_tax cvi taxpayer.taxableIncome cvi bracket.floor cvi - bracket.rate
 <action_number>2</action_number>
 <action_comment>Set guard to prevent further bracket application</action_comment>
 <action_requirement />
-<action_description>set bracket_applied = true</action_description>
+<action_dsl>set bracket_applied = true</action_dsl>
 <action_postfix>
 true cvb /taxpayer.bracket_applied xdef
 </action_postfix>
@@ -560,7 +560,7 @@ true cvb /taxpayer.bracket_applied xdef
 <condition_number>1</condition_number>
 <condition_comment>Always execute</condition_comment>
 <condition_requirement />
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -570,7 +570,7 @@ perform when called
 <action_number>1</action_number>
 <action_comment>Create result entity</action_comment>
 <action_requirement />
-<action_description>create result and push to entity stack</action_description>
+<action_dsl>create result and push to entity stack</action_dsl>
 <action_postfix>
 /result createentity entitypush
 </action_postfix>
@@ -579,7 +579,7 @@ perform when called
 <action_number>2</action_number>
 <action_comment>Add to job results</action_comment>
 <action_requirement />
-<action_description>add result to job.results</action_description>
+<action_dsl>add result to job.results</action_dsl>
 <action_postfix>
 result job.results swap addto
 </action_postfix>
@@ -588,7 +588,7 @@ result job.results swap addto
 <action_number>3</action_number>
 <action_comment>Copy state code</action_comment>
 <action_requirement />
-<action_description>set result.state_code = state_config.state_code</action_description>
+<action_dsl>set result.state_code = state_config.state_code</action_dsl>
 <action_postfix>
 state_config.state_code cvs /result.state_code xdef
 </action_postfix>
@@ -597,7 +597,7 @@ state_config.state_code cvs /result.state_code xdef
 <action_number>4</action_number>
 <action_comment>Copy taxpayer ID</action_comment>
 <action_requirement />
-<action_description>set result.taxpayer_ID = taxpayer.taxpayer_ID</action_description>
+<action_dsl>set result.taxpayer_ID = taxpayer.taxpayer_ID</action_dsl>
 <action_postfix>
 taxpayer.taxpayer_ID cvs /result.taxpayer_ID xdef
 </action_postfix>
@@ -606,7 +606,7 @@ taxpayer.taxpayer_ID cvs /result.taxpayer_ID xdef
 <action_number>5</action_number>
 <action_comment>Copy taxpayer reference</action_comment>
 <action_requirement />
-<action_description>set result.taxpayer = taxpayer</action_description>
+<action_dsl>set result.taxpayer = taxpayer</action_dsl>
 <action_postfix>
 taxpayer.taxpayer cve /result.taxpayer xdef
 </action_postfix>
@@ -615,7 +615,7 @@ taxpayer.taxpayer cve /result.taxpayer xdef
 <action_number>6</action_number>
 <action_comment>Copy filing status</action_comment>
 <action_requirement />
-<action_description>set result.filing_status = taxpayer.filing_status</action_description>
+<action_dsl>set result.filing_status = taxpayer.filing_status</action_dsl>
 <action_postfix>
 taxpayer.filing_status cvs /result.filing_status xdef
 </action_postfix>
@@ -624,7 +624,7 @@ taxpayer.filing_status cvs /result.filing_status xdef
 <action_number>7</action_number>
 <action_comment>Copy gross income</action_comment>
 <action_requirement />
-<action_description>set result.grossIncome</action_description>
+<action_dsl>set result.grossIncome</action_dsl>
 <action_postfix>
 taxpayer.grossIncome cvi /result.grossIncome xdef
 </action_postfix>
@@ -633,7 +633,7 @@ taxpayer.grossIncome cvi /result.grossIncome xdef
 <action_number>8</action_number>
 <action_comment>Copy AGI</action_comment>
 <action_requirement />
-<action_description>set result.agi</action_description>
+<action_dsl>set result.agi</action_dsl>
 <action_postfix>
 taxpayer.agi cvi /result.agi xdef
 </action_postfix>
@@ -642,7 +642,7 @@ taxpayer.agi cvi /result.agi xdef
 <action_number>9</action_number>
 <action_comment>Copy deduction</action_comment>
 <action_requirement />
-<action_description>set result.deduction</action_description>
+<action_dsl>set result.deduction</action_dsl>
 <action_postfix>
 taxpayer.deduction cvi /result.deduction xdef
 </action_postfix>
@@ -651,7 +651,7 @@ taxpayer.deduction cvi /result.deduction xdef
 <action_number>10</action_number>
 <action_comment>Copy exemptions; set result.exemptions</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.exemptions cvi /result.exemptions xdef
 </action_postfix>
@@ -660,7 +660,7 @@ taxpayer.exemptions cvi /result.exemptions xdef
 <action_number>11</action_number>
 <action_comment>Copy taxable income</action_comment>
 <action_requirement />
-<action_description>set result.taxableIncome</action_description>
+<action_dsl>set result.taxableIncome</action_dsl>
 <action_postfix>
 taxpayer.taxableIncome cvi /result.taxableIncome xdef
 </action_postfix>
@@ -669,7 +669,7 @@ taxpayer.taxableIncome cvi /result.taxableIncome xdef
 <action_number>12</action_number>
 <action_comment>Copy tax owed</action_comment>
 <action_requirement />
-<action_description>set result.taxOwed</action_description>
+<action_dsl>set result.taxOwed</action_dsl>
 <action_postfix>
 taxpayer.taxOwed cvi /result.taxOwed xdef
 </action_postfix>
@@ -678,7 +678,7 @@ taxpayer.taxOwed cvi /result.taxOwed xdef
 <action_number>13</action_number>
 <action_comment>Copy notes</action_comment>
 <action_requirement />
-<action_description>copy taxpayer.notes to result.notes</action_description>
+<action_dsl>copy taxpayer.notes to result.notes</action_dsl>
 <action_postfix>
 taxpayer.notes result.notes true addarray
 </action_postfix>
@@ -687,7 +687,7 @@ taxpayer.notes result.notes true addarray
 <action_number>14</action_number>
 <action_comment>Pop result entity</action_comment>
 <action_requirement />
-<action_description>pop result from entity stack</action_description>
+<action_dsl>pop result from entity stack</action_dsl>
 <action_postfix>
 entitypop
 </action_postfix>

--- a/sampleprojects/SyntaxTests/repository/xml/syntaxexample_dt.xml
+++ b/sampleprojects/SyntaxTests/repository/xml/syntaxexample_dt.xml
@@ -10,98 +10,98 @@
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
-<context_description>for all clients whose age == 18 and street == 'that'</context_description>
+<context_dsl>for all clients whose age == 18 and street == 'that'</context_dsl>
 <context_postfix>
 { dup age 18 == { pop street 'that' streq } over if
 if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>8</context_number>
-<context_description>local entity FirstClient</context_description>
+<context_dsl>local entity FirstClient</context_dsl>
 <context_postfix>
 null allocate execute 
 </context_postfix></context_details>
 <context_details>
 <context_number>9</context_number>
-<context_description>local entity FirstClient2 = the client</context_description>
+<context_dsl>local entity FirstClient2 = the client</context_dsl>
 <context_postfix>
 client cve allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>10</context_number>
-<context_description>local long Anumber</context_description>
+<context_dsl>local long Anumber</context_dsl>
 <context_postfix>
 null allocate execute 
 </context_postfix></context_details>
 <context_details>
 <context_number>11</context_number>
-<context_description>local long Anumber2 = 1234</context_description>
+<context_dsl>local long Anumber2 = 1234</context_dsl>
 <context_postfix>
 1234  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>12</context_number>
-<context_description>local double DoubleNumber</context_description>
+<context_dsl>local double DoubleNumber</context_dsl>
 <context_postfix>
 null allocate execute 
 </context_postfix></context_details>
 <context_details>
 <context_number>13</context_number>
-<context_description>local double DoubleNumber2 = 1.234</context_description>
+<context_dsl>local double DoubleNumber2 = 1.234</context_dsl>
 <context_postfix>
 1.234  cvr allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>14</context_number>
-<context_description>local boolean Test</context_description>
+<context_dsl>local boolean Test</context_dsl>
 <context_postfix>
 null allocate execute 
 </context_postfix></context_details>
 <context_details>
 <context_number>15</context_number>
-<context_description>local boolean Test2 = true</context_description>
+<context_dsl>local boolean Test2 = true</context_dsl>
 <context_postfix>
 true cvb allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>16</context_number>
-<context_description>local date Today</context_description>
+<context_dsl>local date Today</context_dsl>
 <context_postfix>
 null allocate execute 
 </context_postfix></context_details>
 <context_details>
 <context_number>17</context_number>
-<context_description>local date Today2 = currentdate</context_description>
+<context_dsl>local date Today2 = currentdate</context_dsl>
 <context_postfix>
 currentdate cvd allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>18</context_number>
-<context_description>local array List</context_description>
+<context_dsl>local array List</context_dsl>
 <context_postfix>
 null allocate execute 
 </context_postfix></context_details>
 <context_details>
 <context_number>19</context_number>
-<context_description>local array List2 = clients</context_description>
+<context_dsl>local array List2 = clients</context_dsl>
 <context_postfix>
 clients allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>20</context_number>
-<context_description>local string Things</context_description>
+<context_dsl>local string Things</context_dsl>
 <context_postfix>
 null allocate execute 
 </context_postfix></context_details>
 <context_details>
 <context_number>21</context_number>
-<context_description>local string Things2 = 'This is a string'</context_description>
+<context_dsl>local string Things2 = 'This is a string'</context_dsl>
 <context_postfix>
 'This is a string' cvs allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -112,7 +112,7 @@ null allocate execute
 <action_number>1</action_number>
 <action_comment>for all clients set eligible = true</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { true cvb /eligible xdef  } clients forallr 
 </action_postfix></action_details>
@@ -120,7 +120,7 @@ null allocate execute
 <action_number>2</action_number>
 <action_comment>for each case in job.cases set eligible=true</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { true cvb /eligible xdef  } job.cases  forallr 
 </action_postfix></action_details>
@@ -128,7 +128,7 @@ null allocate execute
 <action_number>3</action_number>
 <action_comment>for each case in job.cases where city=='spokane' set eligible=true</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { { true cvb /eligible xdef   } city 'spokane' streq if } job.cases forallr 
 </action_postfix></action_details>
@@ -136,7 +136,7 @@ null allocate execute
 <action_number>4</action_number>
 <action_comment>for all clients where age &lt; 18 set eligible=false</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { { false cvb /eligible xdef   } age 18 &lt; if } clients forallr 
 </action_postfix></action_details>
@@ -144,7 +144,7 @@ null allocate execute
 <action_number>5</action_number>
 <action_comment>for each case and its address in job.cases set applying = true</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { address entitypush true cvb /applying xdef   entitypop } job.cases  forallr 
 </action_postfix></action_details>
@@ -152,7 +152,7 @@ null allocate execute
 <action_number>6</action_number>
 <action_comment>for each case and its address in job.cases where validatedCitizenship == false set eligible = false</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { address entitypush { false cvb /eligible xdef   } validatedCitizenship false beq if entitypop } job.cases forallr 
 </action_postfix></action_details></actions></decision_table>
@@ -166,25 +166,25 @@ null allocate execute
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_description>for first of job.cases where validatedCitizenship == true</context_description>
+<context_dsl>for first of job.cases where validatedCitizenship == true</context_dsl>
 <context_postfix>
 dup { validatedCitizenship true beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
-<context_description>for first of job.cases and its case where city == 'New York'</context_description>
+<context_dsl>for first of job.cases and its case where city == 'New York'</context_dsl>
 <context_postfix>
 { case  entitypush dup execute entitypop } { case  entitypush city 'New York' streq  entitypop } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
-<context_description>for first in job.cases where validatedCitizenship == false</context_description>
+<context_dsl>for first in job.cases where validatedCitizenship == false</context_dsl>
 <context_postfix>
 dup { validatedCitizenship false beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
-<context_description>local entity theClient</context_description>
+<context_dsl>local entity theClient</context_dsl>
 <context_postfix>
 null allocate execute 
 </context_postfix></context_details></contexts>
@@ -193,7 +193,7 @@ null allocate execute
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>for first of job.cases where age &lt; 18 then set eligible = true;  else if none are found set eligible = false</initial_action_description>
+<initial_action_dsl>for first of job.cases where age &lt; 18 then set eligible = true;  else if none are found set eligible = false</initial_action_dsl>
 <initial_action_postfix>
 { true cvb /eligible xdef   } { false cvb /eligible xdef   } { age 18 &lt;  } job.cases  forfirstelse 
 </initial_action_postfix></initial_action_details>
@@ -201,7 +201,7 @@ null allocate execute
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>for first of job.cases and its case where city == 'New York' then set eligible = false; else if none are found set eligible = true</initial_action_description>
+<initial_action_dsl>for first of job.cases and its case where city == 'New York' then set eligible = false; else if none are found set eligible = true</initial_action_dsl>
 <initial_action_postfix>
 { case  entitypush false cvb /eligible xdef  entitypop } { true cvb /eligible xdef   } { case  entitypush city 'New York' streq entitypop } job.cases  forfirstelse 
 </initial_action_postfix></initial_action_details>
@@ -209,7 +209,7 @@ null allocate execute
 <intial_action_number>3</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>{ for all clients where age &gt; 18 set eligible = true }</initial_action_description>
+<initial_action_dsl>{ for all clients where age &gt; 18 set eligible = true }</initial_action_dsl>
 <initial_action_postfix>
 { { true cvb /eligible xdef   } age 18 &gt; if } clients forallr 
 
@@ -218,7 +218,7 @@ null allocate execute
 <intial_action_number>4</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalgroupincome = 30400</initial_action_description>
+<initial_action_dsl>set totalgroupincome = 30400</initial_action_dsl>
 <initial_action_postfix>
 30400  cvi /totalgroupincome xdef  
 </initial_action_postfix></initial_action_details>
@@ -226,7 +226,7 @@ null allocate execute
 <intial_action_number>5</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalincome = 1500.55</initial_action_description>
+<initial_action_dsl>set totalincome = 1500.55</initial_action_dsl>
 <initial_action_postfix>
 1500.55  cvr /totalincome xdef  
 </initial_action_postfix></initial_action_details>
@@ -234,7 +234,7 @@ null allocate execute
 <intial_action_number>6</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set pregnant = false</initial_action_description>
+<initial_action_dsl>set pregnant = false</initial_action_dsl>
 <initial_action_postfix>
 false cvb /pregnant xdef  
 </initial_action_postfix></initial_action_details>
@@ -242,7 +242,7 @@ false cvb /pregnant xdef
 <intial_action_number>7</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set address = mailingAddress</initial_action_description>
+<initial_action_dsl>set address = mailingAddress</initial_action_dsl>
 <initial_action_postfix>
 mailingAddress cve /address xdef  
 </initial_action_postfix></initial_action_details>
@@ -250,7 +250,7 @@ mailingAddress cve /address xdef
 <intial_action_number>8</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set state = 'Wyoming'</initial_action_description>
+<initial_action_dsl>set state = 'Wyoming'</initial_action_dsl>
 <initial_action_postfix>
 'Wyoming' cvs /state xdef  
 </initial_action_postfix></initial_action_details>
@@ -258,7 +258,7 @@ mailingAddress cve /address xdef
 <intial_action_number>9</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set currentdate = effectivedate</initial_action_description>
+<initial_action_dsl>set currentdate = effectivedate</initial_action_dsl>
 <initial_action_postfix>
 effectivedate cvd /currentdate xdef  
 </initial_action_postfix></initial_action_details>
@@ -266,7 +266,7 @@ effectivedate cvd /currentdate xdef
 <intial_action_number>10</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalgroupincome = 29400</initial_action_description>
+<initial_action_dsl>set totalgroupincome = 29400</initial_action_dsl>
 <initial_action_postfix>
 29400  cvi /totalgroupincome xdef  
 </initial_action_postfix></initial_action_details>
@@ -274,7 +274,7 @@ effectivedate cvd /currentdate xdef
 <intial_action_number>11</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalincome = 20302.95</initial_action_description>
+<initial_action_dsl>set totalincome = 20302.95</initial_action_dsl>
 <initial_action_postfix>
 20302.95  cvr /totalincome xdef  
 </initial_action_postfix></initial_action_details>
@@ -282,7 +282,7 @@ effectivedate cvd /currentdate xdef
 <intial_action_number>12</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set pregnant = true</initial_action_description>
+<initial_action_dsl>set pregnant = true</initial_action_dsl>
 <initial_action_postfix>
 true cvb /pregnant xdef  
 </initial_action_postfix></initial_action_details>
@@ -290,7 +290,7 @@ true cvb /pregnant xdef
 <intial_action_number>13</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set address = billingAddress</initial_action_description>
+<initial_action_dsl>set address = billingAddress</initial_action_dsl>
 <initial_action_postfix>
 billingAddress cve /address xdef  
 </initial_action_postfix></initial_action_details>
@@ -298,7 +298,7 @@ billingAddress cve /address xdef
 <intial_action_number>14</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set gender = 'male'</initial_action_description>
+<initial_action_dsl>set gender = 'male'</initial_action_dsl>
 <initial_action_postfix>
 'male' cvs /gender xdef  
 </initial_action_postfix></initial_action_details>
@@ -306,7 +306,7 @@ billingAddress cve /address xdef
 <intial_action_number>15</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = 12345</initial_action_description>
+<initial_action_dsl>set street = 12345</initial_action_dsl>
 <initial_action_postfix>
 12345  cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -314,7 +314,7 @@ billingAddress cve /address xdef
 <intial_action_number>16</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set birthday = dateofBirth</initial_action_description>
+<initial_action_dsl>set birthday = dateofBirth</initial_action_dsl>
 <initial_action_postfix>
 dateofBirth cvs /birthday xdef  
 </initial_action_postfix></initial_action_details>
@@ -322,7 +322,7 @@ dateofBirth cvs /birthday xdef
 <intial_action_number>17</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set zip = $unknown</initial_action_description>
+<initial_action_dsl>set zip = $unknown</initial_action_dsl>
 <initial_action_postfix>
 /unknown cvs /zip xdef  
 </initial_action_postfix></initial_action_details>
@@ -330,7 +330,7 @@ dateofBirth cvs /birthday xdef
 <intial_action_number>18</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set pregnant = $unknown</initial_action_description>
+<initial_action_dsl>set pregnant = $unknown</initial_action_dsl>
 <initial_action_postfix>
 /unknown cvb /pregnant xdef  
 </initial_action_postfix></initial_action_details>
@@ -338,7 +338,7 @@ dateofBirth cvs /birthday xdef
 <intial_action_number>19</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectivedate = currentdate</initial_action_description>
+<initial_action_dsl>set effectivedate = currentdate</initial_action_dsl>
 <initial_action_postfix>
 currentdate cvd /effectivedate xdef  
 </initial_action_postfix></initial_action_details>
@@ -346,7 +346,7 @@ currentdate cvd /effectivedate xdef
 <intial_action_number>20</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set interestingCases = cases</initial_action_description>
+<initial_action_dsl>set interestingCases = cases</initial_action_dsl>
 <initial_action_postfix>
 cases /interestingCases xdef 
 </initial_action_postfix></initial_action_details>
@@ -354,7 +354,7 @@ cases /interestingCases xdef
 <intial_action_number>21</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>perform syntax_examples</initial_action_description>
+<initial_action_dsl>perform syntax_examples</initial_action_dsl>
 <initial_action_postfix>
 syntax_examples 
 </initial_action_postfix></initial_action_details>
@@ -362,7 +362,7 @@ syntax_examples
 <intial_action_number>22</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>perform $something</initial_action_description>
+<initial_action_dsl>perform $something</initial_action_dsl>
 <initial_action_postfix>
 something 
 </initial_action_postfix></initial_action_details>
@@ -370,7 +370,7 @@ something
 <intial_action_number>23</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add cases to clients</initial_action_description>
+<initial_action_dsl>add cases to clients</initial_action_dsl>
 <initial_action_postfix>
 cases clients false addarray 
 </initial_action_postfix></initial_action_details>
@@ -378,7 +378,7 @@ cases clients false addarray
 <intial_action_number>24</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add client to interestingCases</initial_action_description>
+<initial_action_dsl>add client to interestingCases</initial_action_dsl>
 <initial_action_postfix>
 client interestingCases swap addto 
 </initial_action_postfix></initial_action_details>
@@ -386,7 +386,7 @@ client interestingCases swap addto
 <intial_action_number>25</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add case_ID to interestingCases</initial_action_description>
+<initial_action_dsl>add case_ID to interestingCases</initial_action_dsl>
 <initial_action_postfix>
 case_ID interestingCases swap addto 
 </initial_action_postfix></initial_action_details>
@@ -394,7 +394,7 @@ case_ID interestingCases swap addto
 <intial_action_number>26</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add clients to cases</initial_action_description>
+<initial_action_dsl>add clients to cases</initial_action_dsl>
 <initial_action_postfix>
 clients cases false addarray 
 </initial_action_postfix></initial_action_details>
@@ -402,7 +402,7 @@ clients cases false addarray
 <intial_action_number>27</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add effectiveDate to interestingDates</initial_action_description>
+<initial_action_dsl>add effectiveDate to interestingDates</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate interestingDates swap addto 
 </initial_action_postfix></initial_action_details>
@@ -410,7 +410,7 @@ effectiveDate interestingDates swap addto
 <intial_action_number>28</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>Add 42 to totalincome</initial_action_description>
+<initial_action_dsl>Add 42 to totalincome</initial_action_dsl>
 <initial_action_postfix>
 42  totalincome f+ /totalincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -418,7 +418,7 @@ effectiveDate interestingDates swap addto
 <intial_action_number>29</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>Subtract 42 from totalincome</initial_action_description>
+<initial_action_dsl>Subtract 42 from totalincome</initial_action_dsl>
 <initial_action_postfix>
 42  totalincome swap f- /totalincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -426,7 +426,7 @@ effectiveDate interestingDates swap addto
 <intial_action_number>30</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add 42 to totalincome</initial_action_description>
+<initial_action_dsl>add 42 to totalincome</initial_action_dsl>
 <initial_action_postfix>
 42  totalincome f+ /totalincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -434,7 +434,7 @@ effectiveDate interestingDates swap addto
 <intial_action_number>31</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add mailingaddress if not member to locations</initial_action_description>
+<initial_action_dsl>add mailingaddress if not member to locations</initial_action_dsl>
 <initial_action_postfix>
 locations  mailingaddress add_no_dups 
 </initial_action_postfix></initial_action_details>
@@ -442,7 +442,7 @@ locations  mailingaddress add_no_dups
 <intial_action_number>32</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add client_ID if not member to cases</initial_action_description>
+<initial_action_dsl>add client_ID if not member to cases</initial_action_dsl>
 <initial_action_postfix>
 cases  client_ID add_no_dups 
 </initial_action_postfix></initial_action_details>
@@ -450,7 +450,7 @@ cases  client_ID add_no_dups
 <intial_action_number>33</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add client to context of this table</initial_action_description>
+<initial_action_dsl>add client to context of this table</initial_action_dsl>
 <initial_action_postfix>
 client entitypush 
 </initial_action_postfix></initial_action_details>
@@ -458,7 +458,7 @@ client entitypush
 <intial_action_number>34</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add client to context for this table</initial_action_description>
+<initial_action_dsl>add client to context for this table</initial_action_dsl>
 <initial_action_postfix>
 client entitypush 
 </initial_action_postfix></initial_action_details>
@@ -466,7 +466,7 @@ client entitypush
 <intial_action_number>35</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>remove each client from clients where age &lt; 18</initial_action_description>
+<initial_action_dsl>remove each client from clients where age &lt; 18</initial_action_dsl>
 <initial_action_postfix>
 clients { { dup 0 entityfetch remove pop } age 18 &lt; if } over forallr pop
 </initial_action_postfix></initial_action_details>
@@ -474,7 +474,7 @@ clients { { dup 0 entityfetch remove pop } age 18 &lt; if } over forallr pop
 <intial_action_number>36</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>remove $steve from clients array</initial_action_description>
+<initial_action_dsl>remove $steve from clients array</initial_action_dsl>
 <initial_action_postfix>
 clients /steve remove pop 
 </initial_action_postfix></initial_action_details>
@@ -482,7 +482,7 @@ clients /steve remove pop
 <intial_action_number>37</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>remove $steve from clients array</initial_action_description>
+<initial_action_dsl>remove $steve from clients array</initial_action_dsl>
 <initial_action_postfix>
 clients /steve remove pop 
 </initial_action_postfix></initial_action_details>
@@ -490,7 +490,7 @@ clients /steve remove pop
 <intial_action_number>38</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>remove importantDates from InterestingDates array</initial_action_description>
+<initial_action_dsl>remove importantDates from InterestingDates array</initial_action_dsl>
 <initial_action_postfix>
 InterestingDates importantDates remove pop 
 </initial_action_postfix></initial_action_details>
@@ -498,7 +498,7 @@ InterestingDates importantDates remove pop
 <intial_action_number>39</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>remove client from clients array</initial_action_description>
+<initial_action_dsl>remove client from clients array</initial_action_dsl>
 <initial_action_postfix>
 clients client remove pop 
 </initial_action_postfix></initial_action_details>
@@ -506,7 +506,7 @@ clients client remove pop
 <intial_action_number>40</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>randomize clients</initial_action_description>
+<initial_action_dsl>randomize clients</initial_action_dsl>
 <initial_action_postfix>
 clients randomize 
 </initial_action_postfix></initial_action_details>
@@ -514,7 +514,7 @@ clients randomize
 <intial_action_number>41</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>clear clients</initial_action_description>
+<initial_action_dsl>clear clients</initial_action_dsl>
 <initial_action_postfix>
 clients clear 
 </initial_action_postfix></initial_action_details>
@@ -522,7 +522,7 @@ clients clear
 <intial_action_number>42</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>sort clients in ascending order by $steve</initial_action_description>
+<initial_action_dsl>sort clients in ascending order by $steve</initial_action_dsl>
 <initial_action_postfix>
 clients /steve true sortentities 
 </initial_action_postfix></initial_action_details>
@@ -530,7 +530,7 @@ clients /steve true sortentities
 <intial_action_number>43</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>sort clients in descending order by $steve</initial_action_description>
+<initial_action_dsl>sort clients in descending order by $steve</initial_action_dsl>
 <initial_action_postfix>
 clients /steve false sortentities 
 </initial_action_postfix></initial_action_details>
@@ -538,7 +538,7 @@ clients /steve false sortentities
 <intial_action_number>44</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>Set InterestingClients = job's clients</initial_action_description>
+<initial_action_dsl>Set InterestingClients = job's clients</initial_action_dsl>
 <initial_action_postfix>
 job entitypush clients entitypop /InterestingClients xdef 
 </initial_action_postfix></initial_action_details>
@@ -546,7 +546,7 @@ job entitypush clients entitypop /InterestingClients xdef
 <intial_action_number>45</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set cases = get copy of interestingCases</initial_action_description>
+<initial_action_dsl>set cases = get copy of interestingCases</initial_action_dsl>
 <initial_action_postfix>
 interestingCases copyelements /cases xdef 
 </initial_action_postfix></initial_action_details>
@@ -554,7 +554,7 @@ interestingCases copyelements /cases xdef
 <intial_action_number>46</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set interestingClients = copy of clients</initial_action_description>
+<initial_action_dsl>set interestingClients = copy of clients</initial_action_dsl>
 <initial_action_postfix>
 clients copyelements /interestingClients xdef 
 </initial_action_postfix></initial_action_details>
@@ -562,7 +562,7 @@ clients copyelements /interestingClients xdef
 <intial_action_number>47</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set cases = get deep copy of interestingCases</initial_action_description>
+<initial_action_dsl>set cases = get deep copy of interestingCases</initial_action_dsl>
 <initial_action_postfix>
 interestingCases deepcopy /cases xdef 
 </initial_action_postfix></initial_action_details>
@@ -570,7 +570,7 @@ interestingCases deepcopy /cases xdef
 <intial_action_number>48</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set interestingClients = deep copy of clients</initial_action_description>
+<initial_action_dsl>set interestingClients = deep copy of clients</initial_action_dsl>
 <initial_action_postfix>
 clients deepcopy /interestingClients xdef 
 </initial_action_postfix></initial_action_details>
@@ -578,7 +578,7 @@ clients deepcopy /interestingClients xdef
 <intial_action_number>49</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set errorCodes = [ 1 , 2, 3, 4 ]</initial_action_description>
+<initial_action_dsl>set errorCodes = [ 1 , 2, 3, 4 ]</initial_action_dsl>
 <initial_action_postfix>
 { 1 2 3 4 } /errorCodes xdef 
 </initial_action_postfix></initial_action_details>
@@ -586,7 +586,7 @@ clients deepcopy /interestingClients xdef
 <intial_action_number>50</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set errorcodes = tokenize errorType by location</initial_action_description>
+<initial_action_dsl>set errorcodes = tokenize errorType by location</initial_action_dsl>
 <initial_action_postfix>
 errorType location tokenize /errorcodes xdef 
 </initial_action_postfix></initial_action_details>
@@ -594,7 +594,7 @@ errorType location tokenize /errorcodes xdef
 <intial_action_number>51</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set errorCodes = [ errorType, location, message ]</initial_action_description>
+<initial_action_dsl>set errorCodes = [ errorType, location, message ]</initial_action_dsl>
 <initial_action_postfix>
 { errorType location message } /errorCodes xdef 
 </initial_action_postfix></initial_action_details>
@@ -602,7 +602,7 @@ errorType location tokenize /errorcodes xdef
 <intial_action_number>52</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set errorCodes = [1.5, 2.75, 3.99]</initial_action_description>
+<initial_action_dsl>set errorCodes = [1.5, 2.75, 3.99]</initial_action_dsl>
 <initial_action_postfix>
 { 1.5 2.75 3.99 } /errorCodes xdef 
 </initial_action_postfix></initial_action_details>
@@ -610,7 +610,7 @@ errorType location tokenize /errorcodes xdef
 <intial_action_number>53</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set theClient = clients [ 0 ]</initial_action_description>
+<initial_action_dsl>set theClient = clients [ 0 ]</initial_action_dsl>
 <initial_action_postfix>
 clients 0 getat cve 0 local!  
 </initial_action_postfix></initial_action_details>
@@ -618,7 +618,7 @@ clients 0 getat cve 0 local!
 <intial_action_number>54</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set InterestingClients = job's clients</initial_action_description>
+<initial_action_dsl>set InterestingClients = job's clients</initial_action_dsl>
 <initial_action_postfix>
 job entitypush clients entitypop /InterestingClients xdef 
 </initial_action_postfix></initial_action_details>
@@ -626,7 +626,7 @@ job entitypush clients entitypop /InterestingClients xdef
 <intial_action_number>55</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = new $theClient entity</initial_action_description>
+<initial_action_dsl>set client = new $theClient entity</initial_action_dsl>
 <initial_action_postfix>
 /theClient  createentity cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -634,7 +634,7 @@ job entitypush clients entitypop /InterestingClients xdef
 <intial_action_number>56</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client  = new client entity</initial_action_description>
+<initial_action_dsl>set client  = new client entity</initial_action_dsl>
 <initial_action_postfix>
 /client createentity cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -642,7 +642,7 @@ job entitypush clients entitypop /InterestingClients xdef
 <intial_action_number>57</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = clone of newClient</initial_action_description>
+<initial_action_dsl>set client = clone of newClient</initial_action_dsl>
 <initial_action_postfix>
 newClient clone cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -650,7 +650,7 @@ newClient clone cve /client xdef
 <intial_action_number>58</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = client's address</initial_action_description>
+<initial_action_dsl>set client = client's address</initial_action_dsl>
 <initial_action_postfix>
 client entitypush address entitypop cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -658,7 +658,7 @@ client entitypush address entitypop cve /client xdef
 <intial_action_number>59</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = first client in clients where age &lt; 18</initial_action_description>
+<initial_action_dsl>set client = first client in clients where age &lt; 18</initial_action_dsl>
 <initial_action_postfix>
 { client } { null } { age 18 &lt; } clients forfirstelse cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -666,7 +666,7 @@ client entitypush address entitypop cve /client xdef
 <intial_action_number>60</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = first client where pregnant == true</initial_action_description>
+<initial_action_dsl>set client = first client where pregnant == true</initial_action_dsl>
 <initial_action_postfix>
 { client } { null } { pregnant true beq } clients forfirstelse cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -674,7 +674,7 @@ client entitypush address entitypop cve /client xdef
 <intial_action_number>61</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = gender of client</initial_action_description>
+<initial_action_dsl>set client = gender of client</initial_action_dsl>
 <initial_action_postfix>
 { source } { null } { gender type == } forfirstelse cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -682,7 +682,7 @@ client entitypush address entitypop cve /client xdef
 <intial_action_number>62</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>subtract 2 years from effectiveDate</initial_action_description>
+<initial_action_dsl>subtract 2 years from effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 2  negate addyears /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -690,7 +690,7 @@ effectiveDate 2  negate addyears /effectiveDate xdef
 <intial_action_number>63</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>subtract 10 months from effectiveDate</initial_action_description>
+<initial_action_dsl>subtract 10 months from effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 10  negate addmonths /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -698,7 +698,7 @@ effectiveDate 10  negate addmonths /effectiveDate xdef
 <intial_action_number>64</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>subtract 25 days from effectiveDate</initial_action_description>
+<initial_action_dsl>subtract 25 days from effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 25  negate adddays /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -706,7 +706,7 @@ effectiveDate 25  negate adddays /effectiveDate xdef
 <intial_action_number>65</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add 3 years to effectiveDate</initial_action_description>
+<initial_action_dsl>add 3 years to effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 3  addyears /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -714,7 +714,7 @@ effectiveDate 3  addyears /effectiveDate xdef
 <intial_action_number>66</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add 8 months to effectiveDate</initial_action_description>
+<initial_action_dsl>add 8 months to effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 8  addmonths /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -722,7 +722,7 @@ effectiveDate 8  addmonths /effectiveDate xdef
 <intial_action_number>67</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add 18 days to effectiveDate</initial_action_description>
+<initial_action_dsl>add 18 days to effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 18  adddays /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -730,7 +730,7 @@ effectiveDate 18  adddays /effectiveDate xdef
 <intial_action_number>68</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = (Date) birthday</initial_action_description>
+<initial_action_dsl>set effectiveDate = (Date) birthday</initial_action_dsl>
 <initial_action_postfix>
 birthday cvd cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -738,7 +738,7 @@ birthday cvd cvd /effectiveDate xdef
 <intial_action_number>69</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = date (birthday)</initial_action_description>
+<initial_action_dsl>set effectiveDate = date (birthday)</initial_action_dsl>
 <initial_action_postfix>
 birthday cvd cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -746,7 +746,7 @@ birthday cvd cvd /effectiveDate xdef
 <intial_action_number>70</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = (date) clients [2]</initial_action_description>
+<initial_action_dsl>set effectiveDate = (date) clients [2]</initial_action_dsl>
 <initial_action_postfix>
 clients 2 getat cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -754,7 +754,7 @@ clients 2 getat cvd /effectiveDate xdef
 <intial_action_number>71</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = using client (currentDate)</initial_action_description>
+<initial_action_dsl>set effectiveDate = using client (currentDate)</initial_action_dsl>
 <initial_action_postfix>
 client entitypush currentDate entitypop cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -762,7 +762,7 @@ client entitypush currentDate entitypop cvd /effectiveDate xdef
 <intial_action_number>72</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = (20 days)</initial_action_description>
+<initial_action_dsl>set effectiveDate = (20 days)</initial_action_dsl>
 <initial_action_postfix>
 20  days cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -770,7 +770,7 @@ client entitypush currentDate entitypop cvd /effectiveDate xdef
 <intial_action_number>73</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate + effectiveDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate + effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate effectiveDate d+ cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -778,7 +778,7 @@ currentDate effectiveDate d+ cvd /effectiveDate xdef
 <intial_action_number>74</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate - effectiveDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate - effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate effectiveDate d- cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -786,7 +786,7 @@ currentDate effectiveDate d- cvd /effectiveDate xdef
 <intial_action_number>75</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = subtract 1 year from currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = subtract 1 year from currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  1  negate addyears cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -794,7 +794,7 @@ currentDate  1  negate addyears cvd /effectiveDate xdef
 <intial_action_number>76</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = subtract 9 months from currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = subtract 9 months from currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  9  negate addmonths cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -802,7 +802,7 @@ currentDate  9  negate addmonths cvd /effectiveDate xdef
 <intial_action_number>77</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = subtract 22 days from currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = subtract 22 days from currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  22  negate adddays cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -810,7 +810,7 @@ currentDate  22  negate adddays cvd /effectiveDate xdef
 <intial_action_number>78</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = add 2 years to currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = add 2 years to currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  2  addyears cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -818,7 +818,7 @@ currentDate  2  addyears cvd /effectiveDate xdef
 <intial_action_number>79</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = add 8 months to currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = add 8 months to currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  8  addmonths cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -826,7 +826,7 @@ currentDate  8  addmonths cvd /effectiveDate xdef
 <intial_action_number>80</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = add 14 days to currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = add 14 days to currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  14  adddays cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -834,7 +834,7 @@ currentDate  14  adddays cvd /effectiveDate xdef
 <intial_action_number>81</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set currentDate = first of year of effectiveDate</initial_action_description>
+<initial_action_dsl>set currentDate = first of year of effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate firstofyear cvd /currentDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -842,7 +842,7 @@ effectiveDate firstofyear cvd /currentDate xdef
 <intial_action_number>82</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set currentDate = first of month of effectiveDate</initial_action_description>
+<initial_action_dsl>set currentDate = first of month of effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate firstofmonth cvd /currentDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -850,7 +850,7 @@ effectiveDate firstofmonth cvd /currentDate xdef
 <intial_action_number>83</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set currentDate = end of month of effectiveDate</initial_action_description>
+<initial_action_dsl>set currentDate = end of month of effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate endofmonth cvd /currentDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -858,7 +858,7 @@ effectiveDate endofmonth cvd /currentDate xdef
 <intial_action_number>84</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = earliest of cases after currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = earliest of cases after currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate dup &gt;r { { pop pop i i } over i d&gt; if pop } cases dup false sortarray for r&gt; pop cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -879,7 +879,7 @@ currentDate dup &gt;r { { pop pop i i } over i d&gt; if pop } cases dup false so
 <action_number>1</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set street = attribute street of client</action_description>
+<action_dsl>set street = attribute street of client</action_dsl>
 <action_postfix>
 client street getXmlAttribute cvs /street xdef  
 </action_postfix></action_details>
@@ -887,7 +887,7 @@ client street getXmlAttribute cvs /street xdef
 <action_number>2</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set street = mapping key</action_description>
+<action_dsl>set street = mapping key</action_dsl>
 <action_postfix>
 "mapping*key" cvn execute cvs /street xdef  
 </action_postfix></action_details>
@@ -895,7 +895,7 @@ client street getXmlAttribute cvs /street xdef
 <action_number>3</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set street = attribute street of client</action_description>
+<action_dsl>set street = attribute street of client</action_dsl>
 <action_postfix>
 client street getXmlAttribute cvs /street xdef  
 </action_postfix></action_details>
@@ -903,7 +903,7 @@ client street getXmlAttribute cvs /street xdef
 <action_number>4</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set programLevel = substring of program from 0 to 10</action_description>
+<action_dsl>set programLevel = substring of program from 0 to 10</action_dsl>
 <action_postfix>
 10 0 program substring cvs /programLevel xdef  
 </action_postfix></action_details>
@@ -911,7 +911,7 @@ client street getXmlAttribute cvs /street xdef
 <action_number>5</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set street = table information</action_description>
+<action_dsl>set street = table information</action_dsl>
 <action_postfix>
 actionstring cvs /street xdef  
 </action_postfix></action_details>
@@ -919,7 +919,7 @@ actionstring cvs /street xdef
 <action_number>6</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set street = string</action_description>
+<action_dsl>set street = string</action_dsl>
 <action_postfix>
 string cvs /street xdef  
 </action_postfix></action_details>
@@ -927,7 +927,7 @@ string cvs /street xdef
 <action_number>7</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set parent = street + zip</action_description>
+<action_dsl>set parent = street + zip</action_dsl>
 <action_postfix>
 street zip strconcat cvs /parent xdef  
 </action_postfix></action_details>
@@ -935,7 +935,7 @@ street zip strconcat cvs /parent xdef
 <action_number>8</action_number>
 <action_comment>set programLevel = (program)</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 program cvs /programLevel xdef  
 </action_postfix></action_details>
@@ -943,7 +943,7 @@ program cvs /programLevel xdef
 <action_number>9</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set wages = wages  + 55</action_description>
+<action_dsl>set wages = wages  + 55</action_dsl>
 <action_postfix>
 wages 55 strconcat cvs /wages xdef  
 </action_postfix></action_details>
@@ -951,7 +951,7 @@ wages 55 strconcat cvs /wages xdef
 <action_number>10</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set tips = tips + 35.50</action_description>
+<action_dsl>set tips = tips + 35.50</action_dsl>
 <action_postfix>
 tips 35.50 strconcat cvs /tips xdef  
 </action_postfix></action_details>
@@ -959,7 +959,7 @@ tips 35.50 strconcat cvs /tips xdef
 <action_number>11</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set street = street + $Oak</action_description>
+<action_dsl>set street = street + $Oak</action_dsl>
 <action_postfix>
 street /Oak strconcat cvs /street xdef  
 </action_postfix></action_details>
@@ -967,7 +967,7 @@ street /Oak strconcat cvs /street xdef
 <action_number>12</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set parent = street + zip</action_description>
+<action_dsl>set parent = street + zip</action_dsl>
 <action_postfix>
 street zip strconcat cvs /parent xdef  
 </action_postfix></action_details>
@@ -975,7 +975,7 @@ street zip strconcat cvs /parent xdef
 <action_number>13</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set street = street + billingAddress</action_description>
+<action_dsl>set street = street + billingAddress</action_dsl>
 <action_postfix>
 street billingAddress strconcat cvs /street xdef  
 </action_postfix></action_details>
@@ -983,7 +983,7 @@ street billingAddress strconcat cvs /street xdef
 <action_number>14</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set importantDates = importantDates + currentDate</action_description>
+<action_dsl>set importantDates = importantDates + currentDate</action_dsl>
 <action_postfix>
 importantDates currentDate strconcat cvs /importantDates xdef  
 </action_postfix></action_details>
@@ -991,7 +991,7 @@ importantDates currentDate strconcat cvs /importantDates xdef
 <action_number>15</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set street = street + clients</action_description>
+<action_dsl>set street = street + clients</action_dsl>
 <action_postfix>
 street clients strconcat cvs /street xdef  
 </action_postfix></action_details>
@@ -999,7 +999,7 @@ street clients strconcat cvs /street xdef
 <action_number>16</action_number>
 <action_comment>set street = using client (street)</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 client entitypush street entitypop cvs /street xdef  
 </action_postfix></action_details>
@@ -1007,7 +1007,7 @@ client entitypush street entitypop cvs /street xdef
 <action_number>17</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = 550.87</action_description>
+<action_dsl>set totalIncome = 550.87</action_dsl>
 <action_postfix>
 550.87  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1015,7 +1015,7 @@ client entitypush street entitypop cvs /street xdef
 <action_number>18</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = (double) wages</action_description>
+<action_dsl>set totalIncome = (double) wages</action_dsl>
 <action_postfix>
 wages cvr  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1023,7 +1023,7 @@ wages cvr  cvr /totalIncome xdef
 <action_number>19</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = (double) totalGroupIncome</action_description>
+<action_dsl>set totalIncome = (double) totalGroupIncome</action_dsl>
 <action_postfix>
 totalGroupIncome cvr  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1031,7 +1031,7 @@ totalGroupIncome cvr  cvr /totalIncome xdef
 <action_number>20</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = totalIncome + totalGroupIncome</action_description>
+<action_dsl>set totalIncome = totalIncome + totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome fadd  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1039,7 +1039,7 @@ totalIncome totalGroupIncome fadd  cvr /totalIncome xdef
 <action_number>21</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = totalGroupIncome + totalIncome</action_description>
+<action_dsl>set totalIncome = totalGroupIncome + totalIncome</action_dsl>
 <action_postfix>
 totalGroupIncome totalIncome fadd  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1047,7 +1047,7 @@ totalGroupIncome totalIncome fadd  cvr /totalIncome xdef
 <action_number>22</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = totalIncome - totalGroupIncome</action_description>
+<action_dsl>set totalIncome = totalIncome - totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome fsub  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1055,7 +1055,7 @@ totalIncome totalGroupIncome fsub  cvr /totalIncome xdef
 <action_number>23</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = totalIncome - additionalIncome</action_description>
+<action_dsl>set totalIncome = totalIncome - additionalIncome</action_dsl>
 <action_postfix>
 totalIncome additionalIncome fsub  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1063,7 +1063,7 @@ totalIncome additionalIncome fsub  cvr /totalIncome xdef
 <action_number>24</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = totalIncome * totalGroupIncome</action_description>
+<action_dsl>set totalIncome = totalIncome * totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome fmul  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1071,7 +1071,7 @@ totalIncome totalGroupIncome fmul  cvr /totalIncome xdef
 <action_number>25</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = totalIncome * additionalIncome</action_description>
+<action_dsl>set totalIncome = totalIncome * additionalIncome</action_dsl>
 <action_postfix>
 totalIncome additionalIncome fmul  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1079,7 +1079,7 @@ totalIncome additionalIncome fmul  cvr /totalIncome xdef
 <action_number>26</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = totalIncome / totalGroupIncome</action_description>
+<action_dsl>set totalIncome = totalIncome / totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome fdiv  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1087,7 +1087,7 @@ totalIncome totalGroupIncome fdiv  cvr /totalIncome xdef
 <action_number>27</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = totalIncome / additionalIncome</action_description>
+<action_dsl>set totalIncome = totalIncome / additionalIncome</action_dsl>
 <action_postfix>
 totalIncome additionalIncome fdiv  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1095,7 +1095,7 @@ totalIncome additionalIncome fdiv  cvr /totalIncome xdef
 <action_number>28</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = - additionalIncome</action_description>
+<action_dsl>set totalIncome = - additionalIncome</action_dsl>
 <action_postfix>
 additionalIncome fnegate  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1103,7 +1103,7 @@ additionalIncome fnegate  cvr /totalIncome xdef
 <action_number>29</action_number>
 <action_comment>set totalIncome = (additionalIncome)</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 additionalIncome  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1111,7 +1111,7 @@ additionalIncome  cvr /totalIncome xdef
 <action_number>30</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = (double) clients [0]</action_description>
+<action_dsl>set totalIncome = (double) clients [0]</action_dsl>
 <action_postfix>
 clients 0 getat  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1119,7 +1119,7 @@ clients 0 getat  cvr /totalIncome xdef
 <action_number>31</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = add to totalIncome 75</action_description>
+<action_dsl>set totalIncome = add to totalIncome 75</action_dsl>
 <action_postfix>
 /75   totalIncome75   fadd def  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1127,7 +1127,7 @@ clients 0 getat  cvr /totalIncome xdef
 <action_number>32</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = subtract from totalIncome 99</action_description>
+<action_dsl>set totalIncome = subtract from totalIncome 99</action_dsl>
 <action_postfix>
 /99   totalIncome99   fsub def  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1135,7 +1135,7 @@ clients 0 getat  cvr /totalIncome xdef
 <action_number>33</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalIncome = absolute value of totalIncome</action_description>
+<action_dsl>set totalIncome = absolute value of totalIncome</action_dsl>
 <action_postfix>
 totalIncome fabs  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1143,7 +1143,7 @@ totalIncome fabs  cvr /totalIncome xdef
 <action_number>34</action_number>
 <action_comment>set totalIncome = using clients (totalIncome)</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 clients entitypush totalIncome  entitypop  cvr /totalIncome xdef  
 </action_postfix></action_details></actions></decision_table>
@@ -1162,7 +1162,7 @@ clients entitypush totalIncome  entitypop  cvr /totalIncome xdef
 <action_number>1</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set FPL_Base = FPL_Base + FPL_PerAdditionalPerson</action_description>
+<action_dsl>set FPL_Base = FPL_Base + FPL_PerAdditionalPerson</action_dsl>
 <action_postfix>
 FPL_Base FPL_PerAdditionalPerson +  cvi /FPL_Base xdef  
 </action_postfix></action_details>
@@ -1170,7 +1170,7 @@ FPL_Base FPL_PerAdditionalPerson +  cvi /FPL_Base xdef
 <action_number>2</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set FPL_Base = FPL_Base - FPL_PerAdditionalPerson</action_description>
+<action_dsl>set FPL_Base = FPL_Base - FPL_PerAdditionalPerson</action_dsl>
 <action_postfix>
 FPL_Base FPL_PerAdditionalPerson -  cvi /FPL_Base xdef  
 </action_postfix></action_details>
@@ -1178,7 +1178,7 @@ FPL_Base FPL_PerAdditionalPerson -  cvi /FPL_Base xdef
 <action_number>3</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set FPL_Base = FPL_Base * FPL_PerAdditionalPerson</action_description>
+<action_dsl>set FPL_Base = FPL_Base * FPL_PerAdditionalPerson</action_dsl>
 <action_postfix>
 FPL_Base FPL_PerAdditionalPerson *  cvi /FPL_Base xdef  
 </action_postfix></action_details>
@@ -1186,7 +1186,7 @@ FPL_Base FPL_PerAdditionalPerson *  cvi /FPL_Base xdef
 <action_number>4</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set FPL_Base = FPL_Base / FPL_PerAdditionalPerson</action_description>
+<action_dsl>set FPL_Base = FPL_Base / FPL_PerAdditionalPerson</action_dsl>
 <action_postfix>
 FPL_Base FPL_PerAdditionalPerson div  cvi /FPL_Base xdef  
 </action_postfix></action_details>
@@ -1194,7 +1194,7 @@ FPL_Base FPL_PerAdditionalPerson div  cvi /FPL_Base xdef
 <action_number>5</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set expectedChildren = 2</action_description>
+<action_dsl>set expectedChildren = 2</action_dsl>
 <action_postfix>
 2  cvi /expectedChildren xdef  
 </action_postfix></action_details>
@@ -1202,7 +1202,7 @@ FPL_Base FPL_PerAdditionalPerson div  cvi /FPL_Base xdef
 <action_number>6</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set FPL_Base = - FPL_Base</action_description>
+<action_dsl>set FPL_Base = - FPL_Base</action_dsl>
 <action_postfix>
 FPL_Base negate  cvi /FPL_Base xdef  
 </action_postfix></action_details>
@@ -1210,7 +1210,7 @@ FPL_Base negate  cvi /FPL_Base xdef
 <action_number>7</action_number>
 <action_comment>set FPL_Base = (client_fpl)</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 client_fpl   cvi /FPL_Base xdef  
 </action_postfix></action_details>
@@ -1218,7 +1218,7 @@ client_fpl   cvi /FPL_Base xdef
 <action_number>8</action_number>
 <action_comment>set FPL_Base = (client_fpl)</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 client_fpl   cvi /FPL_Base xdef  
 </action_postfix></action_details>
@@ -1226,7 +1226,7 @@ client_fpl   cvi /FPL_Base xdef
 <action_number>9</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set DateNumber = get days in months for effectiveDate</action_description>
+<action_dsl>set DateNumber = get days in months for effectiveDate</action_dsl>
 <action_postfix>
 effectiveDate getdaysinmonth  cvi /DateNumber xdef  
 </action_postfix></action_details>
@@ -1234,7 +1234,7 @@ effectiveDate getdaysinmonth  cvi /DateNumber xdef
 <action_number>10</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set DateNumber = get days of months for effectiveDate</action_description>
+<action_dsl>set DateNumber = get days of months for effectiveDate</action_dsl>
 <action_postfix>
 effectiveDate getdayofmonth  cvi /DateNumber xdef  
 </action_postfix></action_details>
@@ -1242,7 +1242,7 @@ effectiveDate getdayofmonth  cvi /DateNumber xdef
 <action_number>11</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set DateNumber = get days in months for effectiveDate</action_description>
+<action_dsl>set DateNumber = get days in months for effectiveDate</action_dsl>
 <action_postfix>
 effectiveDate getdaysinmonth  cvi /DateNumber xdef  
 </action_postfix></action_details>
@@ -1250,7 +1250,7 @@ effectiveDate getdaysinmonth  cvi /DateNumber xdef
 <action_number>12</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalGroupIncome = (long) clients [1]</action_description>
+<action_dsl>set totalGroupIncome = (long) clients [1]</action_dsl>
 <action_postfix>
 clients 1 getat cvi  cvi /totalGroupIncome xdef  
 </action_postfix></action_details>
@@ -1258,7 +1258,7 @@ clients 1 getat cvi  cvi /totalGroupIncome xdef
 <action_number>13</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalGroupIncome = (long) wages</action_description>
+<action_dsl>set totalGroupIncome = (long) wages</action_dsl>
 <action_postfix>
 wages cvi  cvi /totalGroupIncome xdef  
 </action_postfix></action_details>
@@ -1266,7 +1266,7 @@ wages cvi  cvi /totalGroupIncome xdef
 <action_number>14</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalGroupIncome = (long) 450</action_description>
+<action_dsl>set totalGroupIncome = (long) 450</action_dsl>
 <action_postfix>
 450  cvi  cvi /totalGroupIncome xdef  
 </action_postfix></action_details>
@@ -1274,7 +1274,7 @@ wages cvi  cvi /totalGroupIncome xdef
 <action_number>15</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalGroupIncome = number of clients</action_description>
+<action_dsl>set totalGroupIncome = number of clients</action_dsl>
 <action_postfix>
 clients length  cvi /totalGroupIncome xdef  
 </action_postfix></action_details>
@@ -1282,7 +1282,7 @@ clients length  cvi /totalGroupIncome xdef
 <action_number>16</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalGroupIncome = number of clients where age &gt; 18</action_description>
+<action_dsl>set totalGroupIncome = number of clients where age &gt; 18</action_dsl>
 <action_postfix>
 0 { { 1 ladd } age 18 &gt; if }clients forall  cvi /totalGroupIncome xdef  
 </action_postfix></action_details>
@@ -1290,7 +1290,7 @@ clients length  cvi /totalGroupIncome xdef
 <action_number>17</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set DateNumber = get days in months for effectiveDate</action_description>
+<action_dsl>set DateNumber = get days in months for effectiveDate</action_dsl>
 <action_postfix>
 effectiveDate getdaysinmonth  cvi /DateNumber xdef  
 </action_postfix></action_details>
@@ -1298,7 +1298,7 @@ effectiveDate getdaysinmonth  cvi /DateNumber xdef
 <action_number>18</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set IncomeGroupCount = length of clients</action_description>
+<action_dsl>set IncomeGroupCount = length of clients</action_dsl>
 <action_postfix>
 clients length  cvi /IncomeGroupCount xdef  
 </action_postfix></action_details>
@@ -1306,7 +1306,7 @@ clients length  cvi /IncomeGroupCount xdef
 <action_number>19</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set IncomeGroupCount = length of parent</action_description>
+<action_dsl>set IncomeGroupCount = length of parent</action_dsl>
 <action_postfix>
 parent strlength  cvi /IncomeGroupCount xdef  
 </action_postfix></action_details>
@@ -1314,7 +1314,7 @@ parent strlength  cvi /IncomeGroupCount xdef
 <action_number>20</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set DateNumber = index of birthday in importantDates</action_description>
+<action_dsl>set DateNumber = index of birthday in importantDates</action_dsl>
 <action_postfix>
 birthday importantDates indexof  cvi /DateNumber xdef  
 </action_postfix></action_details>
@@ -1322,7 +1322,7 @@ birthday importantDates indexof  cvi /DateNumber xdef
 <action_number>21</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set FPL_Base = using clients 3</action_description>
+<action_dsl>set FPL_Base = using clients 3</action_dsl>
 <action_postfix>
 clients entitypush 3  entitypop  cvi /FPL_Base xdef  
 </action_postfix></action_details>
@@ -1330,7 +1330,7 @@ clients entitypush 3  entitypop  cvi /FPL_Base xdef
 <action_number>22</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalGroupIncome = add to totalGroupIncome 75</action_description>
+<action_dsl>set totalGroupIncome = add to totalGroupIncome 75</action_dsl>
 <action_postfix>
 /75  totalGroupIncome75   ladd def  cvi /totalGroupIncome xdef  
 </action_postfix></action_details>
@@ -1338,7 +1338,7 @@ clients entitypush 3  entitypop  cvi /FPL_Base xdef
 <action_number>23</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalGroupIncome = subtract from totalGroupIncome 50</action_description>
+<action_dsl>set totalGroupIncome = subtract from totalGroupIncome 50</action_dsl>
 <action_postfix>
 /50  totalGroupIncome50   lsub def  cvi /totalGroupIncome xdef  
 </action_postfix></action_details>
@@ -1346,7 +1346,7 @@ clients entitypush 3  entitypop  cvi /FPL_Base xdef
 <action_number>24</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set totalGroupIncome = absolute value of totalGroupIncome</action_description>
+<action_dsl>set totalGroupIncome = absolute value of totalGroupIncome</action_dsl>
 <action_postfix>
 totalGroupIncome labs  cvi /totalGroupIncome xdef  
 </action_postfix></action_details>
@@ -1354,7 +1354,7 @@ totalGroupIncome labs  cvi /totalGroupIncome xdef
 <action_number>25</action_number>
 <action_comment>set totalGroupIncome = using client (IncomeGroupCount)</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 client entitypush IncomeGroupCount entitypop  cvi /totalGroupIncome xdef  
 </action_postfix></action_details>
@@ -1362,7 +1362,7 @@ client entitypush IncomeGroupCount entitypop  cvi /totalGroupIncome xdef
 <action_number>26</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set DateNumber = days from currentDate to effectiveDate</action_description>
+<action_dsl>set DateNumber = days from currentDate to effectiveDate</action_dsl>
 <action_postfix>
 currentDate effectiveDate daysbetween  cvi /DateNumber xdef  
 </action_postfix></action_details>
@@ -1370,7 +1370,7 @@ currentDate effectiveDate daysbetween  cvi /DateNumber xdef
 <action_number>27</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set DateNumber = months from currentDate to effectiveDate</action_description>
+<action_dsl>set DateNumber = months from currentDate to effectiveDate</action_dsl>
 <action_postfix>
 currentDate effectiveDate monthsbetween  cvi /DateNumber xdef  
 </action_postfix></action_details>
@@ -1378,7 +1378,7 @@ currentDate effectiveDate monthsbetween  cvi /DateNumber xdef
 <action_number>28</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set DateNumber = years from currentDate to effectiveDate</action_description>
+<action_dsl>set DateNumber = years from currentDate to effectiveDate</action_dsl>
 <action_postfix>
 currentDate effectiveDate yearsbetween  cvi /DateNumber xdef  
 </action_postfix></action_details>
@@ -1386,7 +1386,7 @@ currentDate effectiveDate yearsbetween  cvi /DateNumber xdef
 <action_number>29</action_number>
 <action_comment>set eligible = clients does not include  case</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 clients case memberof not cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1394,7 +1394,7 @@ clients case memberof not cvb /eligible xdef
 <action_number>30</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = clients does include case</action_description>
+<action_dsl>set eligible = clients does include case</action_dsl>
 <action_postfix>
 clients case memberof cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1402,7 +1402,7 @@ clients case memberof cvb /eligible xdef
 <action_number>31</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = clients includes case</action_description>
+<action_dsl>set eligible = clients includes case</action_dsl>
 <action_postfix>
 clients case memberof cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1410,7 +1410,7 @@ clients case memberof cvb /eligible xdef
 <action_number>32</action_number>
 <action_comment>set applying = there is match for all clients to $applying in cases</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 true { over { { } { swap pop false swap } { dup /applying execute streq } cases forfirstelse } swap if pop } clients for cvb /applying xdef  
 </action_postfix></action_details>
@@ -1418,7 +1418,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>33</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = there is client where FPL_base &lt;867</action_description>
+<action_dsl>set eligible = there is client where FPL_base &lt;867</action_dsl>
 <action_postfix>
 { true } { false } { FPL_base 867 &lt; } clients forfirstelse cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1426,7 +1426,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>34</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = is there mailingAddress in the Address where mailingAddress == billingAddress</action_description>
+<action_dsl>set eligible = is there mailingAddress in the Address where mailingAddress == billingAddress</action_dsl>
 <action_postfix>
 { true } { false } { mailingAddress billingAddress req  } mailingAddresss Address entitypush forfirstelse entitypop cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1434,7 +1434,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>35</action_number>
 <action_comment>set eligible = there is no client where applying == false</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { false } { true } { applying false beq } clients forfirstelse cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1442,7 +1442,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>36</action_number>
 <action_comment>set eligible = there is no client in the case where applying == false</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { false } { true } { applying false beq } clients case entitypush forfirstelse entitypop cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1450,7 +1450,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>37</action_number>
 <action_comment>set eligible = there is no case in the clients where client_FPL &gt; 1000</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { false } { true } { client_FPL 1000 &gt; } clients forfirstelse cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1458,7 +1458,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>38</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = all clients have disabled == true</action_description>
+<action_dsl>set eligible = all clients have disabled == true</action_dsl>
 <action_postfix>
 { false } { true } { disabled true beq not } clients forfirstelse cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1466,7 +1466,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>39</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = one of clients has a FPL_Base &gt; 867</action_description>
+<action_dsl>set eligible = one of clients has a FPL_Base &gt; 867</action_dsl>
 <action_postfix>
 { true } { false } { FPL_Base 867 &gt; } clients forfirstelse cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1474,7 +1474,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>40</action_number>
 <action_comment>set eligible = client does not have SocialSecurity</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 SocialSecurity client { pop pop false } { pop pop true } { over type streq over target req and } relationships forfirstelse cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1482,7 +1482,7 @@ SocialSecurity client { pop pop false } { pop pop true } { over type streq over 
 <action_number>41</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = client has a Wages</action_description>
+<action_dsl>set eligible = client has a Wages</action_dsl>
 <action_postfix>
 Wages client { pop pop true } { pop pop false } { over type streq over target req and } relationships forfirstelse cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1490,7 +1490,7 @@ Wages client { pop pop true } { pop pop false } { over type streq over target re
 <action_number>42</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = case has a FreeCoverage where FPL_Base &lt; 867</action_description>
+<action_dsl>set eligible = case has a FreeCoverage where FPL_Base &lt; 867</action_dsl>
 <action_postfix>
 FreeCoverage case { pop pop true } { pop pop false } { over type streq over target req and source entitypush FPL_Base 867 &lt; entitypop and } relationships forfirstelse cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1498,7 +1498,7 @@ FreeCoverage case { pop pop true } { pop pop false } { over type streq over targ
 <action_number>43</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = client is programLevel of case</action_description>
+<action_dsl>set eligible = client is programLevel of case</action_dsl>
 <action_postfix>
 programLevel { pop true } { pop false } { dup type streq source client  req and target case  req and }  relationships forfirstelse cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1506,7 +1506,7 @@ programLevel { pop true } { pop false } { dup type streq source client  req and 
 <action_number>44</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = additionalIncome is within 20 percent of totalIncome</action_description>
+<action_dsl>set eligible = additionalIncome is within 20 percent of totalIncome</action_dsl>
 <action_postfix>
 totalIncome additionalIncome 20  100.0 f/ over f* swap &gt;r &gt;r &gt;r i j f- k f&lt; r&gt; r&gt; f+ r&gt; f&gt; and cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1514,7 +1514,7 @@ totalIncome additionalIncome 20  100.0 f/ over f* swap &gt;r &gt;r &gt;r i j f- 
 <action_number>45</action_number>
 <action_comment>set eligible = totalIncome is plus or minus 300 of additionalIncome</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 additionalIncome 300  totalIncome &gt;r &gt;r &gt;r i j f- k f&lt; r&gt; r&gt; f+ r&gt; f&gt; and cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1522,7 +1522,7 @@ additionalIncome 300  totalIncome &gt;r &gt;r &gt;r i j f- k f&lt; r&gt; r&gt; f
 <action_number>46</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = IncomeGroupCount is equal to totalGroupIncome</action_description>
+<action_dsl>set eligible = IncomeGroupCount is equal to totalGroupIncome</action_dsl>
 <action_postfix>
 IncomeGroupCount totalGroupIncome == cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1530,7 +1530,7 @@ IncomeGroupCount totalGroupIncome == cvb /eligible xdef
 <action_number>47</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = totalIncome equal to totalGroupIncome</action_description>
+<action_dsl>set eligible = totalIncome equal to totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome f== cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1538,7 +1538,7 @@ totalIncome totalGroupIncome f== cvb /eligible xdef
 <action_number>48</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = IncomeGroupCount is not equal to totalGroupIncome</action_description>
+<action_dsl>set eligible = IncomeGroupCount is not equal to totalGroupIncome</action_dsl>
 <action_postfix>
 IncomeGroupCount totalGroupIncome == not cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1546,7 +1546,7 @@ IncomeGroupCount totalGroupIncome == not cvb /eligible xdef
 <action_number>49</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = totalIncome not equal to totalGroupIncome</action_description>
+<action_dsl>set eligible = totalIncome not equal to totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome f== not cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1554,7 +1554,7 @@ totalIncome totalGroupIncome f== not cvb /eligible xdef
 <action_number>50</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = IncomeGroupCount is greater than totalGroupIncome</action_description>
+<action_dsl>set eligible = IncomeGroupCount is greater than totalGroupIncome</action_dsl>
 <action_postfix>
 IncomeGroupCount totalGroupIncome &gt; cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1562,7 +1562,7 @@ IncomeGroupCount totalGroupIncome &gt; cvb /eligible xdef
 <action_number>51</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = totalIncome greater than totalGroupIncome</action_description>
+<action_dsl>set eligible = totalIncome greater than totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome f&gt; cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1570,7 +1570,7 @@ totalIncome totalGroupIncome f&gt; cvb /eligible xdef
 <action_number>52</action_number>
 <action_comment>set eligible = IncomeGroupCount is greater than or equal to totalGroupIncome</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 IncomeGroupCount totalGroupIncome &gt;= cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1578,7 +1578,7 @@ IncomeGroupCount totalGroupIncome &gt;= cvb /eligible xdef
 <action_number>53</action_number>
 <action_comment>set eligible = totalIncome greater than or equal to totalGroupIncome</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 totalIncome totalGroupIncome f&gt;= cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1586,7 +1586,7 @@ totalIncome totalGroupIncome f&gt;= cvb /eligible xdef
 <action_number>54</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = IncomeGroupCount is less  than totalGroupIncome</action_description>
+<action_dsl>set eligible = IncomeGroupCount is less  than totalGroupIncome</action_dsl>
 <action_postfix>
 IncomeGroupCount totalGroupIncome &lt; cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1594,7 +1594,7 @@ IncomeGroupCount totalGroupIncome &lt; cvb /eligible xdef
 <action_number>55</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = totalIncome less than totalGroupIncome</action_description>
+<action_dsl>set eligible = totalIncome less than totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome f&lt; cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1602,7 +1602,7 @@ totalIncome totalGroupIncome f&lt; cvb /eligible xdef
 <action_number>56</action_number>
 <action_comment>set eligible = IncomeGroupCount is less  than or equal to totalGroupIncome</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 IncomeGroupCount totalGroupIncome &lt;= cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1610,7 +1610,7 @@ IncomeGroupCount totalGroupIncome &lt;= cvb /eligible xdef
 <action_number>57</action_number>
 <action_comment>set eligible = totalIncome less than or equal to totalGroupIncome</action_comment>
 <initial_action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 totalIncome totalGroupIncome f&lt;= cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1618,7 +1618,7 @@ totalIncome totalGroupIncome f&lt;= cvb /eligible xdef
 <action_number>58</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = $aName is equal to $anotherName</action_description>
+<action_dsl>set eligible = $aName is equal to $anotherName</action_dsl>
 <action_postfix>
 /aName /anotherName nameeq cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1626,7 +1626,7 @@ totalIncome totalGroupIncome f&lt;= cvb /eligible xdef
 <action_number>59</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = $aName equal to program</action_description>
+<action_dsl>set eligible = $aName equal to program</action_dsl>
 <action_postfix>
 /aName program streq cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1634,7 +1634,7 @@ totalIncome totalGroupIncome f&lt;= cvb /eligible xdef
 <action_number>60</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = $aName != $anotherName</action_description>
+<action_dsl>set eligible = $aName != $anotherName</action_dsl>
 <action_postfix>
 /aName /anotherName nameeq not cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1642,7 +1642,7 @@ totalIncome totalGroupIncome f&lt;= cvb /eligible xdef
 <action_number>61</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = $aName != program</action_description>
+<action_dsl>set eligible = $aName != program</action_dsl>
 <action_postfix>
 /aName program streq not cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1650,7 +1650,7 @@ totalIncome totalGroupIncome f&lt;= cvb /eligible xdef
 <action_number>62</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = program == programLevel</action_description>
+<action_dsl>set eligible = program == programLevel</action_dsl>
 <action_postfix>
 program programLevel streq cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1658,7 +1658,7 @@ program programLevel streq cvb /eligible xdef
 <action_number>63</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = program != programLevel</action_description>
+<action_dsl>set eligible = program != programLevel</action_dsl>
 <action_postfix>
 program programLevel streq not cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1666,7 +1666,7 @@ program programLevel streq not cvb /eligible xdef
 <action_number>64</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = $aName != $anotherName</action_description>
+<action_dsl>set eligible = $aName != $anotherName</action_dsl>
 <action_postfix>
 /aName /anotherName nameeq not cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1674,7 +1674,7 @@ program programLevel streq not cvb /eligible xdef
 <action_number>66</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = client_ID starts with programLevel</action_description>
+<action_dsl>set eligible = client_ID starts with programLevel</action_dsl>
 <action_postfix>
 client_ID programLevel 0 startswith cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1682,7 +1682,7 @@ client_ID programLevel 0 startswith cvb /eligible xdef
 <action_number>67</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = client_ID is one of clients</action_description>
+<action_dsl>set eligible = client_ID is one of clients</action_dsl>
 <action_postfix>
 clients client_ID memberof cvb /eligible xdef  
 </action_postfix></action_details>
@@ -1690,7 +1690,7 @@ clients client_ID memberof cvb /eligible xdef
 <action_number>68</action_number>
 <action_comment />
 <initial_action_requirement />
-<action_description>set eligible = client_ID is not one of clients</action_description>
+<action_dsl>set eligible = client_ID is not one of clients</action_dsl>
 <action_postfix>
 clients client_ID memberof not cvb /eligible xdef  
 </action_postfix></action_details></actions></decision_table>

--- a/sampleprojects/SyntaxTests/xml/syntaxexample_dt.xml
+++ b/sampleprojects/SyntaxTests/xml/syntaxexample_dt.xml
@@ -11,14 +11,14 @@
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment />
-<context_description>for all clients whose age == 18 and street == 'that'</context_description>
+<context_dsl>for all clients whose age == 18 and street == 'that'</context_dsl>
 <context_postfix>
 { dup age 18 == { pop street 'that' streq } over if
 if } clients forall pop 
@@ -30,137 +30,137 @@ if } clients forall pop
 You can instead have the two context statements:
     For each case in the job allowing cases to be removed 
     Add the case.address to the context of this table</context_comment>
-<context_description>// for each case and its address in the job.cases</context_description>
+<context_dsl>// for each case and its address in the job.cases</context_dsl>
 <context_postfix>execute </context_postfix></context_details>
 <context_details>
 <context_number />
 <context_comment />
-<context_description>For all cases in the job allowing cases to be removed</context_description>
+<context_dsl>For all cases in the job allowing cases to be removed</context_dsl>
 <context_postfix>
 dup job  entitypush cases forallr entitypop pop 
 </context_postfix></context_details>
 <context_details>
 <context_number />
 <context_comment />
-<context_description>Add the case.address to the context of this table</context_description>
+<context_dsl>Add the case.address to the context of this table</context_dsl>
 <context_postfix>
 case.address entitypush execute entitypop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment>no longer supported</context_comment>
-<context_description>// for each case and its address in the job.cases allowing cases to be removed</context_description>
+<context_dsl>// for each case and its address in the job.cases allowing cases to be removed</context_dsl>
 <context_postfix>execute </context_postfix></context_details>
 <context_details>
 <context_number>5</context_number>
 <context_comment>no longer supported</context_comment>
-<context_description>// for each case and its address in the job.cases where 'Austin'==city</context_description>
+<context_dsl>// for each case and its address in the job.cases where 'Austin'==city</context_dsl>
 <context_postfix>execute </context_postfix></context_details>
 <context_details>
 <context_number>6</context_number>
 <context_comment>no longer supported</context_comment>
-<context_description>// For each case and its address in the job.cases where street == 'Opal' allowing job.Cases to be removed</context_description>
+<context_dsl>// For each case and its address in the job.cases where street == 'Opal' allowing job.Cases to be removed</context_dsl>
 <context_postfix>execute </context_postfix></context_details>
 <context_details>
 <context_number>7</context_number>
 <context_comment>no longer supported</context_comment>
-<context_description>// For each case and its address in the job.cases where street == 'Opal' allowing job.Cases to be removed</context_description>
+<context_dsl>// For each case and its address in the job.cases where street == 'Opal' allowing job.Cases to be removed</context_dsl>
 <context_postfix>execute </context_postfix></context_details>
 <context_details>
 <context_number>8</context_number>
 <context_comment />
-<context_description>local entity FirstClient</context_description>
+<context_dsl>local entity FirstClient</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>9</context_number>
 <context_comment />
-<context_description>local entity FirstClient2 = the client</context_description>
+<context_dsl>local entity FirstClient2 = the client</context_dsl>
 <context_postfix>
 client cve allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>10</context_number>
 <context_comment />
-<context_description>local long Anumber</context_description>
+<context_dsl>local long Anumber</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>11</context_number>
 <context_comment />
-<context_description>local long Anumber2 = 1234</context_description>
+<context_dsl>local long Anumber2 = 1234</context_dsl>
 <context_postfix>
 1234  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>12</context_number>
 <context_comment />
-<context_description>local double DoubleNumber</context_description>
+<context_dsl>local double DoubleNumber</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>13</context_number>
 <context_comment />
-<context_description>local double DoubleNumber2 = 1.234</context_description>
+<context_dsl>local double DoubleNumber2 = 1.234</context_dsl>
 <context_postfix>
 1.234  cvr allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>14</context_number>
 <context_comment />
-<context_description>local boolean Test</context_description>
+<context_dsl>local boolean Test</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>15</context_number>
 <context_comment />
-<context_description>local boolean Test2 = true</context_description>
+<context_dsl>local boolean Test2 = true</context_dsl>
 <context_postfix>
 true cvb allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>16</context_number>
 <context_comment />
-<context_description>local date Today</context_description>
+<context_dsl>local date Today</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>17</context_number>
 <context_comment />
-<context_description>local date Today2 = currentdate</context_description>
+<context_dsl>local date Today2 = currentdate</context_dsl>
 <context_postfix>
 currentdate cvd allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>18</context_number>
 <context_comment />
-<context_description>local array List</context_description>
+<context_dsl>local array List</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>19</context_number>
 <context_comment />
-<context_description>local array List2 = clients</context_description>
+<context_dsl>local array List2 = clients</context_dsl>
 <context_postfix>
 clients allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>20</context_number>
 <context_comment />
-<context_description>local string Things</context_description>
+<context_dsl>local string Things</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>21</context_number>
 <context_comment />
-<context_description>local string Things2 = 'This is a string'</context_description>
+<context_dsl>local string Things2 = 'This is a string'</context_dsl>
 <context_postfix>
 'This is a string' cvs allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -170,7 +170,7 @@ null allocate execute deallocate pop
 <condition_number>1</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Perform when called</condition_description>
+<condition_dsl>Perform when called</condition_dsl>
 <condition_postfix>
 Perform when called 
 </condition_postfix>
@@ -180,11 +180,11 @@ Perform when called
 <action_number>1</action_number>
 <action_comment>OK</action_comment>
 <action_requirement />
-<action_description>if (Today2 == currentdate) then 
+<action_dsl>if (Today2 == currentdate) then 
      set test = false ;
 else 
      set test = true ;
- endif</action_description>
+ endif</action_dsl>
 <action_postfix>
 { false cvb 6 local!  } { true cvb 6 local!  } 9 local@  currentdate d== ifelse 
 </action_postfix>
@@ -193,7 +193,7 @@ else
 <action_number>2</action_number>
 <action_comment>for all clients set eligible = true</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { true cvb /eligible xdef  } clients forallr 
 </action_postfix>
@@ -202,7 +202,7 @@ else
 <action_number>3</action_number>
 <action_comment>for each case in job.cases set eligible=true</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { true cvb /eligible xdef  } job.cases  forallr 
 </action_postfix>
@@ -211,7 +211,7 @@ else
 <action_number>4</action_number>
 <action_comment>for each case in job.cases where city=='spokane' set eligible=true</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { { true cvb /eligible xdef   } city 'spokane' streq if } job.cases forallr 
 </action_postfix>
@@ -220,7 +220,7 @@ else
 <action_number>5</action_number>
 <action_comment>for all clients where age &lt; 18 set eligible=false</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { { false cvb /eligible xdef   } age 18 &lt; if } clients forallr 
 </action_postfix>
@@ -229,7 +229,7 @@ else
 <action_number>6</action_number>
 <action_comment>for each case and its address in job.cases set applying = true</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { address entitypush true cvb /applying xdef   entitypop } job.cases  forallr 
 </action_postfix>
@@ -238,7 +238,7 @@ else
 <action_number>7</action_number>
 <action_comment>for each case and its address in job.cases where validatedCitizenship == false set eligible = false</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { address entitypush { false cvb /eligible xdef   } validatedCitizenship false beq if entitypop } job.cases forallr 
 </action_postfix>
@@ -255,7 +255,7 @@ else
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for the first of the job.cases where validatedCitizenship == true</context_description>
+<context_dsl>for the first of the job.cases where validatedCitizenship == true</context_dsl>
 <context_postfix>
 dup { validatedCitizenship true beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
@@ -263,21 +263,21 @@ dup { validatedCitizenship true beq  } job.cases  forfirst pop
 <context_number>2</context_number>
 <context_comment>for first of job.cases and it's case where    
       City == 'New York'</context_comment>
-<context_description>for the first of the job.cases and its address where city == 'New York'</context_description>
+<context_dsl>for the first of the job.cases and its address where city == 'New York'</context_dsl>
 <context_postfix>
 { address  entitypush dup execute entitypop } { address  entitypush city 'New York' streq  entitypop } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment />
-<context_description>for the first in the job.cases where validatedCitizenship == false</context_description>
+<context_dsl>for the first in the job.cases where validatedCitizenship == false</context_dsl>
 <context_postfix>
 dup { validatedCitizenship false beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment />
-<context_description>local entity theClient</context_description>
+<context_dsl>local entity theClient</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -286,7 +286,7 @@ null allocate execute deallocate pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>for first of job.cases where age &lt; 18 then { set eligible = true } else if none are found { set eligible = false } endff</initial_action_description>
+<initial_action_dsl>for first of job.cases where age &lt; 18 then { set eligible = true } else if none are found { set eligible = false } endff</initial_action_dsl>
 <initial_action_postfix>
 { true cvb /eligible xdef  
  } { false cvb /eligible xdef  
@@ -296,7 +296,7 @@ null allocate execute deallocate pop
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>for first of job.cases and its case where city == 'New York' then { set eligible = false } else if none are found { set eligible = true } endff</initial_action_description>
+<initial_action_dsl>for first of job.cases and its case where city == 'New York' then { set eligible = false } else if none are found { set eligible = true } endff</initial_action_dsl>
 <initial_action_postfix>
 { case  entitypush false cvb /eligible xdef  
 entitypop } { true cvb /eligible xdef  
@@ -306,7 +306,7 @@ entitypop } { true cvb /eligible xdef
 <intial_action_number>3</intial_action_number>
 <initial_action_comment>okay, fixed syntax.  Added endff to syntax</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>for first of job.cases where validatedCitizenship == true then { set eligible = true }  endff</initial_action_description>
+<initial_action_dsl>for first of job.cases where validatedCitizenship == true then { set eligible = true }  endff</initial_action_dsl>
 <initial_action_postfix>
 { true cvb /eligible xdef  
 } { validatedCitizenship true beq  } job.cases  forfirst 
@@ -315,7 +315,7 @@ entitypop } { true cvb /eligible xdef
 <intial_action_number>4</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>{ for all clients where age &gt; 18 set eligible = true }</initial_action_description>
+<initial_action_dsl>{ for all clients where age &gt; 18 set eligible = true }</initial_action_dsl>
 <initial_action_postfix>
 { { true cvb /eligible xdef   } age 18 &gt; if } clients forallr 
 
@@ -324,7 +324,7 @@ entitypop } { true cvb /eligible xdef
 <intial_action_number>5</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalgroupincome = 30400</initial_action_description>
+<initial_action_dsl>set totalgroupincome = 30400</initial_action_dsl>
 <initial_action_postfix>
 30400  cvi /totalgroupincome xdef  
 </initial_action_postfix></initial_action_details>
@@ -332,7 +332,7 @@ entitypop } { true cvb /eligible xdef
 <intial_action_number>6</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalincome = 1500.55</initial_action_description>
+<initial_action_dsl>set totalincome = 1500.55</initial_action_dsl>
 <initial_action_postfix>
 1500.55  cvr /totalincome xdef  
 </initial_action_postfix></initial_action_details>
@@ -340,7 +340,7 @@ entitypop } { true cvb /eligible xdef
 <intial_action_number>7</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set pregnant = false</initial_action_description>
+<initial_action_dsl>set pregnant = false</initial_action_dsl>
 <initial_action_postfix>
 false cvb /pregnant xdef  
 </initial_action_postfix></initial_action_details>
@@ -348,7 +348,7 @@ false cvb /pregnant xdef
 <intial_action_number>8</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set address = mailingAddress</initial_action_description>
+<initial_action_dsl>set address = mailingAddress</initial_action_dsl>
 <initial_action_postfix>
 mailingAddress cve /address xdef  
 </initial_action_postfix></initial_action_details>
@@ -356,7 +356,7 @@ mailingAddress cve /address xdef
 <intial_action_number>9</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set state = 'Wyoming'</initial_action_description>
+<initial_action_dsl>set state = 'Wyoming'</initial_action_dsl>
 <initial_action_postfix>
 'Wyoming' cvs /state xdef  
 </initial_action_postfix></initial_action_details>
@@ -364,7 +364,7 @@ mailingAddress cve /address xdef
 <intial_action_number>10</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set currentdate = effectivedate</initial_action_description>
+<initial_action_dsl>set currentdate = effectivedate</initial_action_dsl>
 <initial_action_postfix>
 effectivedate cvd /currentdate xdef  
 </initial_action_postfix></initial_action_details>
@@ -372,7 +372,7 @@ effectivedate cvd /currentdate xdef
 <intial_action_number>11</intial_action_number>
 <initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set translationTable = anotherTable</initial_action_description>
+<initial_action_dsl>set translationTable = anotherTable</initial_action_dsl>
 <initial_action_postfix>
 anotherTable /translationTable xdef  
 </initial_action_postfix></initial_action_details>
@@ -380,7 +380,7 @@ anotherTable /translationTable xdef
 <intial_action_number>12</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalgroupincome = 29400</initial_action_description>
+<initial_action_dsl>set totalgroupincome = 29400</initial_action_dsl>
 <initial_action_postfix>
 29400  cvi /totalgroupincome xdef  
 </initial_action_postfix></initial_action_details>
@@ -388,7 +388,7 @@ anotherTable /translationTable xdef
 <intial_action_number>13</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalincome = 20302.95</initial_action_description>
+<initial_action_dsl>set totalincome = 20302.95</initial_action_dsl>
 <initial_action_postfix>
 20302.95  cvr /totalincome xdef  
 </initial_action_postfix></initial_action_details>
@@ -396,7 +396,7 @@ anotherTable /translationTable xdef
 <intial_action_number>14</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set pregnant = true</initial_action_description>
+<initial_action_dsl>set pregnant = true</initial_action_dsl>
 <initial_action_postfix>
 true cvb /pregnant xdef  
 </initial_action_postfix></initial_action_details>
@@ -404,7 +404,7 @@ true cvb /pregnant xdef
 <intial_action_number>15</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set address = billingAddress</initial_action_description>
+<initial_action_dsl>set address = billingAddress</initial_action_dsl>
 <initial_action_postfix>
 billingAddress cve /address xdef  
 </initial_action_postfix></initial_action_details>
@@ -412,7 +412,7 @@ billingAddress cve /address xdef
 <intial_action_number>16</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set gender = 'male'</initial_action_description>
+<initial_action_dsl>set gender = 'male'</initial_action_dsl>
 <initial_action_postfix>
 'male' cvs /gender xdef  
 </initial_action_postfix></initial_action_details>
@@ -420,7 +420,7 @@ billingAddress cve /address xdef
 <intial_action_number>17</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = 12345</initial_action_description>
+<initial_action_dsl>set street = 12345</initial_action_dsl>
 <initial_action_postfix>
 12345  cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -428,7 +428,7 @@ billingAddress cve /address xdef
 <intial_action_number>18</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set birthday = dateofBirth</initial_action_description>
+<initial_action_dsl>set birthday = dateofBirth</initial_action_dsl>
 <initial_action_postfix>
 dateofBirth cvs /birthday xdef  
 </initial_action_postfix></initial_action_details>
@@ -436,7 +436,7 @@ dateofBirth cvs /birthday xdef
 <intial_action_number>19</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set zip = $unknown</initial_action_description>
+<initial_action_dsl>set zip = $unknown</initial_action_dsl>
 <initial_action_postfix>
 /unknown cvs /zip xdef  
 </initial_action_postfix></initial_action_details>
@@ -444,7 +444,7 @@ dateofBirth cvs /birthday xdef
 <intial_action_number>21</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set pregnant = $unknown</initial_action_description>
+<initial_action_dsl>set pregnant = $unknown</initial_action_dsl>
 <initial_action_postfix>
 /unknown cvb /pregnant xdef  
 </initial_action_postfix></initial_action_details>
@@ -452,7 +452,7 @@ dateofBirth cvs /birthday xdef
 <intial_action_number>22</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectivedate = currentdate</initial_action_description>
+<initial_action_dsl>set effectivedate = currentdate</initial_action_dsl>
 <initial_action_postfix>
 currentdate cvd /effectivedate xdef  
 </initial_action_postfix></initial_action_details>
@@ -460,7 +460,7 @@ currentdate cvd /effectivedate xdef
 <intial_action_number>24</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set interestingCases = cases</initial_action_description>
+<initial_action_dsl>set interestingCases = cases</initial_action_dsl>
 <initial_action_postfix>
 cases /interestingCases xdef 
 </initial_action_postfix></initial_action_details>
@@ -468,7 +468,7 @@ cases /interestingCases xdef
 <intial_action_number />
 <initial_action_comment>Missing scanner for decrement</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>decrement totalincome</initial_action_description>
+<initial_action_dsl>decrement totalincome</initial_action_dsl>
 <initial_action_postfix>
 totalincome 1 dsub /totalincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -476,7 +476,7 @@ totalincome 1 dsub /totalincome xdef
 <intial_action_number>25</intial_action_number>
 <initial_action_comment>Missing scanner for increment</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>increment totalincome</initial_action_description>
+<initial_action_dsl>increment totalincome</initial_action_dsl>
 <initial_action_postfix>
 totalincome 1 dadd /totalincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -484,7 +484,7 @@ totalincome 1 dadd /totalincome xdef
 <intial_action_number>26</intial_action_number>
 <initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>perform Syntax_Examples and on error add the ErrorDetails to the context and perform Error_handling_table</initial_action_description>
+<initial_action_dsl>perform Syntax_Examples and on error add the ErrorDetails to the context and perform Error_handling_table</initial_action_dsl>
 <initial_action_postfix>
 /Syntax_Examples lookup /Error_handling_table lookup ErrorDetails  PerformCatchError 
 </initial_action_postfix></initial_action_details>
@@ -492,7 +492,7 @@ totalincome 1 dadd /totalincome xdef
 <intial_action_number>27</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>perform syntax_examples_2</initial_action_description>
+<initial_action_dsl>perform syntax_examples_2</initial_action_dsl>
 <initial_action_postfix>
 syntax_examples_2 
 </initial_action_postfix></initial_action_details>
@@ -500,7 +500,7 @@ syntax_examples_2
 <intial_action_number>28</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>perform $something</initial_action_description>
+<initial_action_dsl>perform $something</initial_action_dsl>
 <initial_action_postfix>
 something 
 </initial_action_postfix></initial_action_details>
@@ -508,7 +508,7 @@ something
 <intial_action_number>29</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add cases to clients</initial_action_description>
+<initial_action_dsl>add cases to clients</initial_action_dsl>
 <initial_action_postfix>
 cases clients true  addarray 
 </initial_action_postfix></initial_action_details>
@@ -516,7 +516,7 @@ cases clients true  addarray
 <intial_action_number>30</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add client to interestingCases</initial_action_description>
+<initial_action_dsl>add client to interestingCases</initial_action_dsl>
 <initial_action_postfix>
 client interestingCases swap addto 
 </initial_action_postfix></initial_action_details>
@@ -524,7 +524,7 @@ client interestingCases swap addto
 <intial_action_number>31</intial_action_number>
 <initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>add client to InterestingCases and to resolvedCases</initial_action_description>
+<initial_action_dsl>add client to InterestingCases and to resolvedCases</initial_action_dsl>
 <initial_action_postfix>
 client dup InterestingCases swap addto resolvedCases swap addto 
 </initial_action_postfix></initial_action_details>
@@ -532,7 +532,7 @@ client dup InterestingCases swap addto resolvedCases swap addto
 <intial_action_number>32</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add case_ID to interestingCases</initial_action_description>
+<initial_action_dsl>add case_ID to interestingCases</initial_action_dsl>
 <initial_action_postfix>
 case_ID interestingCases swap addto 
 </initial_action_postfix></initial_action_details>
@@ -540,7 +540,7 @@ case_ID interestingCases swap addto
 <intial_action_number>33</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add clients to cases</initial_action_description>
+<initial_action_dsl>add clients to cases</initial_action_dsl>
 <initial_action_postfix>
 clients cases true  addarray 
 </initial_action_postfix></initial_action_details>
@@ -548,7 +548,7 @@ clients cases true  addarray
 <intial_action_number>34</intial_action_number>
 <initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>add case_ID to listOfIDs and to secondListOfIDs</initial_action_description>
+<initial_action_dsl>add case_ID to listOfIDs and to secondListOfIDs</initial_action_dsl>
 <initial_action_postfix>
 case_ID dup listOfIDs swap addto secondListOfIDs swap addto 
 </initial_action_postfix></initial_action_details>
@@ -556,7 +556,7 @@ case_ID dup listOfIDs swap addto secondListOfIDs swap addto
 <intial_action_number>35</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add effectiveDate to interestingDates</initial_action_description>
+<initial_action_dsl>add effectiveDate to interestingDates</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate interestingDates swap addto 
 </initial_action_postfix></initial_action_details>
@@ -564,7 +564,7 @@ effectiveDate interestingDates swap addto
 <intial_action_number>36</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>Add 42 to totalincome</initial_action_description>
+<initial_action_dsl>Add 42 to totalincome</initial_action_dsl>
 <initial_action_postfix>
 42  totalincome f+ /totalincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -572,7 +572,7 @@ effectiveDate interestingDates swap addto
 <intial_action_number>37</intial_action_number>
 <initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>Add 42 to totalincome and to totalgroupincome</initial_action_description>
+<initial_action_dsl>Add 42 to totalincome and to totalgroupincome</initial_action_dsl>
 <initial_action_postfix>
 42  dup totalincome f+ /totalincome xdef totalgroupincome + /totalgroupincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -580,7 +580,7 @@ effectiveDate interestingDates swap addto
 <intial_action_number>38</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>Subtract 42 from totalincome</initial_action_description>
+<initial_action_dsl>Subtract 42 from totalincome</initial_action_dsl>
 <initial_action_postfix>
 42  totalincome swap f- /totalincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -588,7 +588,7 @@ effectiveDate interestingDates swap addto
 <intial_action_number>39</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add 42 to totalincome</initial_action_description>
+<initial_action_dsl>add 42 to totalincome</initial_action_dsl>
 <initial_action_postfix>
 42  totalincome f+ /totalincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -596,7 +596,7 @@ effectiveDate interestingDates swap addto
 <intial_action_number>40</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add mailingaddress if not member to locations</initial_action_description>
+<initial_action_dsl>add mailingaddress if not member to locations</initial_action_dsl>
 <initial_action_postfix>
 locations  mailingaddress add_no_dups 
 </initial_action_postfix></initial_action_details>
@@ -604,7 +604,7 @@ locations  mailingaddress add_no_dups
 <intial_action_number>41</intial_action_number>
 <initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>add mailingaddress if not member to locations and to homeAddresses</initial_action_description>
+<initial_action_dsl>add mailingaddress if not member to locations and to homeAddresses</initial_action_dsl>
 <initial_action_postfix>
 mailingaddress locations over add_no_dups homeAddresses swap add_no_dups 
 </initial_action_postfix></initial_action_details>
@@ -612,7 +612,7 @@ mailingaddress locations over add_no_dups homeAddresses swap add_no_dups
 <intial_action_number>42</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add client_ID if not member to cases</initial_action_description>
+<initial_action_dsl>add client_ID if not member to cases</initial_action_dsl>
 <initial_action_postfix>
 cases  client_ID add_no_dups 
 </initial_action_postfix></initial_action_details>
@@ -620,7 +620,7 @@ cases  client_ID add_no_dups
 <intial_action_number>43</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add client to context of this table</initial_action_description>
+<initial_action_dsl>add client to context of this table</initial_action_dsl>
 <initial_action_postfix>
 client entitypush 
 </initial_action_postfix></initial_action_details>
@@ -628,7 +628,7 @@ client entitypush
 <intial_action_number>44</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add client to context for this table</initial_action_description>
+<initial_action_dsl>add client to context for this table</initial_action_dsl>
 <initial_action_postfix>
 client entitypush 
 </initial_action_postfix></initial_action_details>
@@ -636,7 +636,7 @@ client entitypush
 <intial_action_number>45</intial_action_number>
 <initial_action_comment>Missing scanner for element</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>remove totalgroupincome element from incomes array</initial_action_description>
+<initial_action_dsl>remove totalgroupincome element from incomes array</initial_action_dsl>
 <initial_action_postfix>
 incomes totalgroupincome removeat pop 
 </initial_action_postfix></initial_action_details>
@@ -644,7 +644,7 @@ incomes totalgroupincome removeat pop
 <intial_action_number>46</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>remove each client from clients where age &lt; 18</initial_action_description>
+<initial_action_dsl>remove each client from clients where age &lt; 18</initial_action_dsl>
 <initial_action_postfix>
 clients { { dup 0 entityfetch remove pop } age 18 &lt; if } over forallr pop
 </initial_action_postfix></initial_action_details>
@@ -652,7 +652,7 @@ clients { { dup 0 entityfetch remove pop } age 18 &lt; if } over forallr pop
 <intial_action_number>47</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>remove $steve from clients array</initial_action_description>
+<initial_action_dsl>remove $steve from clients array</initial_action_dsl>
 <initial_action_postfix>
 clients /steve remove pop 
 </initial_action_postfix></initial_action_details>
@@ -660,7 +660,7 @@ clients /steve remove pop
 <intial_action_number>48</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>remove $steve from clients array</initial_action_description>
+<initial_action_dsl>remove $steve from clients array</initial_action_dsl>
 <initial_action_postfix>
 clients /steve remove pop 
 </initial_action_postfix></initial_action_details>
@@ -668,7 +668,7 @@ clients /steve remove pop
 <intial_action_number>49</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>remove importantDates from InterestingDates array</initial_action_description>
+<initial_action_dsl>remove importantDates from InterestingDates array</initial_action_dsl>
 <initial_action_postfix>
 InterestingDates importantDates remove pop 
 </initial_action_postfix></initial_action_details>
@@ -676,7 +676,7 @@ InterestingDates importantDates remove pop
 <intial_action_number>50</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>remove client from clients array</initial_action_description>
+<initial_action_dsl>remove client from clients array</initial_action_dsl>
 <initial_action_postfix>
 clients client remove pop 
 </initial_action_postfix></initial_action_details>
@@ -684,7 +684,7 @@ clients client remove pop
 <intial_action_number>51</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>randomize clients</initial_action_description>
+<initial_action_dsl>randomize clients</initial_action_dsl>
 <initial_action_postfix>
 clients randomize 
 </initial_action_postfix></initial_action_details>
@@ -692,7 +692,7 @@ clients randomize
 <intial_action_number>52</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>clear clients</initial_action_description>
+<initial_action_dsl>clear clients</initial_action_dsl>
 <initial_action_postfix>
 clients clear 
 </initial_action_postfix></initial_action_details>
@@ -700,7 +700,7 @@ clients clear
 <intial_action_number>53</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>sort clients in ascending order by $steve</initial_action_description>
+<initial_action_dsl>sort clients in ascending order by $steve</initial_action_dsl>
 <initial_action_postfix>
 clients /steve true sortentities 
 </initial_action_postfix></initial_action_details>
@@ -708,7 +708,7 @@ clients /steve true sortentities
 <intial_action_number>54</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>sort clients in descending order by $steve</initial_action_description>
+<initial_action_dsl>sort clients in descending order by $steve</initial_action_dsl>
 <initial_action_postfix>
 clients /steve false sortentities 
 </initial_action_postfix></initial_action_details>
@@ -716,7 +716,7 @@ clients /steve false sortentities
 <intial_action_number>56</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>Set InterestingClients = job's clients</initial_action_description>
+<initial_action_dsl>Set InterestingClients = job's clients</initial_action_dsl>
 <initial_action_postfix>
 job entitypush clients entitypop /InterestingClients xdef 
 </initial_action_postfix></initial_action_details>
@@ -724,7 +724,7 @@ job entitypush clients entitypop /InterestingClients xdef
 <intial_action_number>57</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set cases = get copy of interestingCases</initial_action_description>
+<initial_action_dsl>set cases = get copy of interestingCases</initial_action_dsl>
 <initial_action_postfix>
 interestingCases copyelements /cases xdef 
 </initial_action_postfix></initial_action_details>
@@ -732,7 +732,7 @@ interestingCases copyelements /cases xdef
 <intial_action_number>58</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set interestingClients = copy of clients</initial_action_description>
+<initial_action_dsl>set interestingClients = copy of clients</initial_action_dsl>
 <initial_action_postfix>
 clients copyelements /interestingClients xdef 
 </initial_action_postfix></initial_action_details>
@@ -740,7 +740,7 @@ clients copyelements /interestingClients xdef
 <intial_action_number>59</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set cases = get deep copy of interestingCases</initial_action_description>
+<initial_action_dsl>set cases = get deep copy of interestingCases</initial_action_dsl>
 <initial_action_postfix>
 interestingCases deepcopy /cases xdef 
 </initial_action_postfix></initial_action_details>
@@ -748,7 +748,7 @@ interestingCases deepcopy /cases xdef
 <intial_action_number>60</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set interestingClients = deep copy of clients</initial_action_description>
+<initial_action_dsl>set interestingClients = deep copy of clients</initial_action_dsl>
 <initial_action_postfix>
 clients deepcopy /interestingClients xdef 
 </initial_action_postfix></initial_action_details>
@@ -756,7 +756,7 @@ clients deepcopy /interestingClients xdef
 <intial_action_number>61</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set errorCodes = [ 1 , 2, 3, 4 ]</initial_action_description>
+<initial_action_dsl>set errorCodes = [ 1 , 2, 3, 4 ]</initial_action_dsl>
 <initial_action_postfix>
 { 1 2 3 4 } /errorCodes xdef 
 </initial_action_postfix></initial_action_details>
@@ -764,7 +764,7 @@ clients deepcopy /interestingClients xdef
 <intial_action_number>62</intial_action_number>
 <initial_action_comment>Missing scanner for "array of values"</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set errorCodes = array of values [ job, cases, "clients", 10, -0.5, $boy ]</initial_action_description>
+<initial_action_dsl>set errorCodes = array of values [ job, cases, "clients", 10, -0.5, $boy ]</initial_action_dsl>
 <initial_action_postfix>
 mark job cases "clients" 10 0.5 fnegate /boy  arraytomark /errorCodes xdef 
 </initial_action_postfix></initial_action_details>
@@ -772,7 +772,7 @@ mark job cases "clients" 10 0.5 fnegate /boy  arraytomark /errorCodes xdef
 <intial_action_number>63</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set errorcodes = tokenize errorType by location</initial_action_description>
+<initial_action_dsl>set errorcodes = tokenize errorType by location</initial_action_dsl>
 <initial_action_postfix>
 errorType location tokenize /errorcodes xdef 
 </initial_action_postfix></initial_action_details>
@@ -780,7 +780,7 @@ errorType location tokenize /errorcodes xdef
 <intial_action_number>64</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set errorCodes = [ errorType, location, message ]</initial_action_description>
+<initial_action_dsl>set errorCodes = [ errorType, location, message ]</initial_action_dsl>
 <initial_action_postfix>
 { errorType location message } /errorCodes xdef 
 </initial_action_postfix></initial_action_details>
@@ -788,7 +788,7 @@ errorType location tokenize /errorcodes xdef
 <intial_action_number>65</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set errorCodes = [1.5, 2.75, 3.99]</initial_action_description>
+<initial_action_dsl>set errorCodes = [1.5, 2.75, 3.99]</initial_action_dsl>
 <initial_action_postfix>
 { 1.5 2.75 3.99 } /errorCodes xdef 
 </initial_action_postfix></initial_action_details>
@@ -796,7 +796,7 @@ errorType location tokenize /errorcodes xdef
 <intial_action_number>66</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set theClient = clients [ 0 ]</initial_action_description>
+<initial_action_dsl>set theClient = clients [ 0 ]</initial_action_dsl>
 <initial_action_postfix>
 clients 0 getat cve 0 local!  
 </initial_action_postfix></initial_action_details>
@@ -804,7 +804,7 @@ clients 0 getat cve 0 local!
 <intial_action_number>67</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set InterestingClients = job's clients</initial_action_description>
+<initial_action_dsl>set InterestingClients = job's clients</initial_action_dsl>
 <initial_action_postfix>
 job entitypush clients entitypop /InterestingClients xdef 
 </initial_action_postfix></initial_action_details>
@@ -812,7 +812,7 @@ job entitypush clients entitypop /InterestingClients xdef
 <intial_action_number>68</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = new $theClient entity</initial_action_description>
+<initial_action_dsl>set client = new $theClient entity</initial_action_dsl>
 <initial_action_postfix>
 /theClient  createentity cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -820,7 +820,7 @@ job entitypush clients entitypop /InterestingClients xdef
 <intial_action_number>69</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client  = new client entity</initial_action_description>
+<initial_action_dsl>set client  = new client entity</initial_action_dsl>
 <initial_action_postfix>
 /client createentity cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -828,7 +828,7 @@ job entitypush clients entitypop /InterestingClients xdef
 <intial_action_number>70</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = clone of newClient</initial_action_description>
+<initial_action_dsl>set client = clone of newClient</initial_action_dsl>
 <initial_action_postfix>
 newClient clone cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -836,7 +836,7 @@ newClient clone cve /client xdef
 <intial_action_number>71</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = client's address</initial_action_description>
+<initial_action_dsl>set client = client's address</initial_action_dsl>
 <initial_action_postfix>
 client entitypush address entitypop cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -844,7 +844,7 @@ client entitypush address entitypop cve /client xdef
 <intial_action_number>72</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = first client in clients where age &lt; 18</initial_action_description>
+<initial_action_dsl>set client = first client in clients where age &lt; 18</initial_action_dsl>
 <initial_action_postfix>
 { client } { null } { age 18 &lt; } clients forfirstelse cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -852,7 +852,7 @@ client entitypush address entitypop cve /client xdef
 <intial_action_number>73</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = first client where pregnant == true</initial_action_description>
+<initial_action_dsl>set client = first client where pregnant == true</initial_action_dsl>
 <initial_action_postfix>
 { client } { null } { pregnant true beq } clients forfirstelse cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -860,7 +860,7 @@ client entitypush address entitypop cve /client xdef
 <intial_action_number>74</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = gender of client</initial_action_description>
+<initial_action_dsl>set client = gender of client</initial_action_dsl>
 <initial_action_postfix>
 { source } { null } { gender type == } forfirstelse cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -868,7 +868,7 @@ client entitypush address entitypop cve /client xdef
 <intial_action_number>75</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>subtract 2 years from effectiveDate</initial_action_description>
+<initial_action_dsl>subtract 2 years from effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 2  negate addyears /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -876,7 +876,7 @@ effectiveDate 2  negate addyears /effectiveDate xdef
 <intial_action_number>76</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>subtract 10 months from effectiveDate</initial_action_description>
+<initial_action_dsl>subtract 10 months from effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 10  negate addmonths /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -884,7 +884,7 @@ effectiveDate 10  negate addmonths /effectiveDate xdef
 <intial_action_number>77</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>subtract 25 days from effectiveDate</initial_action_description>
+<initial_action_dsl>subtract 25 days from effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 25  negate adddays /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -892,7 +892,7 @@ effectiveDate 25  negate adddays /effectiveDate xdef
 <intial_action_number>78</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add 3 years to effectiveDate</initial_action_description>
+<initial_action_dsl>add 3 years to effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 3  addyears /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -900,7 +900,7 @@ effectiveDate 3  addyears /effectiveDate xdef
 <intial_action_number>79</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add 8 months to effectiveDate</initial_action_description>
+<initial_action_dsl>add 8 months to effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 8  addmonths /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -908,7 +908,7 @@ effectiveDate 8  addmonths /effectiveDate xdef
 <intial_action_number>80</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add 18 days to effectiveDate</initial_action_description>
+<initial_action_dsl>add 18 days to effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 18  adddays /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -916,7 +916,7 @@ effectiveDate 18  adddays /effectiveDate xdef
 <intial_action_number>81</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = (Date) birthday</initial_action_description>
+<initial_action_dsl>set effectiveDate = (Date) birthday</initial_action_dsl>
 <initial_action_postfix>
 birthday cvd cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -924,7 +924,7 @@ birthday cvd cvd /effectiveDate xdef
 <intial_action_number>82</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = date (birthday)</initial_action_description>
+<initial_action_dsl>set effectiveDate = date (birthday)</initial_action_dsl>
 <initial_action_postfix>
 birthday cvd cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -932,7 +932,7 @@ birthday cvd cvd /effectiveDate xdef
 <intial_action_number>83</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = (date) clients [2]</initial_action_description>
+<initial_action_dsl>set effectiveDate = (date) clients [2]</initial_action_dsl>
 <initial_action_postfix>
 clients 2 getat cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -940,7 +940,7 @@ clients 2 getat cvd /effectiveDate xdef
 <intial_action_number>84</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = using client (currentDate)</initial_action_description>
+<initial_action_dsl>set effectiveDate = using client (currentDate)</initial_action_dsl>
 <initial_action_postfix>
 client entitypush currentDate entitypop cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -948,7 +948,7 @@ client entitypush currentDate entitypop cvd /effectiveDate xdef
 <intial_action_number>85</intial_action_number>
 <initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = job's effectiveDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = job's effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 job entitypush effectiveDate entitypop cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -956,7 +956,7 @@ job entitypush effectiveDate entitypop cvd /effectiveDate xdef
 <intial_action_number>86</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = (20 days)</initial_action_description>
+<initial_action_dsl>set effectiveDate = (20 days)</initial_action_dsl>
 <initial_action_postfix>
 20  days cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -964,7 +964,7 @@ job entitypush effectiveDate entitypop cvd /effectiveDate xdef
 <intial_action_number>87</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate + effectiveDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate + effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate effectiveDate d+ cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -972,7 +972,7 @@ currentDate effectiveDate d+ cvd /effectiveDate xdef
 <intial_action_number>88</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate - effectiveDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate - effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate effectiveDate d- cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -980,7 +980,7 @@ currentDate effectiveDate d- cvd /effectiveDate xdef
 <intial_action_number>89</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = subtract 1 year from currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = subtract 1 year from currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  1  negate addyears cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -988,7 +988,7 @@ currentDate  1  negate addyears cvd /effectiveDate xdef
 <intial_action_number>90</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = subtract 9 months from currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = subtract 9 months from currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  9  negate addmonths cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -996,7 +996,7 @@ currentDate  9  negate addmonths cvd /effectiveDate xdef
 <intial_action_number>91</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = subtract 22 days from currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = subtract 22 days from currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  22  negate adddays cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -1004,7 +1004,7 @@ currentDate  22  negate adddays cvd /effectiveDate xdef
 <intial_action_number>92</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = add 2 years to currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = add 2 years to currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  2  addyears cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -1012,7 +1012,7 @@ currentDate  2  addyears cvd /effectiveDate xdef
 <intial_action_number>93</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = add 8 months to currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = add 8 months to currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  8  addmonths cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -1020,7 +1020,7 @@ currentDate  8  addmonths cvd /effectiveDate xdef
 <intial_action_number>94</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = add 14 days to currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = add 14 days to currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  14  adddays cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -1028,7 +1028,7 @@ currentDate  14  adddays cvd /effectiveDate xdef
 <intial_action_number>95</intial_action_number>
 <initial_action_comment>OK</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate - 1 year</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate - 1 year</initial_action_dsl>
 <initial_action_postfix>
 currentDate  1  negate addyears cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -1036,7 +1036,7 @@ currentDate  1  negate addyears cvd /effectiveDate xdef
 <intial_action_number>96</intial_action_number>
 <initial_action_comment>OK</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate - 6 months</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate - 6 months</initial_action_dsl>
 <initial_action_postfix>
 currentDate  6  negate addmonths cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -1044,7 +1044,7 @@ currentDate  6  negate addmonths cvd /effectiveDate xdef
 <intial_action_number>97</intial_action_number>
 <initial_action_comment>OK</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate - 20 days</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate - 20 days</initial_action_dsl>
 <initial_action_postfix>
 currentDate  20  negate adddays cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -1052,7 +1052,7 @@ currentDate  20  negate adddays cvd /effectiveDate xdef
 <intial_action_number>98</intial_action_number>
 <initial_action_comment>OK</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate + 1 year</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate + 1 year</initial_action_dsl>
 <initial_action_postfix>
 currentDate  1  addyears cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -1060,7 +1060,7 @@ currentDate  1  addyears cvd /effectiveDate xdef
 <intial_action_number>99</intial_action_number>
 <initial_action_comment>OK</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate  + 6 months</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate  + 6 months</initial_action_dsl>
 <initial_action_postfix>
 currentDate  6  addmonths cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -1068,7 +1068,7 @@ currentDate  6  addmonths cvd /effectiveDate xdef
 <intial_action_number>100</intial_action_number>
 <initial_action_comment>OK</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate + 20 days</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate + 20 days</initial_action_dsl>
 <initial_action_postfix>
 currentDate  20  adddays cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -1076,7 +1076,7 @@ currentDate  20  adddays cvd /effectiveDate xdef
 <intial_action_number>101</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set currentDate = first of year of effectiveDate</initial_action_description>
+<initial_action_dsl>set currentDate = first of year of effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate firstofyear cvd /currentDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -1084,7 +1084,7 @@ effectiveDate firstofyear cvd /currentDate xdef
 <intial_action_number>102</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set currentDate = first of month of effectiveDate</initial_action_description>
+<initial_action_dsl>set currentDate = first of month of effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate firstofmonth cvd /currentDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -1092,7 +1092,7 @@ effectiveDate firstofmonth cvd /currentDate xdef
 <intial_action_number>103</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set currentDate = end of month of effectiveDate</initial_action_description>
+<initial_action_dsl>set currentDate = end of month of effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate endofmonth cvd /currentDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -1100,7 +1100,7 @@ effectiveDate endofmonth cvd /currentDate xdef
 <intial_action_number>104</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = earliest of cases after currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = earliest of cases after currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate dup &gt;r { { pop pop i i } over i d&gt; if pop } cases dup false sortarray for r&gt; pop cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -1121,7 +1121,7 @@ currentDate dup &gt;r { { pop pop i i } over i d&gt; if pop } cases dup false so
 <condition_number>1</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called 
 </condition_postfix>
@@ -1131,7 +1131,7 @@ perform when called
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set street = attribute street of client</action_description>
+<action_dsl>set street = attribute street of client</action_dsl>
 <action_postfix>
 client street getXmlAttribute cvs /street xdef  
 </action_postfix>
@@ -1140,7 +1140,7 @@ client street getXmlAttribute cvs /street xdef
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set street = mapping key</action_description>
+<action_dsl>set street = mapping key</action_dsl>
 <action_postfix>
 "mapping*key" cvn execute cvs /street xdef  
 </action_postfix>
@@ -1149,7 +1149,7 @@ client street getXmlAttribute cvs /street xdef
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set street = attribute street of client</action_description>
+<action_dsl>set street = attribute street of client</action_dsl>
 <action_postfix>
 client street getXmlAttribute cvs /street xdef  
 </action_postfix>
@@ -1158,7 +1158,7 @@ client street getXmlAttribute cvs /street xdef
 <action_number>4</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set programLevel = substring of program from 0 to 10</action_description>
+<action_dsl>set programLevel = substring of program from 0 to 10</action_dsl>
 <action_postfix>
 10 0 program substring cvs /programLevel xdef  
 </action_postfix>
@@ -1167,7 +1167,7 @@ client street getXmlAttribute cvs /street xdef
 <action_number>5</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set street = table information</action_description>
+<action_dsl>set street = table information</action_dsl>
 <action_postfix>
 actionstring cvs /street xdef  
 </action_postfix>
@@ -1176,7 +1176,7 @@ actionstring cvs /street xdef
 <action_number>6</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set street = string</action_description>
+<action_dsl>set street = string</action_dsl>
 <action_postfix>
 string cvs /street xdef  
 </action_postfix>
@@ -1185,7 +1185,7 @@ string cvs /street xdef
 <action_number>7</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set parent = street + zip</action_description>
+<action_dsl>set parent = street + zip</action_dsl>
 <action_postfix>
 street zip strconcat cvs /parent xdef  
 </action_postfix>
@@ -1194,7 +1194,7 @@ street zip strconcat cvs /parent xdef
 <action_number>8</action_number>
 <action_comment>changed the syntax</action_comment>
 <action_requirement />
-<action_description>set strBuffer = string value of 300.12</action_description>
+<action_dsl>set strBuffer = string value of 300.12</action_dsl>
 <action_postfix>
 300.12 tostring cvs /strBuffer xdef  
 </action_postfix>
@@ -1203,7 +1203,7 @@ street zip strconcat cvs /parent xdef
 <action_number>9</action_number>
 <action_comment>changed the syntax</action_comment>
 <action_requirement />
-<action_description>set tips = string value of 45</action_description>
+<action_dsl>set tips = string value of 45</action_dsl>
 <action_postfix>
 45 tostring cvs /tips xdef  
 </action_postfix></action_details>
@@ -1211,8 +1211,8 @@ street zip strconcat cvs /parent xdef
 <action_number>10</action_number>
 <action_comment>changed the syntax</action_comment>
 <action_requirement />
-<action_description>set importantDates = 
-      String value of  effectiveDate</action_description>
+<action_dsl>set importantDates = 
+      String value of  effectiveDate</action_dsl>
 <action_postfix>
 effectiveDate tostring cvs /importantDates xdef  
 </action_postfix></action_details>
@@ -1220,7 +1220,7 @@ effectiveDate tostring cvs /importantDates xdef
 <action_number>11</action_number>
 <action_comment>changed the syntax</action_comment>
 <action_requirement />
-<action_description>set strBuffer = string value of boolean pregnant</action_description>
+<action_dsl>set strBuffer = string value of boolean pregnant</action_dsl>
 <action_postfix>
 pregnant tostring cvs /strBuffer xdef  
 </action_postfix>
@@ -1229,7 +1229,7 @@ pregnant tostring cvs /strBuffer xdef
 <action_number>12</action_number>
 <action_comment>set programLevel = (program)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 program cvs /programLevel xdef  
 </action_postfix>
@@ -1238,7 +1238,7 @@ program cvs /programLevel xdef
 <action_number>13</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set wages = wages  + 55</action_description>
+<action_dsl>set wages = wages  + 55</action_dsl>
 <action_postfix>
 wages 55 strconcat cvs /wages xdef  
 </action_postfix>
@@ -1247,7 +1247,7 @@ wages 55 strconcat cvs /wages xdef
 <action_number>14</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set tips = tips + 35.50</action_description>
+<action_dsl>set tips = tips + 35.50</action_dsl>
 <action_postfix>
 tips 35.50 strconcat cvs /tips xdef  
 </action_postfix>
@@ -1256,7 +1256,7 @@ tips 35.50 strconcat cvs /tips xdef
 <action_number>15</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set street = street + $Oak</action_description>
+<action_dsl>set street = street + $Oak</action_dsl>
 <action_postfix>
 street /Oak strconcat cvs /street xdef  
 </action_postfix>
@@ -1265,7 +1265,7 @@ street /Oak strconcat cvs /street xdef
 <action_number>16</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set parent = street + zip</action_description>
+<action_dsl>set parent = street + zip</action_dsl>
 <action_postfix>
 street zip strconcat cvs /parent xdef  
 </action_postfix>
@@ -1274,7 +1274,7 @@ street zip strconcat cvs /parent xdef
 <action_number>17</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set street = street + billingAddress</action_description>
+<action_dsl>set street = street + billingAddress</action_dsl>
 <action_postfix>
 street billingAddress strconcat cvs /street xdef  
 </action_postfix>
@@ -1283,7 +1283,7 @@ street billingAddress strconcat cvs /street xdef
 <action_number>18</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set importantDates = importantDates + currentDate</action_description>
+<action_dsl>set importantDates = importantDates + currentDate</action_dsl>
 <action_postfix>
 importantDates currentDate strconcat cvs /importantDates xdef  
 </action_postfix>
@@ -1292,7 +1292,7 @@ importantDates currentDate strconcat cvs /importantDates xdef
 <action_number>19</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set street = street + clients</action_description>
+<action_dsl>set street = street + clients</action_dsl>
 <action_postfix>
 street clients strconcat cvs /street xdef  
 </action_postfix>
@@ -1301,7 +1301,7 @@ street clients strconcat cvs /street xdef
 <action_number>20</action_number>
 <action_comment>Missing Trim; set street = trim (zip)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 zip strtrim cvs /street xdef  
 </action_postfix></action_details>
@@ -1309,7 +1309,7 @@ zip strtrim cvs /street xdef
 <action_number>22</action_number>
 <action_comment>okay... Statement was wrong</action_comment>
 <action_requirement />
-<action_description>set street = change street to lower case</action_description>
+<action_dsl>set street = change street to lower case</action_dsl>
 <action_postfix>
 street tolowercase cvs /street xdef  
 </action_postfix></action_details>
@@ -1317,7 +1317,7 @@ street tolowercase cvs /street xdef
 <action_number />
 <action_comment>USE VERY CAREFULLY.  Can break testing</action_comment>
 <action_requirement />
-<action_description>set effectiveDate = the current date</action_description>
+<action_dsl>set effectiveDate = the current date</action_dsl>
 <action_postfix>
 getdate cvd /effectiveDate xdef  
 </action_postfix></action_details>
@@ -1325,7 +1325,7 @@ getdate cvd /effectiveDate xdef
 <action_number>23</action_number>
 <action_comment>USE VERY CAREFULLY.  Can break testing</action_comment>
 <action_requirement />
-<action_description>set strBuffer = get current timestamp</action_description>
+<action_dsl>set strBuffer = get current timestamp</action_dsl>
 <action_postfix>
 getdate gettimestamp cvs /strBuffer xdef  
 </action_postfix></action_details>
@@ -1333,7 +1333,7 @@ getdate gettimestamp cvs /strBuffer xdef
 <action_number>24</action_number>
 <action_comment>set street = using client (street)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 client entitypush street entitypop cvs /street xdef  
 </action_postfix>
@@ -1342,7 +1342,7 @@ client entitypush street entitypop cvs /street xdef
 <action_number>26</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = 550.87</action_description>
+<action_dsl>set totalIncome = 550.87</action_dsl>
 <action_postfix>
 550.87  cvr /totalIncome xdef  
 </action_postfix>
@@ -1351,7 +1351,7 @@ client entitypush street entitypop cvs /street xdef
 <action_number>27</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = (double) wages</action_description>
+<action_dsl>set totalIncome = (double) wages</action_dsl>
 <action_postfix>
 wages cvr  cvr /totalIncome xdef  
 </action_postfix>
@@ -1360,7 +1360,7 @@ wages cvr  cvr /totalIncome xdef
 <action_number>28</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = (double) totalGroupIncome</action_description>
+<action_dsl>set totalIncome = (double) totalGroupIncome</action_dsl>
 <action_postfix>
 totalGroupIncome cvr  cvr /totalIncome xdef  
 </action_postfix>
@@ -1369,7 +1369,7 @@ totalGroupIncome cvr  cvr /totalIncome xdef
 <action_number>29</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = totalIncome + totalGroupIncome</action_description>
+<action_dsl>set totalIncome = totalIncome + totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome fadd  cvr /totalIncome xdef  
 </action_postfix>
@@ -1378,7 +1378,7 @@ totalIncome totalGroupIncome fadd  cvr /totalIncome xdef
 <action_number>30</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = totalGroupIncome + totalIncome</action_description>
+<action_dsl>set totalIncome = totalGroupIncome + totalIncome</action_dsl>
 <action_postfix>
 totalGroupIncome totalIncome fadd  cvr /totalIncome xdef  
 </action_postfix>
@@ -1387,7 +1387,7 @@ totalGroupIncome totalIncome fadd  cvr /totalIncome xdef
 <action_number>31</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = totalIncome - totalGroupIncome</action_description>
+<action_dsl>set totalIncome = totalIncome - totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome fsub  cvr /totalIncome xdef  
 </action_postfix>
@@ -1396,7 +1396,7 @@ totalIncome totalGroupIncome fsub  cvr /totalIncome xdef
 <action_number>32</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = totalIncome - additionalIncome</action_description>
+<action_dsl>set totalIncome = totalIncome - additionalIncome</action_dsl>
 <action_postfix>
 totalIncome additionalIncome fsub  cvr /totalIncome xdef  
 </action_postfix>
@@ -1405,7 +1405,7 @@ totalIncome additionalIncome fsub  cvr /totalIncome xdef
 <action_number>33</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = totalIncome * totalGroupIncome</action_description>
+<action_dsl>set totalIncome = totalIncome * totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome fmul  cvr /totalIncome xdef  
 </action_postfix>
@@ -1414,7 +1414,7 @@ totalIncome totalGroupIncome fmul  cvr /totalIncome xdef
 <action_number>34</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = totalIncome * additionalIncome</action_description>
+<action_dsl>set totalIncome = totalIncome * additionalIncome</action_dsl>
 <action_postfix>
 totalIncome additionalIncome fmul  cvr /totalIncome xdef  
 </action_postfix>
@@ -1423,7 +1423,7 @@ totalIncome additionalIncome fmul  cvr /totalIncome xdef
 <action_number>35</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = totalIncome / totalGroupIncome</action_description>
+<action_dsl>set totalIncome = totalIncome / totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome fdiv  cvr /totalIncome xdef  
 </action_postfix>
@@ -1432,7 +1432,7 @@ totalIncome totalGroupIncome fdiv  cvr /totalIncome xdef
 <action_number>36</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = totalIncome / additionalIncome</action_description>
+<action_dsl>set totalIncome = totalIncome / additionalIncome</action_dsl>
 <action_postfix>
 totalIncome additionalIncome fdiv  cvr /totalIncome xdef  
 </action_postfix>
@@ -1441,7 +1441,7 @@ totalIncome additionalIncome fdiv  cvr /totalIncome xdef
 <action_number>37</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = - additionalIncome</action_description>
+<action_dsl>set totalIncome = - additionalIncome</action_dsl>
 <action_postfix>
 additionalIncome fnegate  cvr /totalIncome xdef  
 </action_postfix>
@@ -1450,7 +1450,7 @@ additionalIncome fnegate  cvr /totalIncome xdef
 <action_number>38</action_number>
 <action_comment>set totalIncome = (additionalIncome)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 additionalIncome  cvr /totalIncome xdef  
 </action_postfix>
@@ -1459,7 +1459,7 @@ additionalIncome  cvr /totalIncome xdef
 <action_number>39</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = (double) clients [0]</action_description>
+<action_dsl>set totalIncome = (double) clients [0]</action_dsl>
 <action_postfix>
 clients 0 getat  cvr /totalIncome xdef  
 </action_postfix>
@@ -1468,7 +1468,7 @@ clients 0 getat  cvr /totalIncome xdef
 <action_number>40</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = add to totalIncome 75</action_description>
+<action_dsl>set totalIncome = add to totalIncome 75</action_dsl>
 <action_postfix>
 /75   totalIncome75   fadd def  cvr /totalIncome xdef  
 </action_postfix>
@@ -1477,7 +1477,7 @@ clients 0 getat  cvr /totalIncome xdef
 <action_number>41</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = subtract from totalIncome 99</action_description>
+<action_dsl>set totalIncome = subtract from totalIncome 99</action_dsl>
 <action_postfix>
 /99   totalIncome99   fsub def  cvr /totalIncome xdef  
 </action_postfix>
@@ -1486,7 +1486,7 @@ clients 0 getat  cvr /totalIncome xdef
 <action_number>42</action_number>
 <action_comment>Missing Multiply in the scanner</action_comment>
 <action_requirement />
-<action_description>set totalIncome = multiply totalIncome by 2</action_description>
+<action_dsl>set totalIncome = multiply totalIncome by 2</action_dsl>
 <action_postfix>
 /2   totalIncome2   fmul def  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1494,7 +1494,7 @@ clients 0 getat  cvr /totalIncome xdef
 <action_number>43</action_number>
 <action_comment>Missing Divide in the scanner</action_comment>
 <action_requirement />
-<action_description>set totalIncome = divide totalIncome by 2</action_description>
+<action_dsl>set totalIncome = divide totalIncome by 2</action_dsl>
 <action_postfix>
 /2   totalIncome2   fmul def  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1502,7 +1502,7 @@ clients 0 getat  cvr /totalIncome xdef
 <action_number>44</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalIncome = absolute value of totalIncome</action_description>
+<action_dsl>set totalIncome = absolute value of totalIncome</action_dsl>
 <action_postfix>
 totalIncome fabs  cvr /totalIncome xdef  
 </action_postfix>
@@ -1511,7 +1511,7 @@ totalIncome fabs  cvr /totalIncome xdef
 <action_number>45</action_number>
 <action_comment>set totalIncome = using clients (totalIncome)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 clients entitypush totalIncome  entitypop  cvr /totalIncome xdef  
 </action_postfix>
@@ -1520,7 +1520,7 @@ clients entitypush totalIncome  entitypop  cvr /totalIncome xdef
 <action_number>46</action_number>
 <action_comment>missing rounded in the scanner</action_comment>
 <action_requirement />
-<action_description>set totalIncome = totalIncome rounded</action_description>
+<action_dsl>set totalIncome = totalIncome rounded</action_dsl>
 <action_postfix>
 totalIncome 0 0.5 roundto  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1528,7 +1528,7 @@ totalIncome 0 0.5 roundto  cvr /totalIncome xdef
 <action_number>47</action_number>
 <action_comment>missing decimal places in the scanner</action_comment>
 <action_requirement />
-<action_description>set totalIncome = totalIncome rounded to 3 decimal places</action_description>
+<action_dsl>set totalIncome = totalIncome rounded to 3 decimal places</action_dsl>
 <action_postfix>
 totalIncome 3 0.5 roundto  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1536,7 +1536,7 @@ totalIncome 3 0.5 roundto  cvr /totalIncome xdef
 <action_number>48</action_number>
 <action_comment>missing with boundry in the scanner</action_comment>
 <action_requirement />
-<action_description>set totalIncome = totalIncome rounded to 2 decimal places with  boundry .4</action_description>
+<action_dsl>set totalIncome = totalIncome rounded to 2 decimal places with  boundry .4</action_dsl>
 <action_postfix>
 totalIncome 2 .4  roundto  cvr /totalIncome xdef  
 </action_postfix></action_details>
@@ -1544,7 +1544,7 @@ totalIncome 2 .4  roundto  cvr /totalIncome xdef
 <action_number>49</action_number>
 <action_comment>Error</action_comment>
 <action_requirement />
-<action_description>set totalIncome = sum of additionalIncome in clients</action_description>
+<action_dsl>set totalIncome = sum of additionalIncome in clients</action_dsl>
 <action_postfix>
 0 { additionalIncomefadd } clients forall  cvr /totalIncome xdef  
 </action_postfix></action_details></actions>
@@ -1563,7 +1563,7 @@ totalIncome 2 .4  roundto  cvr /totalIncome xdef
 <condition_number>1</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called 
 </condition_postfix>
@@ -1573,7 +1573,7 @@ perform when called
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set FPL_Base = FPL_Base + FPL_PerAdditionalPerson</action_description>
+<action_dsl>set FPL_Base = FPL_Base + FPL_PerAdditionalPerson</action_dsl>
 <action_postfix>
 FPL_Base FPL_PerAdditionalPerson +  cvi /FPL_Base xdef  
 </action_postfix>
@@ -1582,7 +1582,7 @@ FPL_Base FPL_PerAdditionalPerson +  cvi /FPL_Base xdef
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set FPL_Base = FPL_Base - FPL_PerAdditionalPerson</action_description>
+<action_dsl>set FPL_Base = FPL_Base - FPL_PerAdditionalPerson</action_dsl>
 <action_postfix>
 FPL_Base FPL_PerAdditionalPerson -  cvi /FPL_Base xdef  
 </action_postfix>
@@ -1591,7 +1591,7 @@ FPL_Base FPL_PerAdditionalPerson -  cvi /FPL_Base xdef
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set FPL_Base = FPL_Base * FPL_PerAdditionalPerson</action_description>
+<action_dsl>set FPL_Base = FPL_Base * FPL_PerAdditionalPerson</action_dsl>
 <action_postfix>
 FPL_Base FPL_PerAdditionalPerson *  cvi /FPL_Base xdef  
 </action_postfix>
@@ -1600,7 +1600,7 @@ FPL_Base FPL_PerAdditionalPerson *  cvi /FPL_Base xdef
 <action_number>4</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set FPL_Base = FPL_Base / FPL_PerAdditionalPerson</action_description>
+<action_dsl>set FPL_Base = FPL_Base / FPL_PerAdditionalPerson</action_dsl>
 <action_postfix>
 FPL_Base FPL_PerAdditionalPerson div  cvi /FPL_Base xdef  
 </action_postfix>
@@ -1609,7 +1609,7 @@ FPL_Base FPL_PerAdditionalPerson div  cvi /FPL_Base xdef
 <action_number>5</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set expectedChildren = 2</action_description>
+<action_dsl>set expectedChildren = 2</action_dsl>
 <action_postfix>
 2  cvi /expectedChildren xdef  
 </action_postfix>
@@ -1618,7 +1618,7 @@ FPL_Base FPL_PerAdditionalPerson div  cvi /FPL_Base xdef
 <action_number>6</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set FPL_Base = - FPL_Base</action_description>
+<action_dsl>set FPL_Base = - FPL_Base</action_dsl>
 <action_postfix>
 FPL_Base negate  cvi /FPL_Base xdef  
 </action_postfix>
@@ -1627,7 +1627,7 @@ FPL_Base negate  cvi /FPL_Base xdef
 <action_number>7</action_number>
 <action_comment>set FPL_Base = (client_fpl)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 client_fpl   cvi /FPL_Base xdef  
 </action_postfix>
@@ -1636,7 +1636,7 @@ client_fpl   cvi /FPL_Base xdef
 <action_number>8</action_number>
 <action_comment>set FPL_Base = (client_fpl)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 client_fpl   cvi /FPL_Base xdef  
 </action_postfix>
@@ -1645,13 +1645,13 @@ client_fpl   cvi /FPL_Base xdef
 <action_number>9</action_number>
 <action_comment>Error</action_comment>
 <action_requirement />
-<action_description>// set DateNumber = get days in yearof effectiveDate</action_description>
+<action_dsl>// set DateNumber = get days in yearof effectiveDate</action_dsl>
 <action_postfix /></action_details>
 <action_details>
 <action_number>10</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set DateNumber = get days in months for effectiveDate</action_description>
+<action_dsl>set DateNumber = get days in months for effectiveDate</action_dsl>
 <action_postfix>
 effectiveDate getdaysinmonth  cvi /DateNumber xdef  
 </action_postfix>
@@ -1660,7 +1660,7 @@ effectiveDate getdaysinmonth  cvi /DateNumber xdef
 <action_number>11</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set DateNumber = get days of months for effectiveDate</action_description>
+<action_dsl>set DateNumber = get days of months for effectiveDate</action_dsl>
 <action_postfix>
 effectiveDate getdayofmonth  cvi /DateNumber xdef  
 </action_postfix>
@@ -1669,7 +1669,7 @@ effectiveDate getdayofmonth  cvi /DateNumber xdef
 <action_number>12</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set DateNumber = get days in months for effectiveDate</action_description>
+<action_dsl>set DateNumber = get days in months for effectiveDate</action_dsl>
 <action_postfix>
 effectiveDate getdaysinmonth  cvi /DateNumber xdef  
 </action_postfix>
@@ -1678,7 +1678,7 @@ effectiveDate getdaysinmonth  cvi /DateNumber xdef
 <action_number>13</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalGroupIncome = (long) clients [1]</action_description>
+<action_dsl>set totalGroupIncome = (long) clients [1]</action_dsl>
 <action_postfix>
 clients 1 getat cvi  cvi /totalGroupIncome xdef  
 </action_postfix>
@@ -1687,7 +1687,7 @@ clients 1 getat cvi  cvi /totalGroupIncome xdef
 <action_number>14</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalGroupIncome = (long) wages</action_description>
+<action_dsl>set totalGroupIncome = (long) wages</action_dsl>
 <action_postfix>
 wages cvi  cvi /totalGroupIncome xdef  
 </action_postfix>
@@ -1696,7 +1696,7 @@ wages cvi  cvi /totalGroupIncome xdef
 <action_number>15</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalGroupIncome = (long) 450</action_description>
+<action_dsl>set totalGroupIncome = (long) 450</action_dsl>
 <action_postfix>
 450  cvi  cvi /totalGroupIncome xdef  
 </action_postfix>
@@ -1705,7 +1705,7 @@ wages cvi  cvi /totalGroupIncome xdef
 <action_number>16</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalGroupIncome = number of clients</action_description>
+<action_dsl>set totalGroupIncome = number of clients</action_dsl>
 <action_postfix>
 clients length  cvi /totalGroupIncome xdef  
 </action_postfix>
@@ -1714,7 +1714,7 @@ clients length  cvi /totalGroupIncome xdef
 <action_number>17</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalGroupIncome = number of clients where age &gt; 18</action_description>
+<action_dsl>set totalGroupIncome = number of clients where age &gt; 18</action_dsl>
 <action_postfix>
 0 { { 1 ladd } age 18 &gt; if }clients forall  cvi /totalGroupIncome xdef  
 </action_postfix>
@@ -1723,7 +1723,7 @@ clients length  cvi /totalGroupIncome xdef
 <action_number>18</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set DateNumber = get days in months for effectiveDate</action_description>
+<action_dsl>set DateNumber = get days in months for effectiveDate</action_dsl>
 <action_postfix>
 effectiveDate getdaysinmonth  cvi /DateNumber xdef  
 </action_postfix>
@@ -1732,7 +1732,7 @@ effectiveDate getdaysinmonth  cvi /DateNumber xdef
 <action_number>19</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set IncomeGroupCount = length of clients</action_description>
+<action_dsl>set IncomeGroupCount = length of clients</action_dsl>
 <action_postfix>
 clients length  cvi /IncomeGroupCount xdef  
 </action_postfix>
@@ -1741,7 +1741,7 @@ clients length  cvi /IncomeGroupCount xdef
 <action_number>20</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set IncomeGroupCount = length of parent</action_description>
+<action_dsl>set IncomeGroupCount = length of parent</action_dsl>
 <action_postfix>
 parent strlength  cvi /IncomeGroupCount xdef  
 </action_postfix>
@@ -1750,7 +1750,7 @@ parent strlength  cvi /IncomeGroupCount xdef
 <action_number>21</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set DateNumber = index of birthday in importantDates</action_description>
+<action_dsl>set DateNumber = index of birthday in importantDates</action_dsl>
 <action_postfix>
 birthday importantDates indexof  cvi /DateNumber xdef  
 </action_postfix>
@@ -1759,7 +1759,7 @@ birthday importantDates indexof  cvi /DateNumber xdef
 <action_number>22</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set FPL_Base = using clients 3</action_description>
+<action_dsl>set FPL_Base = using clients 3</action_dsl>
 <action_postfix>
 clients entitypush 3  entitypop  cvi /FPL_Base xdef  
 </action_postfix>
@@ -1768,7 +1768,7 @@ clients entitypush 3  entitypop  cvi /FPL_Base xdef
 <action_number>23</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalGroupIncome = add to totalGroupIncome 75</action_description>
+<action_dsl>set totalGroupIncome = add to totalGroupIncome 75</action_dsl>
 <action_postfix>
 /75  totalGroupIncome75   ladd def  cvi /totalGroupIncome xdef  
 </action_postfix>
@@ -1777,7 +1777,7 @@ clients entitypush 3  entitypop  cvi /FPL_Base xdef
 <action_number>24</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalGroupIncome = subtract from totalGroupIncome 50</action_description>
+<action_dsl>set totalGroupIncome = subtract from totalGroupIncome 50</action_dsl>
 <action_postfix>
 /50  totalGroupIncome50   lsub def  cvi /totalGroupIncome xdef  
 </action_postfix>
@@ -1786,19 +1786,19 @@ clients entitypush 3  entitypop  cvi /FPL_Base xdef
 <action_number>25</action_number>
 <action_comment>Error</action_comment>
 <action_requirement />
-<action_description>// set totalGroupIncome = multiply totalGroupIncome by 3</action_description>
+<action_dsl>// set totalGroupIncome = multiply totalGroupIncome by 3</action_dsl>
 <action_postfix /></action_details>
 <action_details>
 <action_number>26</action_number>
 <action_comment>Error</action_comment>
 <action_requirement />
-<action_description>// set totalGroupIncome = divide totalGroupIncome by 2</action_description>
+<action_dsl>// set totalGroupIncome = divide totalGroupIncome by 2</action_dsl>
 <action_postfix /></action_details>
 <action_details>
 <action_number>27</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set totalGroupIncome = absolute value of totalGroupIncome</action_description>
+<action_dsl>set totalGroupIncome = absolute value of totalGroupIncome</action_dsl>
 <action_postfix>
 totalGroupIncome labs  cvi /totalGroupIncome xdef  
 </action_postfix>
@@ -1807,7 +1807,7 @@ totalGroupIncome labs  cvi /totalGroupIncome xdef
 <action_number>28</action_number>
 <action_comment>set totalGroupIncome = using client (IncomeGroupCount)</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 client entitypush IncomeGroupCount entitypop  cvi /totalGroupIncome xdef  
 </action_postfix>
@@ -1816,7 +1816,7 @@ client entitypush IncomeGroupCount entitypop  cvi /totalGroupIncome xdef
 <action_number>29</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set DateNumber = days from currentDate to effectiveDate</action_description>
+<action_dsl>set DateNumber = days from currentDate to effectiveDate</action_dsl>
 <action_postfix>
 currentDate effectiveDate daysbetween  cvi /DateNumber xdef  
 </action_postfix>
@@ -1825,7 +1825,7 @@ currentDate effectiveDate daysbetween  cvi /DateNumber xdef
 <action_number>30</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set DateNumber = months from currentDate to effectiveDate</action_description>
+<action_dsl>set DateNumber = months from currentDate to effectiveDate</action_dsl>
 <action_postfix>
 currentDate effectiveDate monthsbetween  cvi /DateNumber xdef  
 </action_postfix>
@@ -1834,7 +1834,7 @@ currentDate effectiveDate monthsbetween  cvi /DateNumber xdef
 <action_number>31</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set DateNumber = years from currentDate to effectiveDate</action_description>
+<action_dsl>set DateNumber = years from currentDate to effectiveDate</action_dsl>
 <action_postfix>
 currentDate effectiveDate yearsbetween  cvi /DateNumber xdef  
 </action_postfix>
@@ -1843,19 +1843,19 @@ currentDate effectiveDate yearsbetween  cvi /DateNumber xdef
 <action_number>32</action_number>
 <action_comment>Error</action_comment>
 <action_requirement />
-<action_description>// set DateNumber = get years of effectiveDate</action_description>
+<action_dsl>// set DateNumber = get years of effectiveDate</action_dsl>
 <action_postfix /></action_details>
 <action_details>
 <action_number>33</action_number>
 <action_comment>Error</action_comment>
 <action_requirement />
-<action_description>// set totalGroupIncome = sum of totalGroupIncome in clients</action_description>
+<action_dsl>// set totalGroupIncome = sum of totalGroupIncome in clients</action_dsl>
 <action_postfix /></action_details>
 <action_details>
 <action_number>34</action_number>
 <action_comment>set eligible = clients does not include  case</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 clients case memberof not cvb /eligible xdef  
 </action_postfix>
@@ -1864,7 +1864,7 @@ clients case memberof not cvb /eligible xdef
 <action_number>35</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = clients does include case</action_description>
+<action_dsl>set eligible = clients does include case</action_dsl>
 <action_postfix>
 clients case memberof cvb /eligible xdef  
 </action_postfix>
@@ -1873,7 +1873,7 @@ clients case memberof cvb /eligible xdef
 <action_number>36</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = clients includes case</action_description>
+<action_dsl>set eligible = clients includes case</action_dsl>
 <action_postfix>
 clients case memberof cvb /eligible xdef  
 </action_postfix>
@@ -1882,7 +1882,7 @@ clients case memberof cvb /eligible xdef
 <action_number>37</action_number>
 <action_comment>set applying = there is match for all clients to $applying in cases</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 true { over { { } { swap pop false swap } { dup /applying execute streq } cases forfirstelse } swap if pop } clients for cvb /applying xdef  
 </action_postfix>
@@ -1891,7 +1891,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>38</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = there is client where FPL_base &lt;867</action_description>
+<action_dsl>set eligible = there is client where FPL_base &lt;867</action_dsl>
 <action_postfix>
 { true } { false } { FPL_base 867 &lt; } clients forfirstelse cvb /eligible xdef  
 </action_postfix>
@@ -1900,7 +1900,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>39</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = is there mailingAddress in the Address where mailingAddress == billingAddress</action_description>
+<action_dsl>set eligible = is there mailingAddress in the Address where mailingAddress == billingAddress</action_dsl>
 <action_postfix>
 { true } { false } { mailingAddress billingAddress req  } mailingAddresss Address entitypush forfirstelse entitypop cvb /eligible xdef  
 </action_postfix>
@@ -1909,7 +1909,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>40</action_number>
 <action_comment>set eligible = there is no client where applying == false</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { false } { true } { applying false beq } clients forfirstelse cvb /eligible xdef  
 </action_postfix>
@@ -1918,7 +1918,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>41</action_number>
 <action_comment>set eligible = there is no client in the case where applying == false</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { false } { true } { applying false beq } clients case entitypush forfirstelse entitypop cvb /eligible xdef  
 </action_postfix>
@@ -1927,7 +1927,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>42</action_number>
 <action_comment>set eligible = there is no case in the clients where client_FPL &gt; 1000</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 { false } { true } { client_FPL 1000 &gt; } clients forfirstelse cvb /eligible xdef  
 </action_postfix>
@@ -1936,7 +1936,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>43</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = all clients have disabled == true</action_description>
+<action_dsl>set eligible = all clients have disabled == true</action_dsl>
 <action_postfix>
 { false } { true } { disabled true beq not } clients forfirstelse cvb /eligible xdef  
 </action_postfix>
@@ -1945,7 +1945,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>44</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = one of clients has a FPL_Base &gt; 867</action_description>
+<action_dsl>set eligible = one of clients has a FPL_Base &gt; 867</action_dsl>
 <action_postfix>
 { true } { false } { FPL_Base 867 &gt; } clients forfirstelse cvb /eligible xdef  
 </action_postfix>
@@ -1954,7 +1954,7 @@ true { over { { } { swap pop false swap } { dup /applying execute streq } cases 
 <action_number>45</action_number>
 <action_comment>set eligible = client does not have SocialSecurity</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 SocialSecurity client { pop pop false } { pop pop true } { over type streq over target req and } relationships forfirstelse cvb /eligible xdef  
 </action_postfix>
@@ -1963,7 +1963,7 @@ SocialSecurity client { pop pop false } { pop pop true } { over type streq over 
 <action_number>46</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = client has a Wages</action_description>
+<action_dsl>set eligible = client has a Wages</action_dsl>
 <action_postfix>
 Wages client { pop pop true } { pop pop false } { over type streq over target req and } relationships forfirstelse cvb /eligible xdef  
 </action_postfix>
@@ -1972,7 +1972,7 @@ Wages client { pop pop true } { pop pop false } { over type streq over target re
 <action_number>47</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = case has a FreeCoverage where FPL_Base &lt; 867</action_description>
+<action_dsl>set eligible = case has a FreeCoverage where FPL_Base &lt; 867</action_dsl>
 <action_postfix>
 FreeCoverage case { pop pop true } { pop pop false } { over type streq over target req and source entitypush FPL_Base 867 &lt; entitypop and } relationships forfirstelse cvb /eligible xdef  
 </action_postfix>
@@ -1981,7 +1981,7 @@ FreeCoverage case { pop pop true } { pop pop false } { over type streq over targ
 <action_number>48</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = client is programLevel of case</action_description>
+<action_dsl>set eligible = client is programLevel of case</action_dsl>
 <action_postfix>
 /source client /target case /type programLevel relationships findmatch swap popcvb /eligible xdef  
 </action_postfix>
@@ -1990,7 +1990,7 @@ FreeCoverage case { pop pop true } { pop pop false } { over type streq over targ
 <action_number>49</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = additionalIncome is within 20 percent of totalIncome</action_description>
+<action_dsl>set eligible = additionalIncome is within 20 percent of totalIncome</action_dsl>
 <action_postfix>
 totalIncome additionalIncome 20  100.0 f/ over f* swap &gt;r &gt;r &gt;r i j f- k f&lt; r&gt; r&gt; f+ r&gt; f&gt; and cvb /eligible xdef  
 </action_postfix>
@@ -1999,7 +1999,7 @@ totalIncome additionalIncome 20  100.0 f/ over f* swap &gt;r &gt;r &gt;r i j f- 
 <action_number>50</action_number>
 <action_comment>set eligible = totalIncome is plus or minus 300 of additionalIncome</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 additionalIncome 300  totalIncome &gt;r &gt;r &gt;r i j f- k f&lt; r&gt; r&gt; f+ r&gt; f&gt; and cvb /eligible xdef  
 </action_postfix>
@@ -2008,7 +2008,7 @@ additionalIncome 300  totalIncome &gt;r &gt;r &gt;r i j f- k f&lt; r&gt; r&gt; f
 <action_number>51</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = IncomeGroupCount is equal to totalGroupIncome</action_description>
+<action_dsl>set eligible = IncomeGroupCount is equal to totalGroupIncome</action_dsl>
 <action_postfix>
 IncomeGroupCount totalGroupIncome == cvb /eligible xdef  
 </action_postfix>
@@ -2017,7 +2017,7 @@ IncomeGroupCount totalGroupIncome == cvb /eligible xdef
 <action_number>52</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = totalIncome equal to totalGroupIncome</action_description>
+<action_dsl>set eligible = totalIncome equal to totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome f== cvb /eligible xdef  
 </action_postfix>
@@ -2026,7 +2026,7 @@ totalIncome totalGroupIncome f== cvb /eligible xdef
 <action_number>53</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = IncomeGroupCount is not equal to totalGroupIncome</action_description>
+<action_dsl>set eligible = IncomeGroupCount is not equal to totalGroupIncome</action_dsl>
 <action_postfix>
 IncomeGroupCount totalGroupIncome == not cvb /eligible xdef  
 </action_postfix>
@@ -2035,7 +2035,7 @@ IncomeGroupCount totalGroupIncome == not cvb /eligible xdef
 <action_number>54</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = totalIncome not equal to totalGroupIncome</action_description>
+<action_dsl>set eligible = totalIncome not equal to totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome f== not cvb /eligible xdef  
 </action_postfix>
@@ -2044,7 +2044,7 @@ totalIncome totalGroupIncome f== not cvb /eligible xdef
 <action_number>55</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = IncomeGroupCount is greater than totalGroupIncome</action_description>
+<action_dsl>set eligible = IncomeGroupCount is greater than totalGroupIncome</action_dsl>
 <action_postfix>
 IncomeGroupCount totalGroupIncome &gt; cvb /eligible xdef  
 </action_postfix>
@@ -2053,7 +2053,7 @@ IncomeGroupCount totalGroupIncome &gt; cvb /eligible xdef
 <action_number>56</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = totalIncome greater than totalGroupIncome</action_description>
+<action_dsl>set eligible = totalIncome greater than totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome f&gt; cvb /eligible xdef  
 </action_postfix>
@@ -2062,7 +2062,7 @@ totalIncome totalGroupIncome f&gt; cvb /eligible xdef
 <action_number>57</action_number>
 <action_comment>set eligible = IncomeGroupCount is greater than or equal to totalGroupIncome</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 IncomeGroupCount totalGroupIncome &gt;= cvb /eligible xdef  
 </action_postfix>
@@ -2071,7 +2071,7 @@ IncomeGroupCount totalGroupIncome &gt;= cvb /eligible xdef
 <action_number>58</action_number>
 <action_comment>set eligible = totalIncome greater than or equal to totalGroupIncome</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 totalIncome totalGroupIncome f&gt;= cvb /eligible xdef  
 </action_postfix>
@@ -2080,7 +2080,7 @@ totalIncome totalGroupIncome f&gt;= cvb /eligible xdef
 <action_number>59</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = IncomeGroupCount is less  than totalGroupIncome</action_description>
+<action_dsl>set eligible = IncomeGroupCount is less  than totalGroupIncome</action_dsl>
 <action_postfix>
 IncomeGroupCount totalGroupIncome &lt; cvb /eligible xdef  
 </action_postfix>
@@ -2089,7 +2089,7 @@ IncomeGroupCount totalGroupIncome &lt; cvb /eligible xdef
 <action_number>60</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = totalIncome less than totalGroupIncome</action_description>
+<action_dsl>set eligible = totalIncome less than totalGroupIncome</action_dsl>
 <action_postfix>
 totalIncome totalGroupIncome f&lt; cvb /eligible xdef  
 </action_postfix>
@@ -2098,7 +2098,7 @@ totalIncome totalGroupIncome f&lt; cvb /eligible xdef
 <action_number>61</action_number>
 <action_comment>set eligible = IncomeGroupCount is less  than or equal to totalGroupIncome</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 IncomeGroupCount totalGroupIncome &lt;= cvb /eligible xdef  
 </action_postfix>
@@ -2107,7 +2107,7 @@ IncomeGroupCount totalGroupIncome &lt;= cvb /eligible xdef
 <action_number>62</action_number>
 <action_comment>set eligible = totalIncome less than or equal to totalGroupIncome</action_comment>
 <action_requirement />
-<action_description />
+<action_dsl />
 <action_postfix>
 totalIncome totalGroupIncome f&lt;= cvb /eligible xdef  
 </action_postfix>
@@ -2116,7 +2116,7 @@ totalIncome totalGroupIncome f&lt;= cvb /eligible xdef
 <action_number>63</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = $aName is equal to $anotherName</action_description>
+<action_dsl>set eligible = $aName is equal to $anotherName</action_dsl>
 <action_postfix>
 /aName /anotherName nameeq cvb /eligible xdef  
 </action_postfix>
@@ -2125,7 +2125,7 @@ totalIncome totalGroupIncome f&lt;= cvb /eligible xdef
 <action_number>64</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = $aName equal to program</action_description>
+<action_dsl>set eligible = $aName equal to program</action_dsl>
 <action_postfix>
 /aName program streq cvb /eligible xdef  
 </action_postfix>
@@ -2134,7 +2134,7 @@ totalIncome totalGroupIncome f&lt;= cvb /eligible xdef
 <action_number>65</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = $aName != $anotherName</action_description>
+<action_dsl>set eligible = $aName != $anotherName</action_dsl>
 <action_postfix>
 /aName /anotherName nameeq not cvb /eligible xdef  
 </action_postfix>
@@ -2143,7 +2143,7 @@ totalIncome totalGroupIncome f&lt;= cvb /eligible xdef
 <action_number>66</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = $aName != program</action_description>
+<action_dsl>set eligible = $aName != program</action_dsl>
 <action_postfix>
 /aName program streq not cvb /eligible xdef  
 </action_postfix>
@@ -2152,7 +2152,7 @@ totalIncome totalGroupIncome f&lt;= cvb /eligible xdef
 <action_number>67</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = program == programLevel</action_description>
+<action_dsl>set eligible = program == programLevel</action_dsl>
 <action_postfix>
 program programLevel streq cvb /eligible xdef  
 </action_postfix>
@@ -2161,7 +2161,7 @@ program programLevel streq cvb /eligible xdef
 <action_number>68</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = program != programLevel</action_description>
+<action_dsl>set eligible = program != programLevel</action_dsl>
 <action_postfix>
 program programLevel streq not cvb /eligible xdef  
 </action_postfix>
@@ -2170,7 +2170,7 @@ program programLevel streq not cvb /eligible xdef
 <action_number>69</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = $aName != $anotherName</action_description>
+<action_dsl>set eligible = $aName != $anotherName</action_dsl>
 <action_postfix>
 /aName /anotherName nameeq not cvb /eligible xdef  
 </action_postfix>
@@ -2179,13 +2179,13 @@ program programLevel streq not cvb /eligible xdef
 <action_number>70</action_number>
 <action_comment>Error</action_comment>
 <action_requirement />
-<action_description>// set eligible = client_ID at age starts with gender</action_description>
+<action_dsl>// set eligible = client_ID at age starts with gender</action_dsl>
 <action_postfix /></action_details>
 <action_details>
 <action_number>71</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = client_ID starts with programLevel</action_description>
+<action_dsl>set eligible = client_ID starts with programLevel</action_dsl>
 <action_postfix>
 client_ID programLevel 0 startswith cvb /eligible xdef  
 </action_postfix>
@@ -2194,7 +2194,7 @@ client_ID programLevel 0 startswith cvb /eligible xdef
 <action_number>72</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = client_ID is one of clients</action_description>
+<action_dsl>set eligible = client_ID is one of clients</action_dsl>
 <action_postfix>
 clients client_ID memberof cvb /eligible xdef  
 </action_postfix>
@@ -2203,7 +2203,7 @@ clients client_ID memberof cvb /eligible xdef
 <action_number>73</action_number>
 <action_comment />
 <action_requirement />
-<action_description>set eligible = client_ID is not one of clients</action_description>
+<action_dsl>set eligible = client_ID is not one of clients</action_dsl>
 <action_postfix>
 clients client_ID memberof not cvb /eligible xdef  
 </action_postfix>
@@ -2232,112 +2232,112 @@ clients client_ID memberof not cvb /eligible xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for the first of the job.cases where case_ID != ""</context_description>
+<context_dsl>for the first of the job.cases where case_ID != ""</context_dsl>
 <context_postfix>
 dup { case_ID "" streq not  } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>//for all clients whose age == (int)18 and street == "research"</context_comment>
-<context_description>for all clients whose age &gt;18</context_description>
+<context_dsl>for all clients whose age &gt;18</context_dsl>
 <context_postfix>
 { dup age 18 &gt; if } clients forall pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>5</context_number>
 <context_comment />
-<context_description>local entity FirstClient</context_description>
+<context_dsl>local entity FirstClient</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>6</context_number>
 <context_comment />
-<context_description>local entity FirstClient2 = client</context_description>
+<context_dsl>local entity FirstClient2 = client</context_dsl>
 <context_postfix>
 client cve allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>7</context_number>
 <context_comment />
-<context_description>local long Anumber</context_description>
+<context_dsl>local long Anumber</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>8</context_number>
 <context_comment />
-<context_description>local long Anumber2 = 1234</context_description>
+<context_dsl>local long Anumber2 = 1234</context_dsl>
 <context_postfix>
 1234  cvi allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>9</context_number>
 <context_comment />
-<context_description>local double DoubleNumber</context_description>
+<context_dsl>local double DoubleNumber</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>10</context_number>
 <context_comment />
-<context_description>local double DoubleNumber2 = 1.234</context_description>
+<context_dsl>local double DoubleNumber2 = 1.234</context_dsl>
 <context_postfix>
 1.234  cvr allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>11</context_number>
 <context_comment />
-<context_description>local boolean Test</context_description>
+<context_dsl>local boolean Test</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>12</context_number>
 <context_comment />
-<context_description>local boolean Test2 = true</context_description>
+<context_dsl>local boolean Test2 = true</context_dsl>
 <context_postfix>
 true cvb allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>13</context_number>
 <context_comment />
-<context_description>local date Today</context_description>
+<context_dsl>local date Today</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>14</context_number>
 <context_comment />
-<context_description>local date Today2 = currentDate</context_description>
+<context_dsl>local date Today2 = currentDate</context_dsl>
 <context_postfix>
 currentDate cvd allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>15</context_number>
 <context_comment />
-<context_description>local array List</context_description>
+<context_dsl>local array List</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>16</context_number>
 <context_comment />
-<context_description>local array List2 = clients</context_description>
+<context_dsl>local array List2 = clients</context_dsl>
 <context_postfix>
 clients allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>17</context_number>
 <context_comment />
-<context_description>local string Things</context_description>
+<context_dsl>local string Things</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>18</context_number>
 <context_comment />
-<context_description>local string Things2 = 'This is a string'</context_description>
+<context_dsl>local string Things2 = 'This is a string'</context_dsl>
 <context_postfix>
 'This is a string' cvs allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -2346,9 +2346,9 @@ null allocate execute deallocate pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>if (Today2 == currentDate) then 
+<initial_action_dsl>if (Today2 == currentDate) then 
      set test = false ;
-endif</initial_action_description>
+endif</initial_action_dsl>
 <initial_action_postfix>
 { false cvb 6 local!  } 9 local@  currentDate d== if 
 </initial_action_postfix></initial_action_details>
@@ -2356,7 +2356,7 @@ endif</initial_action_description>
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>for all clients set eligible = true</initial_action_description>
+<initial_action_dsl>for all clients set eligible = true</initial_action_dsl>
 <initial_action_postfix>
 { true cvb /eligible xdef  } clients forallr 
 </initial_action_postfix></initial_action_details>
@@ -2364,19 +2364,19 @@ endif</initial_action_description>
 <intial_action_number>3</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>//for each case in job.cases set eligible=true</initial_action_description>
+<initial_action_dsl>//for each case in job.cases set eligible=true</initial_action_dsl>
 <initial_action_postfix /></initial_action_details>
 <initial_action_details>
 <intial_action_number>4</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>//for each case in job.cases where city=='spokane' set eligible=true</initial_action_description>
+<initial_action_dsl>//for each case in job.cases where city=='spokane' set eligible=true</initial_action_dsl>
 <initial_action_postfix /></initial_action_details>
 <initial_action_details>
 <intial_action_number>5</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>for all clients where age &lt; 18 set eligible=false</initial_action_description>
+<initial_action_dsl>for all clients where age &lt; 18 set eligible=false</initial_action_dsl>
 <initial_action_postfix>
 { { false cvb /eligible xdef   } age 18 &lt; if } clients forallr 
 </initial_action_postfix></initial_action_details>
@@ -2384,20 +2384,20 @@ endif</initial_action_description>
 <intial_action_number>6</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>//for each case and its address in job.cases set applying = true</initial_action_description>
+<initial_action_dsl>//for each case and its address in job.cases set applying = true</initial_action_dsl>
 <initial_action_postfix /></initial_action_details>
 <initial_action_details>
 <intial_action_number>7</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>//for each case and its address in job.cases where validatedCitizenship == false set eligible = false</initial_action_description>
+<initial_action_dsl>//for each case and its address in job.cases where validatedCitizenship == false set eligible = false</initial_action_dsl>
 <initial_action_postfix /></initial_action_details></initial_actions>
 <conditions>
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>does test == true ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 6 local@  true beq 
 </condition_postfix>
@@ -2406,7 +2406,7 @@ endif</initial_action_description>
 <condition_number>2</condition_number>
 <condition_comment>does eligible == true ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 eligible true beq 
 </condition_postfix>
@@ -2415,7 +2415,7 @@ eligible true beq
 <condition_number>3</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -2425,7 +2425,7 @@ true
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -2435,14 +2435,14 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>//add currentdate to the results</action_description>
+<action_dsl>//add currentdate to the results</action_dsl>
 <action_postfix />
 <action_column column_value="X" column_number="2" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_2</action_description>
+<action_dsl>perform Run_Test_2</action_dsl>
 <action_postfix>
 Run_Test_2 
 </action_postfix>
@@ -2465,30 +2465,30 @@ Run_Test_2
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>//for all clients //for the first of the job.cases where validatedCitizenship == true</context_description>
+<context_dsl>//for all clients //for the first of the job.cases where validatedCitizenship == true</context_dsl>
 <context_postfix>execute </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>for first of job.cases and it's case where    
       City == 'New York'</context_comment>
-<context_description>//for the first of the job.cases and its address where city == 'Austin'</context_description>
+<context_dsl>//for the first of the job.cases and its address where city == 'Austin'</context_dsl>
 <context_postfix>execute </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment />
-<context_description>//for the first in the job.cases where validatedCitizenship == false</context_description>
+<context_dsl>//for the first in the job.cases where validatedCitizenship == false</context_dsl>
 <context_postfix>execute </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment />
-<context_description>//local entity theClient</context_description>
+<context_dsl>//local entity theClient</context_dsl>
 <context_postfix>execute </context_postfix></context_details></contexts>
 <initial_actions>
 <initial_action_details>
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>for first of job.cases where age &lt; 18 then { set eligible = true } else if none are found { set eligible = false } endff</initial_action_description>
+<initial_action_dsl>for first of job.cases where age &lt; 18 then { set eligible = true } else if none are found { set eligible = false } endff</initial_action_dsl>
 <initial_action_postfix>
 { true cvb /eligible xdef  
  } { false cvb /eligible xdef  
@@ -2498,7 +2498,7 @@ Run_Test_2
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>for first of job.cases and its case where city == 'New York' then { set eligible = false } else if none are found { set eligible = true } endff</initial_action_description>
+<initial_action_dsl>for first of job.cases and its case where city == 'New York' then { set eligible = false } else if none are found { set eligible = true } endff</initial_action_dsl>
 <initial_action_postfix>
 { case  entitypush false cvb /eligible xdef  
 entitypop } { true cvb /eligible xdef  
@@ -2508,7 +2508,7 @@ entitypop } { true cvb /eligible xdef
 <intial_action_number>3</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>for first of job.cases where validatedCitizenship == true then { set eligible = true }  endff</initial_action_description>
+<initial_action_dsl>for first of job.cases where validatedCitizenship == true then { set eligible = true }  endff</initial_action_dsl>
 <initial_action_postfix>
 { true cvb /eligible xdef  
 } { validatedCitizenship true beq  } job.cases  forfirst 
@@ -2517,7 +2517,7 @@ entitypop } { true cvb /eligible xdef
 <intial_action_number>4</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>{ for all clients where age &gt; 18 set eligible = true }</initial_action_description>
+<initial_action_dsl>{ for all clients where age &gt; 18 set eligible = true }</initial_action_dsl>
 <initial_action_postfix>
 { { true cvb /eligible xdef   } age 18 &gt; if } clients forallr 
 
@@ -2526,7 +2526,7 @@ entitypop } { true cvb /eligible xdef
 <intial_action_number>5</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalgroupincome = 30400</initial_action_description>
+<initial_action_dsl>set totalgroupincome = 30400</initial_action_dsl>
 <initial_action_postfix>
 30400  cvi /totalgroupincome xdef  
 </initial_action_postfix></initial_action_details>
@@ -2534,7 +2534,7 @@ entitypop } { true cvb /eligible xdef
 <intial_action_number>6</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalincome = 1500.55</initial_action_description>
+<initial_action_dsl>set totalincome = 1500.55</initial_action_dsl>
 <initial_action_postfix>
 1500.55  cvr /totalincome xdef  
 </initial_action_postfix></initial_action_details>
@@ -2542,7 +2542,7 @@ entitypop } { true cvb /eligible xdef
 <intial_action_number>7</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set pregnant = false</initial_action_description>
+<initial_action_dsl>set pregnant = false</initial_action_dsl>
 <initial_action_postfix>
 false cvb /pregnant xdef  
 </initial_action_postfix></initial_action_details>
@@ -2550,7 +2550,7 @@ false cvb /pregnant xdef
 <intial_action_number>8</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set address = mailingAddress</initial_action_description>
+<initial_action_dsl>set address = mailingAddress</initial_action_dsl>
 <initial_action_postfix>
 mailingAddress cve /address xdef  
 </initial_action_postfix></initial_action_details>
@@ -2558,7 +2558,7 @@ mailingAddress cve /address xdef
 <intial_action_number>9</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set state = 'Wyoming'</initial_action_description>
+<initial_action_dsl>set state = 'Wyoming'</initial_action_dsl>
 <initial_action_postfix>
 'Wyoming' cvs /state xdef  
 </initial_action_postfix></initial_action_details>
@@ -2566,7 +2566,7 @@ mailingAddress cve /address xdef
 <intial_action_number>10</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set currentdate = effectivedate</initial_action_description>
+<initial_action_dsl>set currentdate = effectivedate</initial_action_dsl>
 <initial_action_postfix>
 effectivedate cvd /currentdate xdef  
 </initial_action_postfix></initial_action_details>
@@ -2574,7 +2574,7 @@ effectivedate cvd /currentdate xdef
 <intial_action_number>11</intial_action_number>
 <initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set translationTable = anotherTable</initial_action_description>
+<initial_action_dsl>set translationTable = anotherTable</initial_action_dsl>
 <initial_action_postfix>
 anotherTable /translationTable xdef  
 </initial_action_postfix></initial_action_details>
@@ -2582,7 +2582,7 @@ anotherTable /translationTable xdef
 <intial_action_number>12</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalgroupincome = 29400</initial_action_description>
+<initial_action_dsl>set totalgroupincome = 29400</initial_action_dsl>
 <initial_action_postfix>
 29400  cvi /totalgroupincome xdef  
 </initial_action_postfix></initial_action_details>
@@ -2590,7 +2590,7 @@ anotherTable /translationTable xdef
 <intial_action_number>13</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalincome = 20302.95</initial_action_description>
+<initial_action_dsl>set totalincome = 20302.95</initial_action_dsl>
 <initial_action_postfix>
 20302.95  cvr /totalincome xdef  
 </initial_action_postfix></initial_action_details>
@@ -2598,7 +2598,7 @@ anotherTable /translationTable xdef
 <intial_action_number>14</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set pregnant = true</initial_action_description>
+<initial_action_dsl>set pregnant = true</initial_action_dsl>
 <initial_action_postfix>
 true cvb /pregnant xdef  
 </initial_action_postfix></initial_action_details>
@@ -2606,7 +2606,7 @@ true cvb /pregnant xdef
 <intial_action_number>15</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set address = billingAddress</initial_action_description>
+<initial_action_dsl>set address = billingAddress</initial_action_dsl>
 <initial_action_postfix>
 billingAddress cve /address xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -2615,7 +2615,7 @@ billingAddress cve /address xdef
 <condition_number>1</condition_number>
 <condition_comment>does totalincome &gt; 42?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 totalincome 42 f&gt; 
 </condition_postfix>
@@ -2624,7 +2624,7 @@ totalincome 42 f&gt;
 <condition_number>2</condition_number>
 <condition_comment>does pregnant == false?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 pregnant false beq 
 </condition_postfix>
@@ -2633,7 +2633,7 @@ pregnant false beq
 <condition_number>3</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -2643,7 +2643,7 @@ true
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -2653,14 +2653,14 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>//add currentdate to the results</action_description>
+<action_dsl>//add currentdate to the results</action_dsl>
 <action_postfix />
 <action_column column_value="X" column_number="2" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_3</action_description>
+<action_dsl>perform Run_Test_3</action_dsl>
 <action_postfix>
 Run_Test_3 
 </action_postfix>
@@ -2683,7 +2683,7 @@ Run_Test_3
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for the first of the job.cases where validatedCitizenship == true</context_description>
+<context_dsl>for the first of the job.cases where validatedCitizenship == true</context_dsl>
 <context_postfix>
 dup { validatedCitizenship true beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
@@ -2691,21 +2691,21 @@ dup { validatedCitizenship true beq  } job.cases  forfirst pop
 <context_number>2</context_number>
 <context_comment>for first of job.cases and it's case where    
       City == 'New York'</context_comment>
-<context_description>for the first of the job.cases and its address where city == 'New York'</context_description>
+<context_dsl>for the first of the job.cases and its address where city == 'New York'</context_dsl>
 <context_postfix>
 { address  entitypush dup execute entitypop } { address  entitypush city 'New York' streq  entitypop } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment />
-<context_description>for the first in the job.cases where validatedCitizenship == false</context_description>
+<context_dsl>for the first in the job.cases where validatedCitizenship == false</context_dsl>
 <context_postfix>
 dup { validatedCitizenship false beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment />
-<context_description>local entity theClient</context_description>
+<context_dsl>local entity theClient</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -2714,7 +2714,7 @@ null allocate execute deallocate pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set gender = 'male'</initial_action_description>
+<initial_action_dsl>set gender = 'male'</initial_action_dsl>
 <initial_action_postfix>
 'male' cvs /gender xdef  
 </initial_action_postfix></initial_action_details>
@@ -2722,7 +2722,7 @@ null allocate execute deallocate pop
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = 12345</initial_action_description>
+<initial_action_dsl>set street = 12345</initial_action_dsl>
 <initial_action_postfix>
 12345  cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -2730,7 +2730,7 @@ null allocate execute deallocate pop
 <intial_action_number>3</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set birthday = dateofBirth</initial_action_description>
+<initial_action_dsl>set birthday = dateofBirth</initial_action_dsl>
 <initial_action_postfix>
 dateofBirth cvs /birthday xdef  
 </initial_action_postfix></initial_action_details>
@@ -2738,7 +2738,7 @@ dateofBirth cvs /birthday xdef
 <intial_action_number>4</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set zip = $unknown</initial_action_description>
+<initial_action_dsl>set zip = $unknown</initial_action_dsl>
 <initial_action_postfix>
 /unknown cvs /zip xdef  
 </initial_action_postfix></initial_action_details>
@@ -2746,7 +2746,7 @@ dateofBirth cvs /birthday xdef
 <intial_action_number>5</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set pregnant = $unknown</initial_action_description>
+<initial_action_dsl>set pregnant = $unknown</initial_action_dsl>
 <initial_action_postfix>
 /unknown cvb /pregnant xdef  
 </initial_action_postfix></initial_action_details>
@@ -2754,7 +2754,7 @@ dateofBirth cvs /birthday xdef
 <intial_action_number>6</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectivedate = currentdate</initial_action_description>
+<initial_action_dsl>set effectivedate = currentdate</initial_action_dsl>
 <initial_action_postfix>
 currentdate cvd /effectivedate xdef  
 </initial_action_postfix></initial_action_details>
@@ -2762,7 +2762,7 @@ currentdate cvd /effectivedate xdef
 <intial_action_number>7</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set interestingCases = cases</initial_action_description>
+<initial_action_dsl>set interestingCases = cases</initial_action_dsl>
 <initial_action_postfix>
 cases /interestingCases xdef 
 </initial_action_postfix></initial_action_details>
@@ -2770,7 +2770,7 @@ cases /interestingCases xdef
 <intial_action_number>8</intial_action_number>
 <initial_action_comment>Missing scanner for decrement</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>decrement totalincome</initial_action_description>
+<initial_action_dsl>decrement totalincome</initial_action_dsl>
 <initial_action_postfix>
 totalincome 1 dsub /totalincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -2778,7 +2778,7 @@ totalincome 1 dsub /totalincome xdef
 <intial_action_number>9</intial_action_number>
 <initial_action_comment>Missing scanner for increment</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>increment totalincome</initial_action_description>
+<initial_action_dsl>increment totalincome</initial_action_dsl>
 <initial_action_postfix>
 totalincome 1 dadd /totalincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -2786,7 +2786,7 @@ totalincome 1 dadd /totalincome xdef
 <intial_action_number>10</intial_action_number>
 <initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>perform Syntax_Examples and on error add the ErrorDetails to the context and perform Error_handling_table</initial_action_description>
+<initial_action_dsl>perform Syntax_Examples and on error add the ErrorDetails to the context and perform Error_handling_table</initial_action_dsl>
 <initial_action_postfix>
 /Syntax_Examples lookup /Error_handling_table lookup ErrorDetails  PerformCatchError 
 </initial_action_postfix></initial_action_details>
@@ -2794,7 +2794,7 @@ totalincome 1 dadd /totalincome xdef
 <intial_action_number>11</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>perform syntax_examples_2</initial_action_description>
+<initial_action_dsl>perform syntax_examples_2</initial_action_dsl>
 <initial_action_postfix>
 syntax_examples_2 
 </initial_action_postfix></initial_action_details>
@@ -2802,7 +2802,7 @@ syntax_examples_2
 <intial_action_number>12</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>perform $something</initial_action_description>
+<initial_action_dsl>perform $something</initial_action_dsl>
 <initial_action_postfix>
 something 
 </initial_action_postfix></initial_action_details>
@@ -2810,7 +2810,7 @@ something
 <intial_action_number>13</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add cases to clients</initial_action_description>
+<initial_action_dsl>add cases to clients</initial_action_dsl>
 <initial_action_postfix>
 cases clients true  addarray 
 </initial_action_postfix></initial_action_details>
@@ -2818,7 +2818,7 @@ cases clients true  addarray
 <intial_action_number>14</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add client to interestingCases</initial_action_description>
+<initial_action_dsl>add client to interestingCases</initial_action_dsl>
 <initial_action_postfix>
 client interestingCases swap addto 
 </initial_action_postfix></initial_action_details>
@@ -2826,7 +2826,7 @@ client interestingCases swap addto
 <intial_action_number>15</intial_action_number>
 <initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>add client to InterestingCases and to resolvedCases</initial_action_description>
+<initial_action_dsl>add client to InterestingCases and to resolvedCases</initial_action_dsl>
 <initial_action_postfix>
 client dup InterestingCases swap addto resolvedCases swap addto 
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -2835,7 +2835,7 @@ client dup InterestingCases swap addto resolvedCases swap addto
 <condition_number>1</condition_number>
 <condition_comment>does totalincome &gt; 42?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 totalincome 42 f&gt; 
 </condition_postfix>
@@ -2844,14 +2844,14 @@ totalincome 42 f&gt;
 <condition_number />
 <condition_comment>//does effectiveDate == (1 months) ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix />
 <condition_column column_value="N" column_number="2" /></condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -2861,7 +2861,7 @@ true
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -2871,14 +2871,14 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>//add currentdate to the results</action_description>
+<action_dsl>//add currentdate to the results</action_dsl>
 <action_postfix />
 <action_column column_value="X" column_number="2" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_4</action_description>
+<action_dsl>perform Run_Test_4</action_dsl>
 <action_postfix>
 Run_Test_4 
 </action_postfix>
@@ -2901,7 +2901,7 @@ Run_Test_4
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for the first of the job.cases where validatedCitizenship == true</context_description>
+<context_dsl>for the first of the job.cases where validatedCitizenship == true</context_dsl>
 <context_postfix>
 dup { validatedCitizenship true beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
@@ -2909,21 +2909,21 @@ dup { validatedCitizenship true beq  } job.cases  forfirst pop
 <context_number>2</context_number>
 <context_comment>for first of job.cases and it's case where    
       City == 'New York'</context_comment>
-<context_description>for the first of the job.cases and its address where city == 'New York'</context_description>
+<context_dsl>for the first of the job.cases and its address where city == 'New York'</context_dsl>
 <context_postfix>
 { address  entitypush dup execute entitypop } { address  entitypush city 'New York' streq  entitypop } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment />
-<context_description>for the first in the job.cases where validatedCitizenship == false</context_description>
+<context_dsl>for the first in the job.cases where validatedCitizenship == false</context_dsl>
 <context_postfix>
 dup { validatedCitizenship false beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment />
-<context_description>local entity theClient</context_description>
+<context_dsl>local entity theClient</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -2932,7 +2932,7 @@ null allocate execute deallocate pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add case_ID to interestingCases</initial_action_description>
+<initial_action_dsl>add case_ID to interestingCases</initial_action_dsl>
 <initial_action_postfix>
 case_ID interestingCases swap addto 
 </initial_action_postfix></initial_action_details>
@@ -2940,7 +2940,7 @@ case_ID interestingCases swap addto
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add clients to cases</initial_action_description>
+<initial_action_dsl>add clients to cases</initial_action_dsl>
 <initial_action_postfix>
 clients cases true  addarray 
 </initial_action_postfix></initial_action_details>
@@ -2948,7 +2948,7 @@ clients cases true  addarray
 <intial_action_number>3</intial_action_number>
 <initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>add case_ID to listOfIDs and to secondListOfIDs</initial_action_description>
+<initial_action_dsl>add case_ID to listOfIDs and to secondListOfIDs</initial_action_dsl>
 <initial_action_postfix>
 case_ID dup listOfIDs swap addto secondListOfIDs swap addto 
 </initial_action_postfix></initial_action_details>
@@ -2956,7 +2956,7 @@ case_ID dup listOfIDs swap addto secondListOfIDs swap addto
 <intial_action_number>4</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add effectiveDate to interestingDates</initial_action_description>
+<initial_action_dsl>add effectiveDate to interestingDates</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate interestingDates swap addto 
 </initial_action_postfix></initial_action_details>
@@ -2964,7 +2964,7 @@ effectiveDate interestingDates swap addto
 <intial_action_number>5</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>Add 42 to totalincome</initial_action_description>
+<initial_action_dsl>Add 42 to totalincome</initial_action_dsl>
 <initial_action_postfix>
 42  totalincome f+ /totalincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -2972,7 +2972,7 @@ effectiveDate interestingDates swap addto
 <intial_action_number>6</intial_action_number>
 <initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>Add 42 to totalincome and to totalgroupincome</initial_action_description>
+<initial_action_dsl>Add 42 to totalincome and to totalgroupincome</initial_action_dsl>
 <initial_action_postfix>
 42  dup totalincome f+ /totalincome xdef totalgroupincome + /totalgroupincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -2980,7 +2980,7 @@ effectiveDate interestingDates swap addto
 <intial_action_number>7</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>Subtract 42 from totalincome</initial_action_description>
+<initial_action_dsl>Subtract 42 from totalincome</initial_action_dsl>
 <initial_action_postfix>
 42  totalincome swap f- /totalincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -2988,7 +2988,7 @@ effectiveDate interestingDates swap addto
 <intial_action_number>8</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add 42 to totalincome</initial_action_description>
+<initial_action_dsl>add 42 to totalincome</initial_action_dsl>
 <initial_action_postfix>
 42  totalincome f+ /totalincome xdef 
 </initial_action_postfix></initial_action_details>
@@ -2996,7 +2996,7 @@ effectiveDate interestingDates swap addto
 <intial_action_number>9</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add mailingaddress if not member to locations</initial_action_description>
+<initial_action_dsl>add mailingaddress if not member to locations</initial_action_dsl>
 <initial_action_postfix>
 locations  mailingaddress add_no_dups 
 </initial_action_postfix></initial_action_details>
@@ -3004,7 +3004,7 @@ locations  mailingaddress add_no_dups
 <intial_action_number>10</intial_action_number>
 <initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>add mailingaddress if not member to locations and to homeAddresses</initial_action_description>
+<initial_action_dsl>add mailingaddress if not member to locations and to homeAddresses</initial_action_dsl>
 <initial_action_postfix>
 mailingaddress locations over add_no_dups homeAddresses swap add_no_dups 
 </initial_action_postfix></initial_action_details>
@@ -3012,7 +3012,7 @@ mailingaddress locations over add_no_dups homeAddresses swap add_no_dups
 <intial_action_number>11</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add client_ID if not member to cases</initial_action_description>
+<initial_action_dsl>add client_ID if not member to cases</initial_action_dsl>
 <initial_action_postfix>
 cases  client_ID add_no_dups 
 </initial_action_postfix></initial_action_details>
@@ -3020,7 +3020,7 @@ cases  client_ID add_no_dups
 <intial_action_number>12</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add client to context of this table</initial_action_description>
+<initial_action_dsl>add client to context of this table</initial_action_dsl>
 <initial_action_postfix>
 client entitypush 
 </initial_action_postfix></initial_action_details>
@@ -3028,7 +3028,7 @@ client entitypush
 <intial_action_number>13</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add client to context for this table</initial_action_description>
+<initial_action_dsl>add client to context for this table</initial_action_dsl>
 <initial_action_postfix>
 client entitypush 
 </initial_action_postfix></initial_action_details>
@@ -3036,7 +3036,7 @@ client entitypush
 <intial_action_number>14</intial_action_number>
 <initial_action_comment>Missing scanner for element</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>remove totalgroupincome element from incomes array</initial_action_description>
+<initial_action_dsl>remove totalgroupincome element from incomes array</initial_action_dsl>
 <initial_action_postfix>
 incomes totalgroupincome removeat pop 
 </initial_action_postfix></initial_action_details>
@@ -3044,7 +3044,7 @@ incomes totalgroupincome removeat pop
 <intial_action_number>15</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>remove each client from clients where age &lt; 18</initial_action_description>
+<initial_action_dsl>remove each client from clients where age &lt; 18</initial_action_dsl>
 <initial_action_postfix>
 clients { { dup 0 entityfetch remove pop } age 18 &lt; if } over forallr pop
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -3053,7 +3053,7 @@ clients { { dup 0 entityfetch remove pop } age 18 &lt; if } over forallr pop
 <condition_number>1</condition_number>
 <condition_comment>does totalincome &gt; 42?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 totalincome 42 f&gt; 
 </condition_postfix>
@@ -3062,14 +3062,14 @@ totalincome 42 f&gt;
 <condition_number />
 <condition_comment>//does effectiveDate == (1 months) ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix />
 <condition_column column_value="N" column_number="2" /></condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -3079,7 +3079,7 @@ true
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -3089,14 +3089,14 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>//add currentdate to the results</action_description>
+<action_dsl>//add currentdate to the results</action_dsl>
 <action_postfix />
 <action_column column_value="X" column_number="2" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_5</action_description>
+<action_dsl>perform Run_Test_5</action_dsl>
 <action_postfix>
 Run_Test_5 
 </action_postfix>
@@ -3119,7 +3119,7 @@ Run_Test_5
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for the first of the job.cases where validatedCitizenship == true</context_description>
+<context_dsl>for the first of the job.cases where validatedCitizenship == true</context_dsl>
 <context_postfix>
 dup { validatedCitizenship true beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
@@ -3127,21 +3127,21 @@ dup { validatedCitizenship true beq  } job.cases  forfirst pop
 <context_number>2</context_number>
 <context_comment>for first of job.cases and it's case where    
       City == 'New York'</context_comment>
-<context_description>for the first of the job.cases and its address where city == 'New York'</context_description>
+<context_dsl>for the first of the job.cases and its address where city == 'New York'</context_dsl>
 <context_postfix>
 { address  entitypush dup execute entitypop } { address  entitypush city 'New York' streq  entitypop } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment />
-<context_description>for the first in the job.cases where validatedCitizenship == false</context_description>
+<context_dsl>for the first in the job.cases where validatedCitizenship == false</context_dsl>
 <context_postfix>
 dup { validatedCitizenship false beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment />
-<context_description>local entity theClient</context_description>
+<context_dsl>local entity theClient</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -3150,7 +3150,7 @@ null allocate execute deallocate pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>remove $steve from clients array</initial_action_description>
+<initial_action_dsl>remove $steve from clients array</initial_action_dsl>
 <initial_action_postfix>
 clients /steve remove pop 
 </initial_action_postfix></initial_action_details>
@@ -3158,7 +3158,7 @@ clients /steve remove pop
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>remove importantDates from InterestingDates array</initial_action_description>
+<initial_action_dsl>remove importantDates from InterestingDates array</initial_action_dsl>
 <initial_action_postfix>
 InterestingDates importantDates remove pop 
 </initial_action_postfix></initial_action_details>
@@ -3166,7 +3166,7 @@ InterestingDates importantDates remove pop
 <intial_action_number>3</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>remove client from clients array</initial_action_description>
+<initial_action_dsl>remove client from clients array</initial_action_dsl>
 <initial_action_postfix>
 clients client remove pop 
 </initial_action_postfix></initial_action_details>
@@ -3174,7 +3174,7 @@ clients client remove pop
 <intial_action_number>4</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>randomize clients</initial_action_description>
+<initial_action_dsl>randomize clients</initial_action_dsl>
 <initial_action_postfix>
 clients randomize 
 </initial_action_postfix></initial_action_details>
@@ -3182,7 +3182,7 @@ clients randomize
 <intial_action_number>5</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>clear clients</initial_action_description>
+<initial_action_dsl>clear clients</initial_action_dsl>
 <initial_action_postfix>
 clients clear 
 </initial_action_postfix></initial_action_details>
@@ -3190,7 +3190,7 @@ clients clear
 <intial_action_number>6</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>sort clients in ascending order by $steve</initial_action_description>
+<initial_action_dsl>sort clients in ascending order by $steve</initial_action_dsl>
 <initial_action_postfix>
 clients /steve true sortentities 
 </initial_action_postfix></initial_action_details>
@@ -3198,7 +3198,7 @@ clients /steve true sortentities
 <intial_action_number>7</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>sort clients in descending order by $steve</initial_action_description>
+<initial_action_dsl>sort clients in descending order by $steve</initial_action_dsl>
 <initial_action_postfix>
 clients /steve false sortentities 
 </initial_action_postfix></initial_action_details>
@@ -3206,7 +3206,7 @@ clients /steve false sortentities
 <intial_action_number>8</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>Set InterestingClients = job's clients</initial_action_description>
+<initial_action_dsl>Set InterestingClients = job's clients</initial_action_dsl>
 <initial_action_postfix>
 job entitypush clients entitypop /InterestingClients xdef 
 </initial_action_postfix></initial_action_details>
@@ -3214,7 +3214,7 @@ job entitypush clients entitypop /InterestingClients xdef
 <intial_action_number>9</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set cases = get copy of interestingCases</initial_action_description>
+<initial_action_dsl>set cases = get copy of interestingCases</initial_action_dsl>
 <initial_action_postfix>
 interestingCases copyelements /cases xdef 
 </initial_action_postfix></initial_action_details>
@@ -3222,7 +3222,7 @@ interestingCases copyelements /cases xdef
 <intial_action_number>10</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set interestingClients = copy of clients</initial_action_description>
+<initial_action_dsl>set interestingClients = copy of clients</initial_action_dsl>
 <initial_action_postfix>
 clients copyelements /interestingClients xdef 
 </initial_action_postfix></initial_action_details>
@@ -3230,7 +3230,7 @@ clients copyelements /interestingClients xdef
 <intial_action_number>11</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set cases = get deep copy of interestingCases</initial_action_description>
+<initial_action_dsl>set cases = get deep copy of interestingCases</initial_action_dsl>
 <initial_action_postfix>
 interestingCases deepcopy /cases xdef 
 </initial_action_postfix></initial_action_details>
@@ -3238,7 +3238,7 @@ interestingCases deepcopy /cases xdef
 <intial_action_number>12</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set interestingClients = deep copy of clients</initial_action_description>
+<initial_action_dsl>set interestingClients = deep copy of clients</initial_action_dsl>
 <initial_action_postfix>
 clients deepcopy /interestingClients xdef 
 </initial_action_postfix></initial_action_details>
@@ -3246,7 +3246,7 @@ clients deepcopy /interestingClients xdef
 <intial_action_number>13</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set errorCodes = [ 1 , 2, 3, 4 ]</initial_action_description>
+<initial_action_dsl>set errorCodes = [ 1 , 2, 3, 4 ]</initial_action_dsl>
 <initial_action_postfix>
 { 1 2 3 4 } /errorCodes xdef 
 </initial_action_postfix></initial_action_details>
@@ -3254,7 +3254,7 @@ clients deepcopy /interestingClients xdef
 <intial_action_number>14</intial_action_number>
 <initial_action_comment>Missing scanner for "array of values"</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set errorCodes = array of values [ job, cases, "clients", 10, -0.5, $boy ]</initial_action_description>
+<initial_action_dsl>set errorCodes = array of values [ job, cases, "clients", 10, -0.5, $boy ]</initial_action_dsl>
 <initial_action_postfix>
 mark job cases "clients" 10 0.5 fnegate /boy  arraytomark /errorCodes xdef 
 </initial_action_postfix></initial_action_details>
@@ -3262,7 +3262,7 @@ mark job cases "clients" 10 0.5 fnegate /boy  arraytomark /errorCodes xdef
 <intial_action_number>15</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set errorcodes = tokenize errorType by location</initial_action_description>
+<initial_action_dsl>set errorcodes = tokenize errorType by location</initial_action_dsl>
 <initial_action_postfix>
 errorType location tokenize /errorcodes xdef 
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -3271,7 +3271,7 @@ errorType location tokenize /errorcodes xdef
 <condition_number>1</condition_number>
 <condition_comment>does totalincome &gt; 42?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 totalincome 42 f&gt; 
 </condition_postfix>
@@ -3280,14 +3280,14 @@ totalincome 42 f&gt;
 <condition_number />
 <condition_comment>//does effectiveDate == (1 months) ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix />
 <condition_column column_value="N" column_number="2" /></condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -3297,7 +3297,7 @@ true
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -3307,14 +3307,14 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>//add currentdate to the results</action_description>
+<action_dsl>//add currentdate to the results</action_dsl>
 <action_postfix />
 <action_column column_value="X" column_number="2" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_6</action_description>
+<action_dsl>perform Run_Test_6</action_dsl>
 <action_postfix>
 Run_Test_6 
 </action_postfix>
@@ -3337,7 +3337,7 @@ Run_Test_6
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for the first of the job.cases where validatedCitizenship == true</context_description>
+<context_dsl>for the first of the job.cases where validatedCitizenship == true</context_dsl>
 <context_postfix>
 dup { validatedCitizenship true beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
@@ -3345,21 +3345,21 @@ dup { validatedCitizenship true beq  } job.cases  forfirst pop
 <context_number>2</context_number>
 <context_comment>for first of job.cases and it's case where    
       City == 'New York'</context_comment>
-<context_description>for the first of the job.cases and its address where city == 'New York'</context_description>
+<context_dsl>for the first of the job.cases and its address where city == 'New York'</context_dsl>
 <context_postfix>
 { address  entitypush dup execute entitypop } { address  entitypush city 'New York' streq  entitypop } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment />
-<context_description>for the first in the job.cases where validatedCitizenship == false</context_description>
+<context_dsl>for the first in the job.cases where validatedCitizenship == false</context_dsl>
 <context_postfix>
 dup { validatedCitizenship false beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment />
-<context_description>local entity theClient</context_description>
+<context_dsl>local entity theClient</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -3368,7 +3368,7 @@ null allocate execute deallocate pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set errorCodes = [ errorType, location, message ]</initial_action_description>
+<initial_action_dsl>set errorCodes = [ errorType, location, message ]</initial_action_dsl>
 <initial_action_postfix>
 { errorType location message } /errorCodes xdef 
 </initial_action_postfix></initial_action_details>
@@ -3376,7 +3376,7 @@ null allocate execute deallocate pop
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set errorCodes = [1.5, 2.75, 3.99]</initial_action_description>
+<initial_action_dsl>set errorCodes = [1.5, 2.75, 3.99]</initial_action_dsl>
 <initial_action_postfix>
 { 1.5 2.75 3.99 } /errorCodes xdef 
 </initial_action_postfix></initial_action_details>
@@ -3384,7 +3384,7 @@ null allocate execute deallocate pop
 <intial_action_number>3</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set theClient = clients [ 0 ]</initial_action_description>
+<initial_action_dsl>set theClient = clients [ 0 ]</initial_action_dsl>
 <initial_action_postfix>
 clients 0 getat cve 0 local!  
 </initial_action_postfix></initial_action_details>
@@ -3392,7 +3392,7 @@ clients 0 getat cve 0 local!
 <intial_action_number>4</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set InterestingClients = job's clients</initial_action_description>
+<initial_action_dsl>set InterestingClients = job's clients</initial_action_dsl>
 <initial_action_postfix>
 job entitypush clients entitypop /InterestingClients xdef 
 </initial_action_postfix></initial_action_details>
@@ -3400,7 +3400,7 @@ job entitypush clients entitypop /InterestingClients xdef
 <intial_action_number>5</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = new $theClient entity</initial_action_description>
+<initial_action_dsl>set client = new $theClient entity</initial_action_dsl>
 <initial_action_postfix>
 /theClient  createentity cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -3408,7 +3408,7 @@ job entitypush clients entitypop /InterestingClients xdef
 <intial_action_number>6</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client  = new client entity</initial_action_description>
+<initial_action_dsl>set client  = new client entity</initial_action_dsl>
 <initial_action_postfix>
 /client createentity cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -3416,7 +3416,7 @@ job entitypush clients entitypop /InterestingClients xdef
 <intial_action_number>7</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = clone of newClient</initial_action_description>
+<initial_action_dsl>set client = clone of newClient</initial_action_dsl>
 <initial_action_postfix>
 newClient clone cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -3424,7 +3424,7 @@ newClient clone cve /client xdef
 <intial_action_number>8</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = client's address</initial_action_description>
+<initial_action_dsl>set client = client's address</initial_action_dsl>
 <initial_action_postfix>
 client entitypush address entitypop cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -3432,7 +3432,7 @@ client entitypush address entitypop cve /client xdef
 <intial_action_number>9</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = first client in clients where age &lt; 18</initial_action_description>
+<initial_action_dsl>set client = first client in clients where age &lt; 18</initial_action_dsl>
 <initial_action_postfix>
 { client } { null } { age 18 &lt; } clients forfirstelse cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -3440,7 +3440,7 @@ client entitypush address entitypop cve /client xdef
 <intial_action_number>10</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = first client where pregnant == true</initial_action_description>
+<initial_action_dsl>set client = first client where pregnant == true</initial_action_dsl>
 <initial_action_postfix>
 { client } { null } { pregnant true beq } clients forfirstelse cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -3448,7 +3448,7 @@ client entitypush address entitypop cve /client xdef
 <intial_action_number>11</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set client = gender of client</initial_action_description>
+<initial_action_dsl>set client = gender of client</initial_action_dsl>
 <initial_action_postfix>
 { source } { null } { gender type == } forfirstelse cve /client xdef  
 </initial_action_postfix></initial_action_details>
@@ -3456,7 +3456,7 @@ client entitypush address entitypop cve /client xdef
 <intial_action_number>12</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>subtract 2 years from effectiveDate</initial_action_description>
+<initial_action_dsl>subtract 2 years from effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 2  negate addyears /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -3464,7 +3464,7 @@ effectiveDate 2  negate addyears /effectiveDate xdef
 <intial_action_number>13</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>subtract 10 months from effectiveDate</initial_action_description>
+<initial_action_dsl>subtract 10 months from effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 10  negate addmonths /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -3472,7 +3472,7 @@ effectiveDate 10  negate addmonths /effectiveDate xdef
 <intial_action_number>14</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>subtract 25 days from effectiveDate</initial_action_description>
+<initial_action_dsl>subtract 25 days from effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 25  negate adddays /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -3480,7 +3480,7 @@ effectiveDate 25  negate adddays /effectiveDate xdef
 <intial_action_number>15</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add 3 years to effectiveDate</initial_action_description>
+<initial_action_dsl>add 3 years to effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 3  addyears /effectiveDate xdef 
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -3489,7 +3489,7 @@ effectiveDate 3  addyears /effectiveDate xdef
 <condition_number>1</condition_number>
 <condition_comment>does totalincome &gt; 42?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 totalincome 42 f&gt; 
 </condition_postfix>
@@ -3498,14 +3498,14 @@ totalincome 42 f&gt;
 <condition_number />
 <condition_comment>//does effectiveDate == (1 months) ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix />
 <condition_column column_value="N" column_number="2" /></condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -3515,7 +3515,7 @@ true
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -3525,14 +3525,14 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>//add currentdate to the results</action_description>
+<action_dsl>//add currentdate to the results</action_dsl>
 <action_postfix />
 <action_column column_value="X" column_number="2" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_7</action_description>
+<action_dsl>perform Run_Test_7</action_dsl>
 <action_postfix>
 Run_Test_7 
 </action_postfix>
@@ -3555,7 +3555,7 @@ Run_Test_7
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for the first of the job.cases where validatedCitizenship == true</context_description>
+<context_dsl>for the first of the job.cases where validatedCitizenship == true</context_dsl>
 <context_postfix>
 dup { validatedCitizenship true beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
@@ -3563,21 +3563,21 @@ dup { validatedCitizenship true beq  } job.cases  forfirst pop
 <context_number>2</context_number>
 <context_comment>for first of job.cases and it's case where    
       City == 'New York'</context_comment>
-<context_description>for the first of the job.cases and its address where city == 'New York'</context_description>
+<context_dsl>for the first of the job.cases and its address where city == 'New York'</context_dsl>
 <context_postfix>
 { address  entitypush dup execute entitypop } { address  entitypush city 'New York' streq  entitypop } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment />
-<context_description>for the first in the job.cases where validatedCitizenship == false</context_description>
+<context_dsl>for the first in the job.cases where validatedCitizenship == false</context_dsl>
 <context_postfix>
 dup { validatedCitizenship false beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment />
-<context_description>local entity theClient</context_description>
+<context_dsl>local entity theClient</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -3586,7 +3586,7 @@ null allocate execute deallocate pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add 8 months to effectiveDate</initial_action_description>
+<initial_action_dsl>add 8 months to effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 8  addmonths /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -3594,7 +3594,7 @@ effectiveDate 8  addmonths /effectiveDate xdef
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>add 18 days to effectiveDate</initial_action_description>
+<initial_action_dsl>add 18 days to effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate 18  adddays /effectiveDate xdef 
 </initial_action_postfix></initial_action_details>
@@ -3602,7 +3602,7 @@ effectiveDate 18  adddays /effectiveDate xdef
 <intial_action_number>3</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = (Date) birthday</initial_action_description>
+<initial_action_dsl>set effectiveDate = (Date) birthday</initial_action_dsl>
 <initial_action_postfix>
 birthday cvd cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3610,7 +3610,7 @@ birthday cvd cvd /effectiveDate xdef
 <intial_action_number>4</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = date (birthday)</initial_action_description>
+<initial_action_dsl>set effectiveDate = date (birthday)</initial_action_dsl>
 <initial_action_postfix>
 birthday cvd cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3618,7 +3618,7 @@ birthday cvd cvd /effectiveDate xdef
 <intial_action_number>5</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = (date) clients [2]</initial_action_description>
+<initial_action_dsl>set effectiveDate = (date) clients [2]</initial_action_dsl>
 <initial_action_postfix>
 clients 2 getat cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3626,7 +3626,7 @@ clients 2 getat cvd /effectiveDate xdef
 <intial_action_number>6</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = using client (currentDate)</initial_action_description>
+<initial_action_dsl>set effectiveDate = using client (currentDate)</initial_action_dsl>
 <initial_action_postfix>
 client entitypush currentDate entitypop cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3634,7 +3634,7 @@ client entitypush currentDate entitypop cvd /effectiveDate xdef
 <intial_action_number>7</intial_action_number>
 <initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = job's effectiveDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = job's effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 job entitypush effectiveDate entitypop cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3642,7 +3642,7 @@ job entitypush effectiveDate entitypop cvd /effectiveDate xdef
 <intial_action_number>8</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = (20 days)</initial_action_description>
+<initial_action_dsl>set effectiveDate = (20 days)</initial_action_dsl>
 <initial_action_postfix>
 20  days cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3650,7 +3650,7 @@ job entitypush effectiveDate entitypop cvd /effectiveDate xdef
 <intial_action_number>9</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate + effectiveDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate + effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate effectiveDate d+ cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3658,7 +3658,7 @@ currentDate effectiveDate d+ cvd /effectiveDate xdef
 <intial_action_number>10</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate - effectiveDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate - effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate effectiveDate d- cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3666,7 +3666,7 @@ currentDate effectiveDate d- cvd /effectiveDate xdef
 <intial_action_number>11</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = subtract 1 year from currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = subtract 1 year from currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  1  negate addyears cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3674,7 +3674,7 @@ currentDate  1  negate addyears cvd /effectiveDate xdef
 <intial_action_number>12</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = subtract 9 months from currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = subtract 9 months from currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  9  negate addmonths cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3682,7 +3682,7 @@ currentDate  9  negate addmonths cvd /effectiveDate xdef
 <intial_action_number>13</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = subtract 22 days from currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = subtract 22 days from currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  22  negate adddays cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3690,7 +3690,7 @@ currentDate  22  negate adddays cvd /effectiveDate xdef
 <intial_action_number>14</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = add 2 years to currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = add 2 years to currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  2  addyears cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3698,7 +3698,7 @@ currentDate  2  addyears cvd /effectiveDate xdef
 <intial_action_number>15</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = add 8 months to currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = add 8 months to currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  8  addmonths cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -3707,7 +3707,7 @@ currentDate  8  addmonths cvd /effectiveDate xdef
 <condition_number>1</condition_number>
 <condition_comment>does totalincome &gt; 42?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 totalincome 42 f&gt; 
 </condition_postfix>
@@ -3716,7 +3716,7 @@ totalincome 42 f&gt;
 <condition_number>2</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -3726,7 +3726,7 @@ true
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -3736,14 +3736,14 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>//add currentdate to the results</action_description>
+<action_dsl>//add currentdate to the results</action_dsl>
 <action_postfix />
 <action_column column_value="X" column_number="2" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_8</action_description>
+<action_dsl>perform Run_Test_8</action_dsl>
 <action_postfix>
 Run_Test_8 
 </action_postfix>
@@ -3766,7 +3766,7 @@ Run_Test_8
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for the first of the job.cases where validatedCitizenship == true</context_description>
+<context_dsl>for the first of the job.cases where validatedCitizenship == true</context_dsl>
 <context_postfix>
 dup { validatedCitizenship true beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
@@ -3774,21 +3774,21 @@ dup { validatedCitizenship true beq  } job.cases  forfirst pop
 <context_number>2</context_number>
 <context_comment>for first of job.cases and it's case where    
       City == 'New York'</context_comment>
-<context_description>for the first of the job.cases and its address where city == 'New York'</context_description>
+<context_dsl>for the first of the job.cases and its address where city == 'New York'</context_dsl>
 <context_postfix>
 { address  entitypush dup execute entitypop } { address  entitypush city 'New York' streq  entitypop } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment />
-<context_description>for the first in the job.cases where validatedCitizenship == false</context_description>
+<context_dsl>for the first in the job.cases where validatedCitizenship == false</context_dsl>
 <context_postfix>
 dup { validatedCitizenship false beq  } job.cases  forfirst pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment />
-<context_description>local entity theClient</context_description>
+<context_dsl>local entity theClient</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -3797,7 +3797,7 @@ null allocate execute deallocate pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = add 14 days to currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = add 14 days to currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate  14  adddays cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3805,7 +3805,7 @@ currentDate  14  adddays cvd /effectiveDate xdef
 <intial_action_number>2</intial_action_number>
 <initial_action_comment>OK</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate - 1 year</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate - 1 year</initial_action_dsl>
 <initial_action_postfix>
 currentDate  1  negate addyears cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3813,7 +3813,7 @@ currentDate  1  negate addyears cvd /effectiveDate xdef
 <intial_action_number>3</intial_action_number>
 <initial_action_comment>OK</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate - 6 months</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate - 6 months</initial_action_dsl>
 <initial_action_postfix>
 currentDate  6  negate addmonths cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3821,7 +3821,7 @@ currentDate  6  negate addmonths cvd /effectiveDate xdef
 <intial_action_number>4</intial_action_number>
 <initial_action_comment>OK</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate - 20 days</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate - 20 days</initial_action_dsl>
 <initial_action_postfix>
 currentDate  20  negate adddays cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3829,7 +3829,7 @@ currentDate  20  negate adddays cvd /effectiveDate xdef
 <intial_action_number>5</intial_action_number>
 <initial_action_comment>OK</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate + 1 year</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate + 1 year</initial_action_dsl>
 <initial_action_postfix>
 currentDate  1  addyears cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3837,7 +3837,7 @@ currentDate  1  addyears cvd /effectiveDate xdef
 <intial_action_number>6</intial_action_number>
 <initial_action_comment>OK</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate  + 6 months</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate  + 6 months</initial_action_dsl>
 <initial_action_postfix>
 currentDate  6  addmonths cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3845,7 +3845,7 @@ currentDate  6  addmonths cvd /effectiveDate xdef
 <intial_action_number>7</intial_action_number>
 <initial_action_comment>OK</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = currentDate + 20 days</initial_action_description>
+<initial_action_dsl>set effectiveDate = currentDate + 20 days</initial_action_dsl>
 <initial_action_postfix>
 currentDate  20  adddays cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3853,7 +3853,7 @@ currentDate  20  adddays cvd /effectiveDate xdef
 <intial_action_number>8</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set currentDate = first of year of effectiveDate</initial_action_description>
+<initial_action_dsl>set currentDate = first of year of effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate firstofyear cvd /currentDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3861,7 +3861,7 @@ effectiveDate firstofyear cvd /currentDate xdef
 <intial_action_number>9</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set currentDate = first of month of effectiveDate</initial_action_description>
+<initial_action_dsl>set currentDate = first of month of effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate firstofmonth cvd /currentDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3869,7 +3869,7 @@ effectiveDate firstofmonth cvd /currentDate xdef
 <intial_action_number>10</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set currentDate = end of month of effectiveDate</initial_action_description>
+<initial_action_dsl>set currentDate = end of month of effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate endofmonth cvd /currentDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -3877,7 +3877,7 @@ effectiveDate endofmonth cvd /currentDate xdef
 <intial_action_number>11</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = earliest of cases after currentDate</initial_action_description>
+<initial_action_dsl>set effectiveDate = earliest of cases after currentDate</initial_action_dsl>
 <initial_action_postfix>
 currentDate dup &gt;r { { pop pop i i } over i d&gt; if pop } cases dup false sortarray for r&gt; pop cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -3886,7 +3886,7 @@ currentDate dup &gt;r { { pop pop i i } over i d&gt; if pop } cases dup false so
 <condition_number>1</condition_number>
 <condition_comment>does totalincome &gt; 42?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 totalincome 42 f&gt; 
 </condition_postfix>
@@ -3895,7 +3895,7 @@ totalincome 42 f&gt;
 <condition_number>2</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -3905,7 +3905,7 @@ true
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -3915,14 +3915,14 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>//add currentdate to the results</action_description>
+<action_dsl>//add currentdate to the results</action_dsl>
 <action_postfix />
 <action_column column_value="X" column_number="2" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_9</action_description>
+<action_dsl>perform Run_Test_9</action_dsl>
 <action_postfix>
 Run_Test_9 
 </action_postfix>
@@ -3945,7 +3945,7 @@ Run_Test_9
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -3954,7 +3954,7 @@ dup clients forall pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = attribute street of client</initial_action_description>
+<initial_action_dsl>set street = attribute street of client</initial_action_dsl>
 <initial_action_postfix>
 client street getXmlAttribute cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -3962,7 +3962,7 @@ client street getXmlAttribute cvs /street xdef
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = mapping key</initial_action_description>
+<initial_action_dsl>set street = mapping key</initial_action_dsl>
 <initial_action_postfix>
 "mapping*key" cvn execute cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -3970,7 +3970,7 @@ client street getXmlAttribute cvs /street xdef
 <intial_action_number>3</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = attribute street of client</initial_action_description>
+<initial_action_dsl>set street = attribute street of client</initial_action_dsl>
 <initial_action_postfix>
 client street getXmlAttribute cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -3978,7 +3978,7 @@ client street getXmlAttribute cvs /street xdef
 <intial_action_number>4</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set programLevel = substring of program from 0 to 10</initial_action_description>
+<initial_action_dsl>set programLevel = substring of program from 0 to 10</initial_action_dsl>
 <initial_action_postfix>
 10 0 program substring cvs /programLevel xdef  
 </initial_action_postfix></initial_action_details>
@@ -3986,7 +3986,7 @@ client street getXmlAttribute cvs /street xdef
 <intial_action_number>5</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = table information</initial_action_description>
+<initial_action_dsl>set street = table information</initial_action_dsl>
 <initial_action_postfix>
 actionstring cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -3994,7 +3994,7 @@ actionstring cvs /street xdef
 <intial_action_number>6</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = string</initial_action_description>
+<initial_action_dsl>set street = string</initial_action_dsl>
 <initial_action_postfix>
 string cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4002,7 +4002,7 @@ string cvs /street xdef
 <intial_action_number>7</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set parent = street + zip</initial_action_description>
+<initial_action_dsl>set parent = street + zip</initial_action_dsl>
 <initial_action_postfix>
 street zip strconcat cvs /parent xdef  
 </initial_action_postfix></initial_action_details>
@@ -4010,7 +4010,7 @@ street zip strconcat cvs /parent xdef
 <intial_action_number>8</intial_action_number>
 <initial_action_comment>changed the syntax</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set strBuffer = string value of 300.12</initial_action_description>
+<initial_action_dsl>set strBuffer = string value of 300.12</initial_action_dsl>
 <initial_action_postfix>
 300.12 tostring cvs /strBuffer xdef  
 </initial_action_postfix></initial_action_details>
@@ -4018,7 +4018,7 @@ street zip strconcat cvs /parent xdef
 <intial_action_number>9</intial_action_number>
 <initial_action_comment>changed the syntax</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set tips = string value of 45</initial_action_description>
+<initial_action_dsl>set tips = string value of 45</initial_action_dsl>
 <initial_action_postfix>
 45 tostring cvs /tips xdef  
 </initial_action_postfix></initial_action_details>
@@ -4026,8 +4026,8 @@ street zip strconcat cvs /parent xdef
 <intial_action_number>10</intial_action_number>
 <initial_action_comment>changed the syntax</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set importantDates = 
-      String value of  effectiveDate</initial_action_description>
+<initial_action_dsl>set importantDates = 
+      String value of  effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate tostring cvs /importantDates xdef  
 </initial_action_postfix></initial_action_details>
@@ -4035,7 +4035,7 @@ effectiveDate tostring cvs /importantDates xdef
 <intial_action_number>11</intial_action_number>
 <initial_action_comment>changed the syntax</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set strBuffer = string value of boolean pregnant</initial_action_description>
+<initial_action_dsl>set strBuffer = string value of boolean pregnant</initial_action_dsl>
 <initial_action_postfix>
 pregnant tostring cvs /strBuffer xdef  
 </initial_action_postfix></initial_action_details>
@@ -4043,7 +4043,7 @@ pregnant tostring cvs /strBuffer xdef
 <intial_action_number>12</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set programLevel = (program)</initial_action_description>
+<initial_action_dsl>set programLevel = (program)</initial_action_dsl>
 <initial_action_postfix>
 program cvs /programLevel xdef  
 </initial_action_postfix></initial_action_details>
@@ -4051,7 +4051,7 @@ program cvs /programLevel xdef
 <intial_action_number>13</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set wages = wages  + 55</initial_action_description>
+<initial_action_dsl>set wages = wages  + 55</initial_action_dsl>
 <initial_action_postfix>
 wages 55 strconcat cvs /wages xdef  
 </initial_action_postfix></initial_action_details>
@@ -4059,7 +4059,7 @@ wages 55 strconcat cvs /wages xdef
 <intial_action_number>14</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set tips = tips + 35.50</initial_action_description>
+<initial_action_dsl>set tips = tips + 35.50</initial_action_dsl>
 <initial_action_postfix>
 tips 35.50 strconcat cvs /tips xdef  
 </initial_action_postfix></initial_action_details>
@@ -4067,7 +4067,7 @@ tips 35.50 strconcat cvs /tips xdef
 <intial_action_number>15</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = street + $Oak</initial_action_description>
+<initial_action_dsl>set street = street + $Oak</initial_action_dsl>
 <initial_action_postfix>
 street /Oak strconcat cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4075,7 +4075,7 @@ street /Oak strconcat cvs /street xdef
 <intial_action_number>16</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set parent = street + zip</initial_action_description>
+<initial_action_dsl>set parent = street + zip</initial_action_dsl>
 <initial_action_postfix>
 street zip strconcat cvs /parent xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -4084,7 +4084,7 @@ street zip strconcat cvs /parent xdef
 <condition_number>2</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -4094,7 +4094,7 @@ true
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -4104,14 +4104,14 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>//add currentdate to the results</action_description>
+<action_dsl>//add currentdate to the results</action_dsl>
 <action_postfix />
 <action_column column_value="X" column_number="2" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_10</action_description>
+<action_dsl>perform Run_Test_10</action_dsl>
 <action_postfix>
 Run_Test_10 
 </action_postfix>
@@ -4134,7 +4134,7 @@ Run_Test_10
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -4143,7 +4143,7 @@ dup clients forall pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = street + billingAddress</initial_action_description>
+<initial_action_dsl>set street = street + billingAddress</initial_action_dsl>
 <initial_action_postfix>
 street billingAddress strconcat cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4151,7 +4151,7 @@ street billingAddress strconcat cvs /street xdef
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set importantDates = importantDates + currentDate</initial_action_description>
+<initial_action_dsl>set importantDates = importantDates + currentDate</initial_action_dsl>
 <initial_action_postfix>
 importantDates currentDate strconcat cvs /importantDates xdef  
 </initial_action_postfix></initial_action_details>
@@ -4159,7 +4159,7 @@ importantDates currentDate strconcat cvs /importantDates xdef
 <intial_action_number>3</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = street + clients</initial_action_description>
+<initial_action_dsl>set street = street + clients</initial_action_dsl>
 <initial_action_postfix>
 street clients strconcat cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4167,7 +4167,7 @@ street clients strconcat cvs /street xdef
 <intial_action_number>4</intial_action_number>
 <initial_action_comment>Missing Trim</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set street = trim (zip)</initial_action_description>
+<initial_action_dsl>set street = trim (zip)</initial_action_dsl>
 <initial_action_postfix>
 zip strtrim cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4175,7 +4175,7 @@ zip strtrim cvs /street xdef
 <intial_action_number>5</intial_action_number>
 <initial_action_comment>okay... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set street = change street to lower case</initial_action_description>
+<initial_action_dsl>set street = change street to lower case</initial_action_dsl>
 <initial_action_postfix>
 street tolowercase cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4183,7 +4183,7 @@ street tolowercase cvs /street xdef
 <intial_action_number>6</intial_action_number>
 <initial_action_comment>USE VERY CAREFULLY.  Can break testing</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = the current date</initial_action_description>
+<initial_action_dsl>set effectiveDate = the current date</initial_action_dsl>
 <initial_action_postfix>
 getdate cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -4191,7 +4191,7 @@ getdate cvd /effectiveDate xdef
 <intial_action_number>7</intial_action_number>
 <initial_action_comment>USE VERY CAREFULLY.  Can break testing</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set strBuffer = get current timestamp</initial_action_description>
+<initial_action_dsl>set strBuffer = get current timestamp</initial_action_dsl>
 <initial_action_postfix>
 getdate gettimestamp cvs /strBuffer xdef  
 </initial_action_postfix></initial_action_details>
@@ -4199,7 +4199,7 @@ getdate gettimestamp cvs /strBuffer xdef
 <intial_action_number>8</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = using client (street)</initial_action_description>
+<initial_action_dsl>set street = using client (street)</initial_action_dsl>
 <initial_action_postfix>
 client entitypush street entitypop cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4207,7 +4207,7 @@ client entitypush street entitypop cvs /street xdef
 <intial_action_number>9</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = 550.87</initial_action_description>
+<initial_action_dsl>set totalIncome = 550.87</initial_action_dsl>
 <initial_action_postfix>
 550.87  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4215,7 +4215,7 @@ client entitypush street entitypop cvs /street xdef
 <intial_action_number>10</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = (double) wages</initial_action_description>
+<initial_action_dsl>set totalIncome = (double) wages</initial_action_dsl>
 <initial_action_postfix>
 wages cvr  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4223,7 +4223,7 @@ wages cvr  cvr /totalIncome xdef
 <intial_action_number>11</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = (double) totalGroupIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = (double) totalGroupIncome</initial_action_dsl>
 <initial_action_postfix>
 totalGroupIncome cvr  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4231,7 +4231,7 @@ totalGroupIncome cvr  cvr /totalIncome xdef
 <intial_action_number>12</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome + totalGroupIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome + totalGroupIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome totalGroupIncome fadd  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4239,7 +4239,7 @@ totalIncome totalGroupIncome fadd  cvr /totalIncome xdef
 <intial_action_number>13</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalGroupIncome + totalIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalGroupIncome + totalIncome</initial_action_dsl>
 <initial_action_postfix>
 totalGroupIncome totalIncome fadd  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4247,7 +4247,7 @@ totalGroupIncome totalIncome fadd  cvr /totalIncome xdef
 <intial_action_number>14</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome - totalGroupIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome - totalGroupIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome totalGroupIncome fsub  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4255,7 +4255,7 @@ totalIncome totalGroupIncome fsub  cvr /totalIncome xdef
 <intial_action_number>15</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome - additionalIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome - additionalIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome additionalIncome fsub  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4263,7 +4263,7 @@ totalIncome additionalIncome fsub  cvr /totalIncome xdef
 <intial_action_number>16</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome * totalGroupIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome * totalGroupIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome totalGroupIncome fmul  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -4272,14 +4272,14 @@ totalIncome totalGroupIncome fmul  cvr /totalIncome xdef
 <condition_number>1</condition_number>
 <condition_comment>//does test == true ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix />
 <condition_column column_value="N" column_number="1" /></condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -4289,7 +4289,7 @@ true
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -4299,14 +4299,14 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>//add currentdate to the results</action_description>
+<action_dsl>//add currentdate to the results</action_dsl>
 <action_postfix />
 <action_column column_value="X" column_number="2" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_11</action_description>
+<action_dsl>perform Run_Test_11</action_dsl>
 <action_postfix>
 Run_Test_11 
 </action_postfix>
@@ -4331,7 +4331,7 @@ Run_Test_11
 <intial_action_number>32</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome - totalGroupIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome - totalGroupIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome totalGroupIncome fsub  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4339,7 +4339,7 @@ totalIncome totalGroupIncome fsub  cvr /totalIncome xdef
 <intial_action_number>33</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome - additionalIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome - additionalIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome additionalIncome fsub  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4347,7 +4347,7 @@ totalIncome additionalIncome fsub  cvr /totalIncome xdef
 <intial_action_number>34</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome * totalGroupIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome * totalGroupIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome totalGroupIncome fmul  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4355,7 +4355,7 @@ totalIncome totalGroupIncome fmul  cvr /totalIncome xdef
 <intial_action_number>35</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome * additionalIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome * additionalIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome additionalIncome fmul  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4363,7 +4363,7 @@ totalIncome additionalIncome fmul  cvr /totalIncome xdef
 <intial_action_number>36</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome / totalGroupIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome / totalGroupIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome totalGroupIncome fdiv  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4371,7 +4371,7 @@ totalIncome totalGroupIncome fdiv  cvr /totalIncome xdef
 <intial_action_number>37</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome / additionalIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome / additionalIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome additionalIncome fdiv  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4379,7 +4379,7 @@ totalIncome additionalIncome fdiv  cvr /totalIncome xdef
 <intial_action_number>38</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = - additionalIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = - additionalIncome</initial_action_dsl>
 <initial_action_postfix>
 additionalIncome fnegate  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4387,7 +4387,7 @@ additionalIncome fnegate  cvr /totalIncome xdef
 <intial_action_number>39</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = (additionalIncome)</initial_action_description>
+<initial_action_dsl>set totalIncome = (additionalIncome)</initial_action_dsl>
 <initial_action_postfix>
 additionalIncome  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4395,7 +4395,7 @@ additionalIncome  cvr /totalIncome xdef
 <intial_action_number>40</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = (double) clients [0]</initial_action_description>
+<initial_action_dsl>set totalIncome = (double) clients [0]</initial_action_dsl>
 <initial_action_postfix>
 clients 0 getat  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4403,7 +4403,7 @@ clients 0 getat  cvr /totalIncome xdef
 <intial_action_number>41</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = add to totalIncome 75</initial_action_description>
+<initial_action_dsl>set totalIncome = add to totalIncome 75</initial_action_dsl>
 <initial_action_postfix>
 /75   totalIncome75   fadd def  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4411,7 +4411,7 @@ clients 0 getat  cvr /totalIncome xdef
 <intial_action_number>42</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = subtract from totalIncome 99</initial_action_description>
+<initial_action_dsl>set totalIncome = subtract from totalIncome 99</initial_action_dsl>
 <initial_action_postfix>
 /99   totalIncome99   fsub def  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4419,7 +4419,7 @@ clients 0 getat  cvr /totalIncome xdef
 <intial_action_number>43</intial_action_number>
 <initial_action_comment>Missing Multiply in the scanner</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set totalIncome = multiply totalIncome by 2</initial_action_description>
+<initial_action_dsl>set totalIncome = multiply totalIncome by 2</initial_action_dsl>
 <initial_action_postfix>
 /2   totalIncome2   fmul def  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4427,7 +4427,7 @@ clients 0 getat  cvr /totalIncome xdef
 <intial_action_number>44</intial_action_number>
 <initial_action_comment>Missing Divide in the scanner</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set totalIncome = divide totalIncome by 2</initial_action_description>
+<initial_action_dsl>set totalIncome = divide totalIncome by 2</initial_action_dsl>
 <initial_action_postfix>
 /2   totalIncome2   fmul def  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4435,7 +4435,7 @@ clients 0 getat  cvr /totalIncome xdef
 <intial_action_number>45</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = absolute value of totalIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = absolute value of totalIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome fabs  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4443,7 +4443,7 @@ totalIncome fabs  cvr /totalIncome xdef
 <intial_action_number>46</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = using clients (totalIncome)</initial_action_description>
+<initial_action_dsl>set totalIncome = using clients (totalIncome)</initial_action_dsl>
 <initial_action_postfix>
 clients entitypush totalIncome  entitypop  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4451,7 +4451,7 @@ clients entitypush totalIncome  entitypop  cvr /totalIncome xdef
 <intial_action_number>47</intial_action_number>
 <initial_action_comment>missing rounded in the scanner</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome rounded</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome rounded</initial_action_dsl>
 <initial_action_postfix>
 totalIncome 0 0.5 roundto  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4459,7 +4459,7 @@ totalIncome 0 0.5 roundto  cvr /totalIncome xdef
 <intial_action_number>48</intial_action_number>
 <initial_action_comment>missing decimal places in the scanner</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome rounded to 3 decimal places</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome rounded to 3 decimal places</initial_action_dsl>
 <initial_action_postfix>
 totalIncome 3 0.5 roundto  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4467,7 +4467,7 @@ totalIncome 3 0.5 roundto  cvr /totalIncome xdef
 <intial_action_number>49</intial_action_number>
 <initial_action_comment>missing with boundry in the scanner</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome rounded to 2 decimal places with  boundry .4</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome rounded to 2 decimal places with  boundry .4</initial_action_dsl>
 <initial_action_postfix>
 totalIncome 2 .4  roundto  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4475,7 +4475,7 @@ totalIncome 2 .4  roundto  cvr /totalIncome xdef
 <intial_action_number>50</intial_action_number>
 <initial_action_comment>Error</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set totalIncome = sum of additionalIncome in clients</initial_action_description>
+<initial_action_dsl>set totalIncome = sum of additionalIncome in clients</initial_action_dsl>
 <initial_action_postfix>
 0 { additionalIncomefadd } clients forall  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -4484,14 +4484,14 @@ totalIncome 2 .4  roundto  cvr /totalIncome xdef
 <condition_number>1</condition_number>
 <condition_comment>//does test == true ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix />
 <condition_column column_value="N" column_number="1" /></condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -4501,7 +4501,7 @@ true
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -4511,14 +4511,14 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>//add currentdate to the results</action_description>
+<action_dsl>//add currentdate to the results</action_dsl>
 <action_postfix />
 <action_column column_value="X" column_number="2" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_12</action_description>
+<action_dsl>perform Run_Test_12</action_dsl>
 <action_postfix>
 Run_Test_12 
 </action_postfix>
@@ -4541,7 +4541,7 @@ Run_Test_12
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -4550,7 +4550,7 @@ dup clients forall pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = attribute street of client</initial_action_description>
+<initial_action_dsl>set street = attribute street of client</initial_action_dsl>
 <initial_action_postfix>
 client street getXmlAttribute cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4558,7 +4558,7 @@ client street getXmlAttribute cvs /street xdef
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = mapping key</initial_action_description>
+<initial_action_dsl>set street = mapping key</initial_action_dsl>
 <initial_action_postfix>
 "mapping*key" cvn execute cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4566,7 +4566,7 @@ client street getXmlAttribute cvs /street xdef
 <intial_action_number>3</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = attribute street of client</initial_action_description>
+<initial_action_dsl>set street = attribute street of client</initial_action_dsl>
 <initial_action_postfix>
 client street getXmlAttribute cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4574,7 +4574,7 @@ client street getXmlAttribute cvs /street xdef
 <intial_action_number>4</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set programLevel = substring of program from 0 to 10</initial_action_description>
+<initial_action_dsl>set programLevel = substring of program from 0 to 10</initial_action_dsl>
 <initial_action_postfix>
 10 0 program substring cvs /programLevel xdef  
 </initial_action_postfix></initial_action_details>
@@ -4582,7 +4582,7 @@ client street getXmlAttribute cvs /street xdef
 <intial_action_number>5</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = table information</initial_action_description>
+<initial_action_dsl>set street = table information</initial_action_dsl>
 <initial_action_postfix>
 actionstring cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4590,7 +4590,7 @@ actionstring cvs /street xdef
 <intial_action_number>6</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = string</initial_action_description>
+<initial_action_dsl>set street = string</initial_action_dsl>
 <initial_action_postfix>
 string cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4598,7 +4598,7 @@ string cvs /street xdef
 <intial_action_number>7</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set parent = street + zip</initial_action_description>
+<initial_action_dsl>set parent = street + zip</initial_action_dsl>
 <initial_action_postfix>
 street zip strconcat cvs /parent xdef  
 </initial_action_postfix></initial_action_details>
@@ -4606,7 +4606,7 @@ street zip strconcat cvs /parent xdef
 <intial_action_number>8</intial_action_number>
 <initial_action_comment>changed the syntax</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set strBuffer = string value of 300.12</initial_action_description>
+<initial_action_dsl>set strBuffer = string value of 300.12</initial_action_dsl>
 <initial_action_postfix>
 300.12 tostring cvs /strBuffer xdef  
 </initial_action_postfix></initial_action_details>
@@ -4614,7 +4614,7 @@ street zip strconcat cvs /parent xdef
 <intial_action_number>9</intial_action_number>
 <initial_action_comment>changed the syntax</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set tips = string value of 45</initial_action_description>
+<initial_action_dsl>set tips = string value of 45</initial_action_dsl>
 <initial_action_postfix>
 45 tostring cvs /tips xdef  
 </initial_action_postfix></initial_action_details>
@@ -4622,8 +4622,8 @@ street zip strconcat cvs /parent xdef
 <intial_action_number>10</intial_action_number>
 <initial_action_comment>changed the syntax</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set importantDates = 
-      String value of  effectiveDate</initial_action_description>
+<initial_action_dsl>set importantDates = 
+      String value of  effectiveDate</initial_action_dsl>
 <initial_action_postfix>
 effectiveDate tostring cvs /importantDates xdef  
 </initial_action_postfix></initial_action_details>
@@ -4631,7 +4631,7 @@ effectiveDate tostring cvs /importantDates xdef
 <intial_action_number>11</intial_action_number>
 <initial_action_comment>changed the syntax</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set strBuffer = string value of boolean pregnant</initial_action_description>
+<initial_action_dsl>set strBuffer = string value of boolean pregnant</initial_action_dsl>
 <initial_action_postfix>
 pregnant tostring cvs /strBuffer xdef  
 </initial_action_postfix></initial_action_details>
@@ -4639,7 +4639,7 @@ pregnant tostring cvs /strBuffer xdef
 <intial_action_number>12</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set programLevel = (program)</initial_action_description>
+<initial_action_dsl>set programLevel = (program)</initial_action_dsl>
 <initial_action_postfix>
 program cvs /programLevel xdef  
 </initial_action_postfix></initial_action_details>
@@ -4647,7 +4647,7 @@ program cvs /programLevel xdef
 <intial_action_number>13</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set wages = wages  + 55</initial_action_description>
+<initial_action_dsl>set wages = wages  + 55</initial_action_dsl>
 <initial_action_postfix>
 wages 55 strconcat cvs /wages xdef  
 </initial_action_postfix></initial_action_details>
@@ -4655,7 +4655,7 @@ wages 55 strconcat cvs /wages xdef
 <intial_action_number>14</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set tips = tips + 35.50</initial_action_description>
+<initial_action_dsl>set tips = tips + 35.50</initial_action_dsl>
 <initial_action_postfix>
 tips 35.50 strconcat cvs /tips xdef  
 </initial_action_postfix></initial_action_details>
@@ -4663,7 +4663,7 @@ tips 35.50 strconcat cvs /tips xdef
 <intial_action_number>15</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = street + $Oak</initial_action_description>
+<initial_action_dsl>set street = street + $Oak</initial_action_dsl>
 <initial_action_postfix>
 street /Oak strconcat cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4671,7 +4671,7 @@ street /Oak strconcat cvs /street xdef
 <intial_action_number>16</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set parent = street + zip</initial_action_description>
+<initial_action_dsl>set parent = street + zip</initial_action_dsl>
 <initial_action_postfix>
 street zip strconcat cvs /parent xdef  
 </initial_action_postfix></initial_action_details>
@@ -4679,7 +4679,7 @@ street zip strconcat cvs /parent xdef
 <intial_action_number>17</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = street + billingAddress</initial_action_description>
+<initial_action_dsl>set street = street + billingAddress</initial_action_dsl>
 <initial_action_postfix>
 street billingAddress strconcat cvs /street xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -4688,14 +4688,14 @@ street billingAddress strconcat cvs /street xdef
 <condition_number>1</condition_number>
 <condition_comment>//does test == true ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix />
 <condition_column column_value="N" column_number="1" /></condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -4705,7 +4705,7 @@ true
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -4715,14 +4715,14 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>//add currentdate to the results</action_description>
+<action_dsl>//add currentdate to the results</action_dsl>
 <action_postfix />
 <action_column column_value="X" column_number="2" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_13</action_description>
+<action_dsl>perform Run_Test_13</action_dsl>
 <action_postfix>
 Run_Test_13 
 </action_postfix>
@@ -4745,7 +4745,7 @@ Run_Test_13
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -4754,7 +4754,7 @@ dup clients forall pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set importantDates = importantDates + currentDate</initial_action_description>
+<initial_action_dsl>set importantDates = importantDates + currentDate</initial_action_dsl>
 <initial_action_postfix>
 importantDates currentDate strconcat cvs /importantDates xdef  
 </initial_action_postfix></initial_action_details>
@@ -4762,7 +4762,7 @@ importantDates currentDate strconcat cvs /importantDates xdef
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = street + clients</initial_action_description>
+<initial_action_dsl>set street = street + clients</initial_action_dsl>
 <initial_action_postfix>
 street clients strconcat cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4770,7 +4770,7 @@ street clients strconcat cvs /street xdef
 <intial_action_number>3</intial_action_number>
 <initial_action_comment>Missing Trim</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set street = trim (zip)</initial_action_description>
+<initial_action_dsl>set street = trim (zip)</initial_action_dsl>
 <initial_action_postfix>
 zip strtrim cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4778,7 +4778,7 @@ zip strtrim cvs /street xdef
 <intial_action_number>4</intial_action_number>
 <initial_action_comment>okay... Statement was wrong</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set street = change street to lower case</initial_action_description>
+<initial_action_dsl>set street = change street to lower case</initial_action_dsl>
 <initial_action_postfix>
 street tolowercase cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4786,7 +4786,7 @@ street tolowercase cvs /street xdef
 <intial_action_number>5</intial_action_number>
 <initial_action_comment>USE VERY CAREFULLY.  Can break testing</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set effectiveDate = the current date</initial_action_description>
+<initial_action_dsl>set effectiveDate = the current date</initial_action_dsl>
 <initial_action_postfix>
 getdate cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details>
@@ -4794,7 +4794,7 @@ getdate cvd /effectiveDate xdef
 <intial_action_number>6</intial_action_number>
 <initial_action_comment>USE VERY CAREFULLY.  Can break testing</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set strBuffer = get current timestamp</initial_action_description>
+<initial_action_dsl>set strBuffer = get current timestamp</initial_action_dsl>
 <initial_action_postfix>
 getdate gettimestamp cvs /strBuffer xdef  
 </initial_action_postfix></initial_action_details>
@@ -4802,7 +4802,7 @@ getdate gettimestamp cvs /strBuffer xdef
 <intial_action_number>7</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set street = using client (street)</initial_action_description>
+<initial_action_dsl>set street = using client (street)</initial_action_dsl>
 <initial_action_postfix>
 client entitypush street entitypop cvs /street xdef  
 </initial_action_postfix></initial_action_details>
@@ -4810,7 +4810,7 @@ client entitypush street entitypop cvs /street xdef
 <intial_action_number>8</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = 550.87</initial_action_description>
+<initial_action_dsl>set totalIncome = 550.87</initial_action_dsl>
 <initial_action_postfix>
 550.87  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4818,7 +4818,7 @@ client entitypush street entitypop cvs /street xdef
 <intial_action_number>9</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = (double) wages</initial_action_description>
+<initial_action_dsl>set totalIncome = (double) wages</initial_action_dsl>
 <initial_action_postfix>
 wages cvr  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4826,7 +4826,7 @@ wages cvr  cvr /totalIncome xdef
 <intial_action_number>10</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = (double) totalGroupIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = (double) totalGroupIncome</initial_action_dsl>
 <initial_action_postfix>
 totalGroupIncome cvr  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4834,7 +4834,7 @@ totalGroupIncome cvr  cvr /totalIncome xdef
 <intial_action_number>11</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome + totalGroupIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome + totalGroupIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome totalGroupIncome fadd  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4842,7 +4842,7 @@ totalIncome totalGroupIncome fadd  cvr /totalIncome xdef
 <intial_action_number>12</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalGroupIncome + totalIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalGroupIncome + totalIncome</initial_action_dsl>
 <initial_action_postfix>
 totalGroupIncome totalIncome fadd  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4850,7 +4850,7 @@ totalGroupIncome totalIncome fadd  cvr /totalIncome xdef
 <intial_action_number>13</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome - totalGroupIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome - totalGroupIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome totalGroupIncome fsub  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4858,7 +4858,7 @@ totalIncome totalGroupIncome fsub  cvr /totalIncome xdef
 <intial_action_number>14</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome - additionalIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome - additionalIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome additionalIncome fsub  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4866,7 +4866,7 @@ totalIncome additionalIncome fsub  cvr /totalIncome xdef
 <intial_action_number>15</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome * totalGroupIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome * totalGroupIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome totalGroupIncome fmul  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4874,7 +4874,7 @@ totalIncome totalGroupIncome fmul  cvr /totalIncome xdef
 <intial_action_number>16</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome * additionalIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome * additionalIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome additionalIncome fmul  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -4883,14 +4883,14 @@ totalIncome additionalIncome fmul  cvr /totalIncome xdef
 <condition_number>1</condition_number>
 <condition_comment>//does test == true ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix />
 <condition_column column_value="N" column_number="1" /></condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -4900,7 +4900,7 @@ true
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -4910,14 +4910,14 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>//add currentdate to the results</action_description>
+<action_dsl>//add currentdate to the results</action_dsl>
 <action_postfix />
 <action_column column_value="X" column_number="2" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_14</action_description>
+<action_dsl>perform Run_Test_14</action_dsl>
 <action_postfix>
 Run_Test_14 
 </action_postfix>
@@ -4940,7 +4940,7 @@ Run_Test_14
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -4949,7 +4949,7 @@ dup clients forall pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome / totalGroupIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome / totalGroupIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome totalGroupIncome fdiv  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4957,7 +4957,7 @@ totalIncome totalGroupIncome fdiv  cvr /totalIncome xdef
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome / additionalIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome / additionalIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome additionalIncome fdiv  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4965,7 +4965,7 @@ totalIncome additionalIncome fdiv  cvr /totalIncome xdef
 <intial_action_number>3</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = - additionalIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = - additionalIncome</initial_action_dsl>
 <initial_action_postfix>
 additionalIncome fnegate  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4973,7 +4973,7 @@ additionalIncome fnegate  cvr /totalIncome xdef
 <intial_action_number>4</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = (additionalIncome)</initial_action_description>
+<initial_action_dsl>set totalIncome = (additionalIncome)</initial_action_dsl>
 <initial_action_postfix>
 additionalIncome  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4981,7 +4981,7 @@ additionalIncome  cvr /totalIncome xdef
 <intial_action_number>5</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = (double) clients [0]</initial_action_description>
+<initial_action_dsl>set totalIncome = (double) clients [0]</initial_action_dsl>
 <initial_action_postfix>
 clients 0 getat  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4989,7 +4989,7 @@ clients 0 getat  cvr /totalIncome xdef
 <intial_action_number>6</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = add to totalIncome 75</initial_action_description>
+<initial_action_dsl>set totalIncome = add to totalIncome 75</initial_action_dsl>
 <initial_action_postfix>
 /75   totalIncome75   fadd def  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -4997,7 +4997,7 @@ clients 0 getat  cvr /totalIncome xdef
 <intial_action_number>7</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = subtract from totalIncome 99</initial_action_description>
+<initial_action_dsl>set totalIncome = subtract from totalIncome 99</initial_action_dsl>
 <initial_action_postfix>
 /99   totalIncome99   fsub def  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -5005,7 +5005,7 @@ clients 0 getat  cvr /totalIncome xdef
 <intial_action_number>8</intial_action_number>
 <initial_action_comment>Missing Multiply in the scanner</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set totalIncome = multiply totalIncome by 2</initial_action_description>
+<initial_action_dsl>set totalIncome = multiply totalIncome by 2</initial_action_dsl>
 <initial_action_postfix>
 /2   totalIncome2   fmul def  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -5013,7 +5013,7 @@ clients 0 getat  cvr /totalIncome xdef
 <intial_action_number>9</intial_action_number>
 <initial_action_comment>Missing Divide in the scanner</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set totalIncome = divide totalIncome by 2</initial_action_description>
+<initial_action_dsl>set totalIncome = divide totalIncome by 2</initial_action_dsl>
 <initial_action_postfix>
 /2   totalIncome2   fmul def  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -5021,7 +5021,7 @@ clients 0 getat  cvr /totalIncome xdef
 <intial_action_number>10</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = absolute value of totalIncome</initial_action_description>
+<initial_action_dsl>set totalIncome = absolute value of totalIncome</initial_action_dsl>
 <initial_action_postfix>
 totalIncome fabs  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -5029,7 +5029,7 @@ totalIncome fabs  cvr /totalIncome xdef
 <intial_action_number>11</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set totalIncome = using clients (totalIncome)</initial_action_description>
+<initial_action_dsl>set totalIncome = using clients (totalIncome)</initial_action_dsl>
 <initial_action_postfix>
 clients entitypush totalIncome  entitypop  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -5037,7 +5037,7 @@ clients entitypush totalIncome  entitypop  cvr /totalIncome xdef
 <intial_action_number>12</intial_action_number>
 <initial_action_comment>missing rounded in the scanner</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome rounded</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome rounded</initial_action_dsl>
 <initial_action_postfix>
 totalIncome 0 0.5 roundto  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -5045,7 +5045,7 @@ totalIncome 0 0.5 roundto  cvr /totalIncome xdef
 <intial_action_number>13</intial_action_number>
 <initial_action_comment>missing decimal places in the scanner</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome rounded to 3 decimal places</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome rounded to 3 decimal places</initial_action_dsl>
 <initial_action_postfix>
 totalIncome 3 0.5 roundto  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -5053,7 +5053,7 @@ totalIncome 3 0.5 roundto  cvr /totalIncome xdef
 <intial_action_number>14</intial_action_number>
 <initial_action_comment>missing with boundry in the scanner</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set totalIncome = totalIncome rounded to 2 decimal places with  boundry .4</initial_action_description>
+<initial_action_dsl>set totalIncome = totalIncome rounded to 2 decimal places with  boundry .4</initial_action_dsl>
 <initial_action_postfix>
 totalIncome 2 .4  roundto  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details>
@@ -5061,7 +5061,7 @@ totalIncome 2 .4  roundto  cvr /totalIncome xdef
 <intial_action_number>15</intial_action_number>
 <initial_action_comment>Error</initial_action_comment>
 <initial_action_requirement />
-<initial_action_description>set totalIncome = sum of additionalIncome in clients</initial_action_description>
+<initial_action_dsl>set totalIncome = sum of additionalIncome in clients</initial_action_dsl>
 <initial_action_postfix>
 0 { additionalIncomefadd } clients forall  cvr /totalIncome xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -5070,14 +5070,14 @@ totalIncome 2 .4  roundto  cvr /totalIncome xdef
 <condition_number>1</condition_number>
 <condition_comment>//does test == true ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix />
 <condition_column column_value="N" column_number="1" /></condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true 
 </condition_postfix>
@@ -5087,7 +5087,7 @@ true
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -5097,14 +5097,14 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>//add currentdate to the results</action_description>
+<action_dsl>//add currentdate to the results</action_dsl>
 <action_postfix />
 <action_column column_value="X" column_number="2" /></action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_15</action_description>
+<action_dsl>perform Run_Test_15</action_dsl>
 <action_postfix>
 Run_Test_15 
 </action_postfix>
@@ -5127,28 +5127,28 @@ Run_Test_15
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>local date Today2 = currentdate</context_description>
+<context_dsl>local date Today2 = currentdate</context_dsl>
 <context_postfix>
 currentdate cvd allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment />
-<context_description>local date Today1 = Today2</context_description>
+<context_dsl>local date Today1 = Today2</context_dsl>
 <context_postfix>
 0 local@  cvd allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment />
-<context_description>local long clientAge</context_description>
+<context_dsl>local long clientAge</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number />
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -5157,7 +5157,7 @@ dup clients forall pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set clientAge = 45</initial_action_description>
+<initial_action_dsl>set clientAge = 45</initial_action_dsl>
 <initial_action_postfix>
 45  cvi 2 local!  
 </initial_action_postfix></initial_action_details>
@@ -5165,7 +5165,7 @@ dup clients forall pop
 <intial_action_number>2</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set case_ID = "22344"</initial_action_description>
+<initial_action_dsl>set case_ID = "22344"</initial_action_dsl>
 <initial_action_postfix>
 "22344" cvs /case_ID xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -5174,7 +5174,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today1 == Today2</condition_description>
+<condition_dsl>Today1 == Today2</condition_dsl>
 <condition_postfix>
 1 local@  0 local@  d== 
 </condition_postfix>
@@ -5183,7 +5183,7 @@ dup clients forall pop
 <condition_number>2</condition_number>
 <condition_comment>does Today2 == Today1 ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 0 local@  1 local@  d== 
 </condition_postfix>
@@ -5192,7 +5192,7 @@ dup clients forall pop
 <condition_number>3</condition_number>
 <condition_comment>was Today2 == Today1 ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 0 local@  1 local@  d== 
 </condition_postfix>
@@ -5201,7 +5201,7 @@ dup clients forall pop
 <condition_number>4</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>clientAge &gt; 18</condition_description>
+<condition_dsl>clientAge &gt; 18</condition_dsl>
 <condition_postfix>
 2 local@  18 &gt; 
 </condition_postfix>
@@ -5210,7 +5210,7 @@ dup clients forall pop
 <condition_number>5</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>clientAge &lt; 18</condition_description>
+<condition_dsl>clientAge &lt; 18</condition_dsl>
 <condition_postfix>
 2 local@  18 &lt; 
 </condition_postfix>
@@ -5219,7 +5219,7 @@ dup clients forall pop
 <condition_number>6</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>clientAge &gt;= 65</condition_description>
+<condition_dsl>clientAge &gt;= 65</condition_dsl>
 <condition_postfix>
 2 local@  65 &gt;= 
 </condition_postfix>
@@ -5228,7 +5228,7 @@ dup clients forall pop
 <condition_number>7</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>clientAge &lt;= 65</condition_description>
+<condition_dsl>clientAge &lt;= 65</condition_dsl>
 <condition_postfix>
 2 local@  65 &lt;= 
 </condition_postfix>
@@ -5237,7 +5237,7 @@ dup clients forall pop
 <condition_number>8</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>case_ID matches '22345'</condition_description>
+<condition_dsl>case_ID matches '22345'</condition_dsl>
 <condition_postfix>
 '22345' case_ID regexmatch 
 </condition_postfix>
@@ -5246,7 +5246,7 @@ dup clients forall pop
 <condition_number>9</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>pregnant == true</condition_description>
+<condition_dsl>pregnant == true</condition_dsl>
 <condition_postfix>
 pregnant true beq 
 </condition_postfix>
@@ -5255,7 +5255,7 @@ pregnant true beq
 <condition_number>10</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>pregnant != true</condition_description>
+<condition_dsl>pregnant != true</condition_dsl>
 <condition_postfix>
 pregnant true beq 
 </condition_postfix>
@@ -5264,7 +5264,7 @@ pregnant true beq
 <condition_number>11</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>pregnant == true and clientAge &lt; 18</condition_description>
+<condition_dsl>pregnant == true and clientAge &lt; 18</condition_dsl>
 <condition_postfix>
 pregnant true beq { pop 2 local@  18 &lt; } over if
 
@@ -5274,7 +5274,7 @@ pregnant true beq { pop 2 local@  18 &lt; } over if
 <condition_number>12</condition_number>
 <condition_comment>pregnant == true or clientAge &lt; 18</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 pregnant true beq { pop 2 local@  18 &lt; } over not if
 
@@ -5284,7 +5284,7 @@ pregnant true beq { pop 2 local@  18 &lt; } over not if
 <condition_number>13</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>not pregnant</condition_description>
+<condition_dsl>not pregnant</condition_dsl>
 <condition_postfix>
 pregnant not 
 </condition_postfix>
@@ -5293,7 +5293,7 @@ pregnant not
 <condition_number>14</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>pregnant is null</condition_description>
+<condition_dsl>pregnant is null</condition_dsl>
 <condition_postfix>
 pregnant  isnull 
 </condition_postfix>
@@ -5302,7 +5302,7 @@ pregnant  isnull
 <condition_number>15</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>pregnant is not null</condition_description>
+<condition_dsl>pregnant is not null</condition_dsl>
 <condition_postfix>
 pregnant  isnull not 
 </condition_postfix>
@@ -5312,7 +5312,7 @@ pregnant  isnull not
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -5335,7 +5335,7 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_16</action_description>
+<action_dsl>perform Run_Test_16</action_dsl>
 <action_postfix>
 Run_Test_16 
 </action_postfix>
@@ -5397,42 +5397,42 @@ Run_Test_16
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>local date Today2 = currentdate</context_description>
+<context_dsl>local date Today2 = currentdate</context_dsl>
 <context_postfix>
 currentdate cvd allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment />
-<context_description>local date Today1 = Today2</context_description>
+<context_dsl>local date Today1 = Today2</context_dsl>
 <context_postfix>
 0 local@  cvd allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment />
-<context_description>local entity firstClient</context_description>
+<context_dsl>local entity firstClient</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment />
-<context_description>local array flags</context_description>
+<context_dsl>local array flags</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>5</context_number>
 <context_comment />
-<context_description>local string caseFlag = " false "</context_description>
+<context_dsl>local string caseFlag = " false "</context_dsl>
 <context_postfix>
 " false " cvs allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>6</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -5441,7 +5441,7 @@ dup clients forall pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set firstClient = clients [ 0 ]</initial_action_description>
+<initial_action_dsl>set firstClient = clients [ 0 ]</initial_action_dsl>
 <initial_action_postfix>
 clients 0 getat cve 2 local!  
 </initial_action_postfix></initial_action_details>
@@ -5449,7 +5449,7 @@ clients 0 getat cve 2 local!
 <intial_action_number />
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set flags = array of values [ true ]</initial_action_description>
+<initial_action_dsl>set flags = array of values [ true ]</initial_action_dsl>
 <initial_action_postfix>
 mark true  arraytomark 3 local! 
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -5458,7 +5458,7 @@ mark true  arraytomark 3 local!
 <condition_number>1</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>expectedChildren is null</condition_description>
+<condition_dsl>expectedChildren is null</condition_dsl>
 <condition_postfix>
 expectedChildren   isnull 
 </condition_postfix>
@@ -5467,7 +5467,7 @@ expectedChildren   isnull
 <condition_number>2</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>expectedChildren is not null</condition_description>
+<condition_dsl>expectedChildren is not null</condition_dsl>
 <condition_postfix>
 expectedChildren   isnull not 
 </condition_postfix>
@@ -5476,7 +5476,7 @@ expectedChildren   isnull not
 <condition_number>3</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>effectiveDate is null</condition_description>
+<condition_dsl>effectiveDate is null</condition_dsl>
 <condition_postfix>
 effectiveDate  isnull 
 </condition_postfix>
@@ -5485,7 +5485,7 @@ effectiveDate  isnull
 <condition_number>4</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>errorCodes is null</condition_description>
+<condition_dsl>errorCodes is null</condition_dsl>
 <condition_postfix>
 errorCodes  isnull 
 </condition_postfix>
@@ -5494,7 +5494,7 @@ errorCodes  isnull
 <condition_number>5</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>case_ID is null</condition_description>
+<condition_dsl>case_ID is null</condition_dsl>
 <condition_postfix>
 case_ID  isnull 
 </condition_postfix>
@@ -5503,7 +5503,7 @@ case_ID  isnull
 <condition_number>6</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>firstClient is null</condition_description>
+<condition_dsl>firstClient is null</condition_dsl>
 <condition_postfix>
 2 local@   isnull 
 </condition_postfix>
@@ -5512,7 +5512,7 @@ case_ID  isnull
 <condition_number>7</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 is not null</condition_description>
+<condition_dsl>Today2 is not null</condition_dsl>
 <condition_postfix>
 0 local@   isnull not 
 </condition_postfix>
@@ -5521,7 +5521,7 @@ case_ID  isnull
 <condition_number>8</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>errorCodes is not null</condition_description>
+<condition_dsl>errorCodes is not null</condition_dsl>
 <condition_postfix>
 errorCodes  isnull not 
 </condition_postfix>
@@ -5530,7 +5530,7 @@ errorCodes  isnull not
 <condition_number>9</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>case_ID is not null</condition_description>
+<condition_dsl>case_ID is not null</condition_dsl>
 <condition_postfix>
 case_ID  isnull not 
 </condition_postfix>
@@ -5539,7 +5539,7 @@ case_ID  isnull not
 <condition_number>10</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>firstClient is not null</condition_description>
+<condition_dsl>firstClient is not null</condition_dsl>
 <condition_postfix>
 2 local@   isnull not 
 </condition_postfix>
@@ -5548,7 +5548,7 @@ case_ID  isnull not
 <condition_number>11</condition_number>
 <condition_comment>using firstClient ( pregnant )</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 2 local@  entitypush pregnant entitypop 
 </condition_postfix>
@@ -5557,7 +5557,7 @@ case_ID  isnull not
 <condition_number>12</condition_number>
 <condition_comment>( pregnant )</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 pregnant 
 </condition_postfix>
@@ -5566,7 +5566,7 @@ pregnant
 <condition_number>13</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>( boolean ) flags [ 0 ]</condition_description>
+<condition_dsl>( boolean ) flags [ 0 ]</condition_dsl>
 <condition_postfix>
 3 local@  0 getat 
 </condition_postfix>
@@ -5575,7 +5575,7 @@ pregnant
 <condition_number>14</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>( boolean ) caseFlag</condition_description>
+<condition_dsl>( boolean ) caseFlag</condition_dsl>
 <condition_postfix>
 4 local@  cvb 
 </condition_postfix>
@@ -5584,7 +5584,7 @@ pregnant
 <condition_number>15</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>boolean flags [ 0 ]</condition_description>
+<condition_dsl>boolean flags [ 0 ]</condition_dsl>
 <condition_postfix>
 3 local@  0 getat 
 </condition_postfix>
@@ -5594,7 +5594,7 @@ pregnant
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -5617,7 +5617,7 @@ policystatements results true  addarray
 <action_number>2</action_number>
 <action_comment />
 <action_requirement />
-<action_description>perform Run_Test_17</action_description>
+<action_dsl>perform Run_Test_17</action_dsl>
 <action_postfix>
 Run_Test_17 
 </action_postfix>
@@ -5679,28 +5679,28 @@ Run_Test_17
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>local date Today2 = currentdate</context_description>
+<context_dsl>local date Today2 = currentdate</context_dsl>
 <context_postfix>
 currentdate cvd allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment />
-<context_description>local date Today1</context_description>
+<context_dsl>local date Today1</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment />
-<context_description>local entity firstClient</context_description>
+<context_dsl>local entity firstClient</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment />
-<context_description>for all clients</context_description>
+<context_dsl>for all clients</context_dsl>
 <context_postfix>
 dup clients forall pop 
 </context_postfix></context_details></contexts>
@@ -5709,7 +5709,7 @@ dup clients forall pop
 <intial_action_number>1</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
-<initial_action_description>set Today1 = (date) "02/01/2011"</initial_action_description>
+<initial_action_dsl>set Today1 = (date) "02/01/2011"</initial_action_dsl>
 <initial_action_postfix>
 "02/01/2011" cvd cvd 1 local!  
 </initial_action_postfix></initial_action_details></initial_actions>
@@ -5718,7 +5718,7 @@ dup clients forall pop
 <condition_number>1</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 == currentdate</condition_description>
+<condition_dsl>Today2 == currentdate</condition_dsl>
 <condition_postfix>
 0 local@  currentdate d== 
 </condition_postfix>
@@ -5727,7 +5727,7 @@ dup clients forall pop
 <condition_number>2</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 &lt; currentdate</condition_description>
+<condition_dsl>Today2 &lt; currentdate</condition_dsl>
 <condition_postfix>
 0 local@  currentdate d&lt; 
 </condition_postfix>
@@ -5736,7 +5736,7 @@ dup clients forall pop
 <condition_number>3</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 IS BEFORE  currentdate</condition_description>
+<condition_dsl>Today2 IS BEFORE  currentdate</condition_dsl>
 <condition_postfix>
 0 local@  currentdate d&lt; 
 </condition_postfix>
@@ -5745,7 +5745,7 @@ dup clients forall pop
 <condition_number>4</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 &gt; currentdate</condition_description>
+<condition_dsl>Today2 &gt; currentdate</condition_dsl>
 <condition_postfix>
 0 local@  currentdate d&gt; 
 </condition_postfix>
@@ -5754,7 +5754,7 @@ dup clients forall pop
 <condition_number>5</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 IS AFTER currentdate</condition_description>
+<condition_dsl>Today2 IS AFTER currentdate</condition_dsl>
 <condition_postfix>
 0 local@  currentdate d&gt; 
 </condition_postfix>
@@ -5763,7 +5763,7 @@ dup clients forall pop
 <condition_number>6</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 &gt;= currentdate</condition_description>
+<condition_dsl>Today2 &gt;= currentdate</condition_dsl>
 <condition_postfix>
 0 local@  currentdate d&lt; not 
 </condition_postfix>
@@ -5772,7 +5772,7 @@ dup clients forall pop
 <condition_number>7</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 &lt;= currentdate</condition_description>
+<condition_dsl>Today2 &lt;= currentdate</condition_dsl>
 <condition_postfix>
 0 local@  currentdate d&gt; not 
 </condition_postfix>
@@ -5781,7 +5781,7 @@ dup clients forall pop
 <condition_number>8</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 is between currentdate &amp;&amp; Today1</condition_description>
+<condition_dsl>Today2 is between currentdate &amp;&amp; Today1</condition_dsl>
 <condition_postfix>
 currentdate 0 local@  d&gt; not 0 local@  1 local@   d&gt; not and 
 </condition_postfix>
@@ -5790,7 +5790,7 @@ currentdate 0 local@  d&gt; not 0 local@  1 local@   d&gt; not and
 <condition_number>9</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>firstClient == the client</condition_description>
+<condition_dsl>firstClient == the client</condition_dsl>
 <condition_postfix>
 2 local@  client req  
 </condition_postfix>
@@ -5799,7 +5799,7 @@ currentdate 0 local@  d&gt; not 0 local@  1 local@   d&gt; not and
 <condition_number>10</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>firstClient != the client</condition_description>
+<condition_dsl>firstClient != the client</condition_dsl>
 <condition_postfix>
 2 local@  client req not 
 </condition_postfix>
@@ -5808,7 +5808,7 @@ currentdate 0 local@  d&gt; not 0 local@  1 local@   d&gt; not and
 <condition_number>11</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>address entity is not in context</condition_description>
+<condition_dsl>address entity is not in context</condition_dsl>
 <condition_postfix>
 /address InContext not 
 </condition_postfix>
@@ -5817,7 +5817,7 @@ currentdate 0 local@  d&gt; not 0 local@  1 local@   d&gt; not and
 <condition_number>12</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>address entity is in context</condition_description>
+<condition_dsl>address entity is in context</condition_dsl>
 <condition_postfix>
 /address InContext 
 </condition_postfix>
@@ -5826,7 +5826,7 @@ currentdate 0 local@  d&gt; not 0 local@  1 local@   d&gt; not and
 <condition_number>13</condition_number>
 <condition_comment>boolean value of touppercase ( "true" )</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 "true"  touppercase 
 </condition_postfix>
@@ -5836,7 +5836,7 @@ currentdate 0 local@  d&gt; not 0 local@  1 local@   d&gt; not and
 <action_number>1</action_number>
 <action_comment />
 <action_requirement />
-<action_description>add the policy statements to the results</action_description>
+<action_dsl>add the policy statements to the results</action_dsl>
 <action_postfix>
 policystatements results true  addarray 
 </action_postfix>
@@ -5904,21 +5904,21 @@ policystatements results true  addarray
 <context_details>
 <context_number>1</context_number>
 <context_comment />
-<context_description>local date Today2 = currentdate</context_description>
+<context_dsl>local date Today2 = currentdate</context_dsl>
 <context_postfix>
 currentdate cvd allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment />
-<context_description>local string Things</context_description>
+<context_dsl>local string Things</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment />
-<context_description>local entity firstClient</context_description>
+<context_dsl>local entity firstClient</context_dsl>
 <context_postfix>
 null allocate execute deallocate pop 
 </context_postfix></context_details></contexts>
@@ -5928,7 +5928,7 @@ null allocate execute deallocate pop
 <condition_number>1</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called 
 </condition_postfix>
@@ -5937,7 +5937,7 @@ perform when called
 <condition_number>2</condition_number>
 <condition_comment>does Today2 == currentdate ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 0 local@  currentdate d== 
 </condition_postfix></condition_details>
@@ -5945,7 +5945,7 @@ perform when called
 <condition_number>3</condition_number>
 <condition_comment>is Today2 == currentdate ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 0 local@  currentdate d== 
 </condition_postfix></condition_details>
@@ -5953,7 +5953,7 @@ perform when called
 <condition_number>4</condition_number>
 <condition_comment>was Today2 == currentdate ?</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 0 local@  currentdate d== 
 </condition_postfix></condition_details>
@@ -5961,7 +5961,7 @@ perform when called
 <condition_number>5</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>age &gt; 18</condition_description>
+<condition_dsl>age &gt; 18</condition_dsl>
 <condition_postfix>
 age 18 &gt; 
 </condition_postfix></condition_details>
@@ -5969,7 +5969,7 @@ age 18 &gt;
 <condition_number>6</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>age &lt; 18</condition_description>
+<condition_dsl>age &lt; 18</condition_dsl>
 <condition_postfix>
 age 18 &lt; 
 </condition_postfix></condition_details>
@@ -5977,7 +5977,7 @@ age 18 &lt;
 <condition_number>7</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>age &gt;= 12</condition_description>
+<condition_dsl>age &gt;= 12</condition_dsl>
 <condition_postfix>
 age 12 &gt;= 
 </condition_postfix></condition_details>
@@ -5985,7 +5985,7 @@ age 12 &gt;=
 <condition_number>8</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>age &lt;= 60</condition_description>
+<condition_dsl>age &lt;= 60</condition_dsl>
 <condition_postfix>
 age 60 &lt;= 
 </condition_postfix></condition_details>
@@ -5993,7 +5993,7 @@ age 60 &lt;=
 <condition_number>9</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Things matches 'This is a string'</condition_description>
+<condition_dsl>Things matches 'This is a string'</condition_dsl>
 <condition_postfix>
 'This is a string' 1 local@  regexmatch 
 </condition_postfix></condition_details>
@@ -6001,7 +6001,7 @@ age 60 &lt;=
 <condition_number>10</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>pregnant == true</condition_description>
+<condition_dsl>pregnant == true</condition_dsl>
 <condition_postfix>
 pregnant true beq 
 </condition_postfix></condition_details>
@@ -6009,7 +6009,7 @@ pregnant true beq
 <condition_number>11</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>pregnant != true</condition_description>
+<condition_dsl>pregnant != true</condition_dsl>
 <condition_postfix>
 pregnant true beq 
 </condition_postfix></condition_details>
@@ -6017,7 +6017,7 @@ pregnant true beq
 <condition_number>12</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>pregnant == true and age &lt; 18</condition_description>
+<condition_dsl>pregnant == true and age &lt; 18</condition_dsl>
 <condition_postfix>
 pregnant true beq { pop age 18 &lt; } over if
 
@@ -6026,7 +6026,7 @@ pregnant true beq { pop age 18 &lt; } over if
 <condition_number>13</condition_number>
 <condition_comment>pregnant == true or age &lt; 18</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 pregnant true beq { pop age 18 &lt; } over not if
 
@@ -6035,7 +6035,7 @@ pregnant true beq { pop age 18 &lt; } over not if
 <condition_number>14</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>not pregnant</condition_description>
+<condition_dsl>not pregnant</condition_dsl>
 <condition_postfix>
 pregnant not 
 </condition_postfix></condition_details>
@@ -6043,7 +6043,7 @@ pregnant not
 <condition_number>15</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>pregnant is null</condition_description>
+<condition_dsl>pregnant is null</condition_dsl>
 <condition_postfix>
 pregnant  isnull 
 </condition_postfix></condition_details>
@@ -6051,7 +6051,7 @@ pregnant  isnull
 <condition_number>16</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>pregnant is not null</condition_description>
+<condition_dsl>pregnant is not null</condition_dsl>
 <condition_postfix>
 pregnant  isnull not 
 </condition_postfix></condition_details>
@@ -6059,7 +6059,7 @@ pregnant  isnull not
 <condition_number>17</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>expectedChildren is null</condition_description>
+<condition_dsl>expectedChildren is null</condition_dsl>
 <condition_postfix>
 expectedChildren   isnull 
 </condition_postfix></condition_details>
@@ -6067,7 +6067,7 @@ expectedChildren   isnull
 <condition_number>18</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>expectedChildren is not null</condition_description>
+<condition_dsl>expectedChildren is not null</condition_dsl>
 <condition_postfix>
 expectedChildren   isnull not 
 </condition_postfix></condition_details>
@@ -6075,7 +6075,7 @@ expectedChildren   isnull not
 <condition_number>19</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>effectiveDate is null</condition_description>
+<condition_dsl>effectiveDate is null</condition_dsl>
 <condition_postfix>
 effectiveDate  isnull 
 </condition_postfix></condition_details>
@@ -6083,7 +6083,7 @@ effectiveDate  isnull
 <condition_number>20</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>errorCodes is null</condition_description>
+<condition_dsl>errorCodes is null</condition_dsl>
 <condition_postfix>
 errorCodes  isnull 
 </condition_postfix></condition_details>
@@ -6091,7 +6091,7 @@ errorCodes  isnull
 <condition_number>21</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Things is null</condition_description>
+<condition_dsl>Things is null</condition_dsl>
 <condition_postfix>
 1 local@   isnull 
 </condition_postfix></condition_details>
@@ -6099,7 +6099,7 @@ errorCodes  isnull
 <condition_number>22</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>firstClient is null</condition_description>
+<condition_dsl>firstClient is null</condition_dsl>
 <condition_postfix>
 2 local@   isnull 
 </condition_postfix></condition_details>
@@ -6107,7 +6107,7 @@ errorCodes  isnull
 <condition_number>23</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 is not null</condition_description>
+<condition_dsl>Today2 is not null</condition_dsl>
 <condition_postfix>
 0 local@   isnull not 
 </condition_postfix></condition_details>
@@ -6115,7 +6115,7 @@ errorCodes  isnull
 <condition_number>24</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>errorCodes is not null</condition_description>
+<condition_dsl>errorCodes is not null</condition_dsl>
 <condition_postfix>
 errorCodes  isnull not 
 </condition_postfix></condition_details>
@@ -6123,7 +6123,7 @@ errorCodes  isnull not
 <condition_number>25</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Things is not null</condition_description>
+<condition_dsl>Things is not null</condition_dsl>
 <condition_postfix>
 1 local@   isnull not 
 </condition_postfix></condition_details>
@@ -6131,7 +6131,7 @@ errorCodes  isnull not
 <condition_number>26</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>firstClient is not null</condition_description>
+<condition_dsl>firstClient is not null</condition_dsl>
 <condition_postfix>
 2 local@   isnull not 
 </condition_postfix></condition_details>
@@ -6139,7 +6139,7 @@ errorCodes  isnull not
 <condition_number>27</condition_number>
 <condition_comment>using firstClient ( pregnant )</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 2 local@  entitypush pregnant entitypop 
 </condition_postfix></condition_details>
@@ -6147,7 +6147,7 @@ errorCodes  isnull not
 <condition_number>28</condition_number>
 <condition_comment>( pregnant )</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 pregnant 
 </condition_postfix></condition_details>
@@ -6155,7 +6155,7 @@ pregnant
 <condition_number>29</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>( boolean ) errorCodes [ 1 ]</condition_description>
+<condition_dsl>( boolean ) errorCodes [ 1 ]</condition_dsl>
 <condition_postfix>
 errorCodes 1 getat 
 </condition_postfix></condition_details>
@@ -6163,7 +6163,7 @@ errorCodes 1 getat
 <condition_number>30</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>( boolean ) Things</condition_description>
+<condition_dsl>( boolean ) Things</condition_dsl>
 <condition_postfix>
 1 local@  cvb 
 </condition_postfix></condition_details>
@@ -6171,7 +6171,7 @@ errorCodes 1 getat
 <condition_number>31</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>boolean results [ 1 ]</condition_description>
+<condition_dsl>boolean results [ 1 ]</condition_dsl>
 <condition_postfix>
 results 1 getat 
 </condition_postfix></condition_details>
@@ -6179,7 +6179,7 @@ results 1 getat
 <condition_number>32</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 == currentdate</condition_description>
+<condition_dsl>Today2 == currentdate</condition_dsl>
 <condition_postfix>
 0 local@  currentdate d== 
 </condition_postfix></condition_details>
@@ -6187,7 +6187,7 @@ results 1 getat
 <condition_number>33</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 &lt; currentdate</condition_description>
+<condition_dsl>Today2 &lt; currentdate</condition_dsl>
 <condition_postfix>
 0 local@  currentdate d&lt; 
 </condition_postfix></condition_details>
@@ -6195,7 +6195,7 @@ results 1 getat
 <condition_number>34</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 IS BEFORE  currentdate</condition_description>
+<condition_dsl>Today2 IS BEFORE  currentdate</condition_dsl>
 <condition_postfix>
 0 local@  currentdate d&lt; 
 </condition_postfix></condition_details>
@@ -6203,7 +6203,7 @@ results 1 getat
 <condition_number>35</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 &gt; currentdate</condition_description>
+<condition_dsl>Today2 &gt; currentdate</condition_dsl>
 <condition_postfix>
 0 local@  currentdate d&gt; 
 </condition_postfix></condition_details>
@@ -6211,7 +6211,7 @@ results 1 getat
 <condition_number>36</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 IS AFTER currentdate</condition_description>
+<condition_dsl>Today2 IS AFTER currentdate</condition_dsl>
 <condition_postfix>
 0 local@  currentdate d&gt; 
 </condition_postfix></condition_details>
@@ -6219,7 +6219,7 @@ results 1 getat
 <condition_number>37</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 &gt;= currentdate</condition_description>
+<condition_dsl>Today2 &gt;= currentdate</condition_dsl>
 <condition_postfix>
 0 local@  currentdate d&lt; not 
 </condition_postfix></condition_details>
@@ -6227,7 +6227,7 @@ results 1 getat
 <condition_number>38</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 &lt;= currentdate</condition_description>
+<condition_dsl>Today2 &lt;= currentdate</condition_dsl>
 <condition_postfix>
 0 local@  currentdate d&gt; not 
 </condition_postfix></condition_details>
@@ -6235,7 +6235,7 @@ results 1 getat
 <condition_number>39</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>Today2 is between currentdate and effectiveDate</condition_description>
+<condition_dsl>Today2 is between currentdate and effectiveDate</condition_dsl>
 <condition_postfix>
 currentdate 0 local@  d&gt; not 0 local@  effectiveDate  d&gt; not and 
 </condition_postfix></condition_details>
@@ -6243,7 +6243,7 @@ currentdate 0 local@  d&gt; not 0 local@  effectiveDate  d&gt; not and
 <condition_number>40</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>firstClient == the client</condition_description>
+<condition_dsl>firstClient == the client</condition_dsl>
 <condition_postfix>
 2 local@  client req  
 </condition_postfix></condition_details>
@@ -6251,7 +6251,7 @@ currentdate 0 local@  d&gt; not 0 local@  effectiveDate  d&gt; not and
 <condition_number>41</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>firstClient != the client</condition_description>
+<condition_dsl>firstClient != the client</condition_dsl>
 <condition_postfix>
 2 local@  client req not 
 </condition_postfix></condition_details>
@@ -6259,7 +6259,7 @@ currentdate 0 local@  d&gt; not 0 local@  effectiveDate  d&gt; not and
 <condition_number>42</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>address entity is not in context</condition_description>
+<condition_dsl>address entity is not in context</condition_dsl>
 <condition_postfix>
 /address InContext not 
 </condition_postfix></condition_details>
@@ -6267,7 +6267,7 @@ currentdate 0 local@  d&gt; not 0 local@  effectiveDate  d&gt; not and
 <condition_number>43</condition_number>
 <condition_comment />
 <condition_requirement />
-<condition_description>address entity is in context</condition_description>
+<condition_dsl>address entity is in context</condition_dsl>
 <condition_postfix>
 /address InContext 
 </condition_postfix></condition_details>
@@ -6275,7 +6275,7 @@ currentdate 0 local@  d&gt; not 0 local@  effectiveDate  d&gt; not and
 <condition_number>44</condition_number>
 <condition_comment>boolean value of touppercase ( Things )</condition_comment>
 <condition_requirement />
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 1 local@   touppercase 
 </condition_postfix></condition_details></conditions>

--- a/sampleprojects/TaxReturn/xml/001_Compute_Tax_Return_dt.xml
+++ b/sampleprojects/TaxReturn/xml/001_Compute_Tax_Return_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>new result entity</action_description>
+<action_dsl>new result entity</action_dsl>
 <action_postfix>
 /result createentity entitypush
 result job.results swap addto
@@ -26,7 +26,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>Married Filing Jointly</condition_description>
+<condition_dsl>Married Filing Jointly</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -35,7 +35,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single filer</condition_comment>
-<condition_description>Single filer</condition_description>
+<condition_dsl>Single filer</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -44,7 +44,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>Head of Household</condition_description>
+<condition_dsl>Head of Household</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -53,7 +53,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Default case</condition_comment>
-<condition_description>Default case</condition_description>
+<condition_dsl>Default case</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -64,7 +64,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log filing status per Form 1040 Line 1</action_comment>
-<action_description>Log filing status per Form 1040 Line 1</action_description>
+<action_dsl>Log filing status per Form 1040 Line 1</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -73,7 +73,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Log Single filing status</action_comment>
-<action_description>Log Single filing status</action_description>
+<action_dsl>Log Single filing status</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -82,7 +82,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Log HOH filing status</action_comment>
-<action_description>Log HOH filing status</action_description>
+<action_dsl>Log HOH filing status</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -91,7 +91,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Log MFS or QSS status</action_comment>
-<action_description>Log MFS or QSS status</action_description>
+<action_dsl>Log MFS or QSS status</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -100,7 +100,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate gross income (Form 1040 Lines 1-9)</action_comment>
-<action_description>Calculate gross income (Form 1040 Lines 1-9)</action_description>
+<action_dsl>Calculate gross income (Form 1040 Lines 1-9)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -112,7 +112,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate deductions (Form 1040 Line 12)</action_comment>
-<action_description>Calculate deductions (Form 1040 Line 12)</action_description>
+<action_dsl>Calculate deductions (Form 1040 Line 12)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -124,7 +124,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <action_details>
 <action_number>7</action_number>
 <action_comment>Calculate taxable income (Form 1040 Line 15)</action_comment>
-<action_description>Calculate taxable income (Form 1040 Line 15)</action_description>
+<action_dsl>Calculate taxable income (Form 1040 Line 15)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -136,7 +136,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <action_details>
 <action_number>8</action_number>
 <action_comment>Calculate tax liability (Form 1040 Lines 16-24)</action_comment>
-<action_description>Calculate tax liability (Form 1040 Lines 16-24)</action_description>
+<action_dsl>Calculate tax liability (Form 1040 Lines 16-24)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -148,7 +148,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <action_details>
 <action_number>9</action_number>
 <action_comment>Calculate Alternative Minimum Tax (Form 6251)</action_comment>
-<action_description>Calculate Alternative Minimum Tax (Form 6251)</action_description>
+<action_dsl>Calculate Alternative Minimum Tax (Form 6251)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -160,7 +160,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <action_details>
 <action_number>10</action_number>
 <action_comment>Calculate kiddie tax for dependents with unearned income (Form 8615)</action_comment>
-<action_description>Calculate kiddie tax for dependents with unearned income (Form 8615)</action_description>
+<action_dsl>Calculate kiddie tax for dependents with unearned income (Form 8615)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -172,7 +172,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <action_details>
 <action_number>11</action_number>
 <action_comment>Calculate credits (Form 1040 Lines 19-21)</action_comment>
-<action_description>Calculate credits (Form 1040 Lines 19-21)</action_description>
+<action_dsl>Calculate credits (Form 1040 Lines 19-21)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -184,7 +184,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <action_details>
 <action_number>12</action_number>
 <action_comment>Calculate final balance (Form 1040 Lines 33-37)</action_comment>
-<action_description>Calculate final balance (Form 1040 Lines 33-37)</action_description>
+<action_dsl>Calculate final balance (Form 1040 Lines 33-37)</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/002_Calculate_Gross_Income_dt.xml
+++ b/sampleprojects/TaxReturn/xml/002_Calculate_Gross_Income_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.total_w2_wages = 0</action_description>
+<action_dsl>set result.total_w2_wages = 0</action_dsl>
 <action_postfix>
 0.0 /result.total_w2_wages xdef
 0.0 /result.total_se_income xdef
@@ -27,7 +27,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always execute</condition_comment>
-<condition_description>Always execute</condition_description>
+<condition_dsl>Always execute</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process W-2 income for all taxpayers</action_comment>
-<action_description>Process W-2 income for all taxpayers</action_description>
+<action_dsl>Process W-2 income for all taxpayers</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -47,7 +47,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Process self-employment income (Schedule C)</action_comment>
-<action_description>Process self-employment income (Schedule C)</action_description>
+<action_dsl>Process self-employment income (Schedule C)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -56,7 +56,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Process rental income (Schedule E)</action_comment>
-<action_description>Process rental income (Schedule E)</action_description>
+<action_dsl>Process rental income (Schedule E)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -65,7 +65,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Process other income (pension, interest, dividends)</action_comment>
-<action_description>Process other income (pension, interest, dividends)</action_description>
+<action_dsl>Process other income (pension, interest, dividends)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -74,7 +74,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment>Process capital gains and qualified dividends</action_comment>
-<action_description>Process capital gains and qualified dividends</action_description>
+<action_dsl>Process capital gains and qualified dividends</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -83,7 +83,7 @@
 <action_details>
 <action_number>6</action_number>
 <action_comment>Process Schedule K-1 income (partnerships, S-corps, trusts)</action_comment>
-<action_description>Process Schedule K-1 income (partnerships, S-corps, trusts)</action_description>
+<action_dsl>Process Schedule K-1 income (partnerships, S-corps, trusts)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -92,7 +92,7 @@
 <action_details>
 <action_number>7</action_number>
 <action_comment>Process IRA accounts (Form 8606)</action_comment>
-<action_description>Process IRA accounts (Form 8606)</action_description>
+<action_dsl>Process IRA accounts (Form 8606)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -101,7 +101,7 @@
 <action_details>
 <action_number>8</action_number>
 <action_comment>Process Schedule F farm income</action_comment>
-<action_description>Process Schedule F farm income</action_description>
+<action_dsl>Process Schedule F farm income</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -110,7 +110,7 @@
 <action_details>
 <action_number>9</action_number>
 <action_comment>Process Form 4797 business property sales</action_comment>
-<action_description>Process Form 4797 business property sales</action_description>
+<action_dsl>Process Form 4797 business property sales</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -119,7 +119,7 @@
 <action_details>
 <action_number>10</action_number>
 <action_comment>Process Form 1116 foreign income</action_comment>
-<action_description>Process Form 1116 foreign income</action_description>
+<action_dsl>Process Form 1116 foreign income</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -128,7 +128,7 @@
 <action_details>
 <action_number>11</action_number>
 <action_comment>Calculate total gross income FIRST (for OBBBA phase-out calculations)</action_comment>
-<action_description>Calculate total gross income FIRST (for OBBBA phase-out calculations)</action_description>
+<action_dsl>Calculate total gross income FIRST (for OBBBA phase-out calculations)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -137,7 +137,7 @@
 <action_details>
 <action_number>12</action_number>
 <action_comment>Calculate AGI adjustments (Schedule 1 Part II)</action_comment>
-<action_description>Calculate AGI adjustments (Schedule 1 Part II)</action_description>
+<action_dsl>Calculate AGI adjustments (Schedule 1 Part II)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -146,7 +146,7 @@
 <action_details>
 <action_number>13</action_number>
 <action_comment>Calculate AGI</action_comment>
-<action_description>Calculate AGI</action_description>
+<action_dsl>Calculate AGI</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -155,7 +155,7 @@
 <action_details>
 <action_number>14</action_number>
 <action_comment>Calculate Social Security taxability after AGI is known</action_comment>
-<action_description>Calculate Social Security taxability after AGI is known</action_description>
+<action_dsl>Calculate Social Security taxability after AGI is known</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/003_Process_W2_Income_dt.xml
+++ b/sampleprojects/TaxReturn/xml/003_Process_W2_Income_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Taxpayer has W-2 wages</condition_comment>
-<condition_description>Taxpayer has W-2 wages</condition_description>
+<condition_dsl>Taxpayer has W-2 wages</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxpayer is senior</condition_comment>
-<condition_description>Taxpayer is senior</condition_description>
+<condition_dsl>Taxpayer is senior</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -43,7 +43,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add W-2 wages to total</action_comment>
-<action_description>Add W-2 wages to total</action_description>
+<action_dsl>Add W-2 wages to total</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -53,7 +53,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Track withholding for payments</action_comment>
-<action_description>Track withholding for payments</action_description>
+<action_dsl>Track withholding for payments</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -65,7 +65,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Process OBBBA income sources (tips, overtime, SS)</action_comment>
-<action_description>Process OBBBA income sources (tips, overtime, SS)</action_description>
+<action_dsl>Process OBBBA income sources (tips, overtime, SS)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -77,7 +77,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Count senior taxpayer</action_comment>
-<action_description>Count senior taxpayer</action_description>
+<action_dsl>Count senior taxpayer</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/004_Process_Self_Employment_dt.xml
+++ b/sampleprojects/TaxReturn/xml/004_Process_Self_Employment_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has self-employment income</condition_comment>
-<condition_description>Has self-employment income</condition_description>
+<condition_dsl>Has self-employment income</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log gross receipts</action_comment>
-<action_description>Log gross receipts</action_description>
+<action_dsl>Log gross receipts</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate vehicle deduction</action_comment>
-<action_description>Calculate vehicle deduction</action_description>
+<action_dsl>Calculate vehicle deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -47,7 +47,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate net profit</action_comment>
-<action_description>Calculate net profit</action_description>
+<action_dsl>Calculate net profit</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -56,7 +56,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate SE tax after net profit is known</action_comment>
-<action_description>Calculate SE tax after net profit is known</action_description>
+<action_dsl>Calculate SE tax after net profit is known</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/005_Calculate_SE_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/005_Calculate_SE_Tax_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>SE net profit meets threshold for SE tax</condition_comment>
-<condition_description>SE net profit meets threshold for SE tax</condition_description>
+<condition_dsl>SE net profit meets threshold for SE tax</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate SE tax with proper SS wage base cap and Medicare component</action_comment>
-<action_description>Calculate SE tax with proper SS wage base cap and Medicare component</action_description>
+<action_dsl>Calculate SE tax with proper SS wage base cap and Medicare component</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No SE tax required - net profit below threshold</action_comment>
-<action_description>No SE tax required - net profit below threshold</action_description>
+<action_dsl>No SE tax required - net profit below threshold</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/006_Calculate_Vehicle_Deduction_dt.xml
+++ b/sampleprojects/TaxReturn/xml/006_Calculate_Vehicle_Deduction_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has business miles</condition_comment>
-<condition_description>Has business miles</condition_description>
+<condition_dsl>Has business miles</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Using standard mileage method</condition_comment>
-<condition_description>Using standard mileage method</condition_description>
+<condition_dsl>Using standard mileage method</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -40,7 +40,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate business use percentage</action_comment>
-<action_description>Calculate business use percentage</action_description>
+<action_dsl>Calculate business use percentage</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -50,7 +50,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate standard mileage deduction</action_comment>
-<action_description>Calculate standard mileage deduction</action_description>
+<action_dsl>Calculate standard mileage deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -59,7 +59,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate actual expense deduction</action_comment>
-<action_description>Calculate actual expense deduction</action_description>
+<action_dsl>Calculate actual expense deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/007_Process_Rental_Income_dt.xml
+++ b/sampleprojects/TaxReturn/xml/007_Process_Rental_Income_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is rental property</condition_comment>
-<condition_description>Is rental property</condition_description>
+<condition_dsl>Is rental property</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has rental income</condition_comment>
-<condition_description>Has rental income</condition_description>
+<condition_dsl>Has rental income</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -38,7 +38,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Net income is positive (income not loss)</condition_comment>
-<condition_description>Net income is positive (income not loss)</condition_description>
+<condition_dsl>Net income is positive (income not loss)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -50,7 +50,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log rental property header</action_comment>
-<action_description>Log rental property header</action_description>
+<action_dsl>Log rental property header</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -60,7 +60,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate total rental expenses</action_comment>
-<action_description>Calculate total rental expenses</action_description>
+<action_dsl>Calculate total rental expenses</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -70,7 +70,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate net rental income</action_comment>
-<action_description>Calculate net rental income</action_description>
+<action_dsl>Calculate net rental income</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -80,7 +80,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Log net income</action_comment>
-<action_description>Log net income</action_description>
+<action_dsl>Log net income</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -89,7 +89,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment>Log net loss</action_comment>
-<action_description>Log net loss</action_description>
+<action_dsl>Log net loss</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/008_Process_Other_Income_dt.xml
+++ b/sampleprojects/TaxReturn/xml/008_Process_Other_Income_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has gross amount</condition_comment>
-<condition_description>Has gross amount</condition_description>
+<condition_dsl>Has gross amount</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add income to total other income</action_comment>
-<action_description>Add income to total other income</action_description>
+<action_dsl>Add income to total other income</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Track withholding</action_comment>
-<action_description>Track withholding</action_description>
+<action_dsl>Track withholding</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/009_Calculate_AGI_Adjustments_dt.xml
+++ b/sampleprojects/TaxReturn/xml/009_Calculate_AGI_Adjustments_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has SE tax to deduct</condition_comment>
-<condition_description>Has SE tax to deduct</condition_description>
+<condition_dsl>Has SE tax to deduct</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add SE tax deduction to adjustments</action_comment>
-<action_description>Add SE tax deduction to adjustments</action_description>
+<action_dsl>Add SE tax deduction to adjustments</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Log total adjustments</action_comment>
-<action_description>Log total adjustments</action_description>
+<action_dsl>Log total adjustments</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/010_Calculate_Deductions_dt.xml
+++ b/sampleprojects/TaxReturn/xml/010_Calculate_Deductions_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Calculate_Standard_Deduction</action_description>
+<action_dsl>Calculate_Standard_Deduction</action_dsl>
 <action_postfix>
 &quot;DEDUCTIONS (Form 1040 Line 12)&quot; job.audit_trail swap addto
 /Calculate_Standard_Deduction executetable
@@ -25,7 +25,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Itemized deductions exceed standard deduction</condition_comment>
-<condition_description>Itemized deductions exceed standard deduction</condition_description>
+<condition_dsl>Itemized deductions exceed standard deduction</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -37,7 +37,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Use itemized deductions</action_comment>
-<action_description>Use itemized deductions</action_description>
+<action_dsl>Use itemized deductions</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -46,7 +46,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Use standard deduction</action_comment>
-<action_description>Use standard deduction</action_description>
+<action_dsl>Use standard deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/011_Calculate_Standard_Deduction_dt.xml
+++ b/sampleprojects/TaxReturn/xml/011_Calculate_Standard_Deduction_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly or Qualifying Surviving Spouse</condition_comment>
-<condition_description>Married Filing Jointly or Qualifying Surviving Spouse</condition_description>
+<condition_dsl>Married Filing Jointly or Qualifying Surviving Spouse</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -31,7 +31,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>Head of Household</condition_description>
+<condition_dsl>Head of Household</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Has seniors age 65+</condition_comment>
-<condition_description>Has seniors age 65+</condition_description>
+<condition_dsl>Has seniors age 65+</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -61,7 +61,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>MFJ/QSS standard deduction</action_comment>
-<action_description>MFJ/QSS standard deduction</action_description>
+<action_dsl>MFJ/QSS standard deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -71,7 +71,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>HOH standard deduction</action_comment>
-<action_description>HOH standard deduction</action_description>
+<action_dsl>HOH standard deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -81,7 +81,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Single/MFS standard deduction</action_comment>
-<action_description>Single/MFS standard deduction</action_description>
+<action_dsl>Single/MFS standard deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -91,7 +91,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Add additional standard deduction for married seniors age 65+</action_comment>
-<action_description>Add additional standard deduction for married seniors age 65+</action_description>
+<action_dsl>Add additional standard deduction for married seniors age 65+</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -100,7 +100,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment>Add additional standard deduction for single/HOH seniors age 65+</action_comment>
-<action_description>Add additional standard deduction for single/HOH seniors age 65+</action_description>
+<action_dsl>Add additional standard deduction for single/HOH seniors age 65+</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/012_Calculate_Itemized_Deductions_dt.xml
+++ b/sampleprojects/TaxReturn/xml/012_Calculate_Itemized_Deductions_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.total_itemized = 0</action_description>
+<action_dsl>set result.total_itemized = 0</action_dsl>
 <action_postfix>
 0.0 /result.total_itemized xdef
 &quot;SCHEDULE A - Itemized Deductions&quot; job.audit_trail swap addto
@@ -24,7 +24,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always calculate itemized for comparison</condition_comment>
-<condition_description>Always calculate itemized for comparison</condition_description>
+<condition_dsl>Always calculate itemized for comparison</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -35,7 +35,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate medical expense deduction (Schedule A Lines 1-4)</action_comment>
-<action_description>Calculate medical expense deduction (Schedule A Lines 1-4)</action_description>
+<action_dsl>Calculate medical expense deduction (Schedule A Lines 1-4)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -44,7 +44,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate SALT deduction</action_comment>
-<action_description>Calculate SALT deduction</action_description>
+<action_dsl>Calculate SALT deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -53,7 +53,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate mortgage interest deduction</action_comment>
-<action_description>Calculate mortgage interest deduction</action_description>
+<action_dsl>Calculate mortgage interest deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -62,7 +62,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate charitable contributions</action_comment>
-<action_description>Calculate charitable contributions</action_description>
+<action_dsl>Calculate charitable contributions</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -71,7 +71,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate noncash charitable contributions (Form 8283)</action_comment>
-<action_description>Calculate noncash charitable contributions (Form 8283)</action_description>
+<action_dsl>Calculate noncash charitable contributions (Form 8283)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -80,7 +80,7 @@
 <action_details>
 <action_number>6</action_number>
 <action_comment>Log total itemized</action_comment>
-<action_description>Log total itemized</action_description>
+<action_dsl>Log total itemized</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/013_Calculate_SALT_Deduction_dt.xml
+++ b/sampleprojects/TaxReturn/xml/013_Calculate_SALT_Deduction_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>State has income tax</condition_comment>
-<condition_description>State has income tax</condition_description>
+<condition_dsl>State has income tax</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Total SALT exceeds effective cap</condition_comment>
-<condition_description>Total SALT exceeds effective cap</condition_description>
+<condition_dsl>Total SALT exceeds effective cap</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -43,7 +43,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Apply SALT cap with state income tax</action_comment>
-<action_description>Apply SALT cap with state income tax</action_description>
+<action_dsl>Apply SALT cap with state income tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -52,7 +52,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No state income tax, apply cap if needed</action_comment>
-<action_description>No state income tax, apply cap if needed</action_description>
+<action_dsl>No state income tax, apply cap if needed</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -61,7 +61,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Full SALT with state income tax (under cap)</action_comment>
-<action_description>Full SALT with state income tax (under cap)</action_description>
+<action_dsl>Full SALT with state income tax (under cap)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -70,7 +70,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Full SALT no state income tax (under cap)</action_comment>
-<action_description>Full SALT no state income tax (under cap)</action_description>
+<action_dsl>Full SALT no state income tax (under cap)</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/014_Sum_Primary_Residence_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/014_Sum_Primary_Residence_Tax_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Property is primary residence</condition_comment>
-<condition_description>Property is primary residence</condition_description>
+<condition_dsl>Property is primary residence</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add property tax to total</action_comment>
-<action_description>Add property tax to total</action_description>
+<action_dsl>Add property tax to total</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-primary residence</action_comment>
-<action_description>Skip non-primary residence</action_description>
+<action_dsl>Skip non-primary residence</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/015_Sum_SALT_Deduction_dt.xml
+++ b/sampleprojects/TaxReturn/xml/015_Sum_SALT_Deduction_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Deduction is state or local tax</condition_comment>
-<condition_description>Deduction is state or local tax</condition_description>
+<condition_dsl>Deduction is state or local tax</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add SALT deduction to total</action_comment>
-<action_description>Add SALT deduction to total</action_description>
+<action_dsl>Add SALT deduction to total</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-SALT deduction</action_comment>
-<action_description>Skip non-SALT deduction</action_description>
+<action_dsl>Skip non-SALT deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/016_Calculate_Mortgage_Interest_dt.xml
+++ b/sampleprojects/TaxReturn/xml/016_Calculate_Mortgage_Interest_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has mortgage interest</condition_comment>
-<condition_description>Has mortgage interest</condition_description>
+<condition_dsl>Has mortgage interest</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Mortgage balance within limit</condition_comment>
-<condition_description>Mortgage balance within limit</condition_description>
+<condition_dsl>Mortgage balance within limit</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -40,7 +40,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full mortgage interest deduction</action_comment>
-<action_description>Full mortgage interest deduction</action_description>
+<action_dsl>Full mortgage interest deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -49,7 +49,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Limited mortgage interest deduction</action_comment>
-<action_description>Limited mortgage interest deduction</action_description>
+<action_dsl>Limited mortgage interest deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/017_Filter_Primary_Residence_dt.xml
+++ b/sampleprojects/TaxReturn/xml/017_Filter_Primary_Residence_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Property is primary residence</condition_comment>
-<condition_description>Property is primary residence</condition_description>
+<condition_dsl>Property is primary residence</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process primary residence</action_comment>
-<action_description>Process primary residence</action_description>
+<action_dsl>Process primary residence</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-primary residence</action_comment>
-<action_description>Skip non-primary residence</action_description>
+<action_dsl>Skip non-primary residence</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/018_Calculate_Charitable_Deduction_dt.xml
+++ b/sampleprojects/TaxReturn/xml/018_Calculate_Charitable_Deduction_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has charitable contribution</condition_comment>
-<condition_description>Has charitable contribution</condition_description>
+<condition_dsl>Has charitable contribution</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add charitable contribution</action_comment>
-<action_description>Add charitable contribution</action_description>
+<action_dsl>Add charitable contribution</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/019_Filter_Charity_Deduction_dt.xml
+++ b/sampleprojects/TaxReturn/xml/019_Filter_Charity_Deduction_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Deduction is charity category</condition_comment>
-<condition_description>Deduction is charity category</condition_description>
+<condition_dsl>Deduction is charity category</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process charity deduction</action_comment>
-<action_description>Process charity deduction</action_description>
+<action_dsl>Process charity deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-charity deduction</action_comment>
-<action_description>Skip non-charity deduction</action_description>
+<action_dsl>Skip non-charity deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/020_Calculate_Noncash_Charitable_dt.xml
+++ b/sampleprojects/TaxReturn/xml/020_Calculate_Noncash_Charitable_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has noncash contributions</condition_comment>
-<condition_description>Has noncash contributions</condition_description>
+<condition_dsl>Has noncash contributions</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log total noncash charitable</action_comment>
-<action_description>Log total noncash charitable</action_description>
+<action_dsl>Log total noncash charitable</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No noncash contributions</action_comment>
-<action_description>No noncash contributions</action_description>
+<action_dsl>No noncash contributions</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/021_Process_Noncash_Contribution_dt.xml
+++ b/sampleprojects/TaxReturn/xml/021_Process_Noncash_Contribution_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Requires Section B (appraisal required for over $5,000)</condition_comment>
-<condition_description>Requires Section B (appraisal required for over $5,000)</condition_description>
+<condition_dsl>Requires Section B (appraisal required for over $5,000)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -27,7 +27,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Is appreciated capital gain property (long-term)</condition_comment>
-<condition_description>Is appreciated capital gain property (long-term)</condition_description>
+<condition_dsl>Is appreciated capital gain property (long-term)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -41,7 +41,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Capital gain property - use FMV with 30% AGI limit</action_comment>
-<action_description>Capital gain property - use FMV with 30% AGI limit</action_description>
+<action_dsl>Capital gain property - use FMV with 30% AGI limit</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -50,7 +50,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Ordinary income property or short-term - use lesser of FMV or basis</action_comment>
-<action_description>Ordinary income property or short-term - use lesser of FMV or basis</action_description>
+<action_dsl>Ordinary income property or short-term - use lesser of FMV or basis</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -59,7 +59,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Section A - capital gain property under $5,000, use FMV with 30% limit</action_comment>
-<action_description>Section A - capital gain property under $5,000, use FMV with 30% limit</action_description>
+<action_dsl>Section A - capital gain property under $5,000, use FMV with 30% limit</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -68,7 +68,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Section A - ordinary property under $5,000, use FMV with 50% limit</action_comment>
-<action_description>Section A - ordinary property under $5,000, use FMV with 50% limit</action_description>
+<action_dsl>Section A - ordinary property under $5,000, use FMV with 50% limit</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/022_Calculate_Taxable_Income_dt.xml
+++ b/sampleprojects/TaxReturn/xml/022_Calculate_Taxable_Income_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has self-employment income for QBI</condition_comment>
-<condition_description>Has self-employment income for QBI</condition_description>
+<condition_dsl>Has self-employment income for QBI</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate QBI deduction</action_comment>
-<action_description>Calculate QBI deduction</action_description>
+<action_dsl>Calculate QBI deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No QBI deduction</action_comment>
-<action_description>No QBI deduction</action_description>
+<action_dsl>No QBI deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -47,7 +47,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate taxable income (floor at zero)</action_comment>
-<action_description>Calculate taxable income (floor at zero)</action_description>
+<action_dsl>Calculate taxable income (floor at zero)</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/023_Calculate_Tax_Liability_dt.xml
+++ b/sampleprojects/TaxReturn/xml/023_Calculate_Tax_Liability_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add &quot;TAX CALCULATION (Form 1040 Lines 16-24)&quot; to job.audit_trail</action_description>
+<action_dsl>add &quot;TAX CALCULATION (Form 1040 Lines 16-24)&quot; to job.audit_trail</action_dsl>
 <action_postfix>
 &quot;TAX CALCULATION (Form 1040 Lines 16-24)&quot; job.audit_trail swap addto
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always calculate</condition_comment>
-<condition_description>Always calculate</condition_description>
+<condition_dsl>Always calculate</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -34,7 +34,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate regular tax using brackets</action_comment>
-<action_description>Calculate regular tax using brackets</action_description>
+<action_dsl>Calculate regular tax using brackets</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -43,7 +43,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate capital gains tax</action_comment>
-<action_description>Calculate capital gains tax</action_description>
+<action_dsl>Calculate capital gains tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -52,7 +52,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Add SE tax from all taxpayers</action_comment>
-<action_description>Add SE tax from all taxpayers</action_description>
+<action_dsl>Add SE tax from all taxpayers</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -61,7 +61,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate NIIT</action_comment>
-<action_description>Calculate NIIT</action_description>
+<action_dsl>Calculate NIIT</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -70,7 +70,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate Additional Medicare Tax</action_comment>
-<action_description>Calculate Additional Medicare Tax</action_description>
+<action_dsl>Calculate Additional Medicare Tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -79,7 +79,7 @@
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate Schedule H (household employment taxes)</action_comment>
-<action_description>Calculate Schedule H (household employment taxes)</action_description>
+<action_dsl>Calculate Schedule H (household employment taxes)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -88,7 +88,7 @@
 <action_details>
 <action_number>7</action_number>
 <action_comment>Calculate total tax before credits</action_comment>
-<action_description>Calculate total tax before credits</action_description>
+<action_dsl>Calculate total tax before credits</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/024_Apply_Tax_Brackets_dt.xml
+++ b/sampleprojects/TaxReturn/xml/024_Apply_Tax_Brackets_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>Married Filing Jointly</condition_description>
+<condition_dsl>Married Filing Jointly</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -26,7 +26,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single or other</condition_comment>
-<condition_description>Single or other</condition_description>
+<condition_dsl>Single or other</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -37,7 +37,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate MFJ tax</action_comment>
-<action_description>Calculate MFJ tax</action_description>
+<action_dsl>Calculate MFJ tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -46,7 +46,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate Single tax</action_comment>
-<action_description>Calculate Single tax</action_description>
+<action_dsl>Calculate Single tax</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/025_Apply_Tax_Brackets_MFJ_dt.xml
+++ b/sampleprojects/TaxReturn/xml/025_Apply_Tax_Brackets_MFJ_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>In bracket 1 only</condition_comment>
-<condition_description>In bracket 1 only</condition_description>
+<condition_dsl>In bracket 1 only</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -32,7 +32,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>In bracket 2</condition_comment>
-<condition_description>In bracket 2</condition_description>
+<condition_dsl>In bracket 2</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -47,7 +47,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>In bracket 3</condition_comment>
-<condition_description>In bracket 3</condition_description>
+<condition_dsl>In bracket 3</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -62,7 +62,7 @@
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>In bracket 4</condition_comment>
-<condition_description>In bracket 4</condition_description>
+<condition_dsl>In bracket 4</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -77,7 +77,7 @@
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>In bracket 5</condition_comment>
-<condition_description>In bracket 5</condition_description>
+<condition_dsl>In bracket 5</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -92,7 +92,7 @@
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>In bracket 6</condition_comment>
-<condition_description>In bracket 6</condition_description>
+<condition_dsl>In bracket 6</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -109,7 +109,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Bracket 1 tax</action_comment>
-<action_description>Bracket 1 tax</action_description>
+<action_dsl>Bracket 1 tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -118,7 +118,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bracket 2 tax</action_comment>
-<action_description>Bracket 2 tax</action_description>
+<action_dsl>Bracket 2 tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -127,7 +127,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Bracket 3 tax</action_comment>
-<action_description>Bracket 3 tax</action_description>
+<action_dsl>Bracket 3 tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -136,7 +136,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Bracket 4 tax</action_comment>
-<action_description>Bracket 4 tax</action_description>
+<action_dsl>Bracket 4 tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -145,7 +145,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment>Bracket 5 tax</action_comment>
-<action_description>Bracket 5 tax</action_description>
+<action_dsl>Bracket 5 tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -154,7 +154,7 @@
 <action_details>
 <action_number>6</action_number>
 <action_comment>Bracket 6 tax</action_comment>
-<action_description>Bracket 6 tax</action_description>
+<action_dsl>Bracket 6 tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -163,7 +163,7 @@
 <action_details>
 <action_number>7</action_number>
 <action_comment>Bracket 7 tax</action_comment>
-<action_description>Bracket 7 tax</action_description>
+<action_dsl>Bracket 7 tax</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/026_Apply_Tax_Brackets_Single_dt.xml
+++ b/sampleprojects/TaxReturn/xml/026_Apply_Tax_Brackets_Single_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>In bracket 1 only</condition_comment>
-<condition_description>In bracket 1 only</condition_description>
+<condition_dsl>In bracket 1 only</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -32,7 +32,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>In bracket 2</condition_comment>
-<condition_description>In bracket 2</condition_description>
+<condition_dsl>In bracket 2</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -47,7 +47,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>In bracket 3</condition_comment>
-<condition_description>In bracket 3</condition_description>
+<condition_dsl>In bracket 3</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -62,7 +62,7 @@
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>In bracket 4</condition_comment>
-<condition_description>In bracket 4</condition_description>
+<condition_dsl>In bracket 4</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -77,7 +77,7 @@
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>In bracket 5</condition_comment>
-<condition_description>In bracket 5</condition_description>
+<condition_dsl>In bracket 5</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -92,7 +92,7 @@
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>In bracket 6</condition_comment>
-<condition_description>In bracket 6</condition_description>
+<condition_dsl>In bracket 6</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -109,7 +109,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Bracket 1 tax</action_comment>
-<action_description>Bracket 1 tax</action_description>
+<action_dsl>Bracket 1 tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -118,7 +118,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bracket 2 tax</action_comment>
-<action_description>Bracket 2 tax</action_description>
+<action_dsl>Bracket 2 tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -127,7 +127,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Bracket 3 tax</action_comment>
-<action_description>Bracket 3 tax</action_description>
+<action_dsl>Bracket 3 tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -136,7 +136,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Bracket 4 tax</action_comment>
-<action_description>Bracket 4 tax</action_description>
+<action_dsl>Bracket 4 tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -145,7 +145,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment>Bracket 5 tax</action_comment>
-<action_description>Bracket 5 tax</action_description>
+<action_dsl>Bracket 5 tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -154,7 +154,7 @@
 <action_details>
 <action_number>6</action_number>
 <action_comment>Bracket 6 tax</action_comment>
-<action_description>Bracket 6 tax</action_description>
+<action_dsl>Bracket 6 tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -163,7 +163,7 @@
 <action_details>
 <action_number>7</action_number>
 <action_comment>Bracket 7 tax</action_comment>
-<action_description>Bracket 7 tax</action_description>
+<action_dsl>Bracket 7 tax</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/027_Calculate_Credits_dt.xml
+++ b/sampleprojects/TaxReturn/xml/027_Calculate_Credits_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.total_ctc = 0, set result.total_odc = 0, set result.total_actc = 0, set result.total_credits = 0</action_description>
+<action_dsl>set result.total_ctc = 0, set result.total_odc = 0, set result.total_actc = 0, set result.total_credits = 0</action_dsl>
 <action_postfix>
 0.0 /result.total_ctc xdef
 0.0 /result.total_odc xdef
@@ -27,7 +27,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always process credits</condition_comment>
-<condition_description>Always process credits</condition_description>
+<condition_dsl>Always process credits</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate child tax credits for all dependents</action_comment>
-<action_description>Calculate child tax credits for all dependents</action_description>
+<action_dsl>Calculate child tax credits for all dependents</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -47,7 +47,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Apply CTC phase-out per IRC 24(b)</action_comment>
-<action_description>Apply CTC phase-out per IRC 24(b)</action_description>
+<action_dsl>Apply CTC phase-out per IRC 24(b)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -56,7 +56,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate EITC</action_comment>
-<action_description>Calculate EITC</action_description>
+<action_dsl>Calculate EITC</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -65,7 +65,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate education credits</action_comment>
-<action_description>Calculate education credits</action_description>
+<action_dsl>Calculate education credits</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -74,7 +74,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate Child and Dependent Care Credit</action_comment>
-<action_description>Calculate Child and Dependent Care Credit</action_description>
+<action_dsl>Calculate Child and Dependent Care Credit</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -83,7 +83,7 @@
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate Saver's Credit</action_comment>
-<action_description>Calculate Saver's Credit</action_description>
+<action_dsl>Calculate Saver's Credit</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -92,7 +92,7 @@
 <action_details>
 <action_number>7</action_number>
 <action_comment>Calculate Energy Credits</action_comment>
-<action_description>Calculate Energy Credits</action_description>
+<action_dsl>Calculate Energy Credits</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -101,7 +101,7 @@
 <action_details>
 <action_number>8</action_number>
 <action_comment>Calculate Premium Tax Credit</action_comment>
-<action_description>Calculate Premium Tax Credit</action_description>
+<action_dsl>Calculate Premium Tax Credit</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -110,7 +110,7 @@
 <action_details>
 <action_number>9</action_number>
 <action_comment>Calculate Foreign Tax Credit (Form 1116)</action_comment>
-<action_description>Calculate Foreign Tax Credit (Form 1116)</action_description>
+<action_dsl>Calculate Foreign Tax Credit (Form 1116)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -119,7 +119,7 @@
 <action_details>
 <action_number>10</action_number>
 <action_comment>Calculate DC First-Time Homebuyer Credit (Form 8859)</action_comment>
-<action_description>Calculate DC First-Time Homebuyer Credit (Form 8859)</action_description>
+<action_dsl>Calculate DC First-Time Homebuyer Credit (Form 8859)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -128,7 +128,7 @@
 <action_details>
 <action_number>11</action_number>
 <action_comment>Calculate Mortgage Interest Credit (Form 8396)</action_comment>
-<action_description>Calculate Mortgage Interest Credit (Form 8396)</action_description>
+<action_dsl>Calculate Mortgage Interest Credit (Form 8396)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -137,7 +137,7 @@
 <action_details>
 <action_number>12</action_number>
 <action_comment>Calculate Energy Efficient Appliance Credit (Form 8909)</action_comment>
-<action_description>Calculate Energy Efficient Appliance Credit (Form 8909)</action_description>
+<action_dsl>Calculate Energy Efficient Appliance Credit (Form 8909)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -146,7 +146,7 @@
 <action_details>
 <action_number>13</action_number>
 <action_comment>Calculate General Business Credit (Form 3800)</action_comment>
-<action_description>Calculate General Business Credit (Form 3800)</action_description>
+<action_dsl>Calculate General Business Credit (Form 3800)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -155,7 +155,7 @@
 <action_details>
 <action_number>14</action_number>
 <action_comment>Sum total credits</action_comment>
-<action_description>Sum total credits</action_description>
+<action_dsl>Sum total credits</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/028_Calculate_CTC_Phase_Out_dt.xml
+++ b/sampleprojects/TaxReturn/xml/028_Calculate_CTC_Phase_Out_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly or Qualifying Surviving Spouse</condition_comment>
-<condition_description>Married Filing Jointly or Qualifying Surviving Spouse</condition_description>
+<condition_dsl>Married Filing Jointly or Qualifying Surviving Spouse</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -31,7 +31,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>AGI exceeds MFJ phase-out threshold</condition_comment>
-<condition_description>AGI exceeds MFJ phase-out threshold</condition_description>
+<condition_dsl>AGI exceeds MFJ phase-out threshold</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>AGI exceeds Single phase-out threshold</condition_comment>
-<condition_description>AGI exceeds Single phase-out threshold</condition_description>
+<condition_dsl>AGI exceeds Single phase-out threshold</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -59,7 +59,7 @@
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Has credits to phase out</condition_comment>
-<condition_description>Has credits to phase out</condition_description>
+<condition_dsl>Has credits to phase out</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -75,7 +75,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Set MFJ threshold and calculate values</action_comment>
-<action_description>Set MFJ threshold and calculate values</action_description>
+<action_dsl>Set MFJ threshold and calculate values</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -86,7 +86,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Set Single threshold and calculate values</action_comment>
-<action_description>Set Single threshold and calculate values</action_description>
+<action_dsl>Set Single threshold and calculate values</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -97,7 +97,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate phase-out reduction for MFJ with credits over threshold</action_comment>
-<action_description>Calculate phase-out reduction for MFJ with credits over threshold</action_description>
+<action_dsl>Calculate phase-out reduction for MFJ with credits over threshold</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -106,7 +106,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate phase-out reduction for Single with credits over threshold</action_comment>
-<action_description>Calculate phase-out reduction for Single with credits over threshold</action_description>
+<action_dsl>Calculate phase-out reduction for Single with credits over threshold</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -115,7 +115,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment>AGI over threshold but no credits to reduce</action_comment>
-<action_description>AGI over threshold but no credits to reduce</action_description>
+<action_dsl>AGI over threshold but no credits to reduce</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -125,7 +125,7 @@
 <action_details>
 <action_number>6</action_number>
 <action_comment>AGI does not exceed threshold</action_comment>
-<action_description>AGI does not exceed threshold</action_description>
+<action_dsl>AGI does not exceed threshold</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/029_Calculate_Child_Tax_Credit_dt.xml
+++ b/sampleprojects/TaxReturn/xml/029_Calculate_Child_Tax_Credit_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is a qualifying child (relationship)</condition_comment>
-<condition_description>Is a qualifying child (relationship)</condition_description>
+<condition_dsl>Is a qualifying child (relationship)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Under age 17 at end of year</condition_comment>
-<condition_description>Under age 17 at end of year</condition_description>
+<condition_dsl>Under age 17 at end of year</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -38,7 +38,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Has valid SSN</condition_comment>
-<condition_description>Has valid SSN</condition_description>
+<condition_dsl>Has valid SSN</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -50,7 +50,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Award Child Tax Credit</action_comment>
-<action_description>Award Child Tax Credit</action_description>
+<action_dsl>Award Child Tax Credit</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -59,7 +59,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Award Other Dependent Credit (age 17)</action_comment>
-<action_description>Award Other Dependent Credit (age 17)</action_description>
+<action_dsl>Award Other Dependent Credit (age 17)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -68,7 +68,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Non-child dependent gets ODC</action_comment>
-<action_description>Non-child dependent gets ODC</action_description>
+<action_dsl>Non-child dependent gets ODC</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/030_Calculate_Final_Balance_dt.xml
+++ b/sampleprojects/TaxReturn/xml/030_Calculate_Final_Balance_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.total_tax = tax_before_credits - nonrefundable_credits + ptc_repayment, add refundable credits to payments</action_description>
+<action_dsl>set result.total_tax = tax_before_credits - nonrefundable_credits + ptc_repayment, add refundable credits to payments</action_dsl>
 <action_postfix>
 &quot;FINAL CALCULATION (Form 1040 Lines 33-37)&quot; job.audit_trail swap addto
 result.total_tax_before_credits result.amt_owed f+ /result.tax_before_nonrefundable_credits xdef
@@ -38,7 +38,7 @@ result.total_aotc_refundable result.total_payments f+ /result.total_payments xde
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Total tax is negative (floor at zero)</condition_comment>
-<condition_description>Total tax is negative (floor at zero)</condition_description>
+<condition_dsl>Total tax is negative (floor at zero)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -49,7 +49,7 @@ result.total_aotc_refundable result.total_payments f+ /result.total_payments xde
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Payments exceed tax (refund)</condition_comment>
-<condition_description>Payments exceed tax (refund)</condition_description>
+<condition_dsl>Payments exceed tax (refund)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -62,7 +62,7 @@ result.total_aotc_refundable result.total_payments f+ /result.total_payments xde
 <action_details>
 <action_number>1</action_number>
 <action_comment>Floor total tax at zero</action_comment>
-<action_description>Floor total tax at zero</action_description>
+<action_dsl>Floor total tax at zero</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -71,7 +71,7 @@ result.total_aotc_refundable result.total_payments f+ /result.total_payments xde
 <action_details>
 <action_number>2</action_number>
 <action_comment>Log total tax and payments</action_comment>
-<action_description>Log total tax and payments</action_description>
+<action_dsl>Log total tax and payments</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -82,7 +82,7 @@ result.total_aotc_refundable result.total_payments f+ /result.total_payments xde
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate refund</action_comment>
-<action_description>Calculate refund</action_description>
+<action_dsl>Calculate refund</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -92,7 +92,7 @@ result.total_aotc_refundable result.total_payments f+ /result.total_payments xde
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate amount owed</action_comment>
-<action_description>Calculate amount owed</action_description>
+<action_dsl>Calculate amount owed</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/031_Calculate_EITC_dt.xml
+++ b/sampleprojects/TaxReturn/xml/031_Calculate_EITC_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>for all dependents perform Count_EITC_Qualifying_Child</action_description>
+<action_dsl>for all dependents perform Count_EITC_Qualifying_Child</action_dsl>
 <action_postfix>
 0 allocate
 { Count_EITC_Qualifying_Child performaliased } job.dependents forall
@@ -26,7 +26,7 @@ deallocate pop
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has earned income</condition_comment>
-<condition_description>Has earned income</condition_description>
+<condition_dsl>Has earned income</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -43,7 +43,7 @@ deallocate pop
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>3+ qualifying children</condition_comment>
-<condition_description>3+ qualifying children</condition_description>
+<condition_dsl>3+ qualifying children</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -60,7 +60,7 @@ deallocate pop
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>2 qualifying children</condition_comment>
-<condition_description>2 qualifying children</condition_description>
+<condition_dsl>2 qualifying children</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -77,7 +77,7 @@ deallocate pop
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>1 qualifying child</condition_comment>
-<condition_description>1 qualifying child</condition_description>
+<condition_dsl>1 qualifying child</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -94,7 +94,7 @@ deallocate pop
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>0 qualifying children</condition_comment>
-<condition_description>0 qualifying children</condition_description>
+<condition_dsl>0 qualifying children</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -111,7 +111,7 @@ deallocate pop
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>AGI below phase-out threshold (3+ children)</condition_comment>
-<condition_description>AGI below phase-out threshold (3+ children)</condition_description>
+<condition_dsl>AGI below phase-out threshold (3+ children)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -128,7 +128,7 @@ deallocate pop
 <condition_details>
 <condition_number>7</condition_number>
 <condition_comment>AGI below phase-out threshold (2 children)</condition_comment>
-<condition_description>AGI below phase-out threshold (2 children)</condition_description>
+<condition_dsl>AGI below phase-out threshold (2 children)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -145,7 +145,7 @@ deallocate pop
 <condition_details>
 <condition_number>8</condition_number>
 <condition_comment>AGI below phase-out threshold (1 child)</condition_comment>
-<condition_description>AGI below phase-out threshold (1 child)</condition_description>
+<condition_dsl>AGI below phase-out threshold (1 child)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -162,7 +162,7 @@ deallocate pop
 <condition_details>
 <condition_number>9</condition_number>
 <condition_comment>AGI below phase-out threshold (0 children)</condition_comment>
-<condition_description>AGI below phase-out threshold (0 children)</condition_description>
+<condition_dsl>AGI below phase-out threshold (0 children)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -181,7 +181,7 @@ deallocate pop
 <action_details>
 <action_number>1</action_number>
 <action_comment>EITC 3+ children - full amount</action_comment>
-<action_description>EITC 3+ children - full amount</action_description>
+<action_dsl>EITC 3+ children - full amount</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -190,7 +190,7 @@ deallocate pop
 <action_details>
 <action_number>2</action_number>
 <action_comment>EITC 3+ children - phase-out</action_comment>
-<action_description>EITC 3+ children - phase-out</action_description>
+<action_dsl>EITC 3+ children - phase-out</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -199,7 +199,7 @@ deallocate pop
 <action_details>
 <action_number>3</action_number>
 <action_comment>EITC 2 children - full amount</action_comment>
-<action_description>EITC 2 children - full amount</action_description>
+<action_dsl>EITC 2 children - full amount</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -208,7 +208,7 @@ deallocate pop
 <action_details>
 <action_number>4</action_number>
 <action_comment>EITC 2 children - phase-out</action_comment>
-<action_description>EITC 2 children - phase-out</action_description>
+<action_dsl>EITC 2 children - phase-out</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -217,7 +217,7 @@ deallocate pop
 <action_details>
 <action_number>5</action_number>
 <action_comment>EITC 1 child - full amount</action_comment>
-<action_description>EITC 1 child - full amount</action_description>
+<action_dsl>EITC 1 child - full amount</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -226,7 +226,7 @@ deallocate pop
 <action_details>
 <action_number>6</action_number>
 <action_comment>EITC 1 child - phase-out</action_comment>
-<action_description>EITC 1 child - phase-out</action_description>
+<action_dsl>EITC 1 child - phase-out</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -235,7 +235,7 @@ deallocate pop
 <action_details>
 <action_number>7</action_number>
 <action_comment>EITC 0 children - full amount</action_comment>
-<action_description>EITC 0 children - full amount</action_description>
+<action_dsl>EITC 0 children - full amount</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -244,7 +244,7 @@ deallocate pop
 <action_details>
 <action_number>8</action_number>
 <action_comment>EITC 0 children - phase-out</action_comment>
-<action_description>EITC 0 children - phase-out</action_description>
+<action_dsl>EITC 0 children - phase-out</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -253,7 +253,7 @@ deallocate pop
 <action_details>
 <action_number>9</action_number>
 <action_comment>No EITC - no earned income</action_comment>
-<action_description>No EITC - no earned income</action_description>
+<action_dsl>No EITC - no earned income</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/032_Calculate_Education_Credits_dt.xml
+++ b/sampleprojects/TaxReturn/xml/032_Calculate_Education_Credits_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.education_credit = 0, initialize AOTC refundable/nonrefundable, for all dependents perform Calculate_Education_Credit_Per_Dependent</action_description>
+<action_dsl>set result.education_credit = 0, initialize AOTC refundable/nonrefundable, for all dependents perform Calculate_Education_Credit_Per_Dependent</action_dsl>
 <action_postfix>
 0.0 /result.education_credit xdef
 0.0 /result.total_aotc_refundable xdef
@@ -26,7 +26,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always process</condition_comment>
-<condition_description>Always process</condition_description>
+<condition_dsl>Always process</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -37,7 +37,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log education credit total</action_comment>
-<action_description>Log education credit total</action_description>
+<action_dsl>Log education credit total</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/033_Calculate_Education_Credit_Per_Dependent_dt.xml
+++ b/sampleprojects/TaxReturn/xml/033_Calculate_Education_Credit_Per_Dependent_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is college student</condition_comment>
-<condition_description>Is college student</condition_description>
+<condition_dsl>Is college student</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -30,7 +30,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Eligible for AOTC (years 1-4, not exhausted)</condition_comment>
-<condition_description>Eligible for AOTC (years 1-4, not exhausted)</condition_description>
+<condition_dsl>Eligible for AOTC (years 1-4, not exhausted)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -43,7 +43,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>AGI in AOTC phase-out range</condition_comment>
-<condition_description>AGI in AOTC phase-out range</condition_description>
+<condition_dsl>AGI in AOTC phase-out range</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -56,7 +56,7 @@
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>AGI in LLC phase-out range</condition_comment>
-<condition_description>AGI in LLC phase-out range</condition_description>
+<condition_dsl>AGI in LLC phase-out range</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -71,7 +71,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate AOTC (full amount)</action_comment>
-<action_description>Calculate AOTC (full amount)</action_description>
+<action_dsl>Calculate AOTC (full amount)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -80,7 +80,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate AOTC with phase-out</action_comment>
-<action_description>Calculate AOTC with phase-out</action_description>
+<action_dsl>Calculate AOTC with phase-out</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -89,7 +89,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate LLC (full amount)</action_comment>
-<action_description>Calculate LLC (full amount)</action_description>
+<action_dsl>Calculate LLC (full amount)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -98,7 +98,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate LLC with phase-out</action_comment>
-<action_description>Calculate LLC with phase-out</action_description>
+<action_dsl>Calculate LLC with phase-out</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -107,7 +107,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment>Not a college student</action_comment>
-<action_description>Not a college student</action_description>
+<action_dsl>Not a college student</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/034_Calculate_QBI_Deduction_dt.xml
+++ b/sampleprojects/TaxReturn/xml/034_Calculate_QBI_Deduction_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has qualified business income</condition_comment>
-<condition_description>Has qualified business income</condition_description>
+<condition_dsl>Has qualified business income</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -27,7 +27,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxable income below threshold (simplified calculation)</condition_comment>
-<condition_description>Taxable income below threshold (simplified calculation)</condition_description>
+<condition_dsl>Taxable income below threshold (simplified calculation)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate QBI deduction at 20%</action_comment>
-<action_description>Calculate QBI deduction at 20%</action_description>
+<action_dsl>Calculate QBI deduction at 20%</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -47,7 +47,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No QBI - no qualified business income</action_comment>
-<action_description>No QBI - no qualified business income</action_description>
+<action_dsl>No QBI - no qualified business income</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/035_Validate_Results_dt.xml
+++ b/sampleprojects/TaxReturn/xml/035_Validate_Results_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.validation_passed = true</action_description>
+<action_dsl>set result.validation_passed = true</action_dsl>
 <action_postfix>
 &quot;VALIDATION RESULTS&quot; job.audit_trail swap addto
 true /result.validation_passed xdef
@@ -24,7 +24,7 @@ true /result.validation_passed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Expected values exist</condition_comment>
-<condition_description>Expected values exist</condition_description>
+<condition_dsl>Expected values exist</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -36,7 +36,7 @@ true /result.validation_passed xdef
 <action_details>
 <action_number>1</action_number>
 <action_comment>Run all validations</action_comment>
-<action_description>Run all validations</action_description>
+<action_dsl>Run all validations</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@ true /result.validation_passed xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No expected values</action_comment>
-<action_description>No expected values</action_description>
+<action_dsl>No expected values</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/036_Validate_AGI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/036_Validate_AGI_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>AGI matches expected (within tolerance)</condition_comment>
-<condition_description>AGI matches expected (within tolerance)</condition_description>
+<condition_dsl>AGI matches expected (within tolerance)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>AGI validation passed</action_comment>
-<action_description>AGI validation passed</action_description>
+<action_dsl>AGI validation passed</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>AGI validation failed</action_comment>
-<action_description>AGI validation failed</action_description>
+<action_dsl>AGI validation failed</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/037_Validate_Taxable_Income_dt.xml
+++ b/sampleprojects/TaxReturn/xml/037_Validate_Taxable_Income_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Taxable income matches expected</condition_comment>
-<condition_description>Taxable income matches expected</condition_description>
+<condition_dsl>Taxable income matches expected</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Taxable income validation passed</action_comment>
-<action_description>Taxable income validation passed</action_description>
+<action_dsl>Taxable income validation passed</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Taxable income validation failed</action_comment>
-<action_description>Taxable income validation failed</action_description>
+<action_dsl>Taxable income validation failed</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/038_Validate_Total_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/038_Validate_Total_Tax_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Total tax matches expected</condition_comment>
-<condition_description>Total tax matches expected</condition_description>
+<condition_dsl>Total tax matches expected</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Total tax validation passed</action_comment>
-<action_description>Total tax validation passed</action_description>
+<action_dsl>Total tax validation passed</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Total tax validation failed</action_comment>
-<action_description>Total tax validation failed</action_description>
+<action_dsl>Total tax validation failed</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/039_Validate_Summary_dt.xml
+++ b/sampleprojects/TaxReturn/xml/039_Validate_Summary_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>All validations passed</condition_comment>
-<condition_description>All validations passed</condition_description>
+<condition_dsl>All validations passed</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>All tests passed</action_comment>
-<action_description>All tests passed</action_description>
+<action_dsl>All tests passed</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Some tests failed</action_comment>
-<action_description>Some tests failed</action_description>
+<action_dsl>Some tests failed</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/040_Filter_Self_Employed_Taxpayer_dt.xml
+++ b/sampleprojects/TaxReturn/xml/040_Filter_Self_Employed_Taxpayer_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Taxpayer is self-employed</condition_comment>
-<condition_description>Taxpayer is self-employed</condition_description>
+<condition_dsl>Taxpayer is self-employed</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process self-employed taxpayer</action_comment>
-<action_description>Process self-employed taxpayer</action_description>
+<action_dsl>Process self-employed taxpayer</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-self-employed</action_comment>
-<action_description>Skip non-self-employed</action_description>
+<action_dsl>Skip non-self-employed</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/041_Filter_Taxpayer_Vehicle_dt.xml
+++ b/sampleprojects/TaxReturn/xml/041_Filter_Taxpayer_Vehicle_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Vehicle belongs to current taxpayer</condition_comment>
-<condition_description>Vehicle belongs to current taxpayer</condition_description>
+<condition_dsl>Vehicle belongs to current taxpayer</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process vehicle</action_comment>
-<action_description>Process vehicle</action_description>
+<action_dsl>Process vehicle</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip vehicle</action_comment>
-<action_description>Skip vehicle</action_description>
+<action_dsl>Skip vehicle</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/042_Filter_Rental_Property_dt.xml
+++ b/sampleprojects/TaxReturn/xml/042_Filter_Rental_Property_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Property is rental</condition_comment>
-<condition_description>Property is rental</condition_description>
+<condition_dsl>Property is rental</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process rental</action_comment>
-<action_description>Process rental</action_description>
+<action_dsl>Process rental</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-rental</action_comment>
-<action_description>Skip non-rental</action_description>
+<action_dsl>Skip non-rental</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/043_Count_EITC_Qualifying_Child_dt.xml
+++ b/sampleprojects/TaxReturn/xml/043_Count_EITC_Qualifying_Child_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has child relationship</condition_comment>
-<condition_description>Has child relationship</condition_description>
+<condition_dsl>Has child relationship</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -27,7 +27,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets age test</condition_comment>
-<condition_description>Meets age test</condition_description>
+<condition_dsl>Meets age test</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -37,7 +37,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Meets residency test</condition_comment>
-<condition_description>Meets residency test</condition_description>
+<condition_dsl>Meets residency test</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -49,7 +49,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Increment counter</action_comment>
-<action_description>Increment counter</action_description>
+<action_dsl>Increment counter</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -58,7 +58,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-qualifying</action_comment>
-<action_description>Skip non-qualifying</action_description>
+<action_dsl>Skip non-qualifying</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/044_Calculate_Mortgage_Interest_For_Property_dt.xml
+++ b/sampleprojects/TaxReturn/xml/044_Calculate_Mortgage_Interest_For_Property_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has mortgage interest</condition_comment>
-<condition_description>Has mortgage interest</condition_description>
+<condition_dsl>Has mortgage interest</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process mortgage interest</action_comment>
-<action_description>Process mortgage interest</action_description>
+<action_dsl>Process mortgage interest</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No mortgage interest</action_comment>
-<action_description>No mortgage interest</action_description>
+<action_dsl>No mortgage interest</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/045_Calculate_OBBBA_Deductions_dt.xml
+++ b/sampleprojects/TaxReturn/xml/045_Calculate_OBBBA_Deductions_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.tips_deduction = 0, set result.overtime_deduction = 0, set result.senior_deduction = 0</action_description>
+<action_dsl>set result.tips_deduction = 0, set result.overtime_deduction = 0, set result.senior_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.tips_deduction xdef
 0.0 /result.overtime_deduction xdef
@@ -27,7 +27,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always calculate OBBBA deductions</condition_comment>
-<condition_description>Always calculate OBBBA deductions</condition_description>
+<condition_dsl>Always calculate OBBBA deductions</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate No Tax on Tips deduction</action_comment>
-<action_description>Calculate No Tax on Tips deduction</action_description>
+<action_dsl>Calculate No Tax on Tips deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -47,7 +47,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate No Tax on Overtime deduction</action_comment>
-<action_description>Calculate No Tax on Overtime deduction</action_description>
+<action_dsl>Calculate No Tax on Overtime deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -56,7 +56,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Senior Additional deduction</action_comment>
-<action_description>Calculate Senior Additional deduction</action_description>
+<action_dsl>Calculate Senior Additional deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -65,7 +65,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Sum total OBBBA deductions</action_comment>
-<action_description>Sum total OBBBA deductions</action_description>
+<action_dsl>Sum total OBBBA deductions</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/046_Calculate_Tips_Deduction_dt.xml
+++ b/sampleprojects/TaxReturn/xml/046_Calculate_Tips_Deduction_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has tip income</condition_comment>
-<condition_description>Has tip income</condition_description>
+<condition_dsl>Has tip income</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -30,7 +30,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>Married Filing Jointly</condition_description>
+<condition_dsl>Married Filing Jointly</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -43,7 +43,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ income below phase-out threshold ($300k)</condition_comment>
-<condition_description>MFJ income below phase-out threshold ($300k)</condition_description>
+<condition_dsl>MFJ income below phase-out threshold ($300k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -56,7 +56,7 @@
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Single income below phase-out threshold ($150k)</condition_comment>
-<condition_description>Single income below phase-out threshold ($150k)</condition_description>
+<condition_dsl>Single income below phase-out threshold ($150k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -71,7 +71,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full tips deduction (below phase-out)</action_comment>
-<action_description>Full tips deduction (below phase-out)</action_description>
+<action_dsl>Full tips deduction (below phase-out)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -81,7 +81,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Tips deduction phased out (high income)</action_comment>
-<action_description>Tips deduction phased out (high income)</action_description>
+<action_dsl>Tips deduction phased out (high income)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -91,7 +91,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>No tip income</action_comment>
-<action_description>No tip income</action_description>
+<action_dsl>No tip income</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/047_Calculate_Overtime_Deduction_dt.xml
+++ b/sampleprojects/TaxReturn/xml/047_Calculate_Overtime_Deduction_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has overtime income</condition_comment>
-<condition_description>Has overtime income</condition_description>
+<condition_dsl>Has overtime income</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -30,7 +30,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>Married Filing Jointly</condition_description>
+<condition_dsl>Married Filing Jointly</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -43,7 +43,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ income below phase-out threshold ($300k)</condition_comment>
-<condition_description>MFJ income below phase-out threshold ($300k)</condition_description>
+<condition_dsl>MFJ income below phase-out threshold ($300k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -56,7 +56,7 @@
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Single income below phase-out threshold ($150k)</condition_comment>
-<condition_description>Single income below phase-out threshold ($150k)</condition_description>
+<condition_dsl>Single income below phase-out threshold ($150k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -71,7 +71,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full overtime deduction MFJ (below phase-out)</action_comment>
-<action_description>Full overtime deduction MFJ (below phase-out)</action_description>
+<action_dsl>Full overtime deduction MFJ (below phase-out)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -80,7 +80,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Full overtime deduction Single (below phase-out)</action_comment>
-<action_description>Full overtime deduction Single (below phase-out)</action_description>
+<action_dsl>Full overtime deduction Single (below phase-out)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -89,7 +89,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Overtime deduction phased out (high income)</action_comment>
-<action_description>Overtime deduction phased out (high income)</action_description>
+<action_dsl>Overtime deduction phased out (high income)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -99,7 +99,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>No overtime income</action_comment>
-<action_description>No overtime income</action_description>
+<action_dsl>No overtime income</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/048_Calculate_Senior_Deduction_dt.xml
+++ b/sampleprojects/TaxReturn/xml/048_Calculate_Senior_Deduction_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has seniors</condition_comment>
-<condition_description>Has seniors</condition_description>
+<condition_dsl>Has seniors</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -30,7 +30,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>Married Filing Jointly</condition_description>
+<condition_dsl>Married Filing Jointly</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -43,7 +43,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ income below phase-out threshold ($150k)</condition_comment>
-<condition_description>MFJ income below phase-out threshold ($150k)</condition_description>
+<condition_dsl>MFJ income below phase-out threshold ($150k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -56,7 +56,7 @@
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Single income below phase-out threshold ($75k)</condition_comment>
-<condition_description>Single income below phase-out threshold ($75k)</condition_description>
+<condition_dsl>Single income below phase-out threshold ($75k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -71,7 +71,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full senior deduction (below phase-out)</action_comment>
-<action_description>Full senior deduction (below phase-out)</action_description>
+<action_dsl>Full senior deduction (below phase-out)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -81,7 +81,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Senior deduction phased out (high income)</action_comment>
-<action_description>Senior deduction phased out (high income)</action_description>
+<action_dsl>Senior deduction phased out (high income)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -91,7 +91,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>No seniors</action_comment>
-<action_description>No seniors</action_description>
+<action_dsl>No seniors</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/049_Calculate_SS_Taxability_dt.xml
+++ b/sampleprojects/TaxReturn/xml/049_Calculate_SS_Taxability_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.provisional_income = result.agi + (result.total_social_security * 0.5)</action_description>
+<action_dsl>set result.provisional_income = result.agi + (result.total_social_security * 0.5)</action_dsl>
 <action_postfix>
 result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xdef
 &quot;SOCIAL SECURITY TAXABILITY (Publication 915)&quot; job.audit_trail swap addto
@@ -26,7 +26,7 @@ result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xde
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has Social Security income</condition_comment>
-<condition_description>Has Social Security income</condition_description>
+<condition_dsl>Has Social Security income</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -41,7 +41,7 @@ result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xde
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>Married Filing Jointly</condition_description>
+<condition_dsl>Married Filing Jointly</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -56,7 +56,7 @@ result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xde
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ provisional income at or below base amount ($32k)</condition_comment>
-<condition_description>MFJ provisional income at or below base amount ($32k)</condition_description>
+<condition_dsl>MFJ provisional income at or below base amount ($32k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -71,7 +71,7 @@ result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xde
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>MFJ provisional income at or below additional amount ($44k)</condition_comment>
-<condition_description>MFJ provisional income at or below additional amount ($44k)</condition_description>
+<condition_dsl>MFJ provisional income at or below additional amount ($44k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -86,7 +86,7 @@ result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xde
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>Single provisional income at or below base amount ($25k)</condition_comment>
-<condition_description>Single provisional income at or below base amount ($25k)</condition_description>
+<condition_dsl>Single provisional income at or below base amount ($25k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -101,7 +101,7 @@ result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xde
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>Single provisional income at or below additional amount ($34k)</condition_comment>
-<condition_description>Single provisional income at or below additional amount ($34k)</condition_description>
+<condition_dsl>Single provisional income at or below additional amount ($34k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -118,7 +118,7 @@ result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xde
 <action_details>
 <action_number>1</action_number>
 <action_comment>0% SS taxable - below base amount</action_comment>
-<action_description>0% SS taxable - below base amount</action_description>
+<action_dsl>0% SS taxable - below base amount</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -128,7 +128,7 @@ result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xde
 <action_details>
 <action_number>2</action_number>
 <action_comment>Up to 50% SS taxable MFJ - between base and additional</action_comment>
-<action_description>Up to 50% SS taxable MFJ - between base and additional</action_description>
+<action_dsl>Up to 50% SS taxable MFJ - between base and additional</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -137,7 +137,7 @@ result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xde
 <action_details>
 <action_number>3</action_number>
 <action_comment>Up to 50% SS taxable Single - between base and additional</action_comment>
-<action_description>Up to 50% SS taxable Single - between base and additional</action_description>
+<action_dsl>Up to 50% SS taxable Single - between base and additional</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -146,7 +146,7 @@ result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xde
 <action_details>
 <action_number>4</action_number>
 <action_comment>Up to 85% SS taxable - above additional amount</action_comment>
-<action_description>Up to 85% SS taxable - above additional amount</action_description>
+<action_dsl>Up to 85% SS taxable - above additional amount</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -156,7 +156,7 @@ result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xde
 <action_details>
 <action_number>5</action_number>
 <action_comment>No SS income</action_comment>
-<action_description>No SS income</action_description>
+<action_dsl>No SS income</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/050_Process_Capital_Gains_dt.xml
+++ b/sampleprojects/TaxReturn/xml/050_Process_Capital_Gains_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is capital gain type</condition_comment>
-<condition_description>Is capital gain type</condition_description>
+<condition_dsl>Is capital gain type</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Is long-term holding period</condition_comment>
-<condition_description>Is long-term holding period</condition_description>
+<condition_dsl>Is long-term holding period</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -41,7 +41,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Is dividend type</condition_comment>
-<condition_description>Is dividend type</condition_description>
+<condition_dsl>Is dividend type</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -53,7 +53,7 @@
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Is qualified dividend</condition_comment>
-<condition_description>Is qualified dividend</condition_description>
+<condition_dsl>Is qualified dividend</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -67,7 +67,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add to long-term gains</action_comment>
-<action_description>Add to long-term gains</action_description>
+<action_dsl>Add to long-term gains</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -76,7 +76,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Add to short-term gains</action_comment>
-<action_description>Add to short-term gains</action_description>
+<action_dsl>Add to short-term gains</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -85,7 +85,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Add qualified dividend</action_comment>
-<action_description>Add qualified dividend</action_description>
+<action_dsl>Add qualified dividend</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/051_Calculate_Capital_Gains_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/051_Calculate_Capital_Gains_Tax_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.preferential_rate_income = result.total_long_term_gains + result.qualified_dividends</action_description>
+<action_dsl>set result.preferential_rate_income = result.total_long_term_gains + result.qualified_dividends</action_dsl>
 <action_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ allocate
 result.taxable_income 0 local@ f- /result.ordinary_income_for_cg xdef
@@ -27,7 +27,7 @@ result.taxable_income 0 local@ f- /result.ordinary_income_for_cg xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has preferential rate income</condition_comment>
-<condition_description>Has preferential rate income</condition_description>
+<condition_dsl>Has preferential rate income</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -38,7 +38,7 @@ result.taxable_income 0 local@ f- /result.ordinary_income_for_cg xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>Married Filing Jointly</condition_description>
+<condition_dsl>Married Filing Jointly</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -48,7 +48,7 @@ result.taxable_income 0 local@ f- /result.ordinary_income_for_cg xdef
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>Head of Household</condition_description>
+<condition_dsl>Head of Household</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -59,7 +59,7 @@ result.taxable_income 0 local@ f- /result.ordinary_income_for_cg xdef
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate CG tax for MFJ</action_comment>
-<action_description>Calculate CG tax for MFJ</action_description>
+<action_dsl>Calculate CG tax for MFJ</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -68,7 +68,7 @@ result.taxable_income 0 local@ f- /result.ordinary_income_for_cg xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate CG tax for HOH</action_comment>
-<action_description>Calculate CG tax for HOH</action_description>
+<action_dsl>Calculate CG tax for HOH</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -77,7 +77,7 @@ result.taxable_income 0 local@ f- /result.ordinary_income_for_cg xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate CG tax for Single/Other</action_comment>
-<action_description>Calculate CG tax for Single/Other</action_description>
+<action_dsl>Calculate CG tax for Single/Other</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/052_Apply_CG_Brackets_MFJ_dt.xml
+++ b/sampleprojects/TaxReturn/xml/052_Apply_CG_Brackets_MFJ_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Ordinary income fills 0% bracket</condition_comment>
-<condition_description>Ordinary income fills 0% bracket</condition_description>
+<condition_dsl>Ordinary income fills 0% bracket</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxable income in 15% bracket</condition_comment>
-<condition_description>Taxable income in 15% bracket</condition_description>
+<condition_dsl>Taxable income in 15% bracket</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -41,7 +41,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>0% rate applies to all preferential income</action_comment>
-<action_description>0% rate applies to all preferential income</action_description>
+<action_dsl>0% rate applies to all preferential income</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -50,7 +50,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>15% rate applies</action_comment>
-<action_description>15% rate applies</action_description>
+<action_dsl>15% rate applies</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -59,7 +59,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>20% rate applies</action_comment>
-<action_description>20% rate applies</action_description>
+<action_dsl>20% rate applies</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/053_Apply_CG_Brackets_HOH_dt.xml
+++ b/sampleprojects/TaxReturn/xml/053_Apply_CG_Brackets_HOH_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Ordinary income fills 0% bracket</condition_comment>
-<condition_description>Ordinary income fills 0% bracket</condition_description>
+<condition_dsl>Ordinary income fills 0% bracket</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxable income in 15% bracket</condition_comment>
-<condition_description>Taxable income in 15% bracket</condition_description>
+<condition_dsl>Taxable income in 15% bracket</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -41,7 +41,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>0% rate applies to all preferential income</action_comment>
-<action_description>0% rate applies to all preferential income</action_description>
+<action_dsl>0% rate applies to all preferential income</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -50,7 +50,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>15% rate applies</action_comment>
-<action_description>15% rate applies</action_description>
+<action_dsl>15% rate applies</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -59,7 +59,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>20% rate applies</action_comment>
-<action_description>20% rate applies</action_description>
+<action_dsl>20% rate applies</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/054_Apply_CG_Brackets_Single_dt.xml
+++ b/sampleprojects/TaxReturn/xml/054_Apply_CG_Brackets_Single_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Ordinary income fills 0% bracket</condition_comment>
-<condition_description>Ordinary income fills 0% bracket</condition_description>
+<condition_dsl>Ordinary income fills 0% bracket</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxable income in 15% bracket</condition_comment>
-<condition_description>Taxable income in 15% bracket</condition_description>
+<condition_dsl>Taxable income in 15% bracket</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -41,7 +41,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>0% rate applies to all preferential income</action_comment>
-<action_description>0% rate applies to all preferential income</action_description>
+<action_dsl>0% rate applies to all preferential income</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -50,7 +50,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>15% rate applies</action_comment>
-<action_description>15% rate applies</action_description>
+<action_dsl>15% rate applies</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -59,7 +59,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>20% rate applies</action_comment>
-<action_description>20% rate applies</action_description>
+<action_dsl>20% rate applies</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/055_Calculate_NIIT_dt.xml
+++ b/sampleprojects/TaxReturn/xml/055_Calculate_NIIT_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.net_investment_income = sum of investment income</action_description>
+<action_dsl>set result.net_investment_income = sum of investment income</action_dsl>
 <action_postfix>
 result.total_other_income result.total_long_term_gains f+ result.total_short_term_gains f+ result.total_rental_income f+ result.total_qualified_dividends f+ /result.net_investment_income xdef
 result.agi /result.magi_for_niit xdef
@@ -27,7 +27,7 @@ result.agi /result.magi_for_niit xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has NII</condition_comment>
-<condition_description>Has NII</condition_description>
+<condition_dsl>Has NII</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -42,7 +42,7 @@ result.agi /result.magi_for_niit xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>Married Filing Jointly</condition_description>
+<condition_dsl>Married Filing Jointly</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -57,7 +57,7 @@ result.agi /result.magi_for_niit xdef
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Married Filing Separately</condition_comment>
-<condition_description>Married Filing Separately</condition_description>
+<condition_dsl>Married Filing Separately</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -72,7 +72,7 @@ result.agi /result.magi_for_niit xdef
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>MAGI exceeds MFJ threshold ($250k)</condition_comment>
-<condition_description>MAGI exceeds MFJ threshold ($250k)</condition_description>
+<condition_dsl>MAGI exceeds MFJ threshold ($250k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -87,7 +87,7 @@ result.agi /result.magi_for_niit xdef
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>MAGI exceeds MFS threshold ($125k)</condition_comment>
-<condition_description>MAGI exceeds MFS threshold ($125k)</condition_description>
+<condition_dsl>MAGI exceeds MFS threshold ($125k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -102,7 +102,7 @@ result.agi /result.magi_for_niit xdef
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>MAGI exceeds Single threshold ($200k)</condition_comment>
-<condition_description>MAGI exceeds Single threshold ($200k)</condition_description>
+<condition_dsl>MAGI exceeds Single threshold ($200k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -119,7 +119,7 @@ result.agi /result.magi_for_niit xdef
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate NIIT for MFJ</action_comment>
-<action_description>Calculate NIIT for MFJ</action_description>
+<action_dsl>Calculate NIIT for MFJ</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -128,7 +128,7 @@ result.agi /result.magi_for_niit xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate NIIT for MFS</action_comment>
-<action_description>Calculate NIIT for MFS</action_description>
+<action_dsl>Calculate NIIT for MFS</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -137,7 +137,7 @@ result.agi /result.magi_for_niit xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate NIIT for Single</action_comment>
-<action_description>Calculate NIIT for Single</action_description>
+<action_dsl>Calculate NIIT for Single</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -146,7 +146,7 @@ result.agi /result.magi_for_niit xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>No NIIT - below threshold</action_comment>
-<action_description>No NIIT - below threshold</action_description>
+<action_dsl>No NIIT - below threshold</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -157,7 +157,7 @@ result.agi /result.magi_for_niit xdef
 <action_details>
 <action_number>5</action_number>
 <action_comment>No NII</action_comment>
-<action_description>No NII</action_description>
+<action_dsl>No NII</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/056_Calculate_Additional_Medicare_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/056_Calculate_Additional_Medicare_Tax_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.medicare_wages = sum of taxpayer wages</action_description>
+<action_dsl>set result.medicare_wages = sum of taxpayer wages</action_dsl>
 <action_postfix>
 result.total_w2_wages result.total_se_income f+ /result.wages_for_additional_medicare xdef
 &quot;ADDITIONAL MEDICARE TAX (Form 8959, IRC 3101(b)(2))&quot; job.audit_trail swap addto
@@ -25,7 +25,7 @@ result.total_w2_wages result.total_se_income f+ /result.wages_for_additional_med
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>Married Filing Jointly</condition_description>
+<condition_dsl>Married Filing Jointly</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -39,7 +39,7 @@ result.total_w2_wages result.total_se_income f+ /result.wages_for_additional_med
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Separately</condition_comment>
-<condition_description>Married Filing Separately</condition_description>
+<condition_dsl>Married Filing Separately</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -53,7 +53,7 @@ result.total_w2_wages result.total_se_income f+ /result.wages_for_additional_med
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Wages exceed MFJ threshold ($250k)</condition_comment>
-<condition_description>Wages exceed MFJ threshold ($250k)</condition_description>
+<condition_dsl>Wages exceed MFJ threshold ($250k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -67,7 +67,7 @@ result.total_w2_wages result.total_se_income f+ /result.wages_for_additional_med
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Wages exceed MFS threshold ($125k)</condition_comment>
-<condition_description>Wages exceed MFS threshold ($125k)</condition_description>
+<condition_dsl>Wages exceed MFS threshold ($125k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -81,7 +81,7 @@ result.total_w2_wages result.total_se_income f+ /result.wages_for_additional_med
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>Wages exceed Single threshold ($200k)</condition_comment>
-<condition_description>Wages exceed Single threshold ($200k)</condition_description>
+<condition_dsl>Wages exceed Single threshold ($200k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -97,7 +97,7 @@ result.total_w2_wages result.total_se_income f+ /result.wages_for_additional_med
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Additional Medicare Tax for MFJ</action_comment>
-<action_description>Calculate Additional Medicare Tax for MFJ</action_description>
+<action_dsl>Calculate Additional Medicare Tax for MFJ</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -106,7 +106,7 @@ result.total_w2_wages result.total_se_income f+ /result.wages_for_additional_med
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate Additional Medicare Tax for MFS</action_comment>
-<action_description>Calculate Additional Medicare Tax for MFS</action_description>
+<action_dsl>Calculate Additional Medicare Tax for MFS</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -115,7 +115,7 @@ result.total_w2_wages result.total_se_income f+ /result.wages_for_additional_med
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Additional Medicare Tax for Single</action_comment>
-<action_description>Calculate Additional Medicare Tax for Single</action_description>
+<action_dsl>Calculate Additional Medicare Tax for Single</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -124,7 +124,7 @@ result.total_w2_wages result.total_se_income f+ /result.wages_for_additional_med
 <action_details>
 <action_number>4</action_number>
 <action_comment>No Additional Medicare Tax</action_comment>
-<action_description>No Additional Medicare Tax</action_description>
+<action_dsl>No Additional Medicare Tax</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/057_Calculate_IRA_Deduction_dt.xml
+++ b/sampleprojects/TaxReturn/xml/057_Calculate_IRA_Deduction_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has IRA contribution</condition_comment>
-<condition_description>Has IRA contribution</condition_description>
+<condition_dsl>Has IRA contribution</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -32,7 +32,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Covered by employer plan</condition_comment>
-<condition_description>Covered by employer plan</condition_description>
+<condition_dsl>Covered by employer plan</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -47,7 +47,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Age 50 or over (catchup eligible)</condition_comment>
-<condition_description>Age 50 or over (catchup eligible)</condition_description>
+<condition_dsl>Age 50 or over (catchup eligible)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -62,7 +62,7 @@
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Married Filing Jointly (for phase-out)</condition_comment>
-<condition_description>Married Filing Jointly (for phase-out)</condition_description>
+<condition_dsl>Married Filing Jointly (for phase-out)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -79,7 +79,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full IRA deduction with catchup (not covered, age 50+)</action_comment>
-<action_description>Full IRA deduction with catchup (not covered, age 50+)</action_description>
+<action_dsl>Full IRA deduction with catchup (not covered, age 50+)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -88,7 +88,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Full IRA deduction no catchup (not covered, age under 50)</action_comment>
-<action_description>Full IRA deduction no catchup (not covered, age under 50)</action_description>
+<action_dsl>Full IRA deduction no catchup (not covered, age under 50)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -97,7 +97,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>IRA deduction with MFJ phase-out and catchup</action_comment>
-<action_description>IRA deduction with MFJ phase-out and catchup</action_description>
+<action_dsl>IRA deduction with MFJ phase-out and catchup</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -106,7 +106,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>IRA deduction with MFJ phase-out no catchup</action_comment>
-<action_description>IRA deduction with MFJ phase-out no catchup</action_description>
+<action_dsl>IRA deduction with MFJ phase-out no catchup</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -115,7 +115,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment>IRA deduction with Single phase-out and catchup</action_comment>
-<action_description>IRA deduction with Single phase-out and catchup</action_description>
+<action_dsl>IRA deduction with Single phase-out and catchup</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -124,7 +124,7 @@
 <action_details>
 <action_number>6</action_number>
 <action_comment>IRA deduction with Single phase-out no catchup</action_comment>
-<action_description>IRA deduction with Single phase-out no catchup</action_description>
+<action_dsl>IRA deduction with Single phase-out no catchup</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -133,7 +133,7 @@
 <action_details>
 <action_number>7</action_number>
 <action_comment>No IRA contribution</action_comment>
-<action_description>No IRA contribution</action_description>
+<action_dsl>No IRA contribution</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/058_Calculate_HSA_Deduction_dt.xml
+++ b/sampleprojects/TaxReturn/xml/058_Calculate_HSA_Deduction_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has HSA contribution</condition_comment>
-<condition_description>Has HSA contribution</condition_description>
+<condition_dsl>Has HSA contribution</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -30,7 +30,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Family coverage</condition_comment>
-<condition_description>Family coverage</condition_description>
+<condition_dsl>Family coverage</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -43,7 +43,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Age 55 or over (catchup eligible)</condition_comment>
-<condition_description>Age 55 or over (catchup eligible)</condition_description>
+<condition_dsl>Age 55 or over (catchup eligible)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -58,7 +58,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>HSA deduction - family coverage with catchup</action_comment>
-<action_description>HSA deduction - family coverage with catchup</action_description>
+<action_dsl>HSA deduction - family coverage with catchup</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -67,7 +67,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>HSA deduction - family coverage no catchup</action_comment>
-<action_description>HSA deduction - family coverage no catchup</action_description>
+<action_dsl>HSA deduction - family coverage no catchup</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -76,7 +76,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>HSA deduction - self coverage with catchup</action_comment>
-<action_description>HSA deduction - self coverage with catchup</action_description>
+<action_dsl>HSA deduction - self coverage with catchup</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -85,7 +85,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>HSA deduction - self coverage no catchup</action_comment>
-<action_description>HSA deduction - self coverage no catchup</action_description>
+<action_dsl>HSA deduction - self coverage no catchup</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -94,7 +94,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment>No HSA contribution</action_comment>
-<action_description>No HSA contribution</action_description>
+<action_dsl>No HSA contribution</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/059_Calculate_Student_Loan_Deduction_dt.xml
+++ b/sampleprojects/TaxReturn/xml/059_Calculate_Student_Loan_Deduction_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has student loan interest</condition_comment>
-<condition_description>Has student loan interest</condition_description>
+<condition_dsl>Has student loan interest</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -30,7 +30,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>Married Filing Jointly</condition_description>
+<condition_dsl>Married Filing Jointly</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -43,7 +43,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ AGI below phase-out start</condition_comment>
-<condition_description>MFJ AGI below phase-out start</condition_description>
+<condition_dsl>MFJ AGI below phase-out start</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -56,7 +56,7 @@
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Single AGI below phase-out start</condition_comment>
-<condition_description>Single AGI below phase-out start</condition_description>
+<condition_dsl>Single AGI below phase-out start</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -71,7 +71,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full student loan deduction</action_comment>
-<action_description>Full student loan deduction</action_description>
+<action_dsl>Full student loan deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -81,7 +81,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Student loan deduction with MFJ phase-out</action_comment>
-<action_description>Student loan deduction with MFJ phase-out</action_description>
+<action_dsl>Student loan deduction with MFJ phase-out</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -90,7 +90,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Student loan deduction with Single phase-out</action_comment>
-<action_description>Student loan deduction with Single phase-out</action_description>
+<action_dsl>Student loan deduction with Single phase-out</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -99,7 +99,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>No student loan interest</action_comment>
-<action_description>No student loan interest</action_description>
+<action_dsl>No student loan interest</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/062_Calculate_CDCC_dt.xml
+++ b/sampleprojects/TaxReturn/xml/062_Calculate_CDCC_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has 2+ qualifying persons</condition_comment>
-<condition_description>Has 2+ qualifying persons</condition_description>
+<condition_dsl>Has 2+ qualifying persons</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has 1 qualifying person</condition_comment>
-<condition_description>Has 1 qualifying person</condition_description>
+<condition_dsl>Has 1 qualifying person</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -41,7 +41,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -50,7 +50,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -59,7 +59,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -69,7 +69,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/063_Count_CDCC_Qualifying_Person_dt.xml
+++ b/sampleprojects/TaxReturn/xml/063_Count_CDCC_Qualifying_Person_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Child under 13</condition_comment>
-<condition_description>Child under 13</condition_description>
+<condition_dsl>Child under 13</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Disabled dependent</condition_comment>
-<condition_description>Disabled dependent</condition_description>
+<condition_dsl>Disabled dependent</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -39,7 +39,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Has work-related care expenses</condition_comment>
-<condition_description>Has work-related care expenses</condition_description>
+<condition_dsl>Has work-related care expenses</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -52,7 +52,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -62,7 +62,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/064_Calculate_Savers_Credit_dt.xml
+++ b/sampleprojects/TaxReturn/xml/064_Calculate_Savers_Credit_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has contributions</condition_comment>
-<condition_description>Has contributions</condition_description>
+<condition_dsl>Has contributions</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -38,7 +38,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status MFJ</condition_comment>
-<condition_description>Filing status MFJ</condition_description>
+<condition_dsl>Filing status MFJ</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -58,7 +58,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Filing status HOH</condition_comment>
-<condition_description>Filing status HOH</condition_description>
+<condition_dsl>Filing status HOH</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -74,7 +74,7 @@
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>AGI at 50% tier for MFJ</condition_comment>
-<condition_description>AGI at 50% tier for MFJ</condition_description>
+<condition_dsl>AGI at 50% tier for MFJ</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -86,7 +86,7 @@
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>AGI at 20% tier for MFJ</condition_comment>
-<condition_description>AGI at 20% tier for MFJ</condition_description>
+<condition_dsl>AGI at 20% tier for MFJ</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -97,7 +97,7 @@
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>AGI at 10% tier for MFJ</condition_comment>
-<condition_description>AGI at 10% tier for MFJ</condition_description>
+<condition_dsl>AGI at 10% tier for MFJ</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -107,7 +107,7 @@
 <condition_details>
 <condition_number>7</condition_number>
 <condition_comment>AGI at 50% tier for HOH</condition_comment>
-<condition_description>AGI at 50% tier for HOH</condition_description>
+<condition_dsl>AGI at 50% tier for HOH</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -119,7 +119,7 @@
 <condition_details>
 <condition_number>8</condition_number>
 <condition_comment>AGI at 20% tier for HOH</condition_comment>
-<condition_description>AGI at 20% tier for HOH</condition_description>
+<condition_dsl>AGI at 20% tier for HOH</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -130,7 +130,7 @@
 <condition_details>
 <condition_number>9</condition_number>
 <condition_comment>AGI at 10% tier for HOH</condition_comment>
-<condition_description>AGI at 10% tier for HOH</condition_description>
+<condition_dsl>AGI at 10% tier for HOH</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -140,7 +140,7 @@
 <condition_details>
 <condition_number>10</condition_number>
 <condition_comment>AGI at 50% tier for Single</condition_comment>
-<condition_description>AGI at 50% tier for Single</condition_description>
+<condition_dsl>AGI at 50% tier for Single</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -152,7 +152,7 @@
 <condition_details>
 <condition_number>11</condition_number>
 <condition_comment>AGI at 20% tier for Single</condition_comment>
-<condition_description>AGI at 20% tier for Single</condition_description>
+<condition_dsl>AGI at 20% tier for Single</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -163,7 +163,7 @@
 <condition_details>
 <condition_number>12</condition_number>
 <condition_comment>AGI at 10% tier for Single</condition_comment>
-<condition_description>AGI at 10% tier for Single</condition_description>
+<condition_dsl>AGI at 10% tier for Single</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -175,7 +175,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -186,7 +186,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -197,7 +197,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -208,7 +208,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -219,7 +219,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -239,7 +239,7 @@
 <action_details>
 <action_number>6</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/065_Sum_Savers_Contribution_dt.xml
+++ b/sampleprojects/TaxReturn/xml/065_Sum_Savers_Contribution_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has any IRA contribution</condition_comment>
-<condition_description>Has any IRA contribution</condition_description>
+<condition_dsl>Has any IRA contribution</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/066_Calculate_Energy_Credits_dt.xml
+++ b/sampleprojects/TaxReturn/xml/066_Calculate_Energy_Credits_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.energy_efficiency_credit = the minimum of credit and annual_limit</action_description>
+<action_dsl>set result.energy_efficiency_credit = the minimum of credit and annual_limit</action_dsl>
 <action_postfix>
 result.energy_efficiency_credit constants.energy_efficiency_annual_limit fmin /result.energy_efficiency_credit xdef
 </action_postfix>
@@ -23,7 +23,7 @@ result.energy_efficiency_credit constants.energy_efficiency_annual_limit fmin /r
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has energy credits</condition_comment>
-<condition_description>Has energy credits</condition_description>
+<condition_dsl>Has energy credits</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -35,7 +35,7 @@ result.energy_efficiency_credit constants.energy_efficiency_annual_limit fmin /r
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -44,7 +44,7 @@ result.energy_efficiency_credit constants.energy_efficiency_annual_limit fmin /r
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/067_Calculate_Energy_Credit_Per_Improvement_dt.xml
+++ b/sampleprojects/TaxReturn/xml/067_Calculate_Energy_Credit_Per_Improvement_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Clean energy improvement (25D)</condition_comment>
-<condition_description>Clean energy improvement (25D)</condition_description>
+<condition_dsl>Clean energy improvement (25D)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/068_Calculate_Passive_Activity_Loss_dt.xml
+++ b/sampleprojects/TaxReturn/xml/068_Calculate_Passive_Activity_Loss_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.pal_allowance = ($25k - phaseout_reduction)</action_description>
+<action_dsl>set result.pal_allowance = ($25k - phaseout_reduction)</action_dsl>
 <action_postfix>
 result.agi constants.rental_loss_phaseout_start f- 0 fmax constants.rental_loss_phaseout_rate f* /result.pal_phaseout_reduction xdef
 constants.rental_loss_allowance result.pal_phaseout_reduction f- 0 fmax /result.pal_reduced_allowance xdef
@@ -26,7 +26,7 @@ result.total_rental_loss result.rental_loss_allowed f- /result.suspended_passive
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has rental losses</condition_comment>
-<condition_description>Has rental losses</condition_description>
+<condition_dsl>Has rental losses</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -38,7 +38,7 @@ result.total_rental_loss result.rental_loss_allowed f- /result.suspended_passive
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -47,7 +47,7 @@ result.total_rental_loss result.rental_loss_allowed f- /result.suspended_passive
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/069_Sum_Rental_Loss_dt.xml
+++ b/sampleprojects/TaxReturn/xml/069_Sum_Rental_Loss_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is rental property</condition_comment>
-<condition_description>Is rental property</condition_description>
+<condition_dsl>Is rental property</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -27,7 +27,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Property has loss (negative net income)</condition_comment>
-<condition_description>Property has loss (negative net income)</condition_description>
+<condition_dsl>Property has loss (negative net income)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -39,7 +39,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -48,7 +48,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/070_Calculate_AMT_dt.xml
+++ b/sampleprojects/TaxReturn/xml/070_Calculate_AMT_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.amti = result.taxable_income + amt_adjustments</action_description>
+<action_dsl>set result.amti = result.taxable_income + amt_adjustments</action_dsl>
 <action_postfix>
 result.taxable_income result.salt_deduction f+ /result.amti xdef
 &quot;ALTERNATIVE MINIMUM TAX (Form 6251, IRC 55-59)&quot; job.audit_trail swap addto
@@ -27,7 +27,7 @@ result.taxable_income result.salt_deduction f+ /result.amti xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Filing status MFJ</condition_comment>
-<condition_description>Filing status MFJ</condition_description>
+<condition_dsl>Filing status MFJ</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -38,7 +38,7 @@ result.taxable_income result.salt_deduction f+ /result.amti xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status MFS</condition_comment>
-<condition_description>Filing status MFS</condition_description>
+<condition_dsl>Filing status MFS</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -50,7 +50,7 @@ result.taxable_income result.salt_deduction f+ /result.amti xdef
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -59,7 +59,7 @@ result.taxable_income result.salt_deduction f+ /result.amti xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -68,7 +68,7 @@ result.taxable_income result.salt_deduction f+ /result.amti xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/071_Calculate_Premium_Tax_Credit_dt.xml
+++ b/sampleprojects/TaxReturn/xml/071_Calculate_Premium_Tax_Credit_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.premium_tax_credit = max_ptc - required_contribution</action_description>
+<action_dsl>set result.premium_tax_credit = max_ptc - required_contribution</action_dsl>
 <action_postfix>
 0.0 /result.premium_tax_credit xdef
 0.0 /result.ptc_repayment xdef
@@ -31,7 +31,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has marketplace coverage</condition_comment>
-<condition_description>Has marketplace coverage</condition_description>
+<condition_dsl>Has marketplace coverage</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -43,7 +43,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Eligible for PTC (FPL 100-400%)</condition_comment>
-<condition_description>Eligible for PTC (FPL 100-400%)</condition_description>
+<condition_dsl>Eligible for PTC (FPL 100-400%)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -54,7 +54,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Net PTC is positive (credit owed)</condition_comment>
-<condition_description>Net PTC is positive (credit owed)</condition_description>
+<condition_dsl>Net PTC is positive (credit owed)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -66,7 +66,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -77,7 +77,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -86,7 +86,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -95,7 +95,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -104,7 +104,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <action_details>
 <action_number>5</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/072_Process_K1_Income_dt.xml
+++ b/sampleprojects/TaxReturn/xml/072_Process_K1_Income_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add &quot;K-1 PROCESSING&quot; to job.audit_trail</action_description>
+<action_dsl>add &quot;K-1 PROCESSING&quot; to job.audit_trail</action_dsl>
 <action_postfix>
 &quot;Processing Schedule K-1 Income (Schedule E Part II)&quot; job.audit_trail swap addto
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has K-1 to process</condition_comment>
-<condition_description>Has K-1 to process</condition_description>
+<condition_dsl>Has K-1 to process</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -34,7 +34,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/073_Calculate_K1_SE_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/073_Calculate_K1_SE_Tax_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add K-1 SE tax summary to job.audit_trail</action_description>
+<action_dsl>add K-1 SE tax summary to job.audit_trail</action_dsl>
 <action_postfix>
 &quot;Calculating K-1 Self-Employment Tax (Schedule SE)&quot; job.audit_trail swap addto
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has K-1 SE earnings</condition_comment>
-<condition_description>Has K-1 SE earnings</condition_description>
+<condition_dsl>Has K-1 SE earnings</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -35,7 +35,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -44,7 +44,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/074_Process_IRA_Accounts_dt.xml
+++ b/sampleprojects/TaxReturn/xml/074_Process_IRA_Accounts_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add &quot;IRA PROCESSING&quot; to job.audit_trail</action_description>
+<action_dsl>add &quot;IRA PROCESSING&quot; to job.audit_trail</action_dsl>
 <action_postfix>
 &quot;Processing IRA Accounts (Form 8606)&quot; job.audit_trail swap addto
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has IRA account to process</condition_comment>
-<condition_description>Has IRA account to process</condition_description>
+<condition_dsl>Has IRA account to process</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -32,7 +32,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Is traditional IRA</condition_comment>
-<condition_description>Is traditional IRA</condition_description>
+<condition_dsl>Is traditional IRA</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -43,7 +43,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/075_Calculate_Roth_Conversion_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/075_Calculate_Roth_Conversion_Tax_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add Roth conversion summary to job.audit_trail</action_description>
+<action_dsl>add Roth conversion summary to job.audit_trail</action_dsl>
 <action_postfix>
 &quot;Calculating Roth Conversion Tax (Form 8606 Part II)&quot; job.audit_trail swap addto
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has Roth conversions</condition_comment>
-<condition_description>Has Roth conversions</condition_description>
+<condition_dsl>Has Roth conversions</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -33,7 +33,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has basis to recover</condition_comment>
-<condition_description>Has basis to recover</condition_description>
+<condition_dsl>Has basis to recover</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -44,7 +44,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -53,7 +53,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/076_Process_Farm_Income_dt.xml
+++ b/sampleprojects/TaxReturn/xml/076_Process_Farm_Income_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add &quot;FARM INCOME PROCESSING&quot; to job.audit_trail</action_description>
+<action_dsl>add &quot;FARM INCOME PROCESSING&quot; to job.audit_trail</action_dsl>
 <action_postfix>
 &quot;Processing Schedule F Farm Income (Publication 225)&quot; job.audit_trail swap addto
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has farm to process</condition_comment>
-<condition_description>Has farm to process</condition_description>
+<condition_dsl>Has farm to process</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -34,7 +34,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/077_Calculate_Farm_SE_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/077_Calculate_Farm_SE_Tax_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add farm SE tax summary to job.audit_trail</action_description>
+<action_dsl>add farm SE tax summary to job.audit_trail</action_dsl>
 <action_postfix>
 &quot;Calculating Farm Self-Employment Tax (Schedule SE)&quot; job.audit_trail swap addto
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has farm profit subject to SE tax</condition_comment>
-<condition_description>Has farm profit subject to SE tax</condition_description>
+<condition_dsl>Has farm profit subject to SE tax</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -35,7 +35,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -44,7 +44,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/078_Process_Property_Sales_dt.xml
+++ b/sampleprojects/TaxReturn/xml/078_Process_Property_Sales_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add &quot;PROPERTY SALE PROCESSING&quot; to job.audit_trail</action_description>
+<action_dsl>add &quot;PROPERTY SALE PROCESSING&quot; to job.audit_trail</action_dsl>
 <action_postfix>
 &quot;Processing Form 4797 Business Property Sales&quot; job.audit_trail swap addto
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has property sale to process</condition_comment>
-<condition_description>Has property sale to process</condition_description>
+<condition_dsl>Has property sale to process</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -34,7 +34,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Is Section 1245 property (personal property)</condition_comment>
-<condition_description>Is Section 1245 property (personal property)</condition_description>
+<condition_dsl>Is Section 1245 property (personal property)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Is Section 1250 property (real property)</condition_comment>
-<condition_description>Is Section 1250 property (real property)</condition_description>
+<condition_dsl>Is Section 1250 property (real property)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -57,7 +57,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -68,7 +68,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -77,7 +77,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -86,7 +86,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -95,7 +95,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/079_Calculate_Section_1231_dt.xml
+++ b/sampleprojects/TaxReturn/xml/079_Calculate_Section_1231_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.net_section_1231 = total_gains - total_losses</action_description>
+<action_dsl>set result.net_section_1231 = total_gains - total_losses</action_dsl>
 <action_postfix>
 &quot;Calculating Net Section 1231 Treatment (IRC 1231)&quot; job.audit_trail swap addto
 result.total_1231_gains result.total_1231_losses f- /result.net_1231_gain_loss xdef
@@ -24,7 +24,7 @@ result.total_1231_gains result.total_1231_losses f- /result.net_1231_gain_loss x
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has net Section 1231 gain</condition_comment>
-<condition_description>Has net Section 1231 gain</condition_description>
+<condition_dsl>Has net Section 1231 gain</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -35,7 +35,7 @@ result.total_1231_gains result.total_1231_losses f- /result.net_1231_gain_loss x
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has net Section 1231 loss</condition_comment>
-<condition_description>Has net Section 1231 loss</condition_description>
+<condition_dsl>Has net Section 1231 loss</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -47,7 +47,7 @@ result.total_1231_gains result.total_1231_losses f- /result.net_1231_gain_loss x
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -56,7 +56,7 @@ result.total_1231_gains result.total_1231_losses f- /result.net_1231_gain_loss x
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -65,7 +65,7 @@ result.total_1231_gains result.total_1231_losses f- /result.net_1231_gain_loss x
 <action_details>
 <action_number>3</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/080_Process_Foreign_Income_dt.xml
+++ b/sampleprojects/TaxReturn/xml/080_Process_Foreign_Income_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add &quot;FOREIGN INCOME PROCESSING&quot; to job.audit_trail</action_description>
+<action_dsl>add &quot;FOREIGN INCOME PROCESSING&quot; to job.audit_trail</action_dsl>
 <action_postfix>
 &quot;Processing Form 1116 Foreign Income (IRC 901)&quot; job.audit_trail swap addto
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has foreign income to process</condition_comment>
-<condition_description>Has foreign income to process</condition_description>
+<condition_dsl>Has foreign income to process</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -34,7 +34,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/081_Calculate_Foreign_Tax_Credit_dt.xml
+++ b/sampleprojects/TaxReturn/xml/081_Calculate_Foreign_Tax_Credit_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add FTC calculation summary to job.audit_trail</action_description>
+<action_dsl>add FTC calculation summary to job.audit_trail</action_dsl>
 <action_postfix>
 &quot;Calculating Foreign Tax Credit (Form 1116, IRC 904)&quot; job.audit_trail swap addto
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has foreign taxes paid</condition_comment>
-<condition_description>Has foreign taxes paid</condition_description>
+<condition_dsl>Has foreign taxes paid</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -33,7 +33,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has taxable income</condition_comment>
-<condition_description>Has taxable income</condition_description>
+<condition_dsl>Has taxable income</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -44,7 +44,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -53,7 +53,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/082_Calculate_DC_Homebuyer_Credit_dt.xml
+++ b/sampleprojects/TaxReturn/xml/082_Calculate_DC_Homebuyer_Credit_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize DC homebuyer credit</action_description>
+<action_dsl>Initialize DC homebuyer credit</action_dsl>
 <action_postfix>
 0.0 /result.dc_homebuyer_credit xdef
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Purchased DC home as first-time buyer</condition_comment>
-<condition_description>Purchased DC home as first-time buyer</condition_description>
+<condition_dsl>Purchased DC home as first-time buyer</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -33,7 +33,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Purchase price is greater than zero</condition_comment>
-<condition_description>Purchase price is greater than zero</condition_description>
+<condition_dsl>Purchase price is greater than zero</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -45,7 +45,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate DC homebuyer credit</action_comment>
-<action_description>Calculate DC homebuyer credit</action_description>
+<action_dsl>Calculate DC homebuyer credit</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -54,7 +54,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No DC homebuyer credit</action_comment>
-<action_description>No DC homebuyer credit</action_description>
+<action_dsl>No DC homebuyer credit</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/083_Process_Foreign_Earned_Income_dt.xml
+++ b/sampleprojects/TaxReturn/xml/083_Process_Foreign_Earned_Income_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Qualifies for FEIE</condition_comment>
-<condition_description>Qualifies for FEIE</condition_description>
+<condition_dsl>Qualifies for FEIE</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/084_Calculate_Mortgage_Interest_Credit_dt.xml
+++ b/sampleprojects/TaxReturn/xml/084_Calculate_Mortgage_Interest_Credit_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize mortgage interest credit</action_description>
+<action_dsl>Initialize mortgage interest credit</action_dsl>
 <action_postfix>
 0.0 /result.mortgage_interest_credit xdef
 0.0 /result.carryforward_mortgage_credit xdef
@@ -25,7 +25,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Property has MCC</condition_comment>
-<condition_description>Property has MCC</condition_description>
+<condition_dsl>Property has MCC</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -35,7 +35,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>MCC rate is valid</condition_comment>
-<condition_description>MCC rate is valid</condition_description>
+<condition_dsl>MCC rate is valid</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Has mortgage interest paid</condition_comment>
-<condition_description>Has mortgage interest paid</condition_description>
+<condition_dsl>Has mortgage interest paid</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -57,7 +57,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate mortgage interest credit</action_comment>
-<action_description>Calculate mortgage interest credit</action_description>
+<action_dsl>Calculate mortgage interest credit</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -66,7 +66,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No MCC credit</action_comment>
-<action_description>No MCC credit</action_description>
+<action_dsl>No MCC credit</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/085_Process_Installment_Sales_dt.xml
+++ b/sampleprojects/TaxReturn/xml/085_Process_Installment_Sales_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has payments this year</condition_comment>
-<condition_description>Has payments this year</condition_description>
+<condition_dsl>Has payments this year</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/086_Process_Like_Kind_Exchanges_dt.xml
+++ b/sampleprojects/TaxReturn/xml/086_Process_Like_Kind_Exchanges_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has exchange to process</condition_comment>
-<condition_description>Has exchange to process</condition_description>
+<condition_dsl>Has exchange to process</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/087_Process_Early_Distributions_dt.xml
+++ b/sampleprojects/TaxReturn/xml/087_Process_Early_Distributions_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Subject to penalty</condition_comment>
-<condition_description>Subject to penalty</condition_description>
+<condition_dsl>Subject to penalty</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/088_Process_Kiddie_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/088_Process_Kiddie_Tax_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Subject to kiddie tax</condition_comment>
-<condition_description>Subject to kiddie tax</condition_description>
+<condition_dsl>Subject to kiddie tax</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/089_Calculate_Elderly_Disabled_Credit_dt.xml
+++ b/sampleprojects/TaxReturn/xml/089_Calculate_Elderly_Disabled_Credit_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Qualifies for credit</condition_comment>
-<condition_description>Qualifies for credit</condition_description>
+<condition_dsl>Qualifies for credit</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/090_Calculate_Estimated_Tax_Penalty_dt.xml
+++ b/sampleprojects/TaxReturn/xml/090_Calculate_Estimated_Tax_Penalty_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has estimated payment</condition_comment>
-<condition_description>Has estimated payment</condition_description>
+<condition_dsl>Has estimated payment</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/091_Process_Casualty_Losses_dt.xml
+++ b/sampleprojects/TaxReturn/xml/091_Process_Casualty_Losses_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is disaster loss (deductible)</condition_comment>
-<condition_description>Is disaster loss (deductible)</condition_description>
+<condition_dsl>Is disaster loss (deductible)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/092_Process_Clean_Vehicle_Credit_dt.xml
+++ b/sampleprojects/TaxReturn/xml/092_Process_Clean_Vehicle_Credit_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>New vehicle meeting requirements</condition_comment>
-<condition_description>New vehicle meeting requirements</condition_description>
+<condition_dsl>New vehicle meeting requirements</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/093_Process_Adoption_Credit_dt.xml
+++ b/sampleprojects/TaxReturn/xml/093_Process_Adoption_Credit_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has qualified expenses</condition_comment>
-<condition_description>Has qualified expenses</condition_description>
+<condition_dsl>Has qualified expenses</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/094_Process_Household_Employment_dt.xml
+++ b/sampleprojects/TaxReturn/xml/094_Process_Household_Employment_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Wages meet threshold</condition_comment>
-<condition_description>Wages meet threshold</condition_description>
+<condition_dsl>Wages meet threshold</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/095_Process_NOL_Carryover_dt.xml
+++ b/sampleprojects/TaxReturn/xml/095_Process_NOL_Carryover_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has NOL available</condition_comment>
-<condition_description>Has NOL available</condition_description>
+<condition_dsl>Has NOL available</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/096_Calculate_Mortgage_Interest_Credit_dt.xml
+++ b/sampleprojects/TaxReturn/xml/096_Calculate_Mortgage_Interest_Credit_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Credit rate exceeds 20%</condition_comment>
-<condition_description>Credit rate exceeds 20%</condition_description>
+<condition_dsl>Credit rate exceeds 20%</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/097_Calculate_Prior_Year_AMT_Credit_dt.xml
+++ b/sampleprojects/TaxReturn/xml/097_Calculate_Prior_Year_AMT_Credit_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Credit available</condition_comment>
-<condition_description>Credit available</condition_description>
+<condition_dsl>Credit available</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/098_Calculate_Partnership_Audit_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/098_Calculate_Partnership_Audit_Tax_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has income adjustments</condition_comment>
-<condition_description>Has income adjustments</condition_description>
+<condition_dsl>Has income adjustments</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/099_Calculate_Energy_Appliance_Credit_dt.xml
+++ b/sampleprojects/TaxReturn/xml/099_Calculate_Energy_Appliance_Credit_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize energy appliance credit</action_description>
+<action_dsl>Initialize energy appliance credit</action_dsl>
 <action_postfix>
 0.0 /result.energy_appliance_credit xdef
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Manufacturer has appliance production</condition_comment>
-<condition_description>Manufacturer has appliance production</condition_description>
+<condition_dsl>Manufacturer has appliance production</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -34,7 +34,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/100_Calculate_Unreported_Tips_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/100_Calculate_Unreported_Tips_Tax_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has unreported tips</condition_comment>
-<condition_description>Has unreported tips</condition_description>
+<condition_dsl>Has unreported tips</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/101_Calculate_LIHTC_Recapture_dt.xml
+++ b/sampleprojects/TaxReturn/xml/101_Calculate_LIHTC_Recapture_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has recapture event</condition_comment>
-<condition_description>Has recapture event</condition_description>
+<condition_dsl>Has recapture event</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment></action_comment>
-<action_description></action_description>
+<action_dsl></action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/102_Allocate_Income_By_State_dt.xml
+++ b/sampleprojects/TaxReturn/xml/102_Allocate_Income_By_State_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Log multi-state allocation start</action_description>
+<action_dsl>Log multi-state allocation start</action_dsl>
 <action_postfix>
 &quot;Multi-State Income Allocation&quot; job.audit_trail swap addto
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always execute for each state period</condition_comment>
-<condition_description>Always execute for each state period</condition_description>
+<condition_dsl>Always execute for each state period</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -34,7 +34,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate days in state</action_comment>
-<action_description>Calculate days in state</action_description>
+<action_dsl>Calculate days in state</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -43,7 +43,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate allocation percentage</action_comment>
-<action_description>Calculate allocation percentage</action_description>
+<action_dsl>Calculate allocation percentage</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -52,7 +52,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Allocate income for this state</action_comment>
-<action_description>Allocate income for this state</action_description>
+<action_dsl>Allocate income for this state</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -61,7 +61,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Log allocation results</action_comment>
-<action_description>Log allocation results</action_description>
+<action_dsl>Log allocation results</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/103_Dispatch_State_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/103_Dispatch_State_Tax_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Log state tax calculation start</action_description>
+<action_dsl>Log state tax calculation start</action_dsl>
 <action_postfix>
 job.state_periods length 0 eq
 if
@@ -29,7 +29,7 @@ then
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Illinois state</condition_comment>
-<condition_description>Illinois state</condition_description>
+<condition_dsl>Illinois state</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -42,7 +42,7 @@ then
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>New Hampshire state</condition_comment>
-<condition_description>New Hampshire state</condition_description>
+<condition_dsl>New Hampshire state</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -55,7 +55,7 @@ then
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Montana state</condition_comment>
-<condition_description>Montana state</condition_description>
+<condition_dsl>Montana state</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -68,7 +68,7 @@ then
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>No state income tax (TX, FL, etc.)</condition_comment>
-<condition_description>No state income tax (TX, FL, etc.)</condition_description>
+<condition_dsl>No state income tax (TX, FL, etc.)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -83,7 +83,7 @@ then
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Illinois state tax</action_comment>
-<action_description>Calculate Illinois state tax</action_description>
+<action_dsl>Calculate Illinois state tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -92,7 +92,7 @@ then
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate New Hampshire state tax</action_comment>
-<action_description>Calculate New Hampshire state tax</action_description>
+<action_dsl>Calculate New Hampshire state tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -101,7 +101,7 @@ then
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Montana state tax</action_comment>
-<action_description>Calculate Montana state tax</action_description>
+<action_dsl>Calculate Montana state tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -110,7 +110,7 @@ then
 <action_details>
 <action_number>4</action_number>
 <action_comment>No state income tax</action_comment>
-<action_description>No state income tax</action_description>
+<action_dsl>No state income tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -119,7 +119,7 @@ then
 <action_details>
 <action_number>5</action_number>
 <action_comment>State tax calculation not implemented</action_comment>
-<action_description>State tax calculation not implemented</action_description>
+<action_dsl>State tax calculation not implemented</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/104_Dispatch_Territory_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/104_Dispatch_Territory_Tax_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Log territory tax calculation start</action_description>
+<action_dsl>Log territory tax calculation start</action_dsl>
 <action_postfix>
 job.territory isnull not if
   &quot;US Territory Tax Calculation for &quot; job.territory strconcat job.audit_trail swap addto
@@ -25,7 +25,7 @@ then
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Puerto Rico territory</condition_comment>
-<condition_description>Puerto Rico territory</condition_description>
+<condition_dsl>Puerto Rico territory</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -39,7 +39,7 @@ then
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>US Virgin Islands territory</condition_comment>
-<condition_description>US Virgin Islands territory</condition_description>
+<condition_dsl>US Virgin Islands territory</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -53,7 +53,7 @@ then
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Guam territory</condition_comment>
-<condition_description>Guam territory</condition_description>
+<condition_dsl>Guam territory</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -67,7 +67,7 @@ then
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>American Samoa territory</condition_comment>
-<condition_description>American Samoa territory</condition_description>
+<condition_dsl>American Samoa territory</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -81,7 +81,7 @@ then
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>Northern Mariana Islands territory</condition_comment>
-<condition_description>Northern Mariana Islands territory</condition_description>
+<condition_dsl>Northern Mariana Islands territory</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -95,7 +95,7 @@ then
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>No territory or not applicable</condition_comment>
-<condition_description>No territory or not applicable</condition_description>
+<condition_dsl>No territory or not applicable</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -111,7 +111,7 @@ then
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Puerto Rico territory tax</action_comment>
-<action_description>Calculate Puerto Rico territory tax</action_description>
+<action_dsl>Calculate Puerto Rico territory tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -120,7 +120,7 @@ then
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate US Virgin Islands territory tax</action_comment>
-<action_description>Calculate US Virgin Islands territory tax</action_description>
+<action_dsl>Calculate US Virgin Islands territory tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -129,7 +129,7 @@ then
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Guam territory tax</action_comment>
-<action_description>Calculate Guam territory tax</action_description>
+<action_dsl>Calculate Guam territory tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -138,7 +138,7 @@ then
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate American Samoa territory tax</action_comment>
-<action_description>Calculate American Samoa territory tax</action_description>
+<action_dsl>Calculate American Samoa territory tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -147,7 +147,7 @@ then
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate Northern Mariana Islands territory tax</action_comment>
-<action_description>Calculate Northern Mariana Islands territory tax</action_description>
+<action_dsl>Calculate Northern Mariana Islands territory tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -156,7 +156,7 @@ then
 <action_details>
 <action_number>6</action_number>
 <action_comment>No territory tax</action_comment>
-<action_description>No territory tax</action_description>
+<action_dsl>No territory tax</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/105_Calculate_IL_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/105_Calculate_IL_Tax_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize IL tax calculation</action_description>
+<action_dsl>Initialize IL tax calculation</action_dsl>
 <action_postfix>
 &quot;ILLINOIS FORM IL-1040 - State Income Tax Calculation&quot; job.audit_trail swap addto
 0 local@ num_people &gt;
@@ -25,7 +25,7 @@ result.agi /result.il_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Calculate number of people</condition_comment>
-<condition_description>Calculate number of people</condition_description>
+<condition_dsl>Calculate number of people</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -37,7 +37,7 @@ result.agi /result.il_agi xdef
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate IL tax with exemptions</action_comment>
-<action_description>Calculate IL tax with exemptions</action_description>
+<action_dsl>Calculate IL tax with exemptions</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -46,7 +46,7 @@ result.agi /result.il_agi xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No exemptions - unlikely case</action_comment>
-<action_description>No exemptions - unlikely case</action_description>
+<action_dsl>No exemptions - unlikely case</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/106_Calculate_NH_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/106_Calculate_NH_Tax_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize NH tax calculation</action_description>
+<action_dsl>Initialize NH tax calculation</action_dsl>
 <action_postfix>
 &quot;NEW HAMPSHIRE FORM NH-1040 - State Income Tax Calculation&quot; job.audit_trail swap addto
 result.agi /result.nh_agi xdef
@@ -27,7 +27,7 @@ result.agi /result.nh_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>Married Filing Jointly</condition_description>
+<condition_dsl>Married Filing Jointly</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -39,7 +39,7 @@ result.agi /result.nh_agi xdef
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate NH tax MFJ</action_comment>
-<action_description>Calculate NH tax MFJ</action_description>
+<action_dsl>Calculate NH tax MFJ</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -48,7 +48,7 @@ result.agi /result.nh_agi xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate NH tax Single/other</action_comment>
-<action_description>Calculate NH tax Single/other</action_description>
+<action_dsl>Calculate NH tax Single/other</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/107_Calculate_MT_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/107_Calculate_MT_Tax_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize MT tax calculation</action_description>
+<action_dsl>Initialize MT tax calculation</action_dsl>
 <action_postfix>
 &quot;MONTANA FORM 2 - State Income Tax Calculation&quot; job.audit_trail swap addto
 result.agi /result.mt_agi xdef
@@ -26,7 +26,7 @@ result.agi /result.mt_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>Married Filing Jointly</condition_description>
+<condition_dsl>Married Filing Jointly</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -37,7 +37,7 @@ result.agi /result.mt_agi xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single</condition_comment>
-<condition_description>Single</condition_description>
+<condition_dsl>Single</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -48,7 +48,7 @@ result.agi /result.mt_agi xdef
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>Head of Household</condition_description>
+<condition_dsl>Head of Household</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -61,7 +61,7 @@ result.agi /result.mt_agi xdef
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate MT tax MFJ</action_comment>
-<action_description>Calculate MT tax MFJ</action_description>
+<action_dsl>Calculate MT tax MFJ</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -70,7 +70,7 @@ result.agi /result.mt_agi xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate MT tax Single</action_comment>
-<action_description>Calculate MT tax Single</action_description>
+<action_dsl>Calculate MT tax Single</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -79,7 +79,7 @@ result.agi /result.mt_agi xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate MT tax HOH</action_comment>
-<action_description>Calculate MT tax HOH</action_description>
+<action_dsl>Calculate MT tax HOH</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/108_Calculate_General_Business_Credit_dt.xml
+++ b/sampleprojects/TaxReturn/xml/108_Calculate_General_Business_Credit_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize GBC calculation</action_description>
+<action_dsl>Initialize GBC calculation</action_dsl>
 <action_postfix>
 0.0 /result.general_business_credit_total xdef
 0.0 /result.general_business_credit_used xdef
@@ -26,7 +26,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Any business credits present</condition_comment>
-<condition_description>Any business credits present</condition_description>
+<condition_dsl>Any business credits present</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -38,7 +38,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate total GBC (Part I)</action_comment>
-<action_description>Calculate total GBC (Part I)</action_description>
+<action_dsl>Calculate total GBC (Part I)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -47,7 +47,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate GBC limitation (Part II)</action_comment>
-<action_description>Calculate GBC limitation (Part II)</action_description>
+<action_dsl>Calculate GBC limitation (Part II)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -56,7 +56,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>No business credits</action_comment>
-<action_description>No business credits</action_description>
+<action_dsl>No business credits</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/109_Calculate_Kiddie_Tax_dt.xml
+++ b/sampleprojects/TaxReturn/xml/109_Calculate_Kiddie_Tax_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Log kiddie tax calculation start</action_description>
+<action_dsl>Log kiddie tax calculation start</action_dsl>
 <action_postfix>
 &quot;KIDDIE TAX CALCULATION (Form 8615)&quot; job.audit_trail swap addto
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always process kiddie tax for all dependents</condition_comment>
-<condition_description>Always process kiddie tax for all dependents</condition_description>
+<condition_dsl>Always process kiddie tax for all dependents</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -34,7 +34,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process kiddie tax for each dependent</action_comment>
-<action_description>Process kiddie tax for each dependent</action_description>
+<action_dsl>Process kiddie tax for each dependent</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/110_Calculate_Kiddie_Tax_For_Dependent_dt.xml
+++ b/sampleprojects/TaxReturn/xml/110_Calculate_Kiddie_Tax_For_Dependent_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Dependent is under 19 with unearned income over threshold</condition_comment>
-<condition_description>Dependent is under 19 with unearned income over threshold</condition_description>
+<condition_dsl>Dependent is under 19 with unearned income over threshold</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -26,7 +26,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Dependent is 19-23 full-time student with unearned income over threshold</condition_comment>
-<condition_description>Dependent is 19-23 full-time student with unearned income over threshold</condition_description>
+<condition_dsl>Dependent is 19-23 full-time student with unearned income over threshold</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -35,7 +35,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Kiddie tax does not apply</condition_comment>
-<condition_description>Kiddie tax does not apply</condition_description>
+<condition_dsl>Kiddie tax does not apply</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -46,7 +46,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Mark dependent subject to kiddie tax</action_comment>
-<action_description>Mark dependent subject to kiddie tax</action_description>
+<action_dsl>Mark dependent subject to kiddie tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -56,7 +56,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate net unearned income subject to parent's tax rate</action_comment>
-<action_description>Calculate net unearned income subject to parent's tax rate</action_description>
+<action_dsl>Calculate net unearned income subject to parent's tax rate</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -66,7 +66,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Determine parent's marginal tax rate based on filing status</action_comment>
-<action_description>Determine parent's marginal tax rate based on filing status</action_description>
+<action_dsl>Determine parent's marginal tax rate based on filing status</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -76,7 +76,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Add kiddie tax to total tax before credits</action_comment>
-<action_description>Add kiddie tax to total tax before credits</action_description>
+<action_dsl>Add kiddie tax to total tax before credits</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -86,7 +86,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment>Kiddie tax does not apply - initialize to zero</action_comment>
-<action_description>Kiddie tax does not apply - initialize to zero</action_description>
+<action_dsl>Kiddie tax does not apply - initialize to zero</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/111_Calculate_Schedule_H_dt.xml
+++ b/sampleprojects/TaxReturn/xml/111_Calculate_Schedule_H_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize Schedule H calculation</action_description>
+<action_dsl>Initialize Schedule H calculation</action_dsl>
 <action_postfix>
 &quot;SCHEDULE H - Household Employment Taxes&quot; job.audit_trail swap addto
 0.0 /result.schedule_h_social_security_tax xdef
@@ -27,7 +27,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has household employees</condition_comment>
-<condition_description>Has household employees</condition_description>
+<condition_dsl>Has household employees</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -39,7 +39,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate employer FICA and FUTA for each employee</action_comment>
-<action_description>Calculate employer FICA and FUTA for each employee</action_description>
+<action_dsl>Calculate employer FICA and FUTA for each employee</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -48,7 +48,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No household employees</action_comment>
-<action_description>No household employees</action_description>
+<action_dsl>No household employees</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/112_Calculate_Combat_Zone_Pay_Exclusion_dt.xml
+++ b/sampleprojects/TaxReturn/xml/112_Calculate_Combat_Zone_Pay_Exclusion_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Served in combat zone</condition_comment>
-<condition_description>Served in combat zone</condition_description>
+<condition_dsl>Served in combat zone</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -26,7 +26,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Enlisted rank</condition_comment>
-<condition_description>Enlisted rank</condition_description>
+<condition_dsl>Enlisted rank</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -37,7 +37,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Enlisted - exclude all combat zone pay</action_comment>
-<action_description>Enlisted - exclude all combat zone pay</action_description>
+<action_dsl>Enlisted - exclude all combat zone pay</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -46,7 +46,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Officer - limited exclusion</action_comment>
-<action_description>Officer - limited exclusion</action_description>
+<action_dsl>Officer - limited exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -55,7 +55,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>No combat zone service</action_comment>
-<action_description>No combat zone service</action_description>
+<action_dsl>No combat zone service</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/113_Calculate_Military_Moving_Expenses_dt.xml
+++ b/sampleprojects/TaxReturn/xml/113_Calculate_Military_Moving_Expenses_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Active duty military with PCS move</condition_comment>
-<condition_description>Active duty military with PCS move</condition_description>
+<condition_dsl>Active duty military with PCS move</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -26,7 +26,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Move meets distance test</condition_comment>
-<condition_description>Move meets distance test</condition_description>
+<condition_dsl>Move meets distance test</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -37,7 +37,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Deduct qualifying military moving expenses</action_comment>
-<action_description>Deduct qualifying military moving expenses</action_description>
+<action_dsl>Deduct qualifying military moving expenses</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -46,7 +46,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Not qualified or not military</action_comment>
-<action_description>Not qualified or not military</action_description>
+<action_dsl>Not qualified or not military</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/114_Coordinate_Military_And_Foreign_Income_dt.xml
+++ b/sampleprojects/TaxReturn/xml/114_Coordinate_Military_And_Foreign_Income_dt.xml
@@ -13,7 +13,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize coordination of military and foreign income</action_description>
+<action_dsl>Initialize coordination of military and foreign income</action_dsl>
 <action_postfix>
 &quot;Coordinating Military Combat Zone and Foreign Earned Income Exclusions&quot; job.audit_trail swap addto
 </action_postfix>
@@ -23,7 +23,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Military with combat zone AND foreign earned income</condition_comment>
-<condition_description>Military with combat zone AND foreign earned income</condition_description>
+<condition_dsl>Military with combat zone AND foreign earned income</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -34,7 +34,7 @@
 <action_details>
 <action_number>1</action_number>
 <action_comment>Apply both exclusions (no double benefit)</action_comment>
-<action_description>Apply both exclusions (no double benefit)</action_description>
+<action_dsl>Apply both exclusions (no double benefit)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -43,7 +43,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No coordination needed</action_comment>
-<action_description>No coordination needed</action_description>
+<action_dsl>No coordination needed</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/TaxReturn_dt.xml
+++ b/sampleprojects/TaxReturn/xml/TaxReturn_dt.xml
@@ -16,7 +16,7 @@
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>new result entity</action_description>
+<action_dsl>new result entity</action_dsl>
 <action_postfix>
 /result createentity entitypush
 result job.results swap addto
@@ -29,7 +29,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -38,7 +38,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single filer</condition_comment>
-<condition_description>job.filing_status is equal to "Single"</condition_description>
+<condition_dsl>job.filing_status is equal to "Single"</condition_dsl>
 <condition_postfix>
 job.filing_status SINGLE streq
 </condition_postfix>
@@ -47,7 +47,7 @@ job.filing_status SINGLE streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>job.filing_status is equal to "HOH"</condition_description>
+<condition_dsl>job.filing_status is equal to "HOH"</condition_dsl>
 <condition_postfix>
 job.filing_status HOH streq
 </condition_postfix>
@@ -56,7 +56,7 @@ job.filing_status HOH streq
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Default case</condition_comment>
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>
 otherwise
 </condition_postfix>
@@ -67,7 +67,7 @@ otherwise
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log filing status per Form 1040 Line 1</action_comment>
-<action_description>add "Filing as MFJ per Form 1040 Line 1" to job.audit_trail</action_description>
+<action_dsl>add "Filing as MFJ per Form 1040 Line 1" to job.audit_trail</action_dsl>
 <action_postfix>
 "Filing as Married Filing Jointly per Form 1040 Line 1, Publication 17 Chapter 2, IRC Section 1(a)" job.audit_trail swap addto
 </action_postfix>
@@ -76,7 +76,7 @@ otherwise
 <action_details>
 <action_number>2</action_number>
 <action_comment>Log Single filing status</action_comment>
-<action_description>add "Filing as Single per Form 1040 Line 1" to job.audit_trail</action_description>
+<action_dsl>add "Filing as Single per Form 1040 Line 1" to job.audit_trail</action_dsl>
 <action_postfix>
 "Filing as Single per Form 1040 Line 1, Publication 17 Chapter 2, IRC Section 1(c)" job.audit_trail swap addto
 </action_postfix>
@@ -85,7 +85,7 @@ otherwise
 <action_details>
 <action_number>3</action_number>
 <action_comment>Log HOH filing status</action_comment>
-<action_description>add "Filing as HOH per Form 1040 Line 1" to job.audit_trail</action_description>
+<action_dsl>add "Filing as HOH per Form 1040 Line 1" to job.audit_trail</action_dsl>
 <action_postfix>
 "Filing as Head of Household per Form 1040 Line 1, Publication 17 Chapter 2, IRC Section 1(b)" job.audit_trail swap addto
 </action_postfix>
@@ -94,7 +94,7 @@ otherwise
 <action_details>
 <action_number>4</action_number>
 <action_comment>Log MFS or QSS status</action_comment>
-<action_description>add "Filing as " + job.filing_status + " per Form 1040" to job.audit_trail</action_description>
+<action_dsl>add "Filing as " + job.filing_status + " per Form 1040" to job.audit_trail</action_dsl>
 <action_postfix>
 "Filing as " job.filing_status strconcat " per Form 1040 Line 1, Publication 17 Chapter 2" strconcat job.audit_trail swap addto
 </action_postfix>
@@ -103,7 +103,7 @@ otherwise
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate gross income (Form 1040 Lines 1-9)</action_comment>
-<action_description>perform Calculate_Gross_Income</action_description>
+<action_dsl>perform Calculate_Gross_Income</action_dsl>
 <action_postfix>
 Calculate_Gross_Income
 </action_postfix>
@@ -116,7 +116,7 @@ Calculate_Gross_Income
 <action_details>
 <action_number>6</action_number>
 <action_comment>Validate AGI if expected values exist (validation checkpoint); if job.expected_agi exists</action_comment>
-<action_description>perform Validate_AGI</action_description>
+<action_dsl>perform Validate_AGI</action_dsl>
 <action_postfix>
 { Validate_AGI } job.expected_agi isnull not if
 </action_postfix>
@@ -128,7 +128,7 @@ Calculate_Gross_Income
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate deductions (Form 1040 Line 12)</action_comment>
-<action_description>perform Calculate_Deductions</action_description>
+<action_dsl>perform Calculate_Deductions</action_dsl>
 <action_postfix>
 Calculate_Deductions
 </action_postfix>
@@ -140,7 +140,7 @@ Calculate_Deductions
 <action_details>
 <action_number>7</action_number>
 <action_comment>Calculate taxable income (Form 1040 Line 15)</action_comment>
-<action_description>perform Calculate_Taxable_Income</action_description>
+<action_dsl>perform Calculate_Taxable_Income</action_dsl>
 <action_postfix>
 Calculate_Taxable_Income
 </action_postfix>
@@ -153,7 +153,7 @@ Calculate_Taxable_Income
 <action_details>
 <action_number>7</action_number>
 <action_comment>Validate taxable income if expected values exist (validation checkpoint); if job.expected_taxable_income exists</action_comment>
-<action_description>perform Validate_Taxable_Income</action_description>
+<action_dsl>perform Validate_Taxable_Income</action_dsl>
 <action_postfix>
 { Validate_Taxable_Income } job.expected_taxable_income isnull not if
 </action_postfix>
@@ -165,7 +165,7 @@ Calculate_Taxable_Income
 <action_details>
 <action_number>8</action_number>
 <action_comment>Calculate tax liability (Form 1040 Lines 16-24)</action_comment>
-<action_description>perform Calculate_Tax_Liability</action_description>
+<action_dsl>perform Calculate_Tax_Liability</action_dsl>
 <action_postfix>
 Calculate_Tax_Liability
 </action_postfix>
@@ -178,7 +178,7 @@ Calculate_Tax_Liability
 <action_details>
 <action_number>9</action_number>
 <action_comment>Validate total tax if expected values exist (validation checkpoint); if job.expected_total_tax exists</action_comment>
-<action_description>perform Validate_Total_Tax</action_description>
+<action_dsl>perform Validate_Total_Tax</action_dsl>
 <action_postfix>
 { Validate_Total_Tax } job.expected_total_tax isnull not if
 </action_postfix>
@@ -190,7 +190,7 @@ Calculate_Tax_Liability
 <action_details>
 <action_number>9</action_number>
 <action_comment>Calculate Alternative Minimum Tax (Form 6251)</action_comment>
-<action_description>perform Calculate_AMT</action_description>
+<action_dsl>perform Calculate_AMT</action_dsl>
 <action_postfix>
 Calculate_AMT
 </action_postfix>
@@ -202,7 +202,7 @@ Calculate_AMT
 <action_details>
 <action_number>10</action_number>
 <action_comment>Calculate kiddie tax for dependents with unearned income (Form 8615)</action_comment>
-<action_description>perform Calculate_Kiddie_Tax</action_description>
+<action_dsl>perform Calculate_Kiddie_Tax</action_dsl>
 <action_postfix>
 Calculate_Kiddie_Tax
 </action_postfix>
@@ -214,7 +214,7 @@ Calculate_Kiddie_Tax
 <action_details>
 <action_number>11</action_number>
 <action_comment>Calculate credits (Form 1040 Lines 19-21)</action_comment>
-<action_description>perform Calculate_Credits</action_description>
+<action_dsl>perform Calculate_Credits</action_dsl>
 <action_postfix>
 Calculate_Credits
 </action_postfix>
@@ -226,7 +226,7 @@ Calculate_Credits
 <action_details>
 <action_number>12</action_number>
 <action_comment>Calculate final balance (Form 1040 Lines 33-37)</action_comment>
-<action_description>perform Calculate_Final_Balance</action_description>
+<action_dsl>perform Calculate_Final_Balance</action_dsl>
 <action_postfix>
 Calculate_Final_Balance
 </action_postfix>
@@ -238,7 +238,7 @@ Calculate_Final_Balance
 <action_details>
 <action_number>13</action_number>
 <action_comment>Calculate state income tax if applicable</action_comment>
-<action_description>perform Dispatch_State_Tax</action_description>
+<action_dsl>perform Dispatch_State_Tax</action_dsl>
 <action_postfix>
 {
   /Dispatch_State_Tax executetable
@@ -256,7 +256,7 @@ if
 <action_details>
 <action_number>13</action_number>
 <action_comment>Run validation framework to verify calculations against expected values; master validation coordinator</action_comment>
-<action_description>perform Validate_Results</action_description>
+<action_dsl>perform Validate_Results</action_dsl>
 <action_postfix>
 Validate_Results
 </action_postfix>
@@ -301,7 +301,7 @@ Validate_Results
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>set result.total_w2_wages = 0</action_description>
+<action_dsl>set result.total_w2_wages = 0</action_dsl>
 <action_postfix>
 0.0 /result.total_w2_wages xdef
 0.0 /result.total_se_income xdef
@@ -315,7 +315,7 @@ Validate_Results
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always execute</condition_comment>
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -326,7 +326,7 @@ perform when called
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process W-2 income for all taxpayers</action_comment>
-<action_description>perform Process_W2_Income</action_description>
+<action_dsl>perform Process_W2_Income</action_dsl>
 <action_postfix>
 Process_W2_Income
 </action_postfix>
@@ -335,7 +335,7 @@ Process_W2_Income
 <action_details>
 <action_number>2</action_number>
 <action_comment>Process self-employment income (Schedule C)</action_comment>
-<action_description>perform Process_Self_Employment</action_description>
+<action_dsl>perform Process_Self_Employment</action_dsl>
 <action_postfix>
 Process_Self_Employment
 </action_postfix>
@@ -344,7 +344,7 @@ Process_Self_Employment
 <action_details>
 <action_number>3</action_number>
 <action_comment>Process rental income (Schedule E)</action_comment>
-<action_description>perform Process_Rental_Income</action_description>
+<action_dsl>perform Process_Rental_Income</action_dsl>
 <action_postfix>
 Process_Rental_Income
 Calculate_Passive_Activity_Loss
@@ -354,7 +354,7 @@ Calculate_Passive_Activity_Loss
 <action_details>
 <action_number>4</action_number>
 <action_comment>Process other income (pension, interest, dividends)</action_comment>
-<action_description>perform Process_Other_Income</action_description>
+<action_dsl>perform Process_Other_Income</action_dsl>
 <action_postfix>
 Process_Other_Income
 </action_postfix>
@@ -363,7 +363,7 @@ Process_Other_Income
 <action_details>
 <action_number>5</action_number>
 <action_comment>Process capital gains and qualified dividends</action_comment>
-<action_description>perform Process_Capital_Gains</action_description>
+<action_dsl>perform Process_Capital_Gains</action_dsl>
 <action_postfix>
 Process_Capital_Gains
 </action_postfix>
@@ -372,7 +372,7 @@ Process_Capital_Gains
 <action_details>
 <action_number>6</action_number>
 <action_comment>Process Schedule K-1 income (partnerships, S-corps, trusts)</action_comment>
-<action_description>perform Process_K1_Income</action_description>
+<action_dsl>perform Process_K1_Income</action_dsl>
 <action_postfix>
 Process_K1_Income
 Calculate_K1_SE_Tax
@@ -382,7 +382,7 @@ Calculate_K1_SE_Tax
 <action_details>
 <action_number>7</action_number>
 <action_comment>Process IRA accounts (Form 8606)</action_comment>
-<action_description>perform Process_IRA_Accounts</action_description>
+<action_dsl>perform Process_IRA_Accounts</action_dsl>
 <action_postfix>
 Process_IRA_Accounts
 Calculate_Roth_Conversion_Tax
@@ -392,7 +392,7 @@ Calculate_Roth_Conversion_Tax
 <action_details>
 <action_number>8</action_number>
 <action_comment>Process Schedule F farm income</action_comment>
-<action_description>perform Process_Farm_Income</action_description>
+<action_dsl>perform Process_Farm_Income</action_dsl>
 <action_postfix>
 Process_Farm_Income
 Calculate_Farm_SE_Tax
@@ -402,7 +402,7 @@ Calculate_Farm_SE_Tax
 <action_details>
 <action_number>9</action_number>
 <action_comment>Process Form 4797 business property sales</action_comment>
-<action_description>perform Process_Property_Sales</action_description>
+<action_dsl>perform Process_Property_Sales</action_dsl>
 <action_postfix>
 Process_Property_Sales
 Calculate_Section_1231
@@ -412,7 +412,7 @@ Calculate_Section_1231
 <action_details>
 <action_number>10</action_number>
 <action_comment>Process Form 1116 foreign income</action_comment>
-<action_description>perform Process_Foreign_Income</action_description>
+<action_dsl>perform Process_Foreign_Income</action_dsl>
 <action_postfix>
 Process_Foreign_Income
 </action_postfix>
@@ -420,7 +420,7 @@ Process_Foreign_Income
 </action_details><action_details>
 <action_number>11</action_number>
 <action_comment>Process installment sales (Form 6252) - gain recognized in current year per IRC 453</action_comment>
-<action_description>perform Process_Installment_Sales</action_description>
+<action_dsl>perform Process_Installment_Sales</action_dsl>
 <action_postfix>
 Process_Installment_Sales
 </action_postfix>
@@ -429,7 +429,7 @@ Process_Installment_Sales
 <action_details>
 <action_number>12</action_number>
 <action_comment>Process like-kind exchanges (Form 8824) - recognized gain from boot per IRC 1031</action_comment>
-<action_description>perform Process_Like_Kind_Exchanges</action_description>
+<action_dsl>perform Process_Like_Kind_Exchanges</action_dsl>
 <action_postfix>
 Process_Like_Kind_Exchanges
 </action_postfix>
@@ -438,7 +438,7 @@ Process_Like_Kind_Exchanges
 <action_details>
 <action_number>13</action_number>
 <action_comment>Calculate total gross income FIRST (for OBBBA phase-out calculations)</action_comment>
-<action_description>set result.gross_income = result.total_w2_wages + result.total_se_income + result.total_rental_income + result.total_other_income + result.unemployment_compensation + result.gambling_winnings + result.alimony_received + result.state_tax_refund</action_description>
+<action_dsl>set result.gross_income = result.total_w2_wages + result.total_se_income + result.total_rental_income + result.total_other_income + result.unemployment_compensation + result.gambling_winnings + result.alimony_received + result.state_tax_refund</action_dsl>
 <action_postfix>
 result.total_w2_wages result.total_se_income f+ result.total_rental_income f+ result.total_other_income f+ result.total_tip_income f+ result.total_overtime_income f+ result.total_social_security f+ result.total_long_term_gains f+ result.total_short_term_gains f+ result.total_k1_ordinary_income f+ result.total_k1_rental_income f+ result.net_farm_profit f+ result.total_depreciation_recapture f+ result.total_foreign_income f+ result.total_installment_gain f+ result.total_like_kind_recognized f+ result.unemployment_compensation f+ result.gambling_winnings f+ result.alimony_received f+ result.state_tax_refund f+ /result.gross_income xdef
 "Line 9 - Total Income: $" result.gross_income cvs strconcat " per Form 1040 Line 9" strconcat job.audit_trail swap addto
@@ -448,7 +448,7 @@ result.total_w2_wages result.total_se_income f+ result.total_rental_income f+ re
 <action_details>
 <action_number>14</action_number>
 <action_comment>Calculate AGI adjustments (Schedule 1 Part II)</action_comment>
-<action_description>perform Calculate_AGI_Adjustments</action_description>
+<action_dsl>perform Calculate_AGI_Adjustments</action_dsl>
 <action_postfix>
 Calculate_AGI_Adjustments
 </action_postfix>
@@ -457,7 +457,7 @@ Calculate_AGI_Adjustments
 <action_details>
 <action_number>15</action_number>
 <action_comment>Calculate AGI</action_comment>
-<action_description>set result.agi = result.gross_income - result.total_adjustments</action_description>
+<action_dsl>set result.agi = result.gross_income - result.total_adjustments</action_dsl>
 <action_postfix>
 result.gross_income result.total_adjustments f- /result.agi xdef
 "Line 11 - Adjusted Gross Income (AGI): $" result.agi cvs strconcat " per Form 1040 Line 11" strconcat job.audit_trail swap addto
@@ -467,7 +467,7 @@ result.gross_income result.total_adjustments f- /result.agi xdef
 <action_details>
 <action_number>16</action_number>
 <action_comment>Calculate Social Security taxability after AGI is known</action_comment>
-<action_description>perform Calculate_SS_Taxability</action_description>
+<action_dsl>perform Calculate_SS_Taxability</action_dsl>
 <action_postfix>
 Calculate_SS_Taxability
 </action_postfix>
@@ -493,7 +493,7 @@ Calculate_SS_Taxability
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each taxpayer</context_comment>
-<context_description>for all taxpayers</context_description>
+<context_dsl>for all taxpayers</context_dsl>
 <context_postfix>
 { /Process_W2_Income executetable } job.taxpayers forall
 </context_postfix>
@@ -504,7 +504,7 @@ Calculate_SS_Taxability
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Taxpayer has W-2 wages</condition_comment>
-<condition_description>taxpayer.w2_wages &gt; 0</condition_description>
+<condition_dsl>taxpayer.w2_wages &gt; 0</condition_dsl>
 <condition_postfix>taxpayer.w2_wages 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="Y" />
@@ -514,7 +514,7 @@ Calculate_SS_Taxability
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxpayer is senior</condition_comment>
-<condition_description>taxpayer.is_senior == true</condition_description>
+<condition_dsl>taxpayer.is_senior == true</condition_dsl>
 <condition_postfix>taxpayer.is_senior true beq</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -526,7 +526,7 @@ Calculate_SS_Taxability
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add W-2 wages to total</action_comment>
-<action_description>add taxpayer.w2_wages to result.total_w2_wages</action_description>
+<action_dsl>add taxpayer.w2_wages to result.total_w2_wages</action_dsl>
 <action_postfix>
 taxpayer.w2_wages result.total_w2_wages f+ /result.total_w2_wages xdef
 "  W-2 Wages for " taxpayer.name strconcat ": $" strconcat taxpayer.w2_wages cvs strconcat " (Form W-2, IRC 61(a)(1))" strconcat job.audit_trail swap addto
@@ -537,7 +537,7 @@ taxpayer.w2_wages result.total_w2_wages f+ /result.total_w2_wages xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Track withholding for payments</action_comment>
-<action_description>add taxpayer.w2_withholding to result.total_payments</action_description>
+<action_dsl>add taxpayer.w2_withholding to result.total_payments</action_dsl>
 <action_postfix>
 taxpayer.w2_withholding result.total_payments f+ /result.total_payments xdef
 taxpayer.estimated_payments result.total_payments f+ /result.total_payments xdef
@@ -550,7 +550,7 @@ taxpayer.estimated_payments result.total_payments f+ /result.total_payments xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Process OBBBA income sources (tips, overtime, SS)</action_comment>
-<action_description>add taxpayer.tip_income to result.total_tip_income</action_description>
+<action_dsl>add taxpayer.tip_income to result.total_tip_income</action_dsl>
 <action_postfix>
 taxpayer.tip_income result.total_tip_income f+ /result.total_tip_income xdef
 taxpayer.overtime_income result.total_overtime_income f+ /result.total_overtime_income xdef
@@ -564,7 +564,7 @@ taxpayer.social_security_income result.total_social_security f+ /result.total_so
 <action_details>
 <action_number>4</action_number>
 <action_comment>Count senior taxpayer</action_comment>
-<action_description>add 1 to result.senior_count</action_description>
+<action_dsl>add 1 to result.senior_count</action_dsl>
 <action_postfix>
 result.senior_count 1 + /result.senior_count xdef
 </action_postfix>
@@ -608,7 +608,7 @@ result.senior_count 1 + /result.senior_count xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each self-employed taxpayer</context_comment>
-<context_description>for all taxpayers whose is_self_employed == true</context_description>
+<context_dsl>for all taxpayers whose is_self_employed == true</context_dsl>
 <context_postfix>
 { Filter_Self_Employed_Taxpayer performaliased } job.taxpayers forall
 </context_postfix>
@@ -619,7 +619,7 @@ result.senior_count 1 + /result.senior_count xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has self-employment income</condition_comment>
-<condition_description>taxpayer.se_gross_income &gt; 0</condition_description>
+<condition_dsl>taxpayer.se_gross_income &gt; 0</condition_dsl>
 <condition_postfix>taxpayer.se_gross_income 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -629,7 +629,7 @@ result.senior_count 1 + /result.senior_count xdef
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log gross receipts</action_comment>
-<action_description>add "Gross Receipts: $" + taxpayer.se_gross_income to job.audit_trail</action_description>
+<action_dsl>add "Gross Receipts: $" + taxpayer.se_gross_income to job.audit_trail</action_dsl>
 <action_postfix>
 "SCHEDULE C - " taxpayer.name strconcat " (" strconcat taxpayer.occupation strconcat ")" strconcat job.audit_trail swap addto
 "  Gross Receipts: $" taxpayer.se_gross_income cvs strconcat " (Schedule C Line 1, IRC 61)" strconcat job.audit_trail swap addto
@@ -639,7 +639,7 @@ result.senior_count 1 + /result.senior_count xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate vehicle deduction</action_comment>
-<action_description>perform Calculate_Vehicle_Deduction</action_description>
+<action_dsl>perform Calculate_Vehicle_Deduction</action_dsl>
 <action_postfix>
 Calculate_Vehicle_Deduction
 </action_postfix>
@@ -648,7 +648,7 @@ Calculate_Vehicle_Deduction
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate net profit</action_comment>
-<action_description>set taxpayer.se_net_profit = taxpayer.se_gross_income - taxpayer.se_expenses</action_description>
+<action_dsl>set taxpayer.se_net_profit = taxpayer.se_gross_income - taxpayer.se_expenses</action_dsl>
 <action_postfix>
 taxpayer.se_gross_income taxpayer.se_expenses f- /taxpayer.se_net_profit xdef
 "  Net Profit: $" taxpayer.se_net_profit cvs strconcat " (Schedule C Line 31)" strconcat job.audit_trail swap addto
@@ -659,7 +659,7 @@ taxpayer.se_net_profit result.total_se_income f+ /result.total_se_income xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate SE tax after net profit is known</action_comment>
-<action_description>perform Calculate_SE_Tax</action_description>
+<action_dsl>perform Calculate_SE_Tax</action_dsl>
 <action_postfix>
 Calculate_SE_Tax
 </action_postfix>
@@ -696,7 +696,7 @@ Calculate_SE_Tax
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>SE net profit meets threshold for SE tax; taxpayer.se_net_profit &gt;= se_threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>taxpayer.se_net_profit se_threshold &gt;=</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -706,7 +706,7 @@ Calculate_SE_Tax
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate SE tax with proper SS wage base cap and Medicare component; Calculate SE tax: SS component (12.4% up to wage base) + Medicare component (2.9% all income)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.se_net_profit se_income_multiplier f* dup
 ss_wage_base result.total_w2_wages f- 0 fmax fmin 0.124 f*
@@ -724,7 +724,7 @@ taxpayer.se_tax se_deduction_rate f* /taxpayer.se_tax_deduction xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No SE tax required - net profit below threshold</action_comment>
-<action_description>set taxpayer.se_tax = 0</action_description>
+<action_dsl>set taxpayer.se_tax = 0</action_dsl>
 <action_postfix>
 "  SE Tax: Not required - net SE income below $400 threshold (IRC 1402(b)(2))" job.audit_trail swap addto
 0 /taxpayer.se_tax xdef
@@ -761,7 +761,7 @@ taxpayer.se_tax se_deduction_rate f* /taxpayer.se_tax_deduction xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process vehicles for current taxpayer</context_comment>
-<context_description>for all vehicles where taxpayer_id matches current taxpayer</context_description>
+<context_dsl>for all vehicles where taxpayer_id matches current taxpayer</context_dsl>
 <context_postfix>
 { Filter_Taxpayer_Vehicle performaliased } job.vehicles forall
 </context_postfix>
@@ -772,7 +772,7 @@ taxpayer.se_tax se_deduction_rate f* /taxpayer.se_tax_deduction xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has business miles</condition_comment>
-<condition_description>vehicle.business_miles &gt; 0</condition_description>
+<condition_dsl>vehicle.business_miles &gt; 0</condition_dsl>
 <condition_postfix>
 vehicle.business_miles 0 &gt;
 </condition_postfix>
@@ -783,7 +783,7 @@ vehicle.business_miles 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Using standard mileage method</condition_comment>
-<condition_description>vehicle.method is equal to "standard_mileage"</condition_description>
+<condition_dsl>vehicle.method is equal to "standard_mileage"</condition_dsl>
 <condition_postfix>
 vehicle.method "standard_mileage" streq
 </condition_postfix>
@@ -795,7 +795,7 @@ vehicle.method "standard_mileage" streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate business use percentage</action_comment>
-<action_description>set business_use_percentage = business_miles / total_miles</action_description>
+<action_dsl>set business_use_percentage = business_miles / total_miles</action_dsl>
 <action_postfix>
 business_miles cvr total_miles cvr fdiv /business_use_percentage xdef
 </action_postfix>
@@ -805,7 +805,7 @@ business_miles cvr total_miles cvr fdiv /business_use_percentage xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate standard mileage deduction</action_comment>
-<action_description>set vehicle.vehicle_deduction = vehicle.business_miles * mileage_rate</action_description>
+<action_dsl>set vehicle.vehicle_deduction = vehicle.business_miles * mileage_rate</action_dsl>
 <action_postfix>
 vehicle.business_miles cvr mileage_rate f* /vehicle.standard_mileage_deduction xdef
 vehicle.standard_mileage_deduction /vehicle.vehicle_deduction xdef
@@ -819,7 +819,7 @@ vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate actual expense deduction</action_comment>
-<action_description>set vehicle.vehicle_deduction = (vehicle.actual_expenses + vehicle.vehicle_depreciation) * vehicle.business_use_percentage</action_description>
+<action_dsl>set vehicle.vehicle_deduction = (vehicle.actual_expenses + vehicle.vehicle_depreciation) * vehicle.business_use_percentage</action_dsl>
 <action_postfix>
 vehicle.actual_expenses vehicle.vehicle_depreciation f+ vehicle.business_use_percentage f* /vehicle.vehicle_deduction xdef
 vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
@@ -862,7 +862,7 @@ vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each rental property</context_comment>
-<context_description>for all properties where property.type is equal to "rental"</context_description>
+<context_dsl>for all properties where property.type is equal to "rental"</context_dsl>
 <context_postfix>
 { /Process_Rental_Income executetable } job.properties forall
 </context_postfix>
@@ -873,7 +873,7 @@ vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is rental property</condition_comment>
-<condition_description>property.type is equal to "rental"</condition_description>
+<condition_dsl>property.type is equal to "rental"</condition_dsl>
 <condition_postfix>property.type "rental" streq</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="Y" />
@@ -882,7 +882,7 @@ vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has rental income</condition_comment>
-<condition_description>property.rental_income &gt; 0</condition_description>
+<condition_dsl>property.rental_income &gt; 0</condition_dsl>
 <condition_postfix>property.rental_income 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="Y" />
@@ -890,7 +890,7 @@ vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Net income is positive (income not loss)</condition_comment>
-<condition_description>property.rental_net_income &gt;= 0</condition_description>
+<condition_dsl>property.rental_net_income &gt;= 0</condition_dsl>
 <condition_postfix>property.rental_net_income 0 &gt;=</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -900,7 +900,7 @@ vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log rental property header</action_comment>
-<action_description>add "SCHEDULE E - Rental Property: " + property.address to job.audit_trail</action_description>
+<action_dsl>add "SCHEDULE E - Rental Property: " + property.address to job.audit_trail</action_dsl>
 <action_postfix>
 "SCHEDULE E Part I - Rental Property: " property.address strconcat job.audit_trail swap addto
 "  Rental Income: $" property.rental_income cvs strconcat " (Schedule E Line 3, IRC 61(a)(5))" strconcat job.audit_trail swap addto
@@ -911,7 +911,7 @@ vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate total rental expenses</action_comment>
-<action_description>set property.rental_expenses = property.rental_advertising + property.rental_insurance + property.mortgage_interest + property.property_taxes + property.rental_repairs + property.rental_utilities + property.depreciation</action_description>
+<action_dsl>set property.rental_expenses = property.rental_advertising + property.rental_insurance + property.mortgage_interest + property.property_taxes + property.rental_repairs + property.rental_utilities + property.depreciation</action_dsl>
 <action_postfix>
 property.rental_advertising property.rental_insurance f+ property.mortgage_interest f+ property.property_taxes f+ property.rental_repairs f+ property.rental_utilities f+ property.rental_management f+ property.depreciation f+ /property.rental_expenses xdef
 "  Expenses:" job.audit_trail swap addto
@@ -930,7 +930,7 @@ property.rental_advertising property.rental_insurance f+ property.mortgage_inter
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate net rental income</action_comment>
-<action_description>set property.rental_net_income = property.rental_income - property.rental_expenses</action_description>
+<action_dsl>set property.rental_net_income = property.rental_income - property.rental_expenses</action_dsl>
 <action_postfix>
 property.rental_income property.rental_expenses f- /property.rental_net_income xdef
 property.rental_net_income result.total_rental_income f+ /result.total_rental_income xdef
@@ -941,7 +941,7 @@ property.rental_net_income result.total_rental_income f+ /result.total_rental_in
 <action_details>
 <action_number>4</action_number>
 <action_comment>Log net income</action_comment>
-<action_description>add "Net Rental Income: $" + property.rental_net_income to job.audit_trail</action_description>
+<action_dsl>add "Net Rental Income: $" + property.rental_net_income to job.audit_trail</action_dsl>
 <action_postfix>
 "  Net Rental Income: $" property.rental_net_income cvs strconcat " (Schedule E Line 21)" strconcat job.audit_trail swap addto
 </action_postfix>
@@ -950,7 +950,7 @@ property.rental_net_income result.total_rental_income f+ /result.total_rental_in
 <action_details>
 <action_number>5</action_number>
 <action_comment>Log net loss</action_comment>
-<action_description>add "Net Rental Loss: $" + property.rental_net_income to job.audit_trail</action_description>
+<action_dsl>add "Net Rental Loss: $" + property.rental_net_income to job.audit_trail</action_dsl>
 <action_postfix>
 "  Net Rental Loss: $" property.rental_net_income cvs strconcat " (Schedule E Line 21)" strconcat job.audit_trail swap addto
 "  Note: Rental loss may be subject to passive activity limitations per Form 8582, IRC 469" job.audit_trail swap addto
@@ -990,7 +990,7 @@ property.rental_net_income result.total_rental_income f+ /result.total_rental_in
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each income entity</context_comment>
-<context_description>for all income entities</context_description>
+<context_dsl>for all income entities</context_dsl>
 <context_postfix>
 { /Process_Other_Income executetable } job.incomes forall
 </context_postfix>
@@ -1001,7 +1001,7 @@ property.rental_net_income result.total_rental_income f+ /result.total_rental_in
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has gross amount</condition_comment>
-<condition_description>income.gross_amount &gt; 0</condition_description>
+<condition_dsl>income.gross_amount &gt; 0</condition_dsl>
 <condition_postfix>
 income.gross_amount 0 &gt;
 </condition_postfix>
@@ -1013,7 +1013,7 @@ income.gross_amount 0 &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add income to total other income</action_comment>
-<action_description>add income.gross_amount to result.total_other_income</action_description>
+<action_dsl>add income.gross_amount to result.total_other_income</action_dsl>
 <action_postfix>
 income.gross_amount result.total_other_income f+ /result.total_other_income xdef
 "  Other Income (" income.type strconcat "): $" strconcat income.gross_amount cvs strconcat " from " strconcat income.source strconcat job.audit_trail swap addto
@@ -1023,7 +1023,7 @@ income.gross_amount result.total_other_income f+ /result.total_other_income xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Track withholding</action_comment>
-<action_description>add income.tax_withheld to result.total_payments</action_description>
+<action_dsl>add income.tax_withheld to result.total_payments</action_dsl>
 <action_postfix>
 income.tax_withheld result.total_payments f+ /result.total_payments xdef
 </action_postfix>
@@ -1054,7 +1054,7 @@ income.tax_withheld result.total_payments f+ /result.total_payments xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each taxpayer for adjustments</context_comment>
-<context_description>for all taxpayers</context_description>
+<context_dsl>for all taxpayers</context_dsl>
 <context_postfix>
 0.0 /result.total_adjustments xdef
 "ADJUSTMENTS TO INCOME (Schedule 1 Part II)" job.audit_trail swap addto
@@ -1073,7 +1073,7 @@ result.total_obbba_deductions result.ira_deduction f+ result.hsa_deduction f+ re
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has SE tax to deduct</condition_comment>
-<condition_description>taxpayer.se_tax_deduction &gt; 0</condition_description>
+<condition_dsl>taxpayer.se_tax_deduction &gt; 0</condition_dsl>
 <condition_postfix>
 taxpayer.se_tax_deduction 0 &gt;
 </condition_postfix>
@@ -1085,7 +1085,7 @@ taxpayer.se_tax_deduction 0 &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add SE tax deduction to adjustments</action_comment>
-<action_description>add taxpayer.se_tax_deduction to result.total_adjustments</action_description>
+<action_dsl>add taxpayer.se_tax_deduction to result.total_adjustments</action_dsl>
 <action_postfix>
 taxpayer.se_tax_deduction result.total_adjustments f+ /result.total_adjustments xdef
 "  Line 15 - SE Tax Deduction for " taxpayer.name strconcat ": $" strconcat taxpayer.se_tax_deduction cvs strconcat " (IRC 164(f))" strconcat job.audit_trail swap addto
@@ -1095,7 +1095,7 @@ taxpayer.se_tax_deduction result.total_adjustments f+ /result.total_adjustments 
 <action_details>
 <action_number>2</action_number>
 <action_comment>Log total adjustments</action_comment>
-<action_description>add "Total Adjustments: $" + result.total_adjustments to job.audit_trail</action_description>
+<action_dsl>add "Total Adjustments: $" + result.total_adjustments to job.audit_trail</action_dsl>
 <action_postfix>
 "  Line 26 - Total Adjustments: $" result.total_adjustments cvs strconcat job.audit_trail swap addto
 </action_postfix>
@@ -1121,7 +1121,7 @@ taxpayer.se_tax_deduction result.total_adjustments f+ /result.total_adjustments 
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>perform Calculate_Standard_Deduction</action_description>
+<action_dsl>perform Calculate_Standard_Deduction</action_dsl>
 <action_postfix>
 "DEDUCTIONS (Form 1040 Line 12)" job.audit_trail swap addto
 Calculate_Standard_Deduction
@@ -1133,7 +1133,7 @@ Calculate_Itemized_Deductions
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Itemized deductions exceed standard deduction</condition_comment>
-<condition_description>result.total_itemized &gt; result.standard_deduction</condition_description>
+<condition_dsl>result.total_itemized &gt; result.standard_deduction</condition_dsl>
 <condition_postfix>
 result.total_itemized result.standard_deduction &gt;
 </condition_postfix>
@@ -1145,7 +1145,7 @@ result.total_itemized result.standard_deduction &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Use itemized deductions</action_comment>
-<action_description>set result.deduction_used = result.total_itemized</action_description>
+<action_dsl>set result.deduction_used = result.total_itemized</action_dsl>
 <action_postfix>
 result.total_itemized /result.total_deduction xdef
 "itemized" /result.deduction_used xdef
@@ -1156,7 +1156,7 @@ result.total_itemized /result.total_deduction xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Use standard deduction</action_comment>
-<action_description>set result.deduction_used = result.standard_deduction</action_description>
+<action_dsl>set result.deduction_used = result.standard_deduction</action_dsl>
 <action_postfix>
 result.standard_deduction /result.total_deduction xdef
 "standard" /result.deduction_used xdef
@@ -1196,7 +1196,7 @@ result.standard_deduction /result.total_deduction xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly or Qualifying Surviving Spouse; job.filing_status is equal to "MFJ" or job.filing_status is equal to "QSS"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 job.filing_status MFJ streq job.filing_status QSS streq or
 </condition_postfix>
@@ -1210,7 +1210,7 @@ job.filing_status MFJ streq job.filing_status QSS streq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>job.filing_status is equal to "HOH"</condition_description>
+<condition_dsl>job.filing_status is equal to "HOH"</condition_dsl>
 <condition_postfix>
 job.filing_status HOH streq
 </condition_postfix>
@@ -1224,7 +1224,7 @@ job.filing_status HOH streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Has seniors age 65+</condition_comment>
-<condition_description>result.senior_count &gt; 0</condition_description>
+<condition_dsl>result.senior_count &gt; 0</condition_dsl>
 <condition_postfix>
 result.senior_count 0 &gt;
 </condition_postfix>
@@ -1240,7 +1240,7 @@ result.senior_count 0 &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>MFJ/QSS standard deduction</action_comment>
-<action_description>set result.standard_deduction = standard_deduction_mfj</action_description>
+<action_dsl>set result.standard_deduction = standard_deduction_mfj</action_dsl>
 <action_postfix>
 constants.standard_deduction_mfj /result.standard_deduction xdef
 "Standard Deduction (MFJ): $" result.standard_deduction cvs strconcat " per IRC 63(c)(2)(A)" strconcat job.audit_trail swap addto
@@ -1251,7 +1251,7 @@ constants.standard_deduction_mfj /result.standard_deduction xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>HOH standard deduction</action_comment>
-<action_description>set result.standard_deduction = standard_deduction_hoh</action_description>
+<action_dsl>set result.standard_deduction = standard_deduction_hoh</action_dsl>
 <action_postfix>
 constants.standard_deduction_hoh /result.standard_deduction xdef
 "Standard Deduction (HOH): $" result.standard_deduction cvs strconcat " per IRC 63(c)(2)(B)" strconcat job.audit_trail swap addto
@@ -1262,7 +1262,7 @@ constants.standard_deduction_hoh /result.standard_deduction xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Single/MFS standard deduction</action_comment>
-<action_description>set result.standard_deduction = standard_deduction_single</action_description>
+<action_dsl>set result.standard_deduction = standard_deduction_single</action_dsl>
 <action_postfix>
 constants.standard_deduction_single /result.standard_deduction xdef
 "Standard Deduction (Single/MFS): $" result.standard_deduction cvs strconcat " per IRC 63(c)(2)(C)" strconcat job.audit_trail swap addto
@@ -1273,7 +1273,7 @@ constants.standard_deduction_single /result.standard_deduction xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Add additional standard deduction for married seniors age 65+</action_comment>
-<action_description>add senior_extra_deduction_married to result.standard_deduction</action_description>
+<action_dsl>add senior_extra_deduction_married to result.standard_deduction</action_dsl>
 <action_postfix>
 result.senior_count 1.0 f* constants.additional_std_deduction_married f* result.standard_deduction f+ /result.standard_deduction xdef
 "  Additional for seniors (65+): $" result.senior_count 1.0 f* constants.additional_std_deduction_married f* cvs strconcat " (" strconcat result.senior_count cvs strconcat " x $" strconcat constants.additional_std_deduction_married cvs strconcat ")" strconcat job.audit_trail swap addto
@@ -1283,7 +1283,7 @@ result.senior_count 1.0 f* constants.additional_std_deduction_married f* result.
 <action_details>
 <action_number>5</action_number>
 <action_comment>Add additional standard deduction for single/HOH seniors age 65+</action_comment>
-<action_description>add senior_extra_deduction_single to result.standard_deduction</action_description>
+<action_dsl>add senior_extra_deduction_single to result.standard_deduction</action_dsl>
 <action_postfix>
 result.senior_count 1.0 f* constants.additional_std_deduction_single f* result.standard_deduction f+ /result.standard_deduction xdef
 "  Additional for seniors (65+): $" result.senior_count 1.0 f* constants.additional_std_deduction_single f* cvs strconcat " (" strconcat result.senior_count cvs strconcat " x $" strconcat constants.additional_std_deduction_single cvs strconcat ")" strconcat job.audit_trail swap addto
@@ -1335,7 +1335,7 @@ result.senior_count 1.0 f* constants.additional_std_deduction_single f* result.s
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>set result.total_itemized = 0</action_description>
+<action_dsl>set result.total_itemized = 0</action_dsl>
 <action_postfix>
 0.0 /result.total_itemized xdef
 "SCHEDULE A - Itemized Deductions" job.audit_trail swap addto
@@ -1346,7 +1346,7 @@ result.senior_count 1.0 f* constants.additional_std_deduction_single f* result.s
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always calculate itemized for comparison</condition_comment>
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -1357,7 +1357,7 @@ perform when called
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate medical expense deduction (Schedule A Lines 1-4)</action_comment>
-<action_description>perform Calculate_Medical_Expense_Deduction</action_description>
+<action_dsl>perform Calculate_Medical_Expense_Deduction</action_dsl>
 <action_postfix>
 Calculate_Medical_Expense_Deduction
 result.medical_expense_deduction result.total_itemized f+ /result.total_itemized xdef
@@ -1367,7 +1367,7 @@ result.medical_expense_deduction result.total_itemized f+ /result.total_itemized
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate SALT deduction</action_comment>
-<action_description>perform Calculate_SALT_Deduction</action_description>
+<action_dsl>perform Calculate_SALT_Deduction</action_dsl>
 <action_postfix>
 Calculate_SALT_Deduction
 </action_postfix>
@@ -1376,7 +1376,7 @@ Calculate_SALT_Deduction
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate mortgage interest deduction</action_comment>
-<action_description>perform Calculate_Mortgage_Interest</action_description>
+<action_dsl>perform Calculate_Mortgage_Interest</action_dsl>
 <action_postfix>
 Calculate_Mortgage_Interest
 </action_postfix>
@@ -1385,7 +1385,7 @@ Calculate_Mortgage_Interest
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate charitable contributions</action_comment>
-<action_description>perform Calculate_Charitable_Deduction</action_description>
+<action_dsl>perform Calculate_Charitable_Deduction</action_dsl>
 <action_postfix>
 Calculate_Charitable_Deduction
 </action_postfix>
@@ -1394,7 +1394,7 @@ Calculate_Charitable_Deduction
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate noncash charitable contributions (Form 8283)</action_comment>
-<action_description>perform Calculate_Noncash_Charitable</action_description>
+<action_dsl>perform Calculate_Noncash_Charitable</action_dsl>
 <action_postfix>
 Calculate_Noncash_Charitable
 </action_postfix>
@@ -1402,7 +1402,7 @@ Calculate_Noncash_Charitable
 </action_details><action_details>
 <action_number>6</action_number>
 <action_comment>Process casualty and theft losses (Form 4684) - deductible only for federally declared disasters per IRC 165</action_comment>
-<action_description>perform Process_Casualty_Losses</action_description>
+<action_dsl>perform Process_Casualty_Losses</action_dsl>
 <action_postfix>
 job.casualty_losses length 0 &gt; if
   Process_Casualty_Losses
@@ -1417,7 +1417,7 @@ endif
 <action_details>
 <action_number>7</action_number>
 <action_comment>Log total itemized</action_comment>
-<action_description>add "Total Itemized Deductions: $" + result.total_itemized to job.audit_trail</action_description>
+<action_dsl>add "Total Itemized Deductions: $" + result.total_itemized to job.audit_trail</action_dsl>
 <action_postfix>
 "  Total Itemized Deductions: $" result.total_itemized cvs strconcat job.audit_trail swap addto
 </action_postfix>
@@ -1443,7 +1443,7 @@ endif
 <context_details>
 <context_number>1</context_number>
 <context_comment>Calculate total SALT from property taxes and deductions</context_comment>
-<context_description>local double salt_total = sum of property_taxes + state/local tax deductions</context_description>
+<context_dsl>local double salt_total = sum of property_taxes + state/local tax deductions</context_dsl>
 <context_postfix>
 0.0 allocate
 { Sum_Primary_Residence_Tax performaliased } job.properties forall
@@ -1454,7 +1454,7 @@ endif
 <context_details>
 <context_number>2</context_number>
 <context_comment>Calculate SALT cap with high-income phaseout</context_comment>
-<context_description>local double effective_salt_cap = salt_cap adjusted for MAGI phaseout</context_description>
+<context_dsl>local double effective_salt_cap = salt_cap adjusted for MAGI phaseout</context_dsl>
 <context_postfix>
 result.agi salt_phaseout_start f&lt;= {
   salt_cap /effective_salt_cap local
@@ -1474,7 +1474,7 @@ result.agi salt_phaseout_start f&lt;= {
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>State has income tax</condition_comment>
-<condition_description>job.has_state_income_tax == true</condition_description>
+<condition_dsl>job.has_state_income_tax == true</condition_dsl>
 <condition_postfix>
 job.has_state_income_tax true beq
 </condition_postfix>
@@ -1486,7 +1486,7 @@ job.has_state_income_tax true beq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Total SALT exceeds effective cap</condition_comment>
-<condition_description>salt_total &gt; effective_salt_cap</condition_description>
+<condition_dsl>salt_total &gt; effective_salt_cap</condition_dsl>
 <condition_postfix>
 0 local@ effective_salt_cap &gt;
 </condition_postfix>
@@ -1500,7 +1500,7 @@ job.has_state_income_tax true beq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Apply SALT cap with state income tax</action_comment>
-<action_description>set result.salt_deduction = salt_cap</action_description>
+<action_dsl>set result.salt_deduction = salt_cap</action_dsl>
 <action_postfix>
 "  State and Local Taxes (SALT):" job.audit_trail swap addto
 "    State Income Tax: (applicable)" job.audit_trail swap addto
@@ -1515,7 +1515,7 @@ effective_salt_cap result.total_itemized f+ /result.total_itemized xdef
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate Delaware state tax</action_comment>
-<action_description>perform Calculate_DE_Tax</action_description>
+<action_dsl>perform Calculate_DE_Tax</action_dsl>
 <action_postfix>
 Calculate_DE_Tax
 </action_postfix>
@@ -1525,7 +1525,7 @@ Calculate_DE_Tax
 <action_details>
 <action_number>2</action_number>
 <action_comment>No state income tax, apply cap if needed</action_comment>
-<action_description>set result.salt_deduction = salt_cap</action_description>
+<action_dsl>set result.salt_deduction = salt_cap</action_dsl>
 <action_postfix>
 "  State and Local Taxes (SALT) - " job.state strconcat " (No State Income Tax):" strconcat job.audit_trail swap addto
 "    Real Estate Taxes: $" 0 local@ cvs strconcat " (Line 5b, IRC 164(a)(1))" strconcat job.audit_trail swap addto
@@ -1539,7 +1539,7 @@ effective_salt_cap result.total_itemized f+ /result.total_itemized xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Full SALT with state income tax (under cap)</action_comment>
-<action_description>set result.salt_deduction = salt_total</action_description>
+<action_dsl>set result.salt_deduction = salt_total</action_dsl>
 <action_postfix>
 "  State and Local Taxes (SALT):" job.audit_trail swap addto
 "    Total SALT: $" 0 local@ cvs strconcat " (under $" strconcat effective_salt_cap cvs strconcat " cap)" strconcat job.audit_trail swap addto
@@ -1551,7 +1551,7 @@ effective_salt_cap result.total_itemized f+ /result.total_itemized xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Full SALT no state income tax (under cap)</action_comment>
-<action_description>set result.salt_deduction = property_tax_total</action_description>
+<action_dsl>set result.salt_deduction = property_tax_total</action_dsl>
 <action_postfix>
 "  State and Local Taxes (SALT) - " job.state strconcat " (No State Income Tax):" strconcat job.audit_trail swap addto
 "    Property Taxes: $" 0 local@ cvs strconcat " (under $" strconcat effective_salt_cap cvs strconcat " cap)" strconcat job.audit_trail swap addto
@@ -1591,7 +1591,7 @@ effective_salt_cap result.total_itemized f+ /result.total_itemized xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Property is primary residence</condition_comment>
-<condition_description>property.type is equal to "primary_residence"</condition_description>
+<condition_dsl>property.type is equal to "primary_residence"</condition_dsl>
 <condition_postfix>
 type "primary_residence" streq
 </condition_postfix>
@@ -1603,7 +1603,7 @@ type "primary_residence" streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add property tax to total</action_comment>
-<action_description>add property.property_taxes to salt_total</action_description>
+<action_dsl>add property.property_taxes to salt_total</action_dsl>
 <action_postfix>
 property_taxes 0 local@ f+ 0 local!
 </action_postfix>
@@ -1612,7 +1612,7 @@ property_taxes 0 local@ f+ 0 local!
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-primary residence; otherwise</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -1639,7 +1639,7 @@ property_taxes 0 local@ f+ 0 local!
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Deduction is state or local tax; deduction.category is state_income_tax or local_tax</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 category "state_income_tax" streq category "local_tax" streq or
 </condition_postfix>
@@ -1651,7 +1651,7 @@ category "state_income_tax" streq category "local_tax" streq or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add SALT deduction to total</action_comment>
-<action_description>add taxpayer.state_tax_paid to salt_total</action_description>
+<action_dsl>add taxpayer.state_tax_paid to salt_total</action_dsl>
 <action_postfix>
 amount 0 local@ f+ 0 local!
 </action_postfix>
@@ -1660,7 +1660,7 @@ amount 0 local@ f+ 0 local!
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-SALT deduction; otherwise</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -1685,7 +1685,7 @@ amount 0 local@ f+ 0 local!
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process primary residence properties</context_comment>
-<context_description>for all properties where property.type is equal to "primary_residence"</context_description>
+<context_dsl>for all properties where property.type is equal to "primary_residence"</context_dsl>
 <context_postfix>
 { Filter_Primary_Residence performaliased } job.properties forall
 </context_postfix>
@@ -1696,7 +1696,7 @@ amount 0 local@ f+ 0 local!
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has mortgage interest</condition_comment>
-<condition_description>property.mortgage_interest &gt; 0</condition_description>
+<condition_dsl>property.mortgage_interest &gt; 0</condition_dsl>
 <condition_postfix>
 property.mortgage_interest 0 &gt;
 </condition_postfix>
@@ -1707,7 +1707,7 @@ property.mortgage_interest 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Mortgage balance within limit</condition_comment>
-<condition_description>mortgage_balance &lt;= mortgage_limit_post_tcja</condition_description>
+<condition_dsl>mortgage_balance &lt;= mortgage_limit_post_tcja</condition_dsl>
 <condition_postfix>
 property.mortgage_balance mortgage_limit_post_tcja &lt;=
 </condition_postfix>
@@ -1719,7 +1719,7 @@ property.mortgage_balance mortgage_limit_post_tcja &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full mortgage interest deduction</action_comment>
-<action_description>add property.mortgage_interest to result.total_itemized</action_description>
+<action_dsl>add property.mortgage_interest to result.total_itemized</action_dsl>
 <action_postfix>
 property.mortgage_interest /property.mortgage_interest_deductible xdef
 property.mortgage_interest_deductible result.total_itemized f+ /result.total_itemized xdef
@@ -1733,7 +1733,7 @@ property.mortgage_interest_deductible result.total_itemized f+ /result.total_ite
 <action_details>
 <action_number>2</action_number>
 <action_comment>Limited mortgage interest deduction</action_comment>
-<action_description>add property.mortgage_interest * (mortgage_limit_post_tcja / property.mortgage_balance) to result.total_itemized</action_description>
+<action_dsl>add property.mortgage_interest * (mortgage_limit_post_tcja / property.mortgage_balance) to result.total_itemized</action_dsl>
 <action_postfix>
 property.mortgage_interest mortgage_limit_post_tcja * property.mortgage_balance / /property.mortgage_interest_deductible xdef
 property.mortgage_interest_deductible result.total_itemized f+ /result.total_itemized xdef
@@ -1780,7 +1780,7 @@ property.mortgage_interest_deductible result.total_itemized f+ /result.total_ite
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Property is primary residence</condition_comment>
-<condition_description>property.type is equal to "primary_residence"</condition_description>
+<condition_dsl>property.type is equal to "primary_residence"</condition_dsl>
 <condition_postfix>
 type "primary_residence" streq
 </condition_postfix>
@@ -1792,7 +1792,7 @@ type "primary_residence" streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process primary residence; otherwise</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 Calculate_Mortgage_Interest_For_Property
 </action_postfix>
@@ -1801,7 +1801,7 @@ Calculate_Mortgage_Interest_For_Property
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-primary residence; otherwise</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -1826,7 +1826,7 @@ Calculate_Mortgage_Interest_For_Property
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process charitable deductions</context_comment>
-<context_description>for all deductions where deduction.category is equal to "charity"</context_description>
+<context_dsl>for all deductions where deduction.category is equal to "charity"</context_dsl>
 <context_postfix>
 { Filter_Charity_Deduction performaliased } job.deductions forall
 </context_postfix>
@@ -1837,7 +1837,7 @@ Calculate_Mortgage_Interest_For_Property
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has charitable contribution</condition_comment>
-<condition_description>deduction.amount &gt; 0</condition_description>
+<condition_dsl>deduction.amount &gt; 0</condition_dsl>
 <condition_postfix>
 deduction.amount 0 &gt;
 </condition_postfix>
@@ -1849,7 +1849,7 @@ deduction.amount 0 &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add charitable contribution</action_comment>
-<action_description>add deduction.amount to result.total_itemized</action_description>
+<action_dsl>add deduction.amount to result.total_itemized</action_dsl>
 <action_postfix>
 deduction.amount /deduction.allowed_amount xdef
 deduction.allowed_amount result.total_itemized f+ /result.total_itemized xdef
@@ -1884,7 +1884,7 @@ deduction.allowed_amount result.total_itemized f+ /result.total_itemized xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Deduction is charity category; deduction.category is charity or charitable_cash</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 category "charity" streq category "charitable_cash" streq or
 </condition_postfix>
@@ -1896,7 +1896,7 @@ category "charity" streq category "charitable_cash" streq or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process charity deduction</action_comment>
-<action_description>add deduction.allowed_amount to result.total_itemized</action_description>
+<action_dsl>add deduction.allowed_amount to result.total_itemized</action_dsl>
 <action_postfix>
 amount /deduction.allowed_amount xdef
 deduction.allowed_amount result.total_itemized f+ /result.total_itemized xdef
@@ -1907,7 +1907,7 @@ deduction.allowed_amount result.total_itemized f+ /result.total_itemized xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-charity deduction; otherwise</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -1932,7 +1932,7 @@ deduction.allowed_amount result.total_itemized f+ /result.total_itemized xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each noncash contribution</context_comment>
-<context_description>for all noncash contributions</context_description>
+<context_dsl>for all noncash contributions</context_dsl>
 <context_postfix>
 "NONCASH CHARITABLE CONTRIBUTIONS (Form 8283, IRC 170)" job.audit_trail swap addto
 0.0 /result.total_noncash_charitable xdef
@@ -1945,7 +1945,7 @@ deduction.allowed_amount result.total_itemized f+ /result.total_itemized xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has noncash contributions</condition_comment>
-<condition_description>length of job.noncash_contributions &gt; 0</condition_description>
+<condition_dsl>length of job.noncash_contributions &gt; 0</condition_dsl>
 <condition_postfix>
 job.noncash_contributions length 0 &gt;
 </condition_postfix>
@@ -1957,7 +1957,7 @@ job.noncash_contributions length 0 &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log total noncash charitable</action_comment>
-<action_description>add result.total_noncash_charitable to result.total_itemized</action_description>
+<action_dsl>add result.total_noncash_charitable to result.total_itemized</action_dsl>
 <action_postfix>
 result.total_noncash_charitable result.total_itemized f+ /result.total_itemized xdef
 "  Total Noncash Charitable: $" result.total_noncash_charitable cvs strconcat " (Form 8283)" strconcat job.audit_trail swap addto
@@ -1967,7 +1967,7 @@ result.total_noncash_charitable result.total_itemized f+ /result.total_itemized 
 <action_details>
 <action_number>2</action_number>
 <action_comment>No noncash contributions</action_comment>
-<action_description>set result.total_noncash_charitable = 0</action_description>
+<action_dsl>set result.total_noncash_charitable = 0</action_dsl>
 <action_postfix>
 0.0 /result.total_noncash_charitable xdef
 </action_postfix>
@@ -2000,7 +2000,7 @@ result.total_noncash_charitable result.total_itemized f+ /result.total_itemized 
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Requires Section B (appraisal required for over $5,000)</condition_comment>
-<condition_description>fair_market_value &gt; 5000</condition_description>
+<condition_dsl>fair_market_value &gt; 5000</condition_dsl>
 <condition_postfix>
 fair_market_value 5000 &gt;
 </condition_postfix>
@@ -2010,7 +2010,7 @@ fair_market_value 5000 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Is appreciated capital gain property (long-term)</condition_comment>
-<condition_description>is_appreciated_property == true and holding_period is equal to "long_term"</condition_description>
+<condition_dsl>is_appreciated_property == true and holding_period is equal to "long_term"</condition_dsl>
 <condition_postfix>
 is_appreciated_property true eq holding_period "long_term" streq and
 </condition_postfix>
@@ -2024,7 +2024,7 @@ is_appreciated_property true eq holding_period "long_term" streq and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Capital gain property - use FMV with 30% AGI limit; set noncash_contribution.deduction_amount = fair_market_value, set noncash_contribution.agi_limitation = 0.30</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 fair_market_value /noncash_contribution.deduction_amount xdef
 0.30 /noncash_contribution.agi_limitation xdef
@@ -2036,7 +2036,7 @@ noncash_contribution.deduction_amount result.total_noncash_charitable f+ /result
 <action_details>
 <action_number>2</action_number>
 <action_comment>Ordinary income property or short-term - use lesser of FMV or basis; set noncash_contribution.deduction_amount = the minimum of fair_market_value and cost_basis</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 fair_market_value cost_basis min /noncash_contribution.deduction_amount xdef
 0.50 /noncash_contribution.agi_limitation xdef
@@ -2048,7 +2048,7 @@ noncash_contribution.deduction_amount result.total_noncash_charitable f+ /result
 <action_details>
 <action_number>3</action_number>
 <action_comment>Section A - capital gain property under $5,000, use FMV with 30% limit; set noncash_contribution.deduction_amount = fair_market_value with 30% AGI limit</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 fair_market_value /noncash_contribution.deduction_amount xdef
 0.30 /noncash_contribution.agi_limitation xdef
@@ -2060,7 +2060,7 @@ noncash_contribution.deduction_amount result.total_noncash_charitable f+ /result
 <action_details>
 <action_number>4</action_number>
 <action_comment>Section A - ordinary property under $5,000, use FMV with 50% limit; set noncash_contribution.deduction_amount = fair_market_value with 50% AGI limit</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 fair_market_value /noncash_contribution.deduction_amount xdef
 0.50 /noncash_contribution.agi_limitation xdef
@@ -2108,7 +2108,7 @@ noncash_contribution.deduction_amount result.total_noncash_charitable f+ /result
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always execute</condition_comment>
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -2119,7 +2119,7 @@ perform when called
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate QBI deduction (Form 8995/8995-A, IRC 199A)</action_comment>
-<action_description>perform Calculate_QBI_Deduction</action_description>
+<action_dsl>perform Calculate_QBI_Deduction</action_dsl>
 <action_postfix>
 "TAXABLE INCOME CALCULATION" job.audit_trail swap addto
 Calculate_QBI_Deduction { Form 8995/8995-A - QBI deduction calculated AFTER AGI but BEFORE taxable income per IRC 199A }
@@ -2129,7 +2129,7 @@ Calculate_QBI_Deduction { Form 8995/8995-A - QBI deduction calculated AFTER AGI 
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate taxable income (floor at zero per IRC 63); set result.taxable_income = the maximum of (result.agi - result.total_deduction - result.qbi_deduction) and 0</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.agi result.total_deduction f- result.qbi_deduction f- 0.0 fmax /result.taxable_income xdef
 "  Line 15 - Taxable Income: $" result.taxable_income cvs strconcat " per Form 1040 Line 15" strconcat job.audit_trail swap addto
@@ -2164,7 +2164,7 @@ result.agi result.total_deduction f- result.qbi_deduction f- 0.0 fmax /result.ta
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>add "TAX CALCULATION (Form 1040 Lines 16-24)" to job.audit_trail</action_description>
+<action_dsl>add "TAX CALCULATION (Form 1040 Lines 16-24)" to job.audit_trail</action_dsl>
 <action_postfix>
 "TAX CALCULATION (Form 1040 Lines 16-24)" job.audit_trail swap addto
 </action_postfix>
@@ -2174,7 +2174,7 @@ result.agi result.total_deduction f- result.qbi_deduction f- 0.0 fmax /result.ta
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always calculate</condition_comment>
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -2185,7 +2185,7 @@ perform when called
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate regular tax using brackets</action_comment>
-<action_description>perform Apply_Tax_Brackets</action_description>
+<action_dsl>perform Apply_Tax_Brackets</action_dsl>
 <action_postfix>
 Apply_Tax_Brackets
 </action_postfix>
@@ -2194,7 +2194,7 @@ Apply_Tax_Brackets
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate capital gains tax</action_comment>
-<action_description>perform Calculate_Capital_Gains_Tax</action_description>
+<action_dsl>perform Calculate_Capital_Gains_Tax</action_dsl>
 <action_postfix>
 Calculate_Capital_Gains_Tax
 </action_postfix>
@@ -2203,7 +2203,7 @@ Calculate_Capital_Gains_Tax
 <action_details>
 <action_number>3</action_number>
 <action_comment>Add SE tax from all taxpayers; set result.se_tax = the sum of taxpayer.se_tax for all taxpayers</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 { se_tax + } job.taxpayers forall /result.se_tax xdef
 "  SE Tax (Schedule SE): $" result.se_tax cvs strconcat job.audit_trail swap addto
@@ -2213,7 +2213,7 @@ Calculate_Capital_Gains_Tax
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate NIIT</action_comment>
-<action_description>perform Calculate_NIIT</action_description>
+<action_dsl>perform Calculate_NIIT</action_dsl>
 <action_postfix>
 Calculate_NIIT
 </action_postfix>
@@ -2222,7 +2222,7 @@ Calculate_NIIT
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate Additional Medicare Tax</action_comment>
-<action_description>perform Calculate_Additional_Medicare_Tax</action_description>
+<action_dsl>perform Calculate_Additional_Medicare_Tax</action_dsl>
 <action_postfix>
 Calculate_Additional_Medicare_Tax
 </action_postfix>
@@ -2230,7 +2230,7 @@ Calculate_Additional_Medicare_Tax
 </action_details><action_details>
 <action_number>6</action_number>
 <action_comment>Calculate early distribution penalty (Form 5329) - 10% penalty on early retirement withdrawals per IRC 72(t)</action_comment>
-<action_description>perform Process_Early_Distributions</action_description>
+<action_dsl>perform Process_Early_Distributions</action_dsl>
 <action_postfix>
 job.early_distributions length 0 &gt; if
   Process_Early_Distributions
@@ -2241,7 +2241,7 @@ endif
 <action_details>
 <action_number>7</action_number>
 <action_comment>Calculate Schedule H (household employment taxes)</action_comment>
-<action_description>perform Calculate_Schedule_H</action_description>
+<action_dsl>perform Calculate_Schedule_H</action_dsl>
 <action_postfix>
 Calculate_Schedule_H
 </action_postfix>
@@ -2250,7 +2250,7 @@ Calculate_Schedule_H
 <action_details>
 <action_number>8</action_number>
 <action_comment>Calculate total tax before credits</action_comment>
-<action_description>set result.total_tax_before_credits = result.regular_tax + result.capital_gains_tax + result.se_tax + result.niit_tax + result.additional_medicare_tax</action_description>
+<action_dsl>set result.total_tax_before_credits = result.regular_tax + result.capital_gains_tax + result.se_tax + result.niit_tax + result.additional_medicare_tax</action_dsl>
 <action_postfix>
 result.regular_tax result.capital_gains_tax f+ result.se_tax f+ result.niit_tax f+ result.additional_medicare_tax f+ result.schedule_h_total_tax f+ result.total_early_withdrawal_penalty f+ /result.total_tax_before_credits xdef
 "  Total Tax Before Credits: $" result.total_tax_before_credits cvs strconcat job.audit_trail swap addto
@@ -2279,7 +2279,7 @@ result.regular_tax result.capital_gains_tax f+ result.se_tax f+ result.niit_tax 
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly; job.filing_status is equal to "MFJ" or job.filing_status is equal to "QSS"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 job.filing_status MFJ streq job.filing_status QSS streq or
 </condition_postfix>
@@ -2288,7 +2288,7 @@ job.filing_status MFJ streq job.filing_status QSS streq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single or other</condition_comment>
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>
 otherwise
 </condition_postfix>
@@ -2299,7 +2299,7 @@ otherwise
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate MFJ tax</action_comment>
-<action_description>perform Apply_Tax_Brackets_MFJ</action_description>
+<action_dsl>perform Apply_Tax_Brackets_MFJ</action_dsl>
 <action_postfix>
 Apply_Tax_Brackets_MFJ
 "  Line 16 - Regular Tax (MFJ brackets): $" result.regular_tax cvs strconcat " per IRC 1(a)" strconcat job.audit_trail swap addto
@@ -2309,7 +2309,7 @@ Apply_Tax_Brackets_MFJ
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate Single tax</action_comment>
-<action_description>perform Apply_Tax_Brackets_Single</action_description>
+<action_dsl>perform Apply_Tax_Brackets_Single</action_dsl>
 <action_postfix>
 Apply_Tax_Brackets_Single
 "  Line 16 - Regular Tax (Single brackets): $" result.regular_tax cvs strconcat " per IRC 1(c)" strconcat job.audit_trail swap addto
@@ -2347,7 +2347,7 @@ Apply_Tax_Brackets_Single
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>In bracket 1 only; taxable_income at or below bracket_1_mfj</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income bracket_1_mfj &lt;=
 </condition_postfix>
@@ -2362,7 +2362,7 @@ result.taxable_income bracket_1_mfj &lt;=
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>In bracket 2; taxable_income at or below bracket_2_mfj</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income bracket_2_mfj &lt;=
 </condition_postfix>
@@ -2377,7 +2377,7 @@ result.taxable_income bracket_2_mfj &lt;=
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>In bracket 3; taxable_income at or below bracket_3_mfj</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income bracket_3_mfj &lt;=
 </condition_postfix>
@@ -2392,7 +2392,7 @@ result.taxable_income bracket_3_mfj &lt;=
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>In bracket 4; taxable_income at or below bracket_4_mfj</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income bracket_4_mfj &lt;=
 </condition_postfix>
@@ -2407,7 +2407,7 @@ result.taxable_income bracket_4_mfj &lt;=
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>In bracket 5; taxable_income at or below bracket_5_mfj</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income bracket_5_mfj &lt;=
 </condition_postfix>
@@ -2422,7 +2422,7 @@ result.taxable_income bracket_5_mfj &lt;=
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>In bracket 6; taxable_income at or below bracket_6_mfj</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income bracket_6_mfj &lt;=
 </condition_postfix>
@@ -2439,7 +2439,7 @@ result.taxable_income bracket_6_mfj &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Bracket 1 tax</action_comment>
-<action_description>set result.regular_tax = result.taxable_income * bracket_1_rate</action_description>
+<action_dsl>set result.regular_tax = result.taxable_income * bracket_1_rate</action_dsl>
 <action_postfix>
 result.taxable_income bracket_1_rate f* /result.regular_tax xdef
 </action_postfix>
@@ -2448,7 +2448,7 @@ result.taxable_income bracket_1_rate f* /result.regular_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bracket 2 tax; set result.regular_tax = tax at bracket_1 + excess taxed at bracket_2_rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 bracket_1_mfj bracket_1_rate f*
 result.taxable_income bracket_1_mfj f- bracket_2_rate f* f+
@@ -2459,7 +2459,7 @@ result.taxable_income bracket_1_mfj f- bracket_2_rate f* f+
 <action_details>
 <action_number>3</action_number>
 <action_comment>Bracket 3 tax; set result.regular_tax = tax at brackets 1-2 + excess taxed at bracket_3_rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 bracket_1_mfj bracket_1_rate f*
 bracket_2_mfj bracket_1_mfj f- bracket_2_rate f* f+
@@ -2471,7 +2471,7 @@ result.taxable_income bracket_2_mfj f- bracket_3_rate f* f+
 <action_details>
 <action_number>4</action_number>
 <action_comment>Bracket 4 tax; set result.regular_tax = tax at brackets 1-3 + excess taxed at bracket_4_rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 bracket_1_mfj bracket_1_rate f*
 bracket_2_mfj bracket_1_mfj f- bracket_2_rate f* f+
@@ -2484,7 +2484,7 @@ result.taxable_income bracket_3_mfj f- bracket_4_rate f* f+
 <action_details>
 <action_number>5</action_number>
 <action_comment>Bracket 5 tax; set result.regular_tax = tax at brackets 1-4 + excess taxed at bracket_5_rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 bracket_1_mfj bracket_1_rate f*
 bracket_2_mfj bracket_1_mfj f- bracket_2_rate f* f+
@@ -2498,7 +2498,7 @@ result.taxable_income bracket_4_mfj f- bracket_5_rate f* f+
 <action_details>
 <action_number>6</action_number>
 <action_comment>Bracket 6 tax; set result.regular_tax = tax at brackets 1-5 + excess taxed at bracket_6_rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 bracket_1_mfj bracket_1_rate f*
 bracket_2_mfj bracket_1_mfj f- bracket_2_rate f* f+
@@ -2513,7 +2513,7 @@ result.taxable_income bracket_5_mfj f- bracket_6_rate f* f+
 <action_details>
 <action_number>7</action_number>
 <action_comment>Bracket 7 tax; set result.regular_tax = tax at brackets 1-6 + excess taxed at bracket_7_rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 bracket_1_mfj bracket_1_rate f*
 bracket_2_mfj bracket_1_mfj f- bracket_2_rate f* f+
@@ -2548,7 +2548,7 @@ result.taxable_income bracket_6_mfj f- bracket_7_rate f* f+
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>In bracket 1 only; taxable_income at or below bracket_1_single</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income bracket_1_single &lt;=
 </condition_postfix>
@@ -2563,7 +2563,7 @@ result.taxable_income bracket_1_single &lt;=
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>In bracket 2; taxable_income at or below bracket_2_single</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income bracket_2_single &lt;=
 </condition_postfix>
@@ -2578,7 +2578,7 @@ result.taxable_income bracket_2_single &lt;=
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>In bracket 3; taxable_income at or below bracket_3_single</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income bracket_3_single &lt;=
 </condition_postfix>
@@ -2593,7 +2593,7 @@ result.taxable_income bracket_3_single &lt;=
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>In bracket 4; taxable_income at or below bracket_4_single</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income bracket_4_single &lt;=
 </condition_postfix>
@@ -2608,7 +2608,7 @@ result.taxable_income bracket_4_single &lt;=
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>In bracket 5; taxable_income at or below bracket_5_single</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income bracket_5_single &lt;=
 </condition_postfix>
@@ -2623,7 +2623,7 @@ result.taxable_income bracket_5_single &lt;=
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>In bracket 6; taxable_income at or below bracket_6_single</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income bracket_6_single &lt;=
 </condition_postfix>
@@ -2640,7 +2640,7 @@ result.taxable_income bracket_6_single &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Bracket 1 tax</action_comment>
-<action_description>set result.regular_tax = result.taxable_income * bracket_1_rate</action_description>
+<action_dsl>set result.regular_tax = result.taxable_income * bracket_1_rate</action_dsl>
 <action_postfix>
 result.taxable_income bracket_1_rate f* /result.regular_tax xdef
 </action_postfix>
@@ -2649,7 +2649,7 @@ result.taxable_income bracket_1_rate f* /result.regular_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bracket 2 tax; set result.regular_tax = tax at bracket_1 + excess taxed at bracket_2_rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 bracket_1_single bracket_1_rate f*
 result.taxable_income bracket_1_single f- bracket_2_rate f* f+
@@ -2660,7 +2660,7 @@ result.taxable_income bracket_1_single f- bracket_2_rate f* f+
 <action_details>
 <action_number>3</action_number>
 <action_comment>Bracket 3 tax; set result.regular_tax = tax at brackets 1-2 + excess taxed at bracket_3_rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 bracket_1_single bracket_1_rate f*
 bracket_2_single bracket_1_single f- bracket_2_rate f* f+
@@ -2672,7 +2672,7 @@ result.taxable_income bracket_2_single f- bracket_3_rate f* f+
 <action_details>
 <action_number>4</action_number>
 <action_comment>Bracket 4 tax; set result.regular_tax = tax at brackets 1-3 + excess taxed at bracket_4_rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 bracket_1_single bracket_1_rate f*
 bracket_2_single bracket_1_single f- bracket_2_rate f* f+
@@ -2685,7 +2685,7 @@ result.taxable_income bracket_3_single f- bracket_4_rate f* f+
 <action_details>
 <action_number>5</action_number>
 <action_comment>Bracket 5 tax; set result.regular_tax = tax at brackets 1-4 + excess taxed at bracket_5_rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 bracket_1_single bracket_1_rate f*
 bracket_2_single bracket_1_single f- bracket_2_rate f* f+
@@ -2699,7 +2699,7 @@ result.taxable_income bracket_4_single f- bracket_5_rate f* f+
 <action_details>
 <action_number>6</action_number>
 <action_comment>Bracket 6 tax; set result.regular_tax = tax at brackets 1-5 + excess taxed at bracket_6_rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 bracket_1_single bracket_1_rate f*
 bracket_2_single bracket_1_single f- bracket_2_rate f* f+
@@ -2714,7 +2714,7 @@ result.taxable_income bracket_5_single f- bracket_6_rate f* f+
 <action_details>
 <action_number>7</action_number>
 <action_comment>Bracket 7 tax; set result.regular_tax = tax at brackets 1-6 + excess taxed at bracket_7_rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 bracket_1_single bracket_1_rate f*
 bracket_2_single bracket_1_single f- bracket_2_rate f* f+
@@ -2746,7 +2746,7 @@ result.taxable_income bracket_6_single f- bracket_7_rate f* f+
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.total_ctc xdef
 0.0 /result.total_odc xdef
@@ -2760,7 +2760,7 @@ result.taxable_income bracket_6_single f- bracket_7_rate f* f+
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always process credits</condition_comment>
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -2771,7 +2771,7 @@ perform when called
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate child tax credits for all dependents; for all dependents perform Calculate_Child_Tax_Credit</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 { /Calculate_Child_Tax_Credit executetable } job.dependents forall
 </action_postfix>
@@ -2780,7 +2780,7 @@ perform when called
 <action_details>
 <action_number>2</action_number>
 <action_comment>Apply CTC phase-out per IRC 24(b)</action_comment>
-<action_description>perform Calculate_CTC_Phase_Out</action_description>
+<action_dsl>perform Calculate_CTC_Phase_Out</action_dsl>
 <action_postfix>
 result.total_ctc result.total_odc f+ /result.ctc_before_phaseout xdef
 Calculate_CTC_Phase_Out
@@ -2790,7 +2790,7 @@ Calculate_CTC_Phase_Out
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate EITC</action_comment>
-<action_description>perform Calculate_EITC</action_description>
+<action_dsl>perform Calculate_EITC</action_dsl>
 <action_postfix>
 Calculate_EITC
 </action_postfix>
@@ -2799,7 +2799,7 @@ Calculate_EITC
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate education credits</action_comment>
-<action_description>perform Calculate_Education_Credits</action_description>
+<action_dsl>perform Calculate_Education_Credits</action_dsl>
 <action_postfix>
 Calculate_Education_Credits
 </action_postfix>
@@ -2808,7 +2808,7 @@ Calculate_Education_Credits
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate Child and Dependent Care Credit</action_comment>
-<action_description>perform Calculate_CDCC</action_description>
+<action_dsl>perform Calculate_CDCC</action_dsl>
 <action_postfix>
 Calculate_CDCC
 </action_postfix>
@@ -2817,7 +2817,7 @@ Calculate_CDCC
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate Saver's Credit</action_comment>
-<action_description>perform Calculate_Savers_Credit</action_description>
+<action_dsl>perform Calculate_Savers_Credit</action_dsl>
 <action_postfix>
 Calculate_Savers_Credit
 </action_postfix>
@@ -2826,7 +2826,7 @@ Calculate_Savers_Credit
 <action_details>
 <action_number>7</action_number>
 <action_comment>Calculate Energy Credits</action_comment>
-<action_description>perform Calculate_Energy_Credits</action_description>
+<action_dsl>perform Calculate_Energy_Credits</action_dsl>
 <action_postfix>
 Calculate_Energy_Credits
 </action_postfix>
@@ -2835,7 +2835,7 @@ Calculate_Energy_Credits
 <action_details>
 <action_number>8</action_number>
 <action_comment>Calculate Premium Tax Credit</action_comment>
-<action_description>perform Calculate_Premium_Tax_Credit</action_description>
+<action_dsl>perform Calculate_Premium_Tax_Credit</action_dsl>
 <action_postfix>
 Calculate_Premium_Tax_Credit
 </action_postfix>
@@ -2844,7 +2844,7 @@ Calculate_Premium_Tax_Credit
 <action_details>
 <action_number>9</action_number>
 <action_comment>Calculate Foreign Tax Credit (Form 1116)</action_comment>
-<action_description>perform Calculate_Foreign_Tax_Credit</action_description>
+<action_dsl>perform Calculate_Foreign_Tax_Credit</action_dsl>
 <action_postfix>
 Calculate_Foreign_Tax_Credit
 </action_postfix>
@@ -2853,7 +2853,7 @@ Calculate_Foreign_Tax_Credit
 <action_details>
 <action_number>10</action_number>
 <action_comment>Calculate DC First-Time Homebuyer Credit (Form 8859)</action_comment>
-<action_description>perform Calculate_DC_Homebuyer_Credit</action_description>
+<action_dsl>perform Calculate_DC_Homebuyer_Credit</action_dsl>
 <action_postfix>
 Calculate_DC_Homebuyer_Credit
 </action_postfix>
@@ -2862,7 +2862,7 @@ Calculate_DC_Homebuyer_Credit
 <action_details>
 <action_number>11</action_number>
 <action_comment>Calculate Mortgage Interest Credit (Form 8396)</action_comment>
-<action_description>perform Calculate_Mortgage_Interest_Credit</action_description>
+<action_dsl>perform Calculate_Mortgage_Interest_Credit</action_dsl>
 <action_postfix>
 Calculate_Mortgage_Interest_Credit
 </action_postfix>
@@ -2871,7 +2871,7 @@ Calculate_Mortgage_Interest_Credit
 <action_details>
 <action_number>12</action_number>
 <action_comment>Calculate Energy Efficient Appliance Credit (Form 8909)</action_comment>
-<action_description>perform Calculate_Energy_Appliance_Credit</action_description>
+<action_dsl>perform Calculate_Energy_Appliance_Credit</action_dsl>
 <action_postfix>
 Calculate_Energy_Appliance_Credit
 </action_postfix>
@@ -2880,7 +2880,7 @@ Calculate_Energy_Appliance_Credit
 <action_details>
 <action_number>13</action_number>
 <action_comment>Calculate General Business Credit (Form 3800)</action_comment>
-<action_description>perform Calculate_General_Business_Credit</action_description>
+<action_dsl>perform Calculate_General_Business_Credit</action_dsl>
 <action_postfix>
 Calculate_General_Business_Credit
 </action_postfix>
@@ -2889,7 +2889,7 @@ Calculate_General_Business_Credit
 <action_details>
 <action_number>14</action_number>
 <action_comment>Calculate Prior Year AMT Credit (Form 8801) - Schedule 3 Line 6b</action_comment>
-<action_description>perform Calculate_Prior_Year_AMT_Credit</action_description>
+<action_dsl>perform Calculate_Prior_Year_AMT_Credit</action_dsl>
 <action_postfix>
 Calculate_Prior_Year_AMT_Credit
 </action_postfix>
@@ -2898,7 +2898,7 @@ Calculate_Prior_Year_AMT_Credit
 <action_details>
 <action_number>15</action_number>
 <action_comment>Process Adoption Credit (Form 8839) - Schedule 3 Line 6c</action_comment>
-<action_description>perform Process_Adoption_Credit</action_description>
+<action_dsl>perform Process_Adoption_Credit</action_dsl>
 <action_postfix>
 Process_Adoption_Credit
 </action_postfix>
@@ -2907,7 +2907,7 @@ Process_Adoption_Credit
 <action_details>
 <action_number>16</action_number>
 <action_comment>Calculate Elderly/Disabled Credit (Schedule R) - Schedule 3 Line 6d</action_comment>
-<action_description>perform Calculate_Elderly_Disabled_Credit</action_description>
+<action_dsl>perform Calculate_Elderly_Disabled_Credit</action_dsl>
 <action_postfix>
 Calculate_Elderly_Disabled_Credit
 </action_postfix>
@@ -2916,7 +2916,7 @@ Calculate_Elderly_Disabled_Credit
 <action_details>
 <action_number>17</action_number>
 <action_comment>Process Clean Vehicle Credit (Form 8936) - Nonrefundable</action_comment>
-<action_description>perform Process_Clean_Vehicle_Credit</action_description>
+<action_dsl>perform Process_Clean_Vehicle_Credit</action_dsl>
 <action_postfix>
 Process_Clean_Vehicle_Credit
 </action_postfix>
@@ -2925,7 +2925,7 @@ Process_Clean_Vehicle_Credit
 <action_details>
 <action_number>18</action_number>
 <action_comment>Sum total credits; set result.total_credits = sum of all nonrefundable credit amounts (education credit less AOTC refundable portion)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.total_ctc result.total_odc f+ result.education_credit f+ result.total_aotc_refundable f-
 result.cdcc_credit f+ result.savers_credit f+ result.energy_efficiency_credit f+ result.clean_energy_credit f+
@@ -2980,7 +2980,7 @@ result.total_clean_vehicle_credit f+ /result.total_credits xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly or Qualifying Surviving Spouse; job.filing_status is equal to "MFJ" or job.filing_status is equal to "QSS"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 job.filing_status MFJ streq job.filing_status QSS streq or
 </condition_postfix>
@@ -2994,7 +2994,7 @@ job.filing_status MFJ streq job.filing_status QSS streq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>AGI exceeds MFJ phase-out threshold</condition_comment>
-<condition_description>result.agi &gt; ctc_phaseout_mfj</condition_description>
+<condition_dsl>result.agi &gt; ctc_phaseout_mfj</condition_dsl>
 <condition_postfix>
 result.agi constants.ctc_phase_out_mfj &gt;
 </condition_postfix>
@@ -3008,7 +3008,7 @@ result.agi constants.ctc_phase_out_mfj &gt;
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>AGI exceeds Single phase-out threshold</condition_comment>
-<condition_description>result.agi &gt; ctc_phaseout_single</condition_description>
+<condition_dsl>result.agi &gt; ctc_phaseout_single</condition_dsl>
 <condition_postfix>
 result.agi constants.ctc_phase_out_single &gt;
 </condition_postfix>
@@ -3022,7 +3022,7 @@ result.agi constants.ctc_phase_out_single &gt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Has credits to phase out</condition_comment>
-<condition_description>result.ctc_before_phaseout &gt; 0</condition_description>
+<condition_dsl>result.ctc_before_phaseout &gt; 0</condition_dsl>
 <condition_postfix>
 result.ctc_before_phaseout 0 &gt;
 </condition_postfix>
@@ -3038,7 +3038,7 @@ result.ctc_before_phaseout 0 &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Set MFJ threshold and calculate values; set result.ctc_threshold = constants.ctc_phase_out_mfj</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 constants.ctc_phase_out_mfj /result.ctc_threshold xdef
 result.agi result.ctc_threshold f- /result.agi_over_threshold xdef
@@ -3050,7 +3050,7 @@ result.agi result.ctc_threshold f- /result.agi_over_threshold xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Set Single threshold and calculate values; set result.ctc_threshold = constants.ctc_phase_out_single</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 constants.ctc_phase_out_single /result.ctc_threshold xdef
 result.agi result.ctc_threshold f- /result.agi_over_threshold xdef
@@ -3062,7 +3062,7 @@ result.agi result.ctc_threshold f- /result.agi_over_threshold xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate phase-out reduction for MFJ with credits over threshold; set result.ctc_phase_out_reduction = ($50 per $1000 over threshold), reduce credits proportionally</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.agi_over_threshold 1000.0 fdiv ceiling constants.ctc_phase_out_rate f* result.ctc_before_phaseout fmin /result.ctc_phase_out_reduction xdef
 result.ctc_before_phaseout result.ctc_phase_out_reduction f- 0.0 fmax /result.ctc_after_phaseout xdef
@@ -3077,7 +3077,7 @@ result.ctc_after_phaseout result.ctc_before_phaseout fdiv result.total_odc f* fl
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate phase-out reduction for Single with credits over threshold; set result.ctc_phase_out_reduction = ($50 per $1000 over threshold), reduce credits proportionally</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.agi_over_threshold 1000.0 fdiv ceiling constants.ctc_phase_out_rate f* result.ctc_before_phaseout fmin /result.ctc_phase_out_reduction xdef
 result.ctc_before_phaseout result.ctc_phase_out_reduction f- 0.0 fmax /result.ctc_after_phaseout xdef
@@ -3092,7 +3092,7 @@ result.ctc_after_phaseout result.ctc_before_phaseout fdiv result.total_odc f* fl
 <action_details>
 <action_number>5</action_number>
 <action_comment>AGI over threshold but no credits to reduce; set result.ctc_phase_out_reduction = 0, set result.ctc_after_phaseout = 0</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.agi_over_threshold 1000.0 fdiv ceiling constants.ctc_phase_out_rate f* 0.0 fmin /result.ctc_phase_out_reduction xdef
 0.0 /result.ctc_after_phaseout xdef
@@ -3103,7 +3103,7 @@ result.agi_over_threshold 1000.0 fdiv ceiling constants.ctc_phase_out_rate f* 0.
 <action_details>
 <action_number>6</action_number>
 <action_comment>AGI does not exceed threshold</action_comment>
-<action_description>set result.ctc_after_phaseout = result.ctc_before_phaseout</action_description>
+<action_dsl>set result.ctc_after_phaseout = result.ctc_before_phaseout</action_dsl>
 <action_postfix>
 0.0 /result.agi_over_threshold xdef
 0.0 /result.ctc_phase_out_reduction xdef
@@ -3159,7 +3159,7 @@ result.ctc_before_phaseout /result.ctc_after_phaseout xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is a qualifying child (relationship)</condition_comment>
-<condition_description>dependent.relationship is equal to "child"</condition_description>
+<condition_dsl>dependent.relationship is equal to "child"</condition_dsl>
 <condition_postfix>
 dependent.relationship "child" streq
 </condition_postfix>
@@ -3170,7 +3170,7 @@ dependent.relationship "child" streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Under age 17 at end of year</condition_comment>
-<condition_description>dependent.age &lt; ctc_age_limit</condition_description>
+<condition_dsl>dependent.age &lt; ctc_age_limit</condition_dsl>
 <condition_postfix>
 dependent.age ctc_age_limit &lt;
 </condition_postfix>
@@ -3180,7 +3180,7 @@ dependent.age ctc_age_limit &lt;
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Has valid SSN</condition_comment>
-<condition_description>dependent.has_ssn == true</condition_description>
+<condition_dsl>dependent.has_ssn == true</condition_dsl>
 <condition_postfix>
 dependent.has_ssn true beq
 </condition_postfix>
@@ -3192,7 +3192,7 @@ dependent.has_ssn true beq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Award Child Tax Credit</action_comment>
-<action_description>add constants.ctc_amount to result.total_ctc</action_description>
+<action_dsl>add constants.ctc_amount to result.total_ctc</action_dsl>
 <action_postfix>
 true /dependent.qualifies_for_ctc xdef
 constants.ctc_amount /dependent.ctc_amount xdef
@@ -3205,7 +3205,7 @@ dependent.ctc_amount result.total_ctc f+ /result.total_ctc xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Award Other Dependent Credit (age 17)</action_comment>
-<action_description>add constants.odc_amount to result.total_odc</action_description>
+<action_dsl>add constants.odc_amount to result.total_odc</action_dsl>
 <action_postfix>
 true /dependent.qualifies_for_odc xdef
 constants.odc_amount /dependent.odc_amount xdef
@@ -3219,7 +3219,7 @@ dependent.odc_amount result.total_odc f+ /result.total_odc xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Non-child dependent gets ODC</action_comment>
-<action_description>add constants.odc_amount to result.total_odc</action_description>
+<action_dsl>add constants.odc_amount to result.total_odc</action_dsl>
 <action_postfix>
 true /dependent.qualifies_for_odc xdef
 constants.odc_amount /dependent.odc_amount xdef
@@ -3261,7 +3261,7 @@ dependent.odc_amount result.total_odc f+ /result.total_odc xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 "FINAL CALCULATION (Form 1040 Lines 33-37)" job.audit_trail swap addto
 result.total_tax_before_credits result.amt_owed f+ /result.tax_before_nonrefundable_credits xdef
@@ -3287,7 +3287,7 @@ Calculate_MI_Tax
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Total tax is negative (floor at zero)</condition_comment>
-<condition_description>result.total_tax &lt; 0</condition_description>
+<condition_dsl>result.total_tax &lt; 0</condition_dsl>
 <condition_postfix>
 result.total_tax 0 &lt;
 </condition_postfix>
@@ -3298,7 +3298,7 @@ result.total_tax 0 &lt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Payments exceed tax (refund)</condition_comment>
-<condition_description>result.total_payments &gt; result.total_tax</condition_description>
+<condition_dsl>result.total_payments &gt; result.total_tax</condition_dsl>
 <condition_postfix>
 result.total_payments result.total_tax &gt;
 </condition_postfix>
@@ -3311,7 +3311,7 @@ result.total_payments result.total_tax &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Floor total tax at zero</action_comment>
-<action_description>set result.total_tax = 0</action_description>
+<action_dsl>set result.total_tax = 0</action_dsl>
 <action_postfix>
 0.0 /result.total_tax xdef
 "  Total Tax floored at $0 (credits exceeded tax liability)" job.audit_trail swap addto
@@ -3321,7 +3321,7 @@ result.total_payments result.total_tax &gt;
 <action_details>
 <action_number>2</action_number>
 <action_comment>Log total tax and payments; add tax summary to job.audit_trail</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Line 24 - Total Tax: $" result.total_tax cvs strconcat job.audit_trail swap addto
 "  Line 33 - Total Payments: $" result.total_payments cvs strconcat job.audit_trail swap addto
@@ -3333,7 +3333,7 @@ result.total_payments result.total_tax &gt;
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate refund</action_comment>
-<action_description>set result.refund_or_owed = result.total_payments - result.total_tax</action_description>
+<action_dsl>set result.refund_or_owed = result.total_payments - result.total_tax</action_dsl>
 <action_postfix>
 result.total_payments result.total_tax f- /result.refund_or_owed xdef
 "  Line 34 - REFUND: $" result.refund_or_owed cvs strconcat job.audit_trail swap addto
@@ -3350,7 +3350,7 @@ result.total_payments result.total_tax f- /result.refund_or_owed xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate amount owed</action_comment>
-<action_description>set result.refund_or_owed = result.total_tax - result.total_payments</action_description>
+<action_dsl>set result.refund_or_owed = result.total_tax - result.total_payments</action_dsl>
 <action_postfix>
 result.total_tax result.total_payments f- /result.refund_or_owed xdef
 "  Line 37 - AMOUNT OWED: $" result.refund_or_owed cvs strconcat job.audit_trail swap addto
@@ -3395,7 +3395,7 @@ result.total_tax result.total_payments f- /result.refund_or_owed xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 0 allocate
 { Count_EITC_Qualifying_Child performaliased } job.dependents forall
@@ -3408,7 +3408,7 @@ deallocate pop
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has earned income</condition_comment>
-<condition_description>result.total_earned_income &gt; 0</condition_description>
+<condition_dsl>result.total_earned_income &gt; 0</condition_dsl>
 <condition_postfix>
 result.total_w2_wages result.total_se_income f+ 0 &gt;
 </condition_postfix>
@@ -3425,7 +3425,7 @@ result.total_w2_wages result.total_se_income f+ 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>3+ qualifying children; EITC qualifying children 3 or more</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.eitc_qualifying_children 3 &gt;=
 </condition_postfix>
@@ -3442,7 +3442,7 @@ result.eitc_qualifying_children 3 &gt;=
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>2 qualifying children; result.eitc_qualifying_children == 2</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.eitc_qualifying_children 2 ==
 </condition_postfix>
@@ -3459,7 +3459,7 @@ result.eitc_qualifying_children 2 ==
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>1 qualifying child; result.eitc_qualifying_children == 1</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.eitc_qualifying_children 1 ==
 </condition_postfix>
@@ -3476,7 +3476,7 @@ result.eitc_qualifying_children 1 ==
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>0 qualifying children; result.eitc_qualifying_children == 0</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.eitc_qualifying_children 0 ==
 </condition_postfix>
@@ -3493,7 +3493,7 @@ result.eitc_qualifying_children 0 ==
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>AGI below phase-out threshold (3+ children); AGI at or below threshold for 3+ children</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.agi eitc_threshold_mfj_3 &lt;=
 </condition_postfix>
@@ -3510,7 +3510,7 @@ result.agi eitc_threshold_mfj_3 &lt;=
 <condition_details>
 <condition_number>7</condition_number>
 <condition_comment>AGI below phase-out threshold (2 children); AGI at or below threshold for 2 children</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.agi eitc_threshold_mfj_2 &lt;=
 </condition_postfix>
@@ -3527,7 +3527,7 @@ result.agi eitc_threshold_mfj_2 &lt;=
 <condition_details>
 <condition_number>8</condition_number>
 <condition_comment>AGI below phase-out threshold (1 child); AGI at or below threshold for 1 child</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.agi eitc_threshold_mfj_1 &lt;=
 </condition_postfix>
@@ -3544,7 +3544,7 @@ result.agi eitc_threshold_mfj_1 &lt;=
 <condition_details>
 <condition_number>9</condition_number>
 <condition_comment>AGI below phase-out threshold (0 children); AGI at or below threshold for 0 children</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.agi eitc_threshold_mfj_0 &lt;=
 </condition_postfix>
@@ -3563,7 +3563,7 @@ result.agi eitc_threshold_mfj_0 &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>EITC 3+ children - full amount</action_comment>
-<action_description>set result.eitc = eitc_max_3_children</action_description>
+<action_dsl>set result.eitc = eitc_max_3_children</action_dsl>
 <action_postfix>
 eitc_max_3_children /result.eitc xdef
 "  EITC (3+ children): $" result.eitc cvs strconcat " (maximum) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3573,7 +3573,7 @@ eitc_max_3_children /result.eitc xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>EITC 3+ children - phase-out; EITC for 3+ children with phase-out per IRC 32</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 eitc_max_3_children result.agi eitc_threshold_mfj_3 f- 0.2106 f* f- 0 fmax /result.eitc xdef
 "  EITC (3+ children): $" result.eitc cvs strconcat " (phase-out applied) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3583,7 +3583,7 @@ eitc_max_3_children result.agi eitc_threshold_mfj_3 f- 0.2106 f* f- 0 fmax /resu
 <action_details>
 <action_number>3</action_number>
 <action_comment>EITC 2 children - full amount</action_comment>
-<action_description>set result.eitc = eitc_max_2_children</action_description>
+<action_dsl>set result.eitc = eitc_max_2_children</action_dsl>
 <action_postfix>
 eitc_max_2_children /result.eitc xdef
 "  EITC (2 children): $" result.eitc cvs strconcat " (maximum) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3593,7 +3593,7 @@ eitc_max_2_children /result.eitc xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>EITC 2 children - phase-out; EITC for 2 children with phase-out per IRC 32</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 eitc_max_2_children result.agi eitc_threshold_mfj_2 f- 0.2106 f* f- 0 fmax /result.eitc xdef
 "  EITC (2 children): $" result.eitc cvs strconcat " (phase-out applied) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3603,7 +3603,7 @@ eitc_max_2_children result.agi eitc_threshold_mfj_2 f- 0.2106 f* f- 0 fmax /resu
 <action_details>
 <action_number>5</action_number>
 <action_comment>EITC 1 child - full amount</action_comment>
-<action_description>set result.eitc = eitc_max_1_child</action_description>
+<action_dsl>set result.eitc = eitc_max_1_child</action_dsl>
 <action_postfix>
 eitc_max_1_child /result.eitc xdef
 "  EITC (1 child): $" result.eitc cvs strconcat " (maximum) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3613,7 +3613,7 @@ eitc_max_1_child /result.eitc xdef
 <action_details>
 <action_number>6</action_number>
 <action_comment>EITC 1 child - phase-out; EITC for 1 child with phase-out per IRC 32</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 eitc_max_1_child result.agi eitc_threshold_mfj_1 f- 0.1598 f* f- 0 fmax /result.eitc xdef
 "  EITC (1 child): $" result.eitc cvs strconcat " (phase-out applied) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3623,7 +3623,7 @@ eitc_max_1_child result.agi eitc_threshold_mfj_1 f- 0.1598 f* f- 0 fmax /result.
 <action_details>
 <action_number>7</action_number>
 <action_comment>EITC 0 children - full amount</action_comment>
-<action_description>set result.eitc = eitc_max_0_children</action_description>
+<action_dsl>set result.eitc = eitc_max_0_children</action_dsl>
 <action_postfix>
 eitc_max_0_children /result.eitc xdef
 "  EITC (0 children): $" result.eitc cvs strconcat " (maximum) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3633,7 +3633,7 @@ eitc_max_0_children /result.eitc xdef
 <action_details>
 <action_number>8</action_number>
 <action_comment>EITC 0 children - phase-out; EITC for 0 children with phase-out per IRC 32</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 eitc_max_0_children result.agi eitc_threshold_mfj_0 f- 0.0765 f* f- 0 fmax /result.eitc xdef
 "  EITC (0 children): $" result.eitc cvs strconcat " (phase-out applied) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3643,7 +3643,7 @@ eitc_max_0_children result.agi eitc_threshold_mfj_0 f- 0.0765 f* f- 0 fmax /resu
 <action_details>
 <action_number>9</action_number>
 <action_comment>No EITC - no earned income</action_comment>
-<action_description>set result.eitc = 0</action_description>
+<action_dsl>set result.eitc = 0</action_dsl>
 <action_postfix>
 0.0 /result.eitc xdef
 "  EITC: $0 - No earned income" job.audit_trail swap addto
@@ -3669,7 +3669,7 @@ eitc_max_0_children result.agi eitc_threshold_mfj_0 f- 0.0765 f* f- 0 fmax /resu
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.education_credit xdef
 0.0 /result.total_aotc_refundable xdef
@@ -3682,7 +3682,7 @@ eitc_max_0_children result.agi eitc_threshold_mfj_0 f- 0.0765 f* f- 0 fmax /resu
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always process</condition_comment>
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -3693,7 +3693,7 @@ perform when called
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log education credit total; add education credit summary to job.audit_trail, showing AOTC split</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Total Education Credits: $" result.education_credit cvs strconcat job.audit_trail swap addto
 "    AOTC Refundable (40%, max $1,000): $" result.total_aotc_refundable cvs strconcat " per IRC 25A(i)(5)" strconcat job.audit_trail swap addto
@@ -3724,7 +3724,7 @@ perform when called
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is college student</condition_comment>
-<condition_description>dependent.is_college_student == true</condition_description>
+<condition_dsl>dependent.is_college_student == true</condition_dsl>
 <condition_postfix>
 dependent.is_college_student true beq
 </condition_postfix>
@@ -3737,7 +3737,7 @@ dependent.is_college_student true beq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Eligible for AOTC (years 1-4, not exhausted)</condition_comment>
-<condition_description>dependent.college_year &gt;= 1 and dependent.college_year &lt;= 4 and dependent.aotc_used_years &lt; 4</condition_description>
+<condition_dsl>dependent.college_year &gt;= 1 and dependent.college_year &lt;= 4 and dependent.aotc_used_years &lt; 4</condition_dsl>
 <condition_postfix>
 dependent.college_year 1 &gt;= dependent.college_year 4 &lt;= and dependent.aotc_used_years 4 &lt; and
 </condition_postfix>
@@ -3750,7 +3750,7 @@ dependent.college_year 1 &gt;= dependent.college_year 4 &lt;= and dependent.aotc
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>AGI in AOTC phase-out range</condition_comment>
-<condition_description>result.agi &gt; aotc_phase_out_mfj</condition_description>
+<condition_dsl>result.agi &gt; aotc_phase_out_mfj</condition_dsl>
 <condition_postfix>
 result.agi aotc_phase_out_mfj &gt;
 </condition_postfix>
@@ -3763,7 +3763,7 @@ result.agi aotc_phase_out_mfj &gt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>AGI in LLC phase-out range</condition_comment>
-<condition_description>result.agi &gt; llc_phase_out_mfj</condition_description>
+<condition_dsl>result.agi &gt; llc_phase_out_mfj</condition_dsl>
 <condition_postfix>
 result.agi llc_phase_out_mfj &gt;
 </condition_postfix>
@@ -3778,7 +3778,7 @@ result.agi llc_phase_out_mfj &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate AOTC (full amount); AOTC: 100% of first $2000 + 25% of next $2000, split into refundable (40%, max $1,000) and nonrefundable (60%)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 dependent.qualified_expenses 2000.0 fmin dependent.qualified_expenses 2000.0 f- 0.0 fmax 0.25 f* f+ aotc_max fmin /dependent.education_credit xdef
 dependent.education_credit 0.40 f* 1000 fmin result.total_aotc_refundable f+ /result.total_aotc_refundable xdef
@@ -3791,7 +3791,7 @@ dependent.education_credit result.education_credit f+ /result.education_credit x
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate AOTC with phase-out; AOTC with AGI phase-out reduction, split into refundable (40%, max $1,000) and nonrefundable (60%)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 dependent.qualified_expenses 2000.0 fmin dependent.qualified_expenses 2000.0 f- 0.0 fmax 0.25 f* f+ aotc_max fmin /dependent.education_credit xdef
 dependent.education_credit aotc_phase_out_end_mfj result.agi f- aotc_phase_out_end_mfj aotc_phase_out_mfj f- fdiv f* /dependent.education_credit xdef
@@ -3805,7 +3805,7 @@ dependent.education_credit result.education_credit f+ /result.education_credit x
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate LLC (full amount); LLC: 20% of qualified expenses up to $2000</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 dependent.qualified_expenses 0.20 f* llc_max fmin /dependent.education_credit xdef
 dependent.education_credit result.education_credit f+ /result.education_credit xdef
@@ -3816,7 +3816,7 @@ dependent.education_credit result.education_credit f+ /result.education_credit x
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate LLC with phase-out; LLC with AGI phase-out reduction</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 dependent.qualified_expenses 0.20 f* llc_max fmin /dependent.education_credit xdef
 dependent.education_credit llc_phase_out_end_mfj result.agi f- llc_phase_out_end_mfj llc_phase_out_mfj f- fdiv f* /dependent.education_credit xdef
@@ -3828,7 +3828,7 @@ dependent.education_credit result.education_credit f+ /result.education_credit x
 <action_details>
 <action_number>5</action_number>
 <action_comment>Not a college student; otherwise</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 </action_postfix>
 <action_column column_number="5" column_value="X" />
@@ -3876,7 +3876,7 @@ dependent.education_credit result.education_credit f+ /result.education_credit x
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has qualified business income</condition_comment>
-<condition_description>result.total_se_income &gt; 0</condition_description>
+<condition_dsl>result.total_se_income &gt; 0</condition_dsl>
 <condition_postfix>
 result.total_se_income 0 &gt;
 </condition_postfix>
@@ -3886,7 +3886,7 @@ result.total_se_income 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxable income below threshold (simplified calculation); taxable_income before QBI below $394,600 MFJ threshold (2025)</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.agi result.total_deduction f- 394600 &lt;=
 </condition_postfix>
@@ -3897,7 +3897,7 @@ result.agi result.total_deduction f- 394600 &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate QBI deduction at 20%</action_comment>
-<action_description>set result.qbi_deduction = result.total_se_income * qbi_rate</action_description>
+<action_dsl>set result.qbi_deduction = result.total_se_income * qbi_rate</action_dsl>
 <action_postfix>
 result.total_se_income qbi_rate f* /result.qbi_deduction xdef
 result.agi result.total_deduction f- result.qbi_deduction f- 0.20 f* result.qbi_deduction fmin /result.qbi_deduction xdef
@@ -3909,7 +3909,7 @@ result.agi result.total_deduction f- result.qbi_deduction f- 0.20 f* result.qbi_
 <action_details>
 <action_number>2</action_number>
 <action_comment>No QBI - no qualified business income</action_comment>
-<action_description>set result.qbi_deduction = 0</action_description>
+<action_dsl>set result.qbi_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.qbi_deduction xdef
 "  QBI Deduction: $0 - No qualified business income" job.audit_trail swap addto
@@ -3935,7 +3935,7 @@ result.agi result.total_deduction f- result.qbi_deduction f- 0.20 f* result.qbi_
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>set result.validation_passed = true</action_description>
+<action_dsl>set result.validation_passed = true</action_dsl>
 <action_postfix>
 "VALIDATION RESULTS" job.audit_trail swap addto
 true /result.validation_passed xdef
@@ -3946,7 +3946,7 @@ true /result.validation_passed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Expected values exist</condition_comment>
-<condition_description>job has expected values for validation</condition_description>
+<condition_dsl>job has expected values for validation</condition_dsl>
 <condition_postfix>
 job.expected_agi null neq
 </condition_postfix>
@@ -3958,7 +3958,7 @@ job.expected_agi null neq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Run all validations with guards for each expected value</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 { Validate_AGI } job.expected_agi isnull not if
 { Validate_Taxable_Income } job.expected_taxable_income isnull not if
@@ -3970,7 +3970,7 @@ Validate_Summary
 <action_details>
 <action_number>2</action_number>
 <action_comment>No expected values; add "No expected values provided" to job.audit_trail</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  No expected values provided - validation skipped" job.audit_trail swap addto
 </action_postfix>
@@ -3998,7 +3998,7 @@ Validate_Summary
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>AGI matches expected (within tolerance)</condition_comment>
-<condition_description>agi_difference &lt;= 1.0</condition_description>
+<condition_dsl>agi_difference &lt;= 1.0</condition_dsl>
 <condition_postfix>
 result.agi job.expected_agi f- fabs 1.0 &lt;=
 </condition_postfix>
@@ -4010,7 +4010,7 @@ result.agi job.expected_agi f- fabs 1.0 &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>AGI validation passed; add AGI pass message to job.audit_trail</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  PASS: AGI = $" result.agi cvs strconcat job.audit_trail swap addto
 </action_postfix>
@@ -4019,7 +4019,7 @@ result.agi job.expected_agi f- fabs 1.0 &lt;=
 <action_details>
 <action_number>2</action_number>
 <action_comment>AGI validation failed; add AGI mismatch to job.audit_trail, set result.validation_passed = false</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  FAIL: AGI mismatch - calculated $" result.agi cvs strconcat " vs expected $" strconcat job.expected_agi cvs strconcat job.audit_trail swap addto
 false /result.validation_passed xdef
@@ -4048,7 +4048,7 @@ false /result.validation_passed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Taxable income matches expected</condition_comment>
-<condition_description>taxable_income_difference &lt;= 1.0</condition_description>
+<condition_dsl>taxable_income_difference &lt;= 1.0</condition_dsl>
 <condition_postfix>
 result.taxable_income job.expected_taxable_income f- fabs 1.0 &lt;=
 </condition_postfix>
@@ -4060,7 +4060,7 @@ result.taxable_income job.expected_taxable_income f- fabs 1.0 &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Taxable income validation passed; add taxable income pass message to job.audit_trail</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  PASS: Taxable Income = $" result.taxable_income cvs strconcat job.audit_trail swap addto
 </action_postfix>
@@ -4069,7 +4069,7 @@ result.taxable_income job.expected_taxable_income f- fabs 1.0 &lt;=
 <action_details>
 <action_number>2</action_number>
 <action_comment>Taxable income validation failed; add taxable income mismatch to job.audit_trail, set result.validation_passed = false</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  FAIL: Taxable income mismatch - calculated $" result.taxable_income cvs strconcat " vs expected $" strconcat job.expected_taxable_income cvs strconcat job.audit_trail swap addto
 false /result.validation_passed xdef
@@ -4098,7 +4098,7 @@ false /result.validation_passed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Total tax matches expected</condition_comment>
-<condition_description>total_tax_difference &lt;= 1.0</condition_description>
+<condition_dsl>total_tax_difference &lt;= 1.0</condition_dsl>
 <condition_postfix>
 result.total_tax job.expected_total_tax f- fabs 1.0 &lt;=
 </condition_postfix>
@@ -4110,7 +4110,7 @@ result.total_tax job.expected_total_tax f- fabs 1.0 &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Total tax validation passed; add total tax pass message to job.audit_trail</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  PASS: Total Tax = $" result.total_tax cvs strconcat job.audit_trail swap addto
 </action_postfix>
@@ -4119,7 +4119,7 @@ result.total_tax job.expected_total_tax f- fabs 1.0 &lt;=
 <action_details>
 <action_number>2</action_number>
 <action_comment>Total tax validation failed; add total tax mismatch to job.audit_trail, set result.validation_passed = false</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  FAIL: Total tax mismatch - calculated $" result.total_tax cvs strconcat " vs expected $" strconcat job.expected_total_tax cvs strconcat job.audit_trail swap addto
 false /result.validation_passed xdef
@@ -4148,7 +4148,7 @@ false /result.validation_passed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>All validations passed</condition_comment>
-<condition_description>result.validation_passed == true</condition_description>
+<condition_dsl>result.validation_passed == true</condition_dsl>
 <condition_postfix>
 result.validation_passed true beq
 </condition_postfix>
@@ -4160,7 +4160,7 @@ result.validation_passed true beq
 <action_details>
 <action_number>1</action_number>
 <action_comment>All tests passed</action_comment>
-<action_description>add "VALIDATION: ALL TESTS PASSED" to job.audit_trail</action_description>
+<action_dsl>add "VALIDATION: ALL TESTS PASSED" to job.audit_trail</action_dsl>
 <action_postfix>
 "VALIDATION: ALL TESTS PASSED" job.audit_trail swap addto
 </action_postfix>
@@ -4169,7 +4169,7 @@ result.validation_passed true beq
 <action_details>
 <action_number>2</action_number>
 <action_comment>Some tests failed</action_comment>
-<action_description>add "VALIDATION: SOME TESTS FAILED" to job.audit_trail</action_description>
+<action_dsl>add "VALIDATION: SOME TESTS FAILED" to job.audit_trail</action_dsl>
 <action_postfix>
 "VALIDATION: SOME TESTS FAILED - Review audit trail" job.audit_trail swap addto
 </action_postfix>
@@ -4198,7 +4198,7 @@ result.validation_passed true beq
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Taxpayer is self-employed</condition_comment>
-<condition_description>taxpayer.is_self_employed == true</condition_description>
+<condition_dsl>taxpayer.is_self_employed == true</condition_dsl>
 <condition_postfix>
 is_self_employed true beq
 </condition_postfix>
@@ -4210,7 +4210,7 @@ is_self_employed true beq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process self-employed taxpayer (uses executetable to skip context - avoids infinite recursion)</action_comment>
-<action_description>perform Process_Self_Employment</action_description>
+<action_dsl>perform Process_Self_Employment</action_dsl>
 <action_postfix>
 /Process_Self_Employment executetable
 </action_postfix>
@@ -4219,7 +4219,7 @@ is_self_employed true beq
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-self-employed; otherwise</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -4243,7 +4243,7 @@ is_self_employed true beq
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Vehicle belongs to current taxpayer</condition_comment>
-<condition_description>vehicle.taxpayer_id is equal to taxpayer.id</condition_description>
+<condition_dsl>vehicle.taxpayer_id is equal to taxpayer.id</condition_dsl>
 <condition_postfix>
 taxpayer_id taxpayer.id ==
 </condition_postfix>
@@ -4255,7 +4255,7 @@ taxpayer_id taxpayer.id ==
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process vehicle</action_comment>
-<action_description>perform Calculate_Vehicle_Deduction</action_description>
+<action_dsl>perform Calculate_Vehicle_Deduction</action_dsl>
 <action_postfix>
 Calculate_Vehicle_Deduction
 </action_postfix>
@@ -4264,7 +4264,7 @@ Calculate_Vehicle_Deduction
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip vehicle; otherwise</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -4288,7 +4288,7 @@ Calculate_Vehicle_Deduction
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Property is rental</condition_comment>
-<condition_description>property.type is equal to "rental"</condition_description>
+<condition_dsl>property.type is equal to "rental"</condition_dsl>
 <condition_postfix>
 type "rental" streq
 </condition_postfix>
@@ -4300,7 +4300,7 @@ type "rental" streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process rental</action_comment>
-<action_description>perform Process_Rental_Income</action_description>
+<action_dsl>perform Process_Rental_Income</action_dsl>
 <action_postfix>
 Process_Rental_Income
 </action_postfix>
@@ -4309,7 +4309,7 @@ Process_Rental_Income
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-rental; otherwise</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -4333,7 +4333,7 @@ Process_Rental_Income
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has child relationship</condition_comment>
-<condition_description>relationship is "child"</condition_description>
+<condition_dsl>relationship is "child"</condition_dsl>
 <condition_postfix>
 relationship "child" streq
 </condition_postfix>
@@ -4343,7 +4343,7 @@ relationship "child" streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Meets age test; age &lt; 19 OR (age &lt; 24 AND is_student) OR is_disabled</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 age 19 &lt;
 age 24 &lt; is_student and or
@@ -4355,7 +4355,7 @@ is_disabled or
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Meets residency test</condition_comment>
-<condition_description>months_lived_with &gt; 6</condition_description>
+<condition_dsl>months_lived_with &gt; 6</condition_dsl>
 <condition_postfix>
 months_lived_with 6 &gt;
 </condition_postfix>
@@ -4367,7 +4367,7 @@ months_lived_with 6 &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Increment counter; Qualifies for EITC - increment counter</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0 local@ 1 + 0 local!
 </action_postfix>
@@ -4376,7 +4376,7 @@ months_lived_with 6 &gt;
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-qualifying; Does not qualify for EITC</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -4400,7 +4400,7 @@ months_lived_with 6 &gt;
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has mortgage interest</condition_comment>
-<condition_description>property.mortgage_interest &gt; 0</condition_description>
+<condition_dsl>property.mortgage_interest &gt; 0</condition_dsl>
 <condition_postfix>
 dup mortgage_interest 0 &gt;
 </condition_postfix>
@@ -4412,7 +4412,7 @@ dup mortgage_interest 0 &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process mortgage interest</action_comment>
-<action_description>add property.mortgage_interest to result.total_itemized</action_description>
+<action_dsl>add property.mortgage_interest to result.total_itemized</action_dsl>
 <action_postfix>
 dup mortgage_interest result.total_itemized f+ /result.total_itemized xdef
 "  Mortgage Interest: $" over mortgage_interest cvs strconcat " (Schedule A Line 8a)" strconcat job.audit_trail swap addto
@@ -4423,7 +4423,7 @@ pop
 <action_details>
 <action_number>2</action_number>
 <action_comment>No mortgage interest; otherwise</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 pop
 </action_postfix>
@@ -4448,7 +4448,7 @@ pop
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.tips_deduction xdef
 0.0 /result.overtime_deduction xdef
@@ -4462,7 +4462,7 @@ pop
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always calculate OBBBA deductions</condition_comment>
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -4473,7 +4473,7 @@ perform when called
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate No Tax on Tips deduction</action_comment>
-<action_description>perform Calculate_Tips_Deduction</action_description>
+<action_dsl>perform Calculate_Tips_Deduction</action_dsl>
 <action_postfix>
 Calculate_Tips_Deduction
 </action_postfix>
@@ -4482,7 +4482,7 @@ Calculate_Tips_Deduction
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate No Tax on Overtime deduction</action_comment>
-<action_description>perform Calculate_Overtime_Deduction</action_description>
+<action_dsl>perform Calculate_Overtime_Deduction</action_dsl>
 <action_postfix>
 Calculate_Overtime_Deduction
 </action_postfix>
@@ -4491,7 +4491,7 @@ Calculate_Overtime_Deduction
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Senior Additional deduction</action_comment>
-<action_description>perform Calculate_Senior_Deduction</action_description>
+<action_dsl>perform Calculate_Senior_Deduction</action_dsl>
 <action_postfix>
 Calculate_Senior_Deduction
 </action_postfix>
@@ -4500,7 +4500,7 @@ Calculate_Senior_Deduction
 <action_details>
 <action_number>4</action_number>
 <action_comment>Sum total OBBBA deductions</action_comment>
-<action_description>set result.total_obbba_deductions = result.tips_deduction + result.overtime_deduction + result.senior_deduction</action_description>
+<action_dsl>set result.total_obbba_deductions = result.tips_deduction + result.overtime_deduction + result.senior_deduction</action_dsl>
 <action_postfix>
 result.tips_deduction result.overtime_deduction f+ result.senior_deduction f+ /result.total_obbba_deductions xdef
 "  Total OBBBA Deductions: $" result.total_obbba_deductions cvs strconcat job.audit_trail swap addto
@@ -4530,7 +4530,7 @@ result.tips_deduction result.overtime_deduction f+ result.senior_deduction f+ /r
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has tip income</condition_comment>
-<condition_description>result.total_tip_income &gt; 0</condition_description>
+<condition_dsl>result.total_tip_income &gt; 0</condition_dsl>
 <condition_postfix>
 result.total_tip_income 0 &gt;
 </condition_postfix>
@@ -4543,7 +4543,7 @@ result.total_tip_income 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -4556,7 +4556,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ income below phase-out threshold ($300k); gross income below MFJ tips phase-out threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.gross_income constants.tips_phaseout_joint &lt;
 </condition_postfix>
@@ -4569,7 +4569,7 @@ result.gross_income constants.tips_phaseout_joint &lt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Single income below phase-out threshold ($150k); gross income below Single tips phase-out threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.gross_income constants.tips_phaseout_single &lt;
 </condition_postfix>
@@ -4584,7 +4584,7 @@ result.gross_income constants.tips_phaseout_single &lt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full tips deduction (below phase-out); set result.tips_deduction = the minimum of result.total_tip_income and constants.tips_deduction_max</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.total_tip_income constants.tips_deduction_max fmin /result.tips_deduction xdef
 "  Tips Deduction: $" result.tips_deduction cvs strconcat " (OBBBA No Tax on Tips)" strconcat job.audit_trail swap addto
@@ -4595,7 +4595,7 @@ result.total_tip_income constants.tips_deduction_max fmin /result.tips_deduction
 <action_details>
 <action_number>2</action_number>
 <action_comment>Tips deduction phased out (high income)</action_comment>
-<action_description>set result.tips_deduction = 0</action_description>
+<action_dsl>set result.tips_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.tips_deduction xdef
 "  Tips Deduction: $0 (phased out - income exceeds threshold)" job.audit_trail swap addto
@@ -4606,7 +4606,7 @@ result.total_tip_income constants.tips_deduction_max fmin /result.tips_deduction
 <action_details>
 <action_number>3</action_number>
 <action_comment>No tip income</action_comment>
-<action_description>set result.tips_deduction = 0</action_description>
+<action_dsl>set result.tips_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.tips_deduction xdef
 </action_postfix>
@@ -4657,7 +4657,7 @@ result.total_tip_income constants.tips_deduction_max fmin /result.tips_deduction
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has overtime income</condition_comment>
-<condition_description>result.total_overtime_income &gt; 0</condition_description>
+<condition_dsl>result.total_overtime_income &gt; 0</condition_dsl>
 <condition_postfix>
 result.total_overtime_income 0 &gt;
 </condition_postfix>
@@ -4670,7 +4670,7 @@ result.total_overtime_income 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -4683,7 +4683,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ income below phase-out threshold ($300k); gross income below MFJ overtime phase-out threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.gross_income constants.tips_phaseout_joint &lt;
 </condition_postfix>
@@ -4696,7 +4696,7 @@ result.gross_income constants.tips_phaseout_joint &lt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Single income below phase-out threshold ($150k); gross income below Single overtime phase-out threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.gross_income constants.tips_phaseout_single &lt;
 </condition_postfix>
@@ -4711,7 +4711,7 @@ result.gross_income constants.tips_phaseout_single &lt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full overtime deduction MFJ (below phase-out); set result.overtime_deduction = the minimum of result.total_overtime_income and constants.overtime_deduction_max_joint</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.total_overtime_income constants.overtime_deduction_max_joint fmin /result.overtime_deduction xdef
 "  Overtime Deduction: $" result.overtime_deduction cvs strconcat " (OBBBA No Tax on Overtime - MFJ cap)" strconcat job.audit_trail swap addto
@@ -4721,7 +4721,7 @@ result.total_overtime_income constants.overtime_deduction_max_joint fmin /result
 <action_details>
 <action_number>2</action_number>
 <action_comment>Full overtime deduction Single (below phase-out); set result.overtime_deduction = the minimum of result.total_overtime_income and constants.overtime_deduction_max_single</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.total_overtime_income constants.overtime_deduction_max_single fmin /result.overtime_deduction xdef
 "  Overtime Deduction: $" result.overtime_deduction cvs strconcat " (OBBBA No Tax on Overtime - Single cap)" strconcat job.audit_trail swap addto
@@ -4731,7 +4731,7 @@ result.total_overtime_income constants.overtime_deduction_max_single fmin /resul
 <action_details>
 <action_number>3</action_number>
 <action_comment>Overtime deduction phased out (high income)</action_comment>
-<action_description>set result.overtime_deduction = 0</action_description>
+<action_dsl>set result.overtime_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.overtime_deduction xdef
 "  Overtime Deduction: $0 (phased out - income exceeds threshold)" job.audit_trail swap addto
@@ -4742,7 +4742,7 @@ result.total_overtime_income constants.overtime_deduction_max_single fmin /resul
 <action_details>
 <action_number>4</action_number>
 <action_comment>No overtime income</action_comment>
-<action_description>set result.overtime_deduction = 0</action_description>
+<action_dsl>set result.overtime_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.overtime_deduction xdef
 </action_postfix>
@@ -4793,7 +4793,7 @@ result.total_overtime_income constants.overtime_deduction_max_single fmin /resul
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has seniors</condition_comment>
-<condition_description>result.senior_count &gt; 0</condition_description>
+<condition_dsl>result.senior_count &gt; 0</condition_dsl>
 <condition_postfix>
 result.senior_count 0 &gt;
 </condition_postfix>
@@ -4806,7 +4806,7 @@ result.senior_count 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -4819,7 +4819,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ income below phase-out threshold ($150k); gross income below MFJ senior phase-out threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.gross_income constants.senior_phaseout_joint &lt;
 </condition_postfix>
@@ -4832,7 +4832,7 @@ result.gross_income constants.senior_phaseout_joint &lt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Single income below phase-out threshold ($75k); gross income below Single senior phase-out threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.gross_income constants.senior_phaseout_single &lt;
 </condition_postfix>
@@ -4847,7 +4847,7 @@ result.gross_income constants.senior_phaseout_single &lt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full senior deduction (below phase-out)</action_comment>
-<action_description>set result.senior_deduction = result.senior_count * constants.senior_deduction_amount</action_description>
+<action_dsl>set result.senior_deduction = result.senior_count * constants.senior_deduction_amount</action_dsl>
 <action_postfix>
 result.senior_count 1.0 f* constants.senior_deduction_amount f* /result.senior_deduction xdef
 "  Senior Deduction: $" result.senior_deduction cvs strconcat " (" strconcat result.senior_count cvs strconcat " senior(s) x $6,000 - OBBBA)" strconcat job.audit_trail swap addto
@@ -4858,7 +4858,7 @@ result.senior_count 1.0 f* constants.senior_deduction_amount f* /result.senior_d
 <action_details>
 <action_number>2</action_number>
 <action_comment>Senior deduction phased out (high income)</action_comment>
-<action_description>set result.senior_deduction = 0</action_description>
+<action_dsl>set result.senior_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.senior_deduction xdef
 "  Senior Deduction: $0 (phased out - income exceeds threshold)" job.audit_trail swap addto
@@ -4869,7 +4869,7 @@ result.senior_count 1.0 f* constants.senior_deduction_amount f* /result.senior_d
 <action_details>
 <action_number>3</action_number>
 <action_comment>No seniors</action_comment>
-<action_description>set result.senior_deduction = 0</action_description>
+<action_dsl>set result.senior_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.senior_deduction xdef
 </action_postfix>
@@ -4915,7 +4915,7 @@ result.senior_count 1.0 f* constants.senior_deduction_amount f* /result.senior_d
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xdef
 "SOCIAL SECURITY TAXABILITY (Publication 915)" job.audit_trail swap addto
@@ -4928,7 +4928,7 @@ result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xde
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has Social Security income</condition_comment>
-<condition_description>result.total_social_security &gt; 0</condition_description>
+<condition_dsl>result.total_social_security &gt; 0</condition_dsl>
 <condition_postfix>
 result.total_social_security 0 &gt;
 </condition_postfix>
@@ -4943,7 +4943,7 @@ result.total_social_security 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -4958,7 +4958,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ provisional income at or below base amount ($32k); provisional_income at or below MFJ base amount</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.provisional_income ss_base_amount_mfj le
 </condition_postfix>
@@ -4973,7 +4973,7 @@ result.provisional_income ss_base_amount_mfj le
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>MFJ provisional income at or below additional amount ($44k); provisional_income at or below MFJ additional amount</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.provisional_income ss_additional_amount_mfj le
 </condition_postfix>
@@ -4988,7 +4988,7 @@ result.provisional_income ss_additional_amount_mfj le
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>Single provisional income at or below base amount ($25k); provisional_income at or below Single base amount</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.provisional_income ss_base_amount_single le
 </condition_postfix>
@@ -5003,7 +5003,7 @@ result.provisional_income ss_base_amount_single le
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>Single provisional income at or below additional amount ($34k); provisional_income at or below Single additional amount</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.provisional_income ss_additional_amount_single le
 </condition_postfix>
@@ -5020,7 +5020,7 @@ result.provisional_income ss_additional_amount_single le
 <action_details>
 <action_number>1</action_number>
 <action_comment>0% SS taxable - below base amount</action_comment>
-<action_description>set result.taxable_social_security = 0</action_description>
+<action_dsl>set result.taxable_social_security = 0</action_dsl>
 <action_postfix>
 0.0 /result.ss_taxable_percentage xdef
 0.0 /result.taxable_social_security xdef
@@ -5032,7 +5032,7 @@ result.provisional_income ss_additional_amount_single le
 <action_details>
 <action_number>2</action_number>
 <action_comment>Up to 50% SS taxable MFJ - between base and additional; 50% SS taxable per Pub 915 Worksheet 1 (MFJ thresholds)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.50 /result.ss_taxable_percentage xdef
 result.provisional_income ss_base_amount_mfj f- 0.5 f* result.total_social_security 0.5 f* fmin /result.taxable_social_security xdef
@@ -5044,7 +5044,7 @@ result.provisional_income ss_base_amount_mfj f- 0.5 f* result.total_social_secur
 <action_details>
 <action_number>3</action_number>
 <action_comment>Up to 50% SS taxable Single - between base and additional; 50% SS taxable per Pub 915 Worksheet 1 (Single thresholds)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.50 /result.ss_taxable_percentage xdef
 result.provisional_income ss_base_amount_single f- 0.5 f* result.total_social_security 0.5 f* fmin /result.taxable_social_security xdef
@@ -5056,7 +5056,7 @@ result.provisional_income ss_base_amount_single f- 0.5 f* result.total_social_se
 <action_details>
 <action_number>4</action_number>
 <action_comment>Up to 85% SS taxable - above additional amount; 85% SS taxable per Pub 915 Worksheet 2</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.85 /result.ss_taxable_percentage xdef
 result.total_social_security 0.85 f* /result.taxable_social_security xdef
@@ -5069,7 +5069,7 @@ result.total_social_security 0.85 f* /result.taxable_social_security xdef
 <action_details>
 <action_number>5</action_number>
 <action_comment>No SS income</action_comment>
-<action_description>set result.taxable_social_security = 0</action_description>
+<action_dsl>set result.taxable_social_security = 0</action_dsl>
 <action_postfix>
 0.0 /result.ss_taxable_percentage xdef
 0.0 /result.taxable_social_security xdef
@@ -5125,7 +5125,7 @@ result.total_social_security 0.85 f* /result.taxable_social_security xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each income entity for capital gains</context_comment>
-<context_description>for all income entities</context_description>
+<context_dsl>for all income entities</context_dsl>
 <context_postfix>
 0.0 /result.total_long_term_gains xdef
 0.0 /result.total_short_term_gains xdef
@@ -5140,7 +5140,7 @@ result.total_social_security 0.85 f* /result.taxable_social_security xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is capital gain type</condition_comment>
-<condition_description>income.type is equal to "capital_gain"</condition_description>
+<condition_dsl>income.type is equal to "capital_gain"</condition_dsl>
 <condition_postfix>
 income.type "capital_gain" streq
 </condition_postfix>
@@ -5152,7 +5152,7 @@ income.type "capital_gain" streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Is long-term holding period</condition_comment>
-<condition_description>income.holding_period is equal to "long_term"</condition_description>
+<condition_dsl>income.holding_period is equal to "long_term"</condition_dsl>
 <condition_postfix>
 income.holding_period "long_term" streq
 </condition_postfix>
@@ -5164,7 +5164,7 @@ income.holding_period "long_term" streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Is dividend type</condition_comment>
-<condition_description>income.type is equal to "dividend"</condition_description>
+<condition_dsl>income.type is equal to "dividend"</condition_dsl>
 <condition_postfix>
 income.type "dividend" streq
 </condition_postfix>
@@ -5176,7 +5176,7 @@ income.type "dividend" streq
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Is qualified dividend; income.is_qualified_dividend == true</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 income.is_qualified_dividend true beq
 </condition_postfix>
@@ -5190,7 +5190,7 @@ income.is_qualified_dividend true beq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add to long-term gains</action_comment>
-<action_description>add gain.amount to result.total_long_term_gains</action_description>
+<action_dsl>add gain.amount to result.total_long_term_gains</action_dsl>
 <action_postfix>
 income.gross_amount result.total_long_term_gains f+ /result.total_long_term_gains xdef
 "  Long-Term Capital Gain: $" income.gross_amount cvs strconcat " from " strconcat income.source strconcat " (Schedule D Part II)" strconcat job.audit_trail swap addto
@@ -5200,7 +5200,7 @@ income.gross_amount result.total_long_term_gains f+ /result.total_long_term_gain
 <action_details>
 <action_number>2</action_number>
 <action_comment>Add to short-term gains</action_comment>
-<action_description>add gain.amount to result.total_short_term_gains</action_description>
+<action_dsl>add gain.amount to result.total_short_term_gains</action_dsl>
 <action_postfix>
 income.gross_amount result.total_short_term_gains f+ /result.total_short_term_gains xdef
 "  Short-Term Capital Gain: $" income.gross_amount cvs strconcat " from " strconcat income.source strconcat " (Schedule D Part I)" strconcat job.audit_trail swap addto
@@ -5210,7 +5210,7 @@ income.gross_amount result.total_short_term_gains f+ /result.total_short_term_ga
 <action_details>
 <action_number>3</action_number>
 <action_comment>Add qualified dividend; add dividend.amount to result.qualified_dividends</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 income.gross_amount result.total_qualified_dividends f+ /result.total_qualified_dividends xdef
 "  Qualified Dividend: $" income.gross_amount cvs strconcat " from " strconcat income.source strconcat " (Form 1040 Line 3a)" strconcat job.audit_trail swap addto
@@ -5236,7 +5236,7 @@ income.gross_amount result.total_qualified_dividends f+ /result.total_qualified_
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ allocate
 result.taxable_income 0 local@ f- /result.ordinary_income_for_cg xdef
@@ -5250,7 +5250,7 @@ result.taxable_income 0 local@ f- /result.ordinary_income_for_cg xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has preferential rate income; result.ltcg_and_qualified_dividends &gt; 0</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ 0 &gt;
 </condition_postfix>
@@ -5262,7 +5262,7 @@ result.total_long_term_gains result.total_qualified_dividends f+ 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -5273,7 +5273,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>job.filing_status is equal to "HOH"</condition_description>
+<condition_dsl>job.filing_status is equal to "HOH"</condition_dsl>
 <condition_postfix>
 job.filing_status HOH streq
 </condition_postfix>
@@ -5285,7 +5285,7 @@ job.filing_status HOH streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate CG tax for MFJ</action_comment>
-<action_description>perform Calculate_Capital_Gains_Tax_MFJ</action_description>
+<action_dsl>perform Calculate_Capital_Gains_Tax_MFJ</action_dsl>
 <action_postfix>
 Apply_CG_Brackets_MFJ
 </action_postfix>
@@ -5294,7 +5294,7 @@ Apply_CG_Brackets_MFJ
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate CG tax for HOH</action_comment>
-<action_description>perform Calculate_Capital_Gains_Tax_HOH</action_description>
+<action_dsl>perform Calculate_Capital_Gains_Tax_HOH</action_dsl>
 <action_postfix>
 Apply_CG_Brackets_HOH
 </action_postfix>
@@ -5303,7 +5303,7 @@ Apply_CG_Brackets_HOH
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate CG tax for Single/Other</action_comment>
-<action_description>perform Calculate_Capital_Gains_Tax_Single</action_description>
+<action_dsl>perform Calculate_Capital_Gains_Tax_Single</action_dsl>
 <action_postfix>
 Apply_CG_Brackets_Single
 </action_postfix>
@@ -5312,7 +5312,7 @@ Apply_CG_Brackets_Single
 <action_details>
 <action_number>4</action_number>
 <action_comment>No preferential income - no capital gains tax</action_comment>
-<action_description>set result.capital_gains_tax = 0</action_description>
+<action_dsl>set result.capital_gains_tax = 0</action_dsl>
 <action_postfix>
 0.0 /result.capital_gains_tax xdef
 "  Capital Gains Rate: N/A - No preferential income" job.audit_trail swap addto
@@ -5351,7 +5351,7 @@ deallocate pop
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Ordinary income fills 0% bracket; ordinary_income_for_cg at or below 0% ceiling</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.ordinary_income_for_cg cg_0_percent_mfj le
 </condition_postfix>
@@ -5362,7 +5362,7 @@ result.ordinary_income_for_cg cg_0_percent_mfj le
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxable income in 15% bracket; taxable_income at or below 15% ceiling</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income cg_15_percent_mfj le
 </condition_postfix>
@@ -5375,7 +5375,7 @@ result.taxable_income cg_15_percent_mfj le
 <action_details>
 <action_number>1</action_number>
 <action_comment>0% rate applies to all preferential income</action_comment>
-<action_description>set result.capital_gains_tax = 0</action_description>
+<action_dsl>set result.capital_gains_tax = 0</action_dsl>
 <action_postfix>
 0.0 /result.capital_gains_tax xdef
 "  Capital Gains Rate: 0% - Taxable income within 0% bracket ($94,050 MFJ)" job.audit_trail swap addto
@@ -5386,7 +5386,7 @@ deallocate pop
 <action_details>
 <action_number>2</action_number>
 <action_comment>15% rate applies; LTCG/QD at 15%</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ 0.15 f* /result.capital_gains_tax xdef
 "  Capital Gains Rate: 15% - Taxable income within 15% bracket" job.audit_trail swap addto
@@ -5398,7 +5398,7 @@ deallocate pop
 <action_details>
 <action_number>3</action_number>
 <action_comment>20% rate applies; LTCG/QD at 20%</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ 0.20 f* /result.capital_gains_tax xdef
 "  Capital Gains Rate: 20% - Taxable income above 15% bracket ($583,750 MFJ)" job.audit_trail swap addto
@@ -5431,7 +5431,7 @@ deallocate pop
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Ordinary income fills 0% bracket; ordinary_income_for_cg at or below 0% ceiling</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.ordinary_income_for_cg cg_0_percent_hoh le
 </condition_postfix>
@@ -5442,7 +5442,7 @@ result.ordinary_income_for_cg cg_0_percent_hoh le
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxable income in 15% bracket; taxable_income at or below 15% ceiling</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income cg_15_percent_hoh le
 </condition_postfix>
@@ -5455,7 +5455,7 @@ result.taxable_income cg_15_percent_hoh le
 <action_details>
 <action_number>1</action_number>
 <action_comment>0% rate applies to all preferential income</action_comment>
-<action_description>set result.capital_gains_tax = 0</action_description>
+<action_dsl>set result.capital_gains_tax = 0</action_dsl>
 <action_postfix>
 0.0 /result.capital_gains_tax xdef
 "  Capital Gains Rate: 0% - Taxable income within 0% bracket ($63,000 HOH)" job.audit_trail swap addto
@@ -5466,7 +5466,7 @@ deallocate pop
 <action_details>
 <action_number>2</action_number>
 <action_comment>15% rate applies; LTCG/QD at 15%</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ 0.15 f* /result.capital_gains_tax xdef
 "  Capital Gains Rate: 15% - Taxable income within 15% bracket" job.audit_trail swap addto
@@ -5478,7 +5478,7 @@ deallocate pop
 <action_details>
 <action_number>3</action_number>
 <action_comment>20% rate applies; LTCG/QD at 20%</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ 0.20 f* /result.capital_gains_tax xdef
 "  Capital Gains Rate: 20% - Taxable income above 15% bracket ($551,350 HOH)" job.audit_trail swap addto
@@ -5507,7 +5507,7 @@ deallocate pop
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Ordinary income fills 0% bracket; ordinary_income_for_cg at or below 0% ceiling</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.ordinary_income_for_cg cg_0_percent_single le
 </condition_postfix>
@@ -5518,7 +5518,7 @@ result.ordinary_income_for_cg cg_0_percent_single le
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxable income in 15% bracket; taxable_income at or below 15% ceiling</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.taxable_income cg_15_percent_single le
 </condition_postfix>
@@ -5531,7 +5531,7 @@ result.taxable_income cg_15_percent_single le
 <action_details>
 <action_number>1</action_number>
 <action_comment>0% rate applies to all preferential income</action_comment>
-<action_description>set result.capital_gains_tax = 0</action_description>
+<action_dsl>set result.capital_gains_tax = 0</action_dsl>
 <action_postfix>
 0.0 /result.capital_gains_tax xdef
 "  Capital Gains Rate: 0% - Taxable income within 0% bracket ($47,025 Single)" job.audit_trail swap addto
@@ -5542,7 +5542,7 @@ deallocate pop
 <action_details>
 <action_number>2</action_number>
 <action_comment>15% rate applies; LTCG/QD at 15%</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ 0.15 f* /result.capital_gains_tax xdef
 "  Capital Gains Rate: 15% - Taxable income within 15% bracket" job.audit_trail swap addto
@@ -5554,7 +5554,7 @@ deallocate pop
 <action_details>
 <action_number>3</action_number>
 <action_comment>20% rate applies; LTCG/QD at 20%</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ 0.20 f* /result.capital_gains_tax xdef
 "  Capital Gains Rate: 20% - Taxable income above 15% bracket ($518,900 Single)" job.audit_trail swap addto
@@ -5582,7 +5582,7 @@ deallocate pop
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>set result.net_investment_income = sum of investment income</action_description>
+<action_dsl>set result.net_investment_income = sum of investment income</action_dsl>
 <action_postfix>
 result.total_other_income result.total_long_term_gains f+ result.total_short_term_gains f+ result.total_rental_income f+ result.total_qualified_dividends f+ /result.net_investment_income xdef
 result.agi /result.magi_for_niit xdef
@@ -5596,7 +5596,7 @@ result.agi /result.magi_for_niit xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has NII</condition_comment>
-<condition_description>result.net_investment_income &gt; 0</condition_description>
+<condition_dsl>result.net_investment_income &gt; 0</condition_dsl>
 <condition_postfix>
 result.net_investment_income 0 &gt;
 </condition_postfix>
@@ -5611,7 +5611,7 @@ result.net_investment_income 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -5626,7 +5626,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Married Filing Separately</condition_comment>
-<condition_description>job.filing_status is equal to "MFS"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFS"</condition_dsl>
 <condition_postfix>
 job.filing_status MFS streq
 </condition_postfix>
@@ -5641,7 +5641,7 @@ job.filing_status MFS streq
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>MAGI exceeds MFJ threshold ($250k); result.magi &gt; niit_threshold_mfj</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.magi_for_niit niit_threshold_mfj &gt;
 </condition_postfix>
@@ -5656,7 +5656,7 @@ result.magi_for_niit niit_threshold_mfj &gt;
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>MAGI exceeds MFS threshold ($125k); result.magi &gt; niit_threshold_mfs</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.magi_for_niit niit_threshold_mfs &gt;
 </condition_postfix>
@@ -5671,7 +5671,7 @@ result.magi_for_niit niit_threshold_mfs &gt;
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>MAGI exceeds Single threshold ($200k); result.magi &gt; niit_threshold_single</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.magi_for_niit niit_threshold_single &gt;
 </condition_postfix>
@@ -5688,7 +5688,7 @@ result.magi_for_niit niit_threshold_single &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate NIIT for MFJ; NIIT = 3.8% x MIN(NII, MAGI - $250k)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.magi_for_niit niit_threshold_mfj f- result.net_investment_income fmin niit_rate f* /result.niit_tax xdef
 "  Threshold (MFJ): $" niit_threshold_mfj cvs strconcat job.audit_trail swap addto
@@ -5699,7 +5699,7 @@ result.magi_for_niit niit_threshold_mfj f- result.net_investment_income fmin nii
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate NIIT for MFS; NIIT = 3.8% x MIN(NII, MAGI - $125k)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.magi_for_niit niit_threshold_mfs f- result.net_investment_income fmin niit_rate f* /result.niit_tax xdef
 "  Threshold (MFS): $" niit_threshold_mfs cvs strconcat job.audit_trail swap addto
@@ -5710,7 +5710,7 @@ result.magi_for_niit niit_threshold_mfs f- result.net_investment_income fmin nii
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate NIIT for Single; NIIT = 3.8% x MIN(NII, MAGI - $200k)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.magi_for_niit niit_threshold_single f- result.net_investment_income fmin niit_rate f* /result.niit_tax xdef
 "  Threshold (Single): $" niit_threshold_single cvs strconcat job.audit_trail swap addto
@@ -5721,7 +5721,7 @@ result.magi_for_niit niit_threshold_single f- result.net_investment_income fmin 
 <action_details>
 <action_number>4</action_number>
 <action_comment>No NIIT - below threshold; MAGI below threshold - no NIIT</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.niit_tax xdef
 "  NIIT: $0 - MAGI below threshold" job.audit_trail swap addto
@@ -5733,7 +5733,7 @@ result.magi_for_niit niit_threshold_single f- result.net_investment_income fmin 
 <action_details>
 <action_number>5</action_number>
 <action_comment>No NII</action_comment>
-<action_description>set result.niit_tax = 0</action_description>
+<action_dsl>set result.niit_tax = 0</action_dsl>
 <action_postfix>
 0.0 /result.niit_tax xdef
 "  NIIT: $0 - No net investment income" job.audit_trail swap addto
@@ -5788,7 +5788,7 @@ result.magi_for_niit niit_threshold_single f- result.net_investment_income fmin 
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>set result.medicare_wages = sum of taxpayer wages</action_description>
+<action_dsl>set result.medicare_wages = sum of taxpayer wages</action_dsl>
 <action_postfix>
 result.total_w2_wages result.total_se_income f+ /result.wages_for_additional_medicare xdef
 "ADDITIONAL MEDICARE TAX (Form 8959, IRC 3101(b)(2))" job.audit_trail swap addto
@@ -5800,7 +5800,7 @@ result.total_w2_wages result.total_se_income f+ /result.wages_for_additional_med
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -5814,7 +5814,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Separately</condition_comment>
-<condition_description>job.filing_status is equal to "MFS"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFS"</condition_dsl>
 <condition_postfix>
 job.filing_status MFS streq
 </condition_postfix>
@@ -5828,7 +5828,7 @@ job.filing_status MFS streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Wages exceed MFJ threshold ($250k); result.total_w2_wages &gt; additional_medicare_threshold_mfj</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.wages_for_additional_medicare additional_medicare_threshold_mfj &gt;
 </condition_postfix>
@@ -5842,7 +5842,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_mfj &gt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Wages exceed MFS threshold ($125k); result.total_w2_wages &gt; additional_medicare_threshold_mfs</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.wages_for_additional_medicare additional_medicare_threshold_mfs &gt;
 </condition_postfix>
@@ -5856,7 +5856,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_mfs &gt;
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>Wages exceed Single threshold ($200k); result.total_w2_wages &gt; additional_medicare_threshold_single</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.wages_for_additional_medicare additional_medicare_threshold_single &gt;
 </condition_postfix>
@@ -5872,7 +5872,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_single &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Additional Medicare Tax for MFJ; 0.9% on wages over $250k</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.wages_for_additional_medicare additional_medicare_threshold_mfj f- additional_medicare_rate f* /result.additional_medicare_tax xdef
 "  Threshold (MFJ): $" additional_medicare_threshold_mfj cvs strconcat job.audit_trail swap addto
@@ -5883,7 +5883,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_mfj f- additi
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate Additional Medicare Tax for MFS; 0.9% on wages over $125k</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.wages_for_additional_medicare additional_medicare_threshold_mfs f- additional_medicare_rate f* /result.additional_medicare_tax xdef
 "  Threshold (MFS): $" additional_medicare_threshold_mfs cvs strconcat job.audit_trail swap addto
@@ -5894,7 +5894,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_mfs f- additi
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Additional Medicare Tax for Single; 0.9% on wages over $200k</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.wages_for_additional_medicare additional_medicare_threshold_single f- additional_medicare_rate f* /result.additional_medicare_tax xdef
 "  Threshold (Single): $" additional_medicare_threshold_single cvs strconcat job.audit_trail swap addto
@@ -5905,7 +5905,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_single f- add
 <action_details>
 <action_number>4</action_number>
 <action_comment>No Additional Medicare Tax</action_comment>
-<action_description>set result.additional_medicare_tax = 0</action_description>
+<action_dsl>set result.additional_medicare_tax = 0</action_dsl>
 <action_postfix>
 0.0 /result.additional_medicare_tax xdef
 "  Additional Medicare Tax: $0 - Wages below threshold" job.audit_trail swap addto
@@ -5959,7 +5959,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_single f- add
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each taxpayer for IRA deduction</context_comment>
-<context_description>for all taxpayers</context_description>
+<context_dsl>for all taxpayers</context_dsl>
 <context_postfix>
 0.0 /result.ira_deduction xdef
 "IRA DEDUCTION (Publication 590-A, IRC 219)" job.audit_trail swap addto
@@ -5972,7 +5972,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_single f- add
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has IRA contribution</condition_comment>
-<condition_description>taxpayer.traditional_ira_contribution &gt; 0</condition_description>
+<condition_dsl>taxpayer.traditional_ira_contribution &gt; 0</condition_dsl>
 <condition_postfix>
 taxpayer.traditional_ira_contribution 0 &gt;
 </condition_postfix>
@@ -5987,7 +5987,7 @@ taxpayer.traditional_ira_contribution 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Covered by employer plan</condition_comment>
-<condition_description>taxpayer.covered_by_employer_plan == true</condition_description>
+<condition_dsl>taxpayer.covered_by_employer_plan == true</condition_dsl>
 <condition_postfix>
 taxpayer.covered_by_employer_plan true beq
 </condition_postfix>
@@ -6002,7 +6002,7 @@ taxpayer.covered_by_employer_plan true beq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Age 50 or over (catchup eligible)</condition_comment>
-<condition_description>taxpayer.age_50_or_over == true</condition_description>
+<condition_dsl>taxpayer.age_50_or_over == true</condition_dsl>
 <condition_postfix>
 taxpayer.age_50_or_over true beq
 </condition_postfix>
@@ -6017,7 +6017,7 @@ taxpayer.age_50_or_over true beq
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Married Filing Jointly (for phase-out)</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -6034,7 +6034,7 @@ job.filing_status MFJ streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full IRA deduction with catchup (not covered, age 50+); set taxpayer.ira_deduction = the minimum of contribution and ira_catchup_limit</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.traditional_ira_contribution ira_contribution_limit ira_catchup_limit f+ fmin result.ira_deduction f+ /result.ira_deduction xdef
 "  IRA Deduction for " taxpayer.name strconcat ": $" strconcat result.ira_deduction cvs strconcat " (full with catchup - not covered)" strconcat job.audit_trail swap addto
@@ -6044,7 +6044,7 @@ taxpayer.traditional_ira_contribution ira_contribution_limit ira_catchup_limit f
 <action_details>
 <action_number>2</action_number>
 <action_comment>Full IRA deduction no catchup (not covered, age under 50); set taxpayer.ira_deduction = the minimum of contribution and ira_standard_limit</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.traditional_ira_contribution ira_contribution_limit fmin result.ira_deduction f+ /result.ira_deduction xdef
 "  IRA Deduction for " taxpayer.name strconcat ": $" strconcat result.ira_deduction cvs strconcat " (full - not covered)" strconcat job.audit_trail swap addto
@@ -6054,7 +6054,7 @@ taxpayer.traditional_ira_contribution ira_contribution_limit fmin result.ira_ded
 <action_details>
 <action_number>3</action_number>
 <action_comment>IRA deduction with MFJ phase-out and catchup; set taxpayer.ira_deduction = phased out deduction with catchup (MFJ)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.traditional_ira_contribution ira_contribution_limit ira_catchup_limit f+ fmin /ira_max allocate
 result.agi ira_phaseout_start_mfj f- ira_phaseout_end_mfj ira_phaseout_start_mfj f- fdiv 1 fmin 0 fmax /phaseout_pct allocate
@@ -6067,7 +6067,7 @@ deallocate pop deallocate pop
 <action_details>
 <action_number>4</action_number>
 <action_comment>IRA deduction with MFJ phase-out no catchup; set taxpayer.ira_deduction = phased out deduction standard (MFJ)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.traditional_ira_contribution ira_contribution_limit fmin /ira_max allocate
 result.agi ira_phaseout_start_mfj f- ira_phaseout_end_mfj ira_phaseout_start_mfj f- fdiv 1 fmin 0 fmax /phaseout_pct allocate
@@ -6080,7 +6080,7 @@ deallocate pop deallocate pop
 <action_details>
 <action_number>5</action_number>
 <action_comment>IRA deduction with Single phase-out and catchup; set taxpayer.ira_deduction = phased out deduction with catchup (Single)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.traditional_ira_contribution ira_contribution_limit ira_catchup_limit f+ fmin /ira_max allocate
 result.agi ira_phaseout_start_single f- ira_phaseout_end_single ira_phaseout_start_single f- fdiv 1 fmin 0 fmax /phaseout_pct allocate
@@ -6093,7 +6093,7 @@ deallocate pop deallocate pop
 <action_details>
 <action_number>6</action_number>
 <action_comment>IRA deduction with Single phase-out no catchup; set taxpayer.ira_deduction = phased out deduction standard (Single)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.traditional_ira_contribution ira_contribution_limit fmin /ira_max allocate
 result.agi ira_phaseout_start_single f- ira_phaseout_end_single ira_phaseout_start_single f- fdiv 1 fmin 0 fmax /phaseout_pct allocate
@@ -6106,7 +6106,7 @@ deallocate pop deallocate pop
 <action_details>
 <action_number>7</action_number>
 <action_comment>No IRA contribution - result.ira_deduction already initialized to 0 in context</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 </action_postfix>
 <action_column column_number="7" column_value="X" />
@@ -6160,7 +6160,7 @@ deallocate pop deallocate pop
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each taxpayer for HSA deduction</context_comment>
-<context_description>for all taxpayers</context_description>
+<context_dsl>for all taxpayers</context_dsl>
 <context_postfix>
 0.0 /result.hsa_deduction xdef
 "HSA DEDUCTION (Form 8889, IRC 223)" job.audit_trail swap addto
@@ -6173,7 +6173,7 @@ deallocate pop deallocate pop
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has HSA contribution</condition_comment>
-<condition_description>taxpayer.hsa_contribution &gt; 0</condition_description>
+<condition_dsl>taxpayer.hsa_contribution &gt; 0</condition_dsl>
 <condition_postfix>
 taxpayer.hsa_contribution 0 &gt;
 </condition_postfix>
@@ -6186,7 +6186,7 @@ taxpayer.hsa_contribution 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Family coverage</condition_comment>
-<condition_description>taxpayer.hsa_coverage_type is equal to "family"</condition_description>
+<condition_dsl>taxpayer.hsa_coverage_type is equal to "family"</condition_dsl>
 <condition_postfix>
 taxpayer.hsa_coverage_type "family" streq
 </condition_postfix>
@@ -6199,7 +6199,7 @@ taxpayer.hsa_coverage_type "family" streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Age 55 or over (catchup eligible)</condition_comment>
-<condition_description>taxpayer.age_50_or_over == true</condition_description>
+<condition_dsl>taxpayer.age_50_or_over == true</condition_dsl>
 <condition_postfix>
 taxpayer.age_50_or_over true beq
 </condition_postfix>
@@ -6214,7 +6214,7 @@ taxpayer.age_50_or_over true beq
 <action_details>
 <action_number>1</action_number>
 <action_comment>HSA deduction - family coverage with catchup; set taxpayer.hsa_deduction = the minimum of contribution and hsa_family_catchup_limit</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.hsa_contribution hsa_limit_family hsa_catchup f+ fmin result.hsa_deduction f+ /result.hsa_deduction xdef
 "  HSA Deduction for " taxpayer.name strconcat ": $" strconcat result.hsa_deduction cvs strconcat " (family with catchup)" strconcat job.audit_trail swap addto
@@ -6224,7 +6224,7 @@ taxpayer.hsa_contribution hsa_limit_family hsa_catchup f+ fmin result.hsa_deduct
 <action_details>
 <action_number>2</action_number>
 <action_comment>HSA deduction - family coverage no catchup; set taxpayer.hsa_deduction = the minimum of contribution and hsa_family_limit</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.hsa_contribution hsa_limit_family fmin result.hsa_deduction f+ /result.hsa_deduction xdef
 "  HSA Deduction for " taxpayer.name strconcat ": $" strconcat result.hsa_deduction cvs strconcat " (family coverage)" strconcat job.audit_trail swap addto
@@ -6234,7 +6234,7 @@ taxpayer.hsa_contribution hsa_limit_family fmin result.hsa_deduction f+ /result.
 <action_details>
 <action_number>3</action_number>
 <action_comment>HSA deduction - self coverage with catchup; set taxpayer.hsa_deduction = the minimum of contribution and hsa_self_catchup_limit</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.hsa_contribution hsa_limit_self hsa_catchup f+ fmin result.hsa_deduction f+ /result.hsa_deduction xdef
 "  HSA Deduction for " taxpayer.name strconcat ": $" strconcat result.hsa_deduction cvs strconcat " (self with catchup)" strconcat job.audit_trail swap addto
@@ -6244,7 +6244,7 @@ taxpayer.hsa_contribution hsa_limit_self hsa_catchup f+ fmin result.hsa_deductio
 <action_details>
 <action_number>4</action_number>
 <action_comment>HSA deduction - self coverage no catchup; set taxpayer.hsa_deduction = the minimum of contribution and hsa_self_limit</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.hsa_contribution hsa_limit_self fmin result.hsa_deduction f+ /result.hsa_deduction xdef
 "  HSA Deduction for " taxpayer.name strconcat ": $" strconcat result.hsa_deduction cvs strconcat " (self-only coverage)" strconcat job.audit_trail swap addto
@@ -6254,7 +6254,7 @@ taxpayer.hsa_contribution hsa_limit_self fmin result.hsa_deduction f+ /result.hs
 <action_details>
 <action_number>5</action_number>
 <action_comment>No HSA contribution - result.hsa_deduction already initialized to 0 in context</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 </action_postfix>
 <action_column column_number="5" column_value="X" />
@@ -6300,7 +6300,7 @@ taxpayer.hsa_contribution hsa_limit_self fmin result.hsa_deduction f+ /result.hs
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each taxpayer for student loan deduction</context_comment>
-<context_description>for all taxpayers</context_description>
+<context_dsl>for all taxpayers</context_dsl>
 <context_postfix>
 0.0 /result.student_loan_deduction xdef
 "STUDENT LOAN INTEREST DEDUCTION (Schedule 1 Line 21, IRC 221)" job.audit_trail swap addto
@@ -6313,7 +6313,7 @@ taxpayer.hsa_contribution hsa_limit_self fmin result.hsa_deduction f+ /result.hs
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has student loan interest</condition_comment>
-<condition_description>taxpayer.student_loan_interest_paid &gt; 0</condition_description>
+<condition_dsl>taxpayer.student_loan_interest_paid &gt; 0</condition_dsl>
 <condition_postfix>
 taxpayer.student_loan_interest_paid 0 &gt;
 </condition_postfix>
@@ -6326,7 +6326,7 @@ taxpayer.student_loan_interest_paid 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -6339,7 +6339,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ AGI below phase-out start</condition_comment>
-<condition_description>AGI below MFJ phase-out start</condition_description>
+<condition_dsl>AGI below MFJ phase-out start</condition_dsl>
 <condition_postfix>
 result.agi student_loan_phaseout_start_mfj &lt;
 </condition_postfix>
@@ -6352,7 +6352,7 @@ result.agi student_loan_phaseout_start_mfj &lt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Single AGI below phase-out start</condition_comment>
-<condition_description>AGI below Single phase-out start</condition_description>
+<condition_dsl>AGI below Single phase-out start</condition_dsl>
 <condition_postfix>
 result.agi student_loan_phaseout_start_single &lt;
 </condition_postfix>
@@ -6367,7 +6367,7 @@ result.agi student_loan_phaseout_start_single &lt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full student loan deduction; set result.student_loan_deduction = the minimum of interest_paid and 2500</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.student_loan_interest_paid student_loan_max_deduction fmin result.student_loan_deduction f+ /result.student_loan_deduction xdef
 "  Student Loan Interest for " taxpayer.name strconcat ": $" strconcat result.student_loan_deduction cvs strconcat " (full - MAGI below phase-out)" strconcat job.audit_trail swap addto
@@ -6378,7 +6378,7 @@ taxpayer.student_loan_interest_paid student_loan_max_deduction fmin result.stude
 <action_details>
 <action_number>2</action_number>
 <action_comment>Student loan deduction with MFJ phase-out; set result.student_loan_deduction = phased out deduction (MFJ)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.student_loan_interest_paid student_loan_max_deduction fmin /sl_max allocate
 result.agi student_loan_phaseout_start_mfj f- student_loan_phaseout_end_mfj student_loan_phaseout_start_mfj f- fdiv 1 fmin 0 fmax /phaseout_pct allocate
@@ -6391,7 +6391,7 @@ deallocate pop deallocate pop
 <action_details>
 <action_number>3</action_number>
 <action_comment>Student loan deduction with Single phase-out; set result.student_loan_deduction = phased out deduction (Single)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.student_loan_interest_paid student_loan_max_deduction fmin /sl_max allocate
 result.agi student_loan_phaseout_start_single f- student_loan_phaseout_end_single student_loan_phaseout_start_single f- fdiv 1 fmin 0 fmax /phaseout_pct allocate
@@ -6404,7 +6404,7 @@ deallocate pop deallocate pop
 <action_details>
 <action_number>4</action_number>
 <action_comment>No student loan interest</action_comment>
-<action_description>set result.student_loan_deduction = 0</action_description>
+<action_dsl>set result.student_loan_deduction = 0</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="5" column_value="X" />
@@ -6445,13 +6445,13 @@ deallocate pop deallocate pop
 <contexts />
 <initial_actions>
 <initial_action>
-<initial_action_description>set result.educator_deduction = 0</initial_action_description>
+<initial_action_dsl>set result.educator_deduction = 0</initial_action_dsl>
 <initial_action_postfix>0 /result.educator_expense_deduction xdef</initial_action_postfix>
 </initial_action>
 </initial_actions>
 <conditions>
 <condition_details>
-<condition_description />
+<condition_dsl />
 <condition_postfix>taxpayer.is_educator</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -6459,7 +6459,7 @@ deallocate pop deallocate pop
 </conditions>
 <actions>
 <action_details>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.educator_expenses constants.educator_expense_limit fmin result.educator_expense_deduction f+ /result.educator_expense_deduction xdef
 result.total_adjustments result.educator_expense_deduction f+ /result.total_adjustments xdef
@@ -6487,7 +6487,7 @@ result.total_adjustments result.educator_expense_deduction f+ /result.total_adju
 <contexts />
 <initial_actions>
 <initial_action>
-<initial_action_description>set result.total_medical_expenses = sum of taxpayer medical expenses</initial_action_description>
+<initial_action_dsl>set result.total_medical_expenses = sum of taxpayer medical expenses</initial_action_dsl>
 <initial_action_postfix>
 0.0 { medical_expenses + } job.taxpayers forall /result.total_medical_expenses xdef
 </initial_action_postfix>
@@ -6495,7 +6495,7 @@ result.total_adjustments result.educator_expense_deduction f+ /result.total_adju
 </initial_actions>
 <conditions>
 <condition_details>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.total_medical_expenses 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -6503,7 +6503,7 @@ result.total_adjustments result.educator_expense_deduction f+ /result.total_adju
 </conditions>
 <actions>
 <action_details>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.agi constants.medical_floor_percentage f* /result.medical_expense_floor xdef
 result.total_medical_expenses result.medical_expense_floor f- 0 fmax /result.medical_expense_deduction xdef
@@ -6536,7 +6536,7 @@ result.total_medical_expenses result.medical_expense_floor f- 0 fmax /result.med
 <context_details>
 <context_number>1</context_number>
 <context_comment>Count qualifying persons and sum expenses</context_comment>
-<context_description>for all dependents</context_description>
+<context_dsl>for all dependents</context_dsl>
 <context_postfix>
 0 /result.qualifying_care_persons xdef
 0.0 /result.total_care_expenses xdef
@@ -6552,7 +6552,7 @@ result.total_medical_expenses result.medical_expense_floor f- 0 fmax /result.med
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has 2+ qualifying persons; result.qualifying_care_persons &gt; 1</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.qualifying_care_persons 1 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -6561,7 +6561,7 @@ result.total_medical_expenses result.medical_expense_floor f- 0 fmax /result.med
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has 1 qualifying person; result.qualifying_care_persons == 1</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.qualifying_care_persons 1 ==</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -6571,7 +6571,7 @@ result.total_medical_expenses result.medical_expense_floor f- 0 fmax /result.med
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.cdcc_expense_limit = 6000</action_description>
+<action_dsl>set result.cdcc_expense_limit = 6000</action_dsl>
 <action_postfix>
 constants.cdcc_expense_limit_2 /result.cdcc_expense_limit xdef
 </action_postfix>
@@ -6579,7 +6579,7 @@ constants.cdcc_expense_limit_2 /result.cdcc_expense_limit xdef
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.cdcc_expense_limit = 3000</action_description>
+<action_dsl>set result.cdcc_expense_limit = 3000</action_dsl>
 <action_postfix>
 constants.cdcc_expense_limit_1 /result.cdcc_expense_limit xdef
 </action_postfix>
@@ -6587,7 +6587,7 @@ constants.cdcc_expense_limit_1 /result.cdcc_expense_limit xdef
 </action_details>
 <action_details>
 <action_number>3</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.total_care_expenses result.cdcc_expense_limit fmin /result.cdcc_allowed_expenses xdef
 result.agi constants.cdcc_rate_reduction_start f- constants.cdcc_rate_reduction_increment fdiv 0 fmax floor /result.cdcc_rate_reductions xdef
@@ -6606,7 +6606,7 @@ result.cdcc_credit result.total_credits f+ /result.total_credits xdef
 <action_comment>set result.cdcc_credit = qualified_expenses * credit_rate</action_comment></action_details>
 <action_details>
 <action_number>4</action_number>
-<action_description>set result.cdcc_credit = 0</action_description>
+<action_dsl>set result.cdcc_credit = 0</action_dsl>
 <action_postfix>
 "  No qualifying persons for CDCC" job.audit_trail swap addto
 </action_postfix>
@@ -6646,7 +6646,7 @@ result.cdcc_credit result.total_credits f+ /result.total_credits xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Child under 13</condition_comment>
-<condition_description>dependent.age &lt; 13</condition_description>
+<condition_dsl>dependent.age &lt; 13</condition_dsl>
 <condition_postfix>dependent.age 13 &lt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -6655,7 +6655,7 @@ result.cdcc_credit result.total_credits f+ /result.total_credits xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Disabled dependent</condition_comment>
-<condition_description>dependent.is_disabled == true</condition_description>
+<condition_dsl>dependent.is_disabled == true</condition_dsl>
 <condition_postfix>dependent.is_disabled true beq</condition_postfix>
 <condition_column column_number="1" column_value="-" />
 <condition_column column_number="2" column_value="Y" />
@@ -6664,7 +6664,7 @@ result.cdcc_credit result.total_credits f+ /result.total_credits xdef
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Has work-related care expenses</condition_comment>
-<condition_description>dependent.care_expenses &gt; 0</condition_description>
+<condition_dsl>dependent.care_expenses &gt; 0</condition_dsl>
 <condition_postfix>dependent.care_expenses 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="Y" />
@@ -6674,7 +6674,7 @@ result.cdcc_credit result.total_credits f+ /result.total_credits xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.qualifying_care_persons 1 + /result.qualifying_care_persons xdef
 dependent.care_expenses result.total_care_expenses f+ /result.total_care_expenses xdef
@@ -6685,7 +6685,7 @@ true /dependent.qualifies_for_cdcc xdef
 <action_comment>increment qualifying_person_count, add dependent.care_expenses to total</action_comment></action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 false /dependent.qualifies_for_cdcc xdef
 </action_postfix>
@@ -6720,7 +6720,7 @@ false /dependent.qualifies_for_cdcc xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Sum eligible contributions</context_comment>
-<context_description>for all taxpayers</context_description>
+<context_dsl>for all taxpayers</context_dsl>
 <context_postfix>
 0.0 /result.total_savers_contribution xdef
 0.0 /result.savers_credit xdef
@@ -6735,7 +6735,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has contributions</condition_comment>
-<condition_description>result.total_savers_contribution &gt; 0</condition_description>
+<condition_dsl>result.total_savers_contribution &gt; 0</condition_dsl>
 <condition_postfix>result.total_savers_contribution 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="Y" />
@@ -6754,7 +6754,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status MFJ</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>job.filing_status MFJ streq</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="Y" />
@@ -6772,7 +6772,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Filing status HOH</condition_comment>
-<condition_description>job.filing_status is equal to "HOH"</condition_description>
+<condition_dsl>job.filing_status is equal to "HOH"</condition_dsl>
 <condition_postfix>job.filing_status HOH streq</condition_postfix>
 <condition_column column_number="5" column_value="Y" />
 <condition_column column_number="6" column_value="Y" />
@@ -6786,7 +6786,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>AGI at 50% tier for MFJ; result.agi &lt;= savers_credit_50pct_threshold_mfj</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.agi constants.savers_50_percent_mfj &lt;=</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -6796,7 +6796,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>AGI at 20% tier for MFJ; result.agi &lt;= savers_credit_20pct_threshold_mfj</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.agi constants.savers_20_percent_mfj &lt;=</condition_postfix>
 <condition_column column_number="2" column_value="Y" />
 <condition_column column_number="3" column_value="N" />
@@ -6805,7 +6805,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>AGI at 10% tier for MFJ; result.agi &lt;= savers_credit_10pct_threshold_mfj</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.agi constants.savers_10_percent_mfj &lt;=</condition_postfix>
 <condition_column column_number="3" column_value="Y" />
 <condition_column column_number="4" column_value="N" />
@@ -6813,7 +6813,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>7</condition_number>
 <condition_comment>AGI at 50% tier for HOH; result.agi &lt;= savers_credit_50pct_threshold_hoh</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.agi constants.savers_50_percent_hoh &lt;=</condition_postfix>
 <condition_column column_number="5" column_value="Y" />
 <condition_column column_number="6" column_value="N" />
@@ -6823,7 +6823,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>8</condition_number>
 <condition_comment>AGI at 20% tier for HOH; result.agi &lt;= savers_credit_20pct_threshold_hoh</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.agi constants.savers_20_percent_hoh &lt;=</condition_postfix>
 <condition_column column_number="6" column_value="Y" />
 <condition_column column_number="7" column_value="N" />
@@ -6832,7 +6832,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>9</condition_number>
 <condition_comment>AGI at 10% tier for HOH; result.agi &lt;= savers_credit_10pct_threshold_hoh</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.agi constants.savers_10_percent_hoh &lt;=</condition_postfix>
 <condition_column column_number="7" column_value="Y" />
 <condition_column column_number="8" column_value="N" />
@@ -6840,7 +6840,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>10</condition_number>
 <condition_comment>AGI at 50% tier for Single; result.agi &lt;= savers_credit_50pct_threshold_single</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.agi constants.savers_50_percent_single &lt;=</condition_postfix>
 <condition_column column_number="9" column_value="Y" />
 <condition_column column_number="10" column_value="N" />
@@ -6850,7 +6850,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>11</condition_number>
 <condition_comment>AGI at 20% tier for Single; result.agi &lt;= savers_credit_20pct_threshold_single</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.agi constants.savers_20_percent_single &lt;=</condition_postfix>
 <condition_column column_number="10" column_value="Y" />
 <condition_column column_number="11" column_value="N" />
@@ -6859,7 +6859,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>12</condition_number>
 <condition_comment>AGI at 10% tier for Single; result.agi &lt;= savers_credit_10pct_threshold_single</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.agi constants.savers_10_percent_single &lt;=</condition_postfix>
 <condition_column column_number="11" column_value="Y" />
 <condition_column column_number="12" column_value="N" />
@@ -6868,7 +6868,7 @@ false /dependent.qualifies_for_cdcc xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.savers_credit_rate = 0.50</action_description>
+<action_dsl>set result.savers_credit_rate = 0.50</action_dsl>
 <action_postfix>0.50 /result.savers_credit_rate xdef</action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="5" column_value="X" />
@@ -6876,7 +6876,7 @@ false /dependent.qualifies_for_cdcc xdef
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.savers_credit_rate = 0.20</action_description>
+<action_dsl>set result.savers_credit_rate = 0.20</action_dsl>
 <action_postfix>0.20 /result.savers_credit_rate xdef</action_postfix>
 <action_column column_number="2" column_value="X" />
 <action_column column_number="6" column_value="X" />
@@ -6884,7 +6884,7 @@ false /dependent.qualifies_for_cdcc xdef
 </action_details>
 <action_details>
 <action_number>3</action_number>
-<action_description>set result.savers_credit_rate = 0.10</action_description>
+<action_dsl>set result.savers_credit_rate = 0.10</action_dsl>
 <action_postfix>0.10 /result.savers_credit_rate xdef</action_postfix>
 <action_column column_number="3" column_value="X" />
 <action_column column_number="7" column_value="X" />
@@ -6892,7 +6892,7 @@ false /dependent.qualifies_for_cdcc xdef
 </action_details>
 <action_details>
 <action_number>4</action_number>
-<action_description>set result.savers_credit_rate = 0</action_description>
+<action_dsl>set result.savers_credit_rate = 0</action_dsl>
 <action_postfix>0.0 /result.savers_credit_rate xdef</action_postfix>
 <action_column column_number="4" column_value="X" />
 <action_column column_number="8" column_value="X" />
@@ -6900,7 +6900,7 @@ false /dependent.qualifies_for_cdcc xdef
 </action_details>
 <action_details>
 <action_number>5</action_number>
-<action_description>set result.savers_credit = eligible_contributions * result.savers_credit_rate</action_description>
+<action_dsl>set result.savers_credit = eligible_contributions * result.savers_credit_rate</action_dsl>
 <action_postfix>
 result.total_savers_contribution result.savers_credit_rate f* /result.savers_credit xdef
 "  Eligible contributions: $" result.total_savers_contribution cvs strconcat job.audit_trail swap addto
@@ -6923,7 +6923,7 @@ result.savers_credit result.total_credits f+ /result.total_credits xdef
 </action_details>
 <action_details>
 <action_number>6</action_number>
-<action_description>set result.savers_credit = 0</action_description>
+<action_dsl>set result.savers_credit = 0</action_dsl>
 <action_postfix>
 "  No eligible retirement contributions for Saver's Credit" job.audit_trail swap addto
 </action_postfix>
@@ -7003,7 +7003,7 @@ result.savers_credit result.total_credits f+ /result.total_credits xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has any IRA contribution</condition_comment>
-<condition_description>taxpayer has IRA contributions</condition_description>
+<condition_dsl>taxpayer has IRA contributions</condition_dsl>
 <condition_postfix>taxpayer.traditional_ira_contribution taxpayer.roth_ira_contribution f+ 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -7012,7 +7012,7 @@ result.savers_credit result.total_credits f+ /result.total_credits xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 taxpayer.traditional_ira_contribution taxpayer.roth_ira_contribution f+ constants.savers_credit_max_contribution fmin result.total_savers_contribution f+ /result.total_savers_contribution xdef
 </action_postfix>
@@ -7042,7 +7042,7 @@ taxpayer.traditional_ira_contribution taxpayer.roth_ira_contribution f+ constant
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each energy improvement</context_comment>
-<context_description>for all energy improvements</context_description>
+<context_dsl>for all energy improvements</context_dsl>
 <context_postfix>
 0.0 /result.clean_energy_credit xdef
 0.0 /result.energy_efficiency_credit xdef
@@ -7054,7 +7054,7 @@ taxpayer.traditional_ira_contribution taxpayer.roth_ira_contribution f+ constant
 <initial_actions>
 <initial_action>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.energy_efficiency_credit constants.energy_efficiency_annual_limit fmin /result.energy_efficiency_credit xdef
 </action_postfix>
@@ -7064,7 +7064,7 @@ result.energy_efficiency_credit constants.energy_efficiency_annual_limit fmin /r
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has energy credits</condition_comment>
-<condition_description>result.total_credits &gt; 0</condition_description>
+<condition_dsl>result.total_credits &gt; 0</condition_dsl>
 <condition_postfix>result.clean_energy_credit result.energy_efficiency_credit f+ 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -7073,7 +7073,7 @@ result.energy_efficiency_credit constants.energy_efficiency_annual_limit fmin /r
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Clean Energy Credit (25D): $" result.clean_energy_credit cvs strconcat job.audit_trail swap addto
 "  Energy Efficiency Credit (25C): $" result.energy_efficiency_credit cvs strconcat job.audit_trail swap addto
@@ -7083,7 +7083,7 @@ result.clean_energy_credit result.energy_efficiency_credit f+ result.total_credi
 <action_comment>add energy credit summary to job.audit_trail</action_comment></action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  No qualifying energy improvements" job.audit_trail swap addto
 </action_postfix>
@@ -7115,7 +7115,7 @@ result.clean_energy_credit result.energy_efficiency_credit f+ result.total_credi
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Clean energy improvement (25D)</condition_comment>
-<condition_description>category is clean_energy</condition_description>
+<condition_dsl>category is clean_energy</condition_dsl>
 <condition_postfix>energy_improvement.category clean_energy streq</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -7124,7 +7124,7 @@ result.clean_energy_credit result.energy_efficiency_credit f+ result.total_credi
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add (improvement.cost * 0.30) to result.clean_energy_credit</action_description>
+<action_dsl>add (improvement.cost * 0.30) to result.clean_energy_credit</action_dsl>
 <action_postfix>
 energy_improvement.cost constants.clean_energy_rate f* result.clean_energy_credit f+ /result.clean_energy_credit xdef
 "    " energy_improvement.type strconcat ": $" strconcat energy_improvement.cost cvs strconcat " (25D 30%)" strconcat job.audit_trail swap addto
@@ -7133,7 +7133,7 @@ energy_improvement.cost constants.clean_energy_rate f* result.clean_energy_credi
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>add (improvement.cost * 0.30) to result.energy_efficiency_credit</action_description>
+<action_dsl>add (improvement.cost * 0.30) to result.energy_efficiency_credit</action_dsl>
 <action_postfix>
 energy_improvement.cost constants.energy_efficiency_rate f* result.energy_efficiency_credit f+ /result.energy_efficiency_credit xdef
 "    " energy_improvement.type strconcat ": $" strconcat energy_improvement.cost cvs strconcat " (25C 30%)" strconcat job.audit_trail swap addto
@@ -7168,7 +7168,7 @@ energy_improvement.cost constants.energy_efficiency_rate f* result.energy_effici
 <context_details>
 <context_number>1</context_number>
 <context_comment>Sum rental losses from all properties</context_comment>
-<context_description>for all properties</context_description>
+<context_dsl>for all properties</context_dsl>
 <context_postfix>
 0.0 /result.total_rental_loss xdef
 0.0 /result.rental_loss_allowed xdef
@@ -7183,7 +7183,7 @@ energy_improvement.cost constants.energy_efficiency_rate f* result.energy_effici
 <initial_actions>
 <initial_action>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.agi constants.rental_loss_phaseout_start f- 0 fmax constants.rental_loss_phaseout_rate f* /result.pal_phaseout_reduction xdef
 constants.rental_loss_allowance result.pal_phaseout_reduction f- 0 fmax /result.pal_reduced_allowance xdef
@@ -7196,7 +7196,7 @@ result.total_rental_loss result.rental_loss_allowed f- /result.suspended_passive
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has rental losses</condition_comment>
-<condition_description>result.total_rental_loss &gt; 0</condition_description>
+<condition_dsl>result.total_rental_loss &gt; 0</condition_dsl>
 <condition_postfix>result.total_rental_loss 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -7205,7 +7205,7 @@ result.total_rental_loss result.rental_loss_allowed f- /result.suspended_passive
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Total rental loss: $" result.total_rental_loss cvs strconcat job.audit_trail swap addto
 "  Allowance after phaseout: $" result.pal_reduced_allowance cvs strconcat job.audit_trail swap addto
@@ -7216,7 +7216,7 @@ result.total_rental_loss result.rental_loss_allowed f- /result.suspended_passive
 <action_comment>add PAL summary to job.audit_trail</action_comment></action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.pal_deduction = 0</action_description>
+<action_dsl>set result.pal_deduction = 0</action_dsl>
 <action_postfix>
 "  No rental losses to analyze" job.audit_trail swap addto
 </action_postfix>
@@ -7248,7 +7248,7 @@ result.total_rental_loss result.rental_loss_allowed f- /result.suspended_passive
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is rental property</condition_comment>
-<condition_description>property.type == "rental"</condition_description>
+<condition_dsl>property.type == "rental"</condition_dsl>
 <condition_postfix>property.type "rental" streq</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -7256,7 +7256,7 @@ result.total_rental_loss result.rental_loss_allowed f- /result.suspended_passive
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Property has loss (negative net income)</condition_comment>
-<condition_description>property.rental_net_income &lt; 0</condition_description>
+<condition_dsl>property.rental_net_income &lt; 0</condition_dsl>
 <condition_postfix>property.rental_net_income 0 &lt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="-" />
@@ -7265,7 +7265,7 @@ result.total_rental_loss result.rental_loss_allowed f- /result.suspended_passive
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add (-rental.net_loss) to result.total_rental_losses</action_description>
+<action_dsl>add (-rental.net_loss) to result.total_rental_losses</action_dsl>
 <action_postfix>
 property.rental_net_income fnegate result.total_rental_loss f+ /result.total_rental_loss xdef
 </action_postfix>
@@ -7273,7 +7273,7 @@ property.rental_net_income fnegate result.total_rental_loss f+ /result.total_ren
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X" />
@@ -7303,7 +7303,7 @@ property.rental_net_income fnegate result.total_rental_loss f+ /result.total_ren
 <initial_actions>
 <initial_action>
 <action_number>1</action_number>
-<action_description>set result.amti = result.taxable_income + amt_adjustments</action_description>
+<action_dsl>set result.amti = result.taxable_income + amt_adjustments</action_dsl>
 <action_postfix>
 result.taxable_income result.salt_deduction f+ /result.amti xdef
 "ALTERNATIVE MINIMUM TAX (Form 6251, IRC 55-59)" job.audit_trail swap addto
@@ -7317,7 +7317,7 @@ result.taxable_income result.salt_deduction f+ /result.amti xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Filing status MFJ</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>job.filing_status MFJ streq</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -7326,7 +7326,7 @@ result.taxable_income result.salt_deduction f+ /result.amti xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status MFS</condition_comment>
-<condition_description>job.filing_status is equal to "MFS"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFS"</condition_dsl>
 <condition_postfix>job.filing_status MFS streq</condition_postfix>
 <condition_column column_number="2" column_value="Y" />
 <condition_column column_number="3" column_value="N" />
@@ -7335,7 +7335,7 @@ result.taxable_income result.salt_deduction f+ /result.amti xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.amti amt_phaseout_mfj f- 0.25 f* 0 fmax /result.amt_exemption_reduction xdef
 amt_exemption_mfj result.amt_exemption_reduction f- 0 fmax /result.amt_exemption xdef
@@ -7352,7 +7352,7 @@ result.amt_tax result.total_tax_before_credits f- 0 fmax /result.amt_owed xdef
 <action_comment>set result.amt_owed = (amti - exemption) * amt_rate (MFJ)</action_comment></action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.amti amt_phaseout_mfs f- 0.25 f* 0 fmax /result.amt_exemption_reduction xdef
 amt_exemption_mfs result.amt_exemption_reduction f- 0 fmax /result.amt_exemption xdef
@@ -7369,7 +7369,7 @@ result.amt_tax result.total_tax_before_credits f- 0 fmax /result.amt_owed xdef
 <action_comment>set result.amt_owed = (amti - exemption) * amt_rate (MFS)</action_comment></action_details>
 <action_details>
 <action_number>3</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.amti amt_phaseout_single f- 0.25 f* 0 fmax /result.amt_exemption_reduction xdef
 amt_exemption_single result.amt_exemption_reduction f- 0 fmax /result.amt_exemption xdef
@@ -7416,7 +7416,7 @@ result.amt_tax result.total_tax_before_credits f- 0 fmax /result.amt_owed xdef
 <initial_actions>
 <initial_action>
 <action_number>1</action_number>
-<action_description>set result.premium_tax_credit = max_ptc - required_contribution</action_description>
+<action_dsl>set result.premium_tax_credit = max_ptc - required_contribution</action_dsl>
 <action_postfix>
 0.0 /result.premium_tax_credit xdef
 0.0 /result.ptc_repayment xdef
@@ -7434,7 +7434,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has marketplace coverage</condition_comment>
-<condition_description>job.has_marketplace_coverage == true</condition_description>
+<condition_dsl>job.has_marketplace_coverage == true</condition_dsl>
 <condition_postfix>job.has_marketplace_coverage true beq</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="Y" />
@@ -7444,7 +7444,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Eligible for PTC (FPL 100-400%)</condition_comment>
-<condition_description>FPL between 100 and 400</condition_description>
+<condition_dsl>FPL between 100 and 400</condition_dsl>
 <condition_postfix>result.fpl_percentage 100 &gt;= result.fpl_percentage 400 &lt;= and</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="Y" />
@@ -7453,7 +7453,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Net PTC is positive (credit owed)</condition_comment>
-<condition_description>result.net_ptc &gt;= 0</condition_description>
+<condition_dsl>result.net_ptc &gt;= 0</condition_dsl>
 <condition_postfix>result.net_ptc 0 &gt;=</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -7462,7 +7462,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Household size: " job.household_size cvs strconcat job.audit_trail swap addto
 "  FPL: $" result.fpl_amount cvs strconcat job.audit_trail swap addto
@@ -7476,7 +7476,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <action_comment>add PTC summary to job.audit_trail</action_comment></action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>add result.premium_tax_credit to result.total_credits</action_description>
+<action_dsl>add result.premium_tax_credit to result.total_credits</action_dsl>
 <action_postfix>
 result.net_ptc /result.premium_tax_credit xdef
 result.premium_tax_credit result.total_credits f+ /result.total_credits xdef
@@ -7486,7 +7486,7 @@ result.premium_tax_credit result.total_credits f+ /result.total_credits xdef
 </action_details>
 <action_details>
 <action_number>3</action_number>
-<action_description>set result.ptc_repayment = excess_advance_ptc</action_description>
+<action_dsl>set result.ptc_repayment = excess_advance_ptc</action_dsl>
 <action_postfix>
 result.net_ptc fnegate /result.ptc_repayment xdef
 "  PTC Repayment required: $" result.ptc_repayment cvs strconcat job.audit_trail swap addto
@@ -7495,7 +7495,7 @@ result.net_ptc fnegate /result.ptc_repayment xdef
 </action_details>
 <action_details>
 <action_number>4</action_number>
-<action_description>set result.ptc_repayment = total_advance_ptc</action_description>
+<action_dsl>set result.ptc_repayment = total_advance_ptc</action_dsl>
 <action_postfix>
 job.advance_ptc_received /result.ptc_repayment xdef
 "  FPL percentage: " result.fpl_percentage cvs strconcat "% (outside 100-400% range)" strconcat job.audit_trail swap addto
@@ -7505,7 +7505,7 @@ job.advance_ptc_received /result.ptc_repayment xdef
 </action_details>
 <action_details>
 <action_number>5</action_number>
-<action_description>set result.premium_tax_credit = 0</action_description>
+<action_dsl>set result.premium_tax_credit = 0</action_dsl>
 <action_postfix>
 "  No marketplace coverage - PTC not applicable" job.audit_trail swap addto
 </action_postfix>
@@ -7549,7 +7549,7 @@ job.advance_ptc_received /result.ptc_repayment xdef
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>add "K-1 PROCESSING" to job.audit_trail</action_description>
+<action_dsl>add "K-1 PROCESSING" to job.audit_trail</action_dsl>
 <action_postfix>
 "Processing Schedule K-1 Income (Schedule E Part II)" job.audit_trail swap addto
 </action_postfix>
@@ -7559,7 +7559,7 @@ job.advance_ptc_received /result.ptc_repayment xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has K-1 to process; K-1 entity exists in context</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>k1 isnull not</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 </condition_details>
@@ -7567,7 +7567,7 @@ job.advance_ptc_received /result.ptc_repayment xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  K-1 from: " k1.entity_name strconcat " (" strconcat k1.source_type strconcat ")" strconcat job.audit_trail swap addto
 k1.ordinary_income result.total_k1_ordinary_income f+ /result.total_k1_ordinary_income xdef
@@ -7603,7 +7603,7 @@ k1.qbi_income result.total_k1_qbi f+ /result.total_k1_qbi xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 "Calculating K-1 Self-Employment Tax (Schedule SE)" job.audit_trail swap addto
 </action_postfix>
@@ -7613,7 +7613,7 @@ k1.qbi_income result.total_k1_qbi f+ /result.total_k1_qbi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has K-1 SE earnings; result.total_k1_se_earnings &gt; se_threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.total_k1_se_earnings se_threshold &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -7622,7 +7622,7 @@ k1.qbi_income result.total_k1_qbi f+ /result.total_k1_qbi xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set taxpayer.k1_se_tax = k1_se_earnings * se_tax_rate</action_description>
+<action_dsl>set taxpayer.k1_se_tax = k1_se_earnings * se_tax_rate</action_dsl>
 <action_postfix>
 result.total_k1_se_earnings se_income_multiplier f* /k1_se_base xdef
 k1_se_base se_tax_rate f* /k1_se_tax xdef
@@ -7635,7 +7635,7 @@ k1_se_tax se_deduction_rate f* result.total_adjustments f+ /result.total_adjustm
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set taxpayer.k1_se_tax = 0</action_description>
+<action_dsl>set taxpayer.k1_se_tax = 0</action_dsl>
 <action_postfix>
 "  No K-1 SE earnings or below threshold" job.audit_trail swap addto
 </action_postfix>
@@ -7665,7 +7665,7 @@ k1_se_tax se_deduction_rate f* result.total_adjustments f+ /result.total_adjustm
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>add "IRA PROCESSING" to job.audit_trail</action_description>
+<action_dsl>add "IRA PROCESSING" to job.audit_trail</action_dsl>
 <action_postfix>
 "Processing IRA Accounts (Form 8606)" job.audit_trail swap addto
 </action_postfix>
@@ -7675,14 +7675,14 @@ k1_se_tax se_deduction_rate f* result.total_adjustments f+ /result.total_adjustm
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has IRA account to process; IRA account exists in context</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>ira isnull not</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 </condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Is traditional IRA</condition_comment>
-<condition_description>Account type is traditional</condition_description>
+<condition_dsl>Account type is traditional</condition_dsl>
 <condition_postfix>ira.account_type traditional streq</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 </condition_details>
@@ -7690,7 +7690,7 @@ k1_se_tax se_deduction_rate f* result.total_adjustments f+ /result.total_adjustm
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Traditional IRA at: " ira.institution strconcat job.audit_trail swap addto
 ira.year_end_balance result.total_ira_balance f+ /result.total_ira_balance xdef
@@ -7721,7 +7721,7 @@ ira.distribution_amount result.total_ira_distributions f+ /result.total_ira_dist
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 "Calculating Roth Conversion Tax (Form 8606 Part II)" job.audit_trail swap addto
 </action_postfix>
@@ -7731,7 +7731,7 @@ ira.distribution_amount result.total_ira_distributions f+ /result.total_ira_dist
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has Roth conversions</condition_comment>
-<condition_description>result.total_roth_conversions &gt; 0</condition_description>
+<condition_dsl>result.total_roth_conversions &gt; 0</condition_dsl>
 <condition_postfix>result.total_roth_conversions 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -7739,7 +7739,7 @@ ira.distribution_amount result.total_ira_distributions f+ /result.total_ira_dist
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has basis to recover</condition_comment>
-<condition_description>result.total_ira_basis &gt; 0</condition_description>
+<condition_dsl>result.total_ira_basis &gt; 0</condition_dsl>
 <condition_postfix>result.total_ira_basis 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 </condition_details>
@@ -7747,7 +7747,7 @@ ira.distribution_amount result.total_ira_distributions f+ /result.total_ira_dist
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set conversion.taxable_amount = conversion_amount * taxable_ratio</action_description>
+<action_dsl>set conversion.taxable_amount = conversion_amount * taxable_ratio</action_dsl>
 <action_postfix>
 result.total_ira_balance result.total_ira_basis f- result.total_ira_balance f/ /taxable_pct xdef
 result.total_roth_conversions taxable_pct f* /result.taxable_conversions xdef
@@ -7762,7 +7762,7 @@ result.taxable_conversions result.total_other_income f+ /result.total_other_inco
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set conversion.taxable_amount = 0</action_description>
+<action_dsl>set conversion.taxable_amount = 0</action_dsl>
 <action_postfix>
 "  No Roth conversions this year" job.audit_trail swap addto
 </action_postfix>
@@ -7792,7 +7792,7 @@ result.taxable_conversions result.total_other_income f+ /result.total_other_inco
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>add "FARM INCOME PROCESSING" to job.audit_trail</action_description>
+<action_dsl>add "FARM INCOME PROCESSING" to job.audit_trail</action_dsl>
 <action_postfix>
 "Processing Schedule F Farm Income (Publication 225)" job.audit_trail swap addto
 </action_postfix>
@@ -7802,7 +7802,7 @@ result.taxable_conversions result.total_other_income f+ /result.total_other_inco
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has farm to process; Farm entity exists in context</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>farm isnull not</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 </condition_details>
@@ -7810,7 +7810,7 @@ result.taxable_conversions result.total_other_income f+ /result.total_other_inco
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.farm_net_income = farm.gross_income - farm.expenses</action_description>
+<action_dsl>set result.farm_net_income = farm.gross_income - farm.expenses</action_dsl>
 <action_postfix>
 "  Farm: " farm.farm_name strconcat job.audit_trail swap addto
 farm.sales_livestock_raised farm.sales_crops f+ farm.coop_distributions f+ farm.agricultural_payments f+ farm.ccc_loans f+ farm.crop_insurance f+ farm.custom_hire f+ farm.other_farm_income f+ farm.sales_livestock_bought f- /farm.gross_income xdef
@@ -7843,7 +7843,7 @@ farm.net_profit result.net_farm_profit f+ /result.net_farm_profit xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 "Calculating Farm Self-Employment Tax (Schedule SE)" job.audit_trail swap addto
 </action_postfix>
@@ -7853,7 +7853,7 @@ farm.net_profit result.net_farm_profit f+ /result.net_farm_profit xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has farm profit subject to SE tax; result.net_farm_profit &gt; se_threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.net_farm_profit se_threshold &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -7862,7 +7862,7 @@ farm.net_profit result.net_farm_profit f+ /result.net_farm_profit xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set taxpayer.farm_se_tax = farm_net_income * se_tax_rate</action_description>
+<action_dsl>set taxpayer.farm_se_tax = farm_net_income * se_tax_rate</action_dsl>
 <action_postfix>
 result.net_farm_profit se_income_multiplier f* /farm_se_base xdef
 farm_se_base se_tax_rate f* /result.farm_se_tax xdef
@@ -7875,7 +7875,7 @@ result.farm_se_tax se_deduction_rate f* result.total_adjustments f+ /result.tota
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set taxpayer.farm_se_tax = 0</action_description>
+<action_dsl>set taxpayer.farm_se_tax = 0</action_dsl>
 <action_postfix>
 "  No farm profit or below SE threshold" job.audit_trail swap addto
 </action_postfix>
@@ -7905,7 +7905,7 @@ result.farm_se_tax se_deduction_rate f* result.total_adjustments f+ /result.tota
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>add "PROPERTY SALE PROCESSING" to job.audit_trail</action_description>
+<action_dsl>add "PROPERTY SALE PROCESSING" to job.audit_trail</action_dsl>
 <action_postfix>
 "Processing Form 4797 Business Property Sales" job.audit_trail swap addto
 </action_postfix>
@@ -7915,7 +7915,7 @@ result.farm_se_tax se_deduction_rate f* result.total_adjustments f+ /result.tota
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has property sale to process; Property sale exists in context</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>sale isnull not</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="Y" />
@@ -7924,7 +7924,7 @@ result.farm_se_tax se_deduction_rate f* result.total_adjustments f+ /result.tota
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Is Section 1245 property (personal property)</condition_comment>
-<condition_description>Property type is 1245</condition_description>
+<condition_dsl>Property type is 1245</condition_dsl>
 <condition_postfix>sale.property_type 1245 streq</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -7933,7 +7933,7 @@ result.farm_se_tax se_deduction_rate f* result.total_adjustments f+ /result.tota
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Is Section 1250 property (real property); Property type is 1250 or is real property</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>sale.property_type 1250 streq sale.is_real_property or</condition_postfix>
 <condition_column column_number="2" column_value="Y" />
 <condition_column column_number="3" column_value="N" />
@@ -7942,7 +7942,7 @@ result.farm_se_tax se_deduction_rate f* result.total_adjustments f+ /result.tota
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set sale.gain = sale.proceeds - sale.adjusted_basis</action_description>
+<action_dsl>set sale.gain = sale.proceeds - sale.adjusted_basis</action_dsl>
 <action_postfix>
 "  Property: " sale.description strconcat job.audit_trail swap addto
 sale.cost_basis sale.improvements f+ sale.depreciation_allowed f- /sale.adjusted_basis xdef
@@ -7958,7 +7958,7 @@ sale.amount_realized sale.adjusted_basis f- /sale.total_gain_loss xdef
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 sale.total_gain_loss 0 &gt; { sale.depreciation_allowed sale.total_gain_loss fmin /sale.ordinary_income_recapture xdef } if
 sale.total_gain_loss sale.ordinary_income_recapture f- /sale.section_1231_gain xdef
@@ -7969,7 +7969,7 @@ sale.ordinary_income_recapture result.total_depreciation_recapture f+ /result.to
 <action_comment>add sale.depreciation to result.ordinary_income (Section 1245)</action_comment></action_details>
 <action_details>
 <action_number>3</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 sale.total_gain_loss 0 &gt; { sale.depreciation_allowed sale.total_gain_loss fmin /sale.unrecaptured_1250_gain xdef } if
 sale.total_gain_loss sale.unrecaptured_1250_gain f- /sale.section_1231_gain xdef
@@ -7980,7 +7980,7 @@ sale.unrecaptured_1250_gain result.total_unrecaptured_1250 f+ /result.total_unre
 <action_comment>add sale.depreciation to result.section_1250_gain (25% max rate)</action_comment></action_details>
 <action_details>
 <action_number>4</action_number>
-<action_description>add sale.gain to result.section_1231_gain</action_description>
+<action_dsl>add sale.gain to result.section_1231_gain</action_dsl>
 <action_postfix>
 sale.total_gain_loss /sale.section_1231_gain xdef
 "    Section 1231 gain/loss: $" sale.section_1231_gain cvs strconcat job.audit_trail swap addto
@@ -7989,7 +7989,7 @@ sale.total_gain_loss /sale.section_1231_gain xdef
 </action_details>
 <action_details>
 <action_number>5</action_number>
-<action_description>add sale.section_1231_gain to result.total_section_1231</action_description>
+<action_dsl>add sale.section_1231_gain to result.total_section_1231</action_dsl>
 <action_postfix>
 sale.section_1231_gain 0 &gt; { sale.section_1231_gain result.total_1231_gains f+ /result.total_1231_gains xdef } if
 sale.section_1231_gain 0 &lt; { sale.section_1231_gain fnegate result.total_1231_losses f+ /result.total_1231_losses xdef } if
@@ -8016,7 +8016,7 @@ sale.section_1231_gain 0 &lt; { sale.section_1231_gain fnegate result.total_1231
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>set result.net_section_1231 = total_gains - total_losses</action_description>
+<action_dsl>set result.net_section_1231 = total_gains - total_losses</action_dsl>
 <action_postfix>
 "Calculating Net Section 1231 Treatment (IRC 1231)" job.audit_trail swap addto
 result.total_1231_gains result.total_1231_losses f- /result.net_1231_gain_loss xdef
@@ -8027,7 +8027,7 @@ result.total_1231_gains result.total_1231_losses f- /result.net_1231_gain_loss x
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has net Section 1231 gain</condition_comment>
-<condition_description>result.net_1231_gain &gt; 0</condition_description>
+<condition_dsl>result.net_1231_gain &gt; 0</condition_dsl>
 <condition_postfix>result.net_1231_gain_loss 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -8036,7 +8036,7 @@ result.total_1231_gains result.total_1231_losses f- /result.net_1231_gain_loss x
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has net Section 1231 loss; Net 1231 loss (negative)</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>result.net_1231_gain_loss 0 &lt;</condition_postfix>
 <condition_column column_number="2" column_value="Y" />
 <condition_column column_number="3" column_value="N" />
@@ -8045,7 +8045,7 @@ result.total_1231_gains result.total_1231_losses f- /result.net_1231_gain_loss x
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add result.net_section_1231 to result.total_long_term_gains</action_description>
+<action_dsl>add result.net_section_1231 to result.total_long_term_gains</action_dsl>
 <action_postfix>
 result.net_1231_gain_loss result.total_long_term_gains f+ /result.total_long_term_gains xdef
 "  Net Section 1231 gain: $" result.net_1231_gain_loss cvs strconcat job.audit_trail swap addto
@@ -8055,7 +8055,7 @@ result.net_1231_gain_loss result.total_long_term_gains f+ /result.total_long_ter
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>add result.net_section_1231 to result.ordinary_loss</action_description>
+<action_dsl>add result.net_section_1231 to result.ordinary_loss</action_dsl>
 <action_postfix>
 result.net_1231_gain_loss result.total_other_income f+ /result.total_other_income xdef
 "  Net Section 1231 loss: $" result.net_1231_gain_loss cvs strconcat job.audit_trail swap addto
@@ -8065,7 +8065,7 @@ result.net_1231_gain_loss result.total_other_income f+ /result.total_other_incom
 </action_details>
 <action_details>
 <action_number>3</action_number>
-<action_description>set result.net_section_1231 = 0</action_description>
+<action_dsl>set result.net_section_1231 = 0</action_dsl>
 <action_postfix>
 "  No Section 1231 gains or losses" job.audit_trail swap addto
 </action_postfix>
@@ -8095,7 +8095,7 @@ result.net_1231_gain_loss result.total_other_income f+ /result.total_other_incom
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>add "FOREIGN INCOME PROCESSING" to job.audit_trail</action_description>
+<action_dsl>add "FOREIGN INCOME PROCESSING" to job.audit_trail</action_dsl>
 <action_postfix>
 "Processing Form 1116 Foreign Income (IRC 901)" job.audit_trail swap addto
 </action_postfix>
@@ -8105,7 +8105,7 @@ result.net_1231_gain_loss result.total_other_income f+ /result.total_other_incom
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has foreign income to process; Foreign income entity exists in context</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>foreign isnull not</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 </condition_details>
@@ -8113,7 +8113,7 @@ result.net_1231_gain_loss result.total_other_income f+ /result.total_other_incom
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add foreign_income.amount to result.total_foreign_income</action_description>
+<action_dsl>add foreign_income.amount to result.total_foreign_income</action_dsl>
 <action_postfix>
 "  Country: " foreign.country strconcat " (" strconcat foreign.income_category strconcat ")" strconcat job.audit_trail swap addto
 foreign.gross_income foreign.directly_allocable_deductions f- /foreign.foreign_source_taxable xdef
@@ -8143,7 +8143,7 @@ foreign.foreign_taxes_paid foreign.foreign_taxes_withheld f+ result.total_foreig
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 "Calculating Foreign Tax Credit (Form 1116, IRC 904)" job.audit_trail swap addto
 </action_postfix>
@@ -8153,7 +8153,7 @@ foreign.foreign_taxes_paid foreign.foreign_taxes_withheld f+ result.total_foreig
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has foreign taxes paid</condition_comment>
-<condition_description>result.total_foreign_taxes_paid &gt; 0</condition_description>
+<condition_dsl>result.total_foreign_taxes_paid &gt; 0</condition_dsl>
 <condition_postfix>result.total_foreign_taxes_paid 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -8161,7 +8161,7 @@ foreign.foreign_taxes_paid foreign.foreign_taxes_withheld f+ result.total_foreig
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has taxable income</condition_comment>
-<condition_description>result.taxable_income &gt; 0</condition_description>
+<condition_dsl>result.taxable_income &gt; 0</condition_dsl>
 <condition_postfix>result.taxable_income 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 </condition_details>
@@ -8169,7 +8169,7 @@ foreign.foreign_taxes_paid foreign.foreign_taxes_withheld f+ result.total_foreig
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.total_foreign_income result.taxable_income f/ result.regular_tax f* /result.foreign_tax_credit_limit xdef
 result.total_foreign_taxes_paid result.foreign_tax_credit_limit fmin /result.foreign_tax_credit xdef
@@ -8182,7 +8182,7 @@ result.total_foreign_taxes_paid result.foreign_tax_credit_limit fmin /result.for
 <action_comment>set result.foreign_tax_credit = the minimum of taxes_paid and ftc_limitation</action_comment></action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.foreign_tax_credit = 0</action_description>
+<action_dsl>set result.foreign_tax_credit = 0</action_dsl>
 <action_postfix>
 "  No foreign taxes paid - FTC not applicable" job.audit_trail swap addto
 </action_postfix>
@@ -8206,7 +8206,7 @@ result.total_foreign_taxes_paid result.foreign_tax_credit_limit fmin /result.for
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize DC homebuyer credit</action_description>
+<action_dsl>Initialize DC homebuyer credit</action_dsl>
 <action_postfix>
 0.0 /result.dc_homebuyer_credit xdef
 </action_postfix>
@@ -8216,7 +8216,7 @@ result.total_foreign_taxes_paid result.foreign_tax_credit_limit fmin /result.for
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Purchased DC home as first-time buyer</condition_comment>
-<condition_description>job.purchased_dc_home_first_time equals true</condition_description>
+<condition_dsl>job.purchased_dc_home_first_time equals true</condition_dsl>
 <condition_postfix>job.purchased_dc_home_first_time</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -8224,7 +8224,7 @@ result.total_foreign_taxes_paid result.foreign_tax_credit_limit fmin /result.for
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Purchase price is greater than zero</condition_comment>
-<condition_description>job.dc_home_purchase_price &gt; 0</condition_description>
+<condition_dsl>job.dc_home_purchase_price &gt; 0</condition_dsl>
 <condition_postfix>job.dc_home_purchase_price 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -8234,7 +8234,7 @@ result.total_foreign_taxes_paid result.foreign_tax_credit_limit fmin /result.for
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate DC homebuyer credit; Calculate DC credit (lesser of $5,000 or purchase price)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "Calculating DC First-Time Homebuyer Credit (Form 8859)" job.audit_trail swap addto
 5000.0 job.dc_home_purchase_price fmin /result.dc_homebuyer_credit xdef
@@ -8246,7 +8246,7 @@ result.total_foreign_taxes_paid result.foreign_tax_credit_limit fmin /result.for
 <action_details>
 <action_number>2</action_number>
 <action_comment>No DC homebuyer credit; DC homebuyer credit not applicable</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "DC Homebuyer Credit not applicable" job.audit_trail swap addto
 </action_postfix>
@@ -8272,7 +8272,7 @@ result.total_foreign_taxes_paid result.foreign_tax_credit_limit fmin /result.for
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each foreign earned income record</context_comment>
-<context_description>for all foreign earned income records</context_description>
+<context_dsl>for all foreign earned income records</context_dsl>
 <context_postfix>
 0.0 /result.total_foreign_earned_income xdef
 0.0 /result.foreign_earned_income_exclusion xdef
@@ -8287,7 +8287,7 @@ result.total_foreign_taxes_paid result.foreign_tax_credit_limit fmin /result.for
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Qualifies for FEIE; Meets bona fide residence or physical presence test</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 foreign_earned_income.bona_fide_resident foreign_earned_income.physical_presence_days physical_presence_days_required &gt;= or
 </condition_postfix>
@@ -8298,7 +8298,7 @@ foreign_earned_income.bona_fide_resident foreign_earned_income.physical_presence
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 foreign_earned_income.foreign_wages foreign_earned_income.foreign_se_income f+ result.total_foreign_earned_income f+ /result.total_foreign_earned_income xdef
 result.total_foreign_earned_income feie_max_exclusion fmin result.foreign_earned_income_exclusion f+ /result.foreign_earned_income_exclusion xdef
@@ -8312,7 +8312,7 @@ foreign_earned_income.housing_exclusion result.foreign_housing_exclusion f+ /res
 <action_comment>Calculate FEIE exclusion and housing exclusion</action_comment></action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 false /foreign_earned_income.qualifies_exclusion xdef
 "  Does not qualify for FEIE - did not meet residence or presence test" job.audit_trail swap addto
@@ -8338,7 +8338,7 @@ false /foreign_earned_income.qualifies_exclusion xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each property for MCC</context_comment>
-<context_description>for all properties</context_description>
+<context_dsl>for all properties</context_dsl>
 <context_postfix>
 { /Calculate_Mortgage_Interest_Credit executetable } job.properties forall
 </context_postfix>
@@ -8346,7 +8346,7 @@ false /foreign_earned_income.qualifies_exclusion xdef
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize mortgage interest credit</action_description>
+<action_dsl>Initialize mortgage interest credit</action_dsl>
 <action_postfix>
 0.0 /result.mortgage_interest_credit xdef
 0.0 /result.carryforward_mortgage_credit xdef
@@ -8358,7 +8358,7 @@ false /foreign_earned_income.qualifies_exclusion xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Property has MCC</condition_comment>
-<condition_description>property.has_mortgage_credit_certificate equals true</condition_description>
+<condition_dsl>property.has_mortgage_credit_certificate equals true</condition_dsl>
 <condition_postfix>property.has_mortgage_credit_certificate</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -8366,7 +8366,7 @@ false /foreign_earned_income.qualifies_exclusion xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>MCC rate is valid; property.mcc_rate &gt; 0 and &lt;= 0.50</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>property.mcc_rate 0 &gt; property.mcc_rate 0.50 &lt;= and</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -8374,7 +8374,7 @@ false /foreign_earned_income.qualifies_exclusion xdef
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Has mortgage interest paid</condition_comment>
-<condition_description>Mortgage interest paid &gt; 0</condition_description>
+<condition_dsl>Mortgage interest paid &gt; 0</condition_dsl>
 <condition_postfix>
 property.mortgage_interest_paid 0 &gt; property.mortgage_interest_paid property.mortgage_interest if 0 &gt;
 </condition_postfix>
@@ -8386,7 +8386,7 @@ property.mortgage_interest_paid 0 &gt; property.mortgage_interest_paid property.
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate mortgage interest credit; Calculate MCC credit and adjust deduction</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 property.mortgage_interest_paid 0 &gt; property.mortgage_interest_paid property.mortgage_interest if local@ interest_paid &gt;
 interest_paid property.mcc_rate f* /property.mcc_credit xdef
@@ -8400,7 +8400,7 @@ property.mcc_credit_allowed /result.mortgage_interest_deduction_reduction xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No MCC credit; Property does not qualify for MCC</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /property.mcc_credit_allowed xdef
 </action_postfix>
@@ -8426,7 +8426,7 @@ property.mcc_credit_allowed /result.mortgage_interest_deduction_reduction xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each installment sale</context_comment>
-<context_description>for all installment sales</context_description>
+<context_dsl>for all installment sales</context_dsl>
 <context_postfix>
 0.0 /result.total_installment_gain xdef
 0.0 /result.total_installment_interest xdef
@@ -8440,7 +8440,7 @@ property.mcc_credit_allowed /result.mortgage_interest_deduction_reduction xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has payments this year</condition_comment>
-<condition_description>result.payments_received &gt; 0</condition_description>
+<condition_dsl>result.payments_received &gt; 0</condition_dsl>
 <condition_postfix>installment_sale.payments_received 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 </condition_details>
@@ -8448,7 +8448,7 @@ property.mcc_credit_allowed /result.mortgage_interest_deduction_reduction xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.installment_gain = payments_received * gross_profit_ratio</action_description>
+<action_dsl>set result.installment_gain = payments_received * gross_profit_ratio</action_dsl>
 <action_postfix>
 installment_sale.selling_price installment_sale.adjusted_basis f- installment_sale.selling_expenses f- /installment_sale.gross_profit xdef
 installment_sale.selling_price installment_sale.selling_expenses f- /installment_sale.contract_price xdef
@@ -8482,7 +8482,7 @@ installment_sale.interest_received result.total_installment_interest f+ /result.
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each like-kind exchange</context_comment>
-<context_description>for all like-kind exchanges</context_description>
+<context_dsl>for all like-kind exchanges</context_dsl>
 <context_postfix>
 0.0 /result.total_like_kind_recognized xdef
 0.0 /result.total_like_kind_deferred xdef
@@ -8496,7 +8496,7 @@ installment_sale.interest_received result.total_installment_interest f+ /result.
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has exchange to process; Exchange entity exists</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>like_kind_exchange isnull not</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 </condition_details>
@@ -8504,7 +8504,7 @@ installment_sale.interest_received result.total_installment_interest f+ /result.
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.recognized_gain = total_gain * recognition_ratio</action_description>
+<action_dsl>set result.recognized_gain = total_gain * recognition_ratio</action_dsl>
 <action_postfix>
 like_kind_exchange.cash_received like_kind_exchange.other_property_fmv f+ like_kind_exchange.mortgage_relieved f+ like_kind_exchange.mortgage_assumed f- like_kind_exchange.cash_paid f- /like_kind_exchange.boot_received xdef
 like_kind_exchange.boot_received 0 fmax /like_kind_exchange.boot_received xdef
@@ -8540,7 +8540,7 @@ like_kind_exchange.deferred_gain result.total_like_kind_deferred f+ /result.tota
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each early distribution</context_comment>
-<context_description>for all early distributions</context_description>
+<context_dsl>for all early distributions</context_dsl>
 <context_postfix>
 0.0 /result.total_early_withdrawal_penalty xdef
 "Processing Form 5329 Early Distributions (IRC 72(t))" job.audit_trail swap addto
@@ -8553,7 +8553,7 @@ like_kind_exchange.deferred_gain result.total_like_kind_deferred f+ /result.tota
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Subject to penalty; Early distribution with no exception</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 early_distribution.age_at_distribution early_withdrawal_age_limit &lt;
 early_distribution.exception_code "" streq
@@ -8566,7 +8566,7 @@ and
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.early_withdrawal_penalty = distribution.amount * 0.10</action_description>
+<action_dsl>set result.early_withdrawal_penalty = distribution.amount * 0.10</action_dsl>
 <action_postfix>
 true /early_distribution.subject_to_penalty xdef
 early_distribution.taxable_amount early_withdrawal_penalty_rate f* /early_distribution.penalty_amount xdef
@@ -8578,7 +8578,7 @@ early_distribution.penalty_amount result.total_early_withdrawal_penalty f+ /resu
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.early_withdrawal_penalty = 0</action_description>
+<action_dsl>set result.early_withdrawal_penalty = 0</action_dsl>
 <action_postfix>
 false /early_distribution.subject_to_penalty xdef
 0 /early_distribution.penalty_amount xdef
@@ -8605,7 +8605,7 @@ false /early_distribution.subject_to_penalty xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each child unearned income record</context_comment>
-<context_description>for all child unearned income records</context_description>
+<context_dsl>for all child unearned income records</context_dsl>
 <context_postfix>
 0.0 /result.total_kiddie_tax xdef
 "Processing Form 8615 Kiddie Tax (IRC 1(g))" job.audit_trail swap addto
@@ -8618,7 +8618,7 @@ false /early_distribution.subject_to_penalty xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Subject to kiddie tax; Child under age limit with unearned income over threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 child_unearned_income.child_age kiddie_tax_age_limit &lt;
 child_unearned_income.is_student child_unearned_income.child_age kiddie_tax_student_age &lt; and or
@@ -8632,7 +8632,7 @@ and
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.kiddie_tax = unearned_income * parent_marginal_rate</action_description>
+<action_dsl>set result.kiddie_tax = unearned_income * parent_marginal_rate</action_dsl>
 <action_postfix>
 true /child_unearned_income.subject_to_kiddie_tax xdef
 child_unearned_income.unearned_income_amount kiddie_tax_threshold f- /child_unearned_income.net_unearned_income xdef
@@ -8646,7 +8646,7 @@ child_unearned_income.kiddie_tax result.total_kiddie_tax f+ /result.total_kiddie
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.kiddie_tax = 0</action_description>
+<action_dsl>set result.kiddie_tax = 0</action_dsl>
 <action_postfix>
 false /child_unearned_income.subject_to_kiddie_tax xdef
 0.0 /child_unearned_income.kiddie_tax xdef
@@ -8673,7 +8673,7 @@ false /child_unearned_income.subject_to_kiddie_tax xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process elderly/disabled records</context_comment>
-<context_description>for all elderly/disabled records</context_description>
+<context_dsl>for all elderly/disabled records</context_dsl>
 <context_postfix>
 0.0 /result.elderly_disabled_credit xdef
 "Processing Schedule R Credit for Elderly/Disabled (IRC 22)" job.audit_trail swap addto
@@ -8686,7 +8686,7 @@ false /child_unearned_income.subject_to_kiddie_tax xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Qualifies for credit; Age 65+ or permanently disabled</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>elderly_disabled.age_65_or_older elderly_disabled.permanently_disabled or</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -8695,7 +8695,7 @@ false /child_unearned_income.subject_to_kiddie_tax xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.elderly_disabled_credit = credit_calculation</action_description>
+<action_dsl>set result.elderly_disabled_credit = credit_calculation</action_dsl>
 <action_postfix>
 true /elderly_disabled.qualifies xdef
 elderly_credit_single /elderly_disabled.initial_amount xdef
@@ -8712,7 +8712,7 @@ elderly_disabled.credit_amount result.elderly_disabled_credit f+ /result.elderly
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.elderly_disabled_credit = 0</action_description>
+<action_dsl>set result.elderly_disabled_credit = 0</action_dsl>
 <action_postfix>
 false /elderly_disabled.qualifies xdef
 "  Does not qualify for Schedule R credit" job.audit_trail swap addto
@@ -8738,7 +8738,7 @@ false /elderly_disabled.qualifies xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process estimated payments</context_comment>
-<context_description>for all estimated payments</context_description>
+<context_dsl>for all estimated payments</context_dsl>
 <context_postfix>
 0.0 /result.total_estimated_payments xdef
 0.0 /result.estimated_tax_penalty xdef
@@ -8753,7 +8753,7 @@ false /result.safe_harbor_met xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has estimated payment</condition_comment>
-<condition_description>result.payment_amount &gt; 0</condition_description>
+<condition_dsl>result.payment_amount &gt; 0</condition_dsl>
 <condition_postfix>estimated_payment.payment_amount 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 </condition_details>
@@ -8761,7 +8761,7 @@ false /result.safe_harbor_met xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add estimated_payment.amount to result.total_estimated_payments</action_description>
+<action_dsl>add estimated_payment.amount to result.total_estimated_payments</action_dsl>
 <action_postfix>
 estimated_payment.payment_amount result.total_estimated_payments f+ /result.total_estimated_payments xdef
 result.total_tax 4 f/ /estimated_payment.required_payment xdef
@@ -8789,7 +8789,7 @@ estimated_payment.required_payment estimated_payment.payment_amount f- 0 fmax /e
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process casualty losses</context_comment>
-<context_description>for all casualty losses</context_description>
+<context_dsl>for all casualty losses</context_dsl>
 <context_postfix>
 0.0 /result.total_casualty_loss xdef
 false /result.is_disaster_loss xdef
@@ -8803,7 +8803,7 @@ false /result.is_disaster_loss xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is disaster loss (deductible)</condition_comment>
-<condition_description>Federally declared disaster</condition_description>
+<condition_dsl>Federally declared disaster</condition_dsl>
 <condition_postfix>casualty_loss.disaster_designation "" streq not</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -8812,7 +8812,7 @@ false /result.is_disaster_loss xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 true /result.is_disaster_loss xdef
 casualty_loss.fmv_before casualty_loss.fmv_after f- /casualty_loss.decrease_in_fmv xdef
@@ -8827,7 +8827,7 @@ casualty_loss.deductible_loss result.total_casualty_loss f+ /result.total_casual
 <action_comment>set result.disaster_loss_deduction = (loss - $500 floor) - (10% of AGI)</action_comment></action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.casualty_deduction = 0</action_description>
+<action_dsl>set result.casualty_deduction = 0</action_dsl>
 <action_postfix>
 0 /casualty_loss.deductible_loss xdef
 "  Personal casualty loss not from federally declared disaster - not deductible (TCJA)" job.audit_trail swap addto
@@ -8853,7 +8853,7 @@ casualty_loss.deductible_loss result.total_casualty_loss f+ /result.total_casual
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process clean vehicles</context_comment>
-<context_description>for all clean vehicles</context_description>
+<context_dsl>for all clean vehicles</context_dsl>
 <context_postfix>
 0.0 /result.total_clean_vehicle_credit xdef
 "Processing Form 8936 Clean Vehicle Credit (IRC 30D)" job.audit_trail swap addto
@@ -8866,7 +8866,7 @@ casualty_loss.deductible_loss result.total_casualty_loss f+ /result.total_casual
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>New vehicle meeting requirements</condition_comment>
-<condition_description>Final assembly in NA and meets MSRP limit</condition_description>
+<condition_dsl>Final assembly in NA and meets MSRP limit</condition_dsl>
 <condition_postfix>
 clean_vehicle.vehicle_type "new" streq
 clean_vehicle.final_assembly_us
@@ -8880,7 +8880,7 @@ and and
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 true /clean_vehicle.qualifies xdef
 clean_vehicle.critical_minerals_pct 0.4 &gt;= { 3750 } { 0 } ifelse /clean_vehicle.critical_minerals_credit xdef
@@ -8894,7 +8894,7 @@ clean_vehicle.total_credit result.total_clean_vehicle_credit f+ /result.total_cl
 <action_comment>set result.clean_vehicle_credit = credit_amount (up to $7,500)</action_comment></action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.clean_vehicle_credit = 0</action_description>
+<action_dsl>set result.clean_vehicle_credit = 0</action_dsl>
 <action_postfix>
 false /clean_vehicle.qualifies xdef
 0 /clean_vehicle.total_credit xdef
@@ -8921,7 +8921,7 @@ false /clean_vehicle.qualifies xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process adoptions</context_comment>
-<context_description>for all adoptions</context_description>
+<context_dsl>for all adoptions</context_dsl>
 <context_postfix>
 0.0 /result.total_adoption_credit xdef
 0.0 /result.adoption_credit_carryforward xdef
@@ -8935,7 +8935,7 @@ false /clean_vehicle.qualifies xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has qualified expenses; result.qualified_adoption_expenses &gt; 0</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>adoption.qualified_expenses 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 </condition_details>
@@ -8943,7 +8943,7 @@ false /clean_vehicle.qualifies xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 adoption_credit_max /adoption.max_credit xdef
 adoption.qualified_expenses adoption.employer_assistance f- adoption.prior_year_expenses f- adoption.max_credit fmin /adoption.credit_before_limit xdef
@@ -8974,7 +8974,7 @@ adoption.credit_allowed result.total_adoption_credit f+ /result.total_adoption_c
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process household employees</context_comment>
-<context_description>for all household employees</context_description>
+<context_dsl>for all household employees</context_dsl>
 <context_postfix>
 0.0 /result.total_household_tax xdef
 "Processing Schedule H Household Employment Taxes" job.audit_trail swap addto
@@ -8987,7 +8987,7 @@ adoption.credit_allowed result.total_adoption_credit f+ /result.total_adoption_c
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Wages meet threshold; Cash wages at or above threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>household_employee.cash_wages household_ss_threshold &gt;=</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -8996,7 +8996,7 @@ adoption.credit_allowed result.total_adoption_credit f+ /result.total_adoption_c
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.household_employment_tax = wages * combined_rate</action_description>
+<action_dsl>set result.household_employment_tax = wages * combined_rate</action_dsl>
 <action_postfix>
 household_employee.ss_wages 0.062 f* /household_employee.ss_tax_employer xdef
 household_employee.medicare_wages 0.0145 f* /household_employee.medicare_tax_employer xdef
@@ -9010,7 +9010,7 @@ household_employee.total_household_tax result.total_household_tax f+ /result.tot
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.household_employment_tax = 0</action_description>
+<action_dsl>set result.household_employment_tax = 0</action_dsl>
 <action_postfix>
 0 /household_employee.total_household_tax xdef
 "  Household employee wages below threshold - no tax due" job.audit_trail swap addto
@@ -9036,7 +9036,7 @@ household_employee.total_household_tax result.total_household_tax f+ /result.tot
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process NOL carryovers</context_comment>
-<context_description>for all NOL carryovers</context_description>
+<context_dsl>for all NOL carryovers</context_dsl>
 <context_postfix>
 0.0 /result.nol_deduction xdef
 0.0 /result.nol_carryforward_remaining xdef
@@ -9050,7 +9050,7 @@ household_employee.total_household_tax result.total_household_tax f+ /result.tot
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has NOL available</condition_comment>
-<condition_description>result.nol_amount_available &gt; 0</condition_description>
+<condition_dsl>result.nol_amount_available &gt; 0</condition_dsl>
 <condition_postfix>nol_carryover.amount_available 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 </condition_details>
@@ -9058,7 +9058,7 @@ household_employee.total_household_tax result.total_household_tax f+ /result.tot
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.taxable_income result.nol_deduction f+ nol_limitation_rate f* /nol_carryover.deduction_limit xdef
 nol_carryover.amount_available nol_carryover.deduction_limit fmin /nol_carryover.amount_used xdef
@@ -9088,7 +9088,7 @@ nol_carryover.remaining_carryover result.nol_carryforward_remaining f+ /result.n
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process mortgage credit certificates</context_comment>
-<context_description>for all mortgage credit certificates</context_description>
+<context_dsl>for all mortgage credit certificates</context_dsl>
 <context_postfix>
 0.0 /result.mortgage_interest_credit xdef
 0.0 /result.mortgage_credit_carryforward xdef
@@ -9102,7 +9102,7 @@ nol_carryover.remaining_carryover result.nol_carryforward_remaining f+ /result.n
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Credit rate exceeds 20%</condition_comment>
-<condition_description>result.mcc_credit_rate &gt; 0.20</condition_description>
+<condition_dsl>result.mcc_credit_rate &gt; 0.20</condition_dsl>
 <condition_postfix>mortgage_credit_certificate.credit_rate 0.20 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -9111,7 +9111,7 @@ nol_carryover.remaining_carryover result.nol_carryforward_remaining f+ /result.n
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 mortgage_credit_certificate.mortgage_interest_paid mortgage_credit_certificate.credit_rate f* /mortgage_credit_certificate.tentative_credit xdef
 2000.0 /mortgage_credit_certificate.credit_limit xdef
@@ -9126,7 +9126,7 @@ mortgage_credit_certificate.carryforward_to_next result.mortgage_credit_carryfor
 <action_comment>set result.credit_amount = the minimum of credit and 2000</action_comment></action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.credit_amount = full_credit_amount</action_description>
+<action_dsl>set result.credit_amount = full_credit_amount</action_dsl>
 <action_postfix>
 mortgage_credit_certificate.mortgage_interest_paid mortgage_credit_certificate.credit_rate f* /mortgage_credit_certificate.tentative_credit xdef
 mortgage_credit_certificate.tentative_credit mortgage_credit_certificate.prior_year_carryforward f+ /mortgage_credit_certificate.current_year_credit xdef
@@ -9156,7 +9156,7 @@ mortgage_credit_certificate.current_year_credit result.mortgage_interest_credit 
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process prior year AMT credits</context_comment>
-<context_description>for all prior year AMT credits</context_description>
+<context_dsl>for all prior year AMT credits</context_dsl>
 <context_postfix>
 0.0 /result.prior_year_amt_credit xdef
 0.0 /result.amt_credit_carryforward xdef
@@ -9170,7 +9170,7 @@ mortgage_credit_certificate.current_year_credit result.mortgage_interest_credit 
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Credit available</condition_comment>
-<condition_description>Prior year AMT credit is available</condition_description>
+<condition_dsl>Prior year AMT credit is available</condition_dsl>
 <condition_postfix>prior_year_amt.credit_available 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -9179,7 +9179,7 @@ mortgage_credit_certificate.current_year_credit result.mortgage_interest_credit 
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.regular_tax result.amt_owed f- /prior_year_amt.net_regular_tax xdef
 result.tentative_minimum_tax /prior_year_amt.tentative_minimum_tax xdef
@@ -9194,7 +9194,7 @@ prior_year_amt.carryforward_remaining result.amt_credit_carryforward f+ /result.
 <action_comment>set result.amt_credit_used = the minimum of available_credit and (regular_tax - tentative_minimum_tax)</action_comment></action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.amt_credit_used = 0</action_description>
+<action_dsl>set result.amt_credit_used = 0</action_dsl>
 <action_postfix>
 "  No prior year AMT credit available" job.audit_trail swap addto
 </action_postfix>
@@ -9219,7 +9219,7 @@ prior_year_amt.carryforward_remaining result.amt_credit_carryforward f+ /result.
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process partnership audit adjustments</context_comment>
-<context_description>for all partnership audit adjustments</context_description>
+<context_dsl>for all partnership audit adjustments</context_dsl>
 <context_postfix>
 0.0 /result.partnership_audit_tax xdef
 "Calculating Partnership Audit Additional Tax (Form 8978, IRC 6226)" job.audit_trail swap addto
@@ -9232,7 +9232,7 @@ prior_year_amt.carryforward_remaining result.amt_credit_carryforward f+ /result.
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has income adjustments</condition_comment>
-<condition_description>Partnership audit has income adjustments</condition_description>
+<condition_dsl>Partnership audit has income adjustments</condition_dsl>
 <condition_postfix>
 partnership_audit.ordinary_income_adjustment partnership_audit.capital_gain_adjustment f+
 partnership_audit.dividend_adjustment f+ partnership_audit.interest_adjustment f+
@@ -9244,7 +9244,7 @@ partnership_audit.rental_adjustment f+ partnership_audit.other_adjustment f+ 0 !
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 partnership_audit.ordinary_income_adjustment partnership_audit.capital_gain_adjustment f+
 partnership_audit.dividend_adjustment f+ partnership_audit.interest_adjustment f+
@@ -9279,7 +9279,7 @@ partnership_audit.total_amount_due result.partnership_audit_tax f+ /result.partn
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each taxpayer for energy appliance credit</context_comment>
-<context_description>for all taxpayers</context_description>
+<context_dsl>for all taxpayers</context_dsl>
 <context_postfix>
 { /Calculate_Energy_Appliance_Credit executetable } job.taxpayers forall
 </context_postfix>
@@ -9287,7 +9287,7 @@ partnership_audit.total_amount_due result.partnership_audit_tax f+ /result.partn
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize energy appliance credit</action_description>
+<action_dsl>Initialize energy appliance credit</action_dsl>
 <action_postfix>
 0.0 /result.energy_appliance_credit xdef
 </action_postfix>
@@ -9297,7 +9297,7 @@ partnership_audit.total_amount_due result.partnership_audit_tax f+ /result.partn
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Manufacturer has appliance production</condition_comment>
-<condition_description>Has energy efficient appliances produced</condition_description>
+<condition_dsl>Has energy efficient appliances produced</condition_dsl>
 <condition_postfix>
 taxpayer.energy_efficient_appliances_produced 0 &gt;
 </condition_postfix>
@@ -9307,7 +9307,7 @@ taxpayer.energy_efficient_appliances_produced 0 &gt;
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /taxpayer.appliance_credit xdef
 "  Energy appliance credit placeholder" job.audit_trail swap addto
@@ -9334,7 +9334,7 @@ taxpayer.energy_efficient_appliances_produced 0 &gt;
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process unreported tips</context_comment>
-<context_description>for all unreported tips records</context_description>
+<context_dsl>for all unreported tips records</context_dsl>
 <context_postfix>
 0.0 /result.unreported_tips_tax xdef
 "Calculating Unreported Tips Tax (Form 4137, IRC 3121(q))" job.audit_trail swap addto
@@ -9347,7 +9347,7 @@ taxpayer.energy_efficient_appliances_produced 0 &gt;
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has unreported tips</condition_comment>
-<condition_description>Taxpayer has unreported tip income</condition_description>
+<condition_dsl>Taxpayer has unreported tip income</condition_dsl>
 <condition_postfix>unreported_tips.unreported_tips_amount 0 &gt;</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -9356,7 +9356,7 @@ taxpayer.energy_efficient_appliances_produced 0 &gt;
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.unreported_tips_tax = unreported_tips * fica_rate</action_description>
+<action_dsl>set result.unreported_tips_tax = unreported_tips * fica_rate</action_dsl>
 <action_postfix>
 unreported_tips.w2_wages unreported_tips.w2_ss_tips f+ unreported_tips.unreported_tips_amount f+ /unreported_tips.ss_wages_and_tips xdef
 unreported_tips.ss_wages_and_tips ss_wage_base fmin unreported_tips.w2_wages unreported_tips.w2_ss_tips f+ f- 0 fmax /unreported_tips.ss_tax_on_tips xdef
@@ -9371,7 +9371,7 @@ unreported_tips.total_fica_on_tips result.unreported_tips_tax f+ /result.unrepor
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.unreported_tips_tax = 0</action_description>
+<action_dsl>set result.unreported_tips_tax = 0</action_dsl>
 <action_postfix>
 0 /unreported_tips.total_fica_on_tips xdef
 </action_postfix>
@@ -9396,7 +9396,7 @@ unreported_tips.total_fica_on_tips result.unreported_tips_tax f+ /result.unrepor
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process LIHTC recaptures</context_comment>
-<context_description>for all LIHTC recapture events</context_description>
+<context_dsl>for all LIHTC recapture events</context_dsl>
 <context_postfix>
 0.0 /result.lihtc_recapture_tax xdef
 "Calculating LIHTC Recapture (Form 8611, IRC 42(j))" job.audit_trail swap addto
@@ -9409,7 +9409,7 @@ unreported_tips.total_fica_on_tips result.unreported_tips_tax f+ /result.unrepor
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has recapture event</condition_comment>
-<condition_description>LIHTC property has recapture event</condition_description>
+<condition_dsl>LIHTC property has recapture event</condition_dsl>
 <condition_postfix>lihtc_recapture.accelerated_portion 0 &gt; lihtc_recapture.percentage_decrease 0 &gt; or</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -9418,7 +9418,7 @@ unreported_tips.total_fica_on_tips result.unreported_tips_tax f+ /result.unrepor
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.recapture_tax = recapture_amount + interest</action_description>
+<action_dsl>set result.recapture_tax = recapture_amount + interest</action_dsl>
 <action_postfix>
 lihtc_recapture.accelerated_portion lihtc_recapture.percentage_decrease f* /lihtc_recapture.recapture_amount xdef
 lihtc_recapture.recapture_amount 0.0 f= if
@@ -9434,7 +9434,7 @@ lihtc_recapture.total_recapture_tax result.lihtc_recapture_tax f+ /result.lihtc_
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.recapture_tax = 0</action_description>
+<action_dsl>set result.recapture_tax = 0</action_dsl>
 <action_postfix>
 0 /lihtc_recapture.total_recapture_tax xdef
 "  No LIHTC recapture required" job.audit_trail swap addto
@@ -9459,12 +9459,12 @@ lihtc_recapture.total_recapture_tax result.lihtc_recapture_tax f+ /result.lihtc_
 <contexts>
 <context>
 <context_formal>state_tax_result</context_formal>
-<context_description>State tax result to process</context_description>
+<context_dsl>State tax result to process</context_dsl>
 </context>
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize part-year calculation</action_description>
+<action_dsl>Initialize part-year calculation</action_dsl>
 <action_postfix>
 state_tax_result.residency_status "part_year_resident" streq if
   "  Part-Year Resident Calculation for " state_tax_result.state_code strconcat job.audit_trail swap addto
@@ -9486,7 +9486,7 @@ endif
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Part-year resident</condition_comment>
-<condition_description>residency_status is "part_year_resident"</condition_description>
+<condition_dsl>residency_status is "part_year_resident"</condition_dsl>
 <condition_postfix>
 state_tax_result.residency_status "part_year_resident" streq
 </condition_postfix>
@@ -9498,7 +9498,7 @@ state_tax_result.residency_status "part_year_resident" streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Allocate income and deductions for part-year resident; Prorate income and deductions based on resident_ratio</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.agi state_tax_result.resident_ratio f* /state_tax_result.resident_income xdef
 "    Resident income (prorated): $" state_tax_result.resident_income cvs strconcat job.audit_trail swap addto
@@ -9513,7 +9513,7 @@ state_tax_result.resident_income state_tax_result.non_resident_income f+ /state_
 <action_details>
 <action_number>2</action_number>
 <action_comment>Full-year resident or non-resident; No allocation needed</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 12 /state_tax_result.resident_months xdef
 1.0 /state_tax_result.resident_ratio xdef
@@ -9556,7 +9556,7 @@ result.total_deductions /state_tax_result.allocated_deductions xdef
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 "Multi-State Income Allocation" job.audit_trail swap addto
 </action_postfix>
@@ -9566,7 +9566,7 @@ result.total_deductions /state_tax_result.allocated_deductions xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always execute for each state period; Always allocate income for each state period in the iteration</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -9577,7 +9577,7 @@ perform when called
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate days in state; Calculate days between start_date and end_date</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 state_period.end_date state_period.start_date daysbetween state_period.days_in_state !
 </action_postfix>
@@ -9586,7 +9586,7 @@ state_period.end_date state_period.start_date daysbetween state_period.days_in_s
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate allocation percentage; Calculate allocation percentage based on days in state</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 state_period.days_in_state cvt:d 365.0 div state_period.allocation_percentage !
 </action_postfix>
@@ -9595,7 +9595,7 @@ state_period.days_in_state cvt:d 365.0 div state_period.allocation_percentage !
 <action_details>
 <action_number>3</action_number>
 <action_comment>Allocate income for this state; Allocate income to this state based on state_code match or allocation percentage</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0 state_period.allocated_income !
 0 state_period.allocated_withholding !
@@ -9613,7 +9613,7 @@ done
 <action_details>
 <action_number>4</action_number>
 <action_comment>Log allocation results; Log the allocation results for audit trail</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Allocated " state_period.allocated_income formatnumber strconcat " to " strconcat state_period.state_code strconcat
 " (" strconcat state_period.days_in_state cvt:s strconcat " days)" strconcat job.audit_trail swap addto
@@ -9643,7 +9643,7 @@ done
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize state-source income calculation</action_description>
+<action_dsl>Initialize state-source income calculation</action_dsl>
 <action_postfix>
 "Calculating state-source income for non-resident tax allocation" job.audit_trail swap addto
 {} local@ state_income_hash &gt;
@@ -9654,7 +9654,7 @@ done
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always calculate state-source income; Calculate state-source income for all states</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 true
 </condition_postfix>
@@ -9665,7 +9665,7 @@ true
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate state-source income for each state; Allocate income to states based on source location</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 {
   dup w2_state_source w2_state &gt;
@@ -9758,7 +9758,7 @@ endif
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 { "State Tax Calculation for " job.state strconcat job.audit_trail swap addto }
 { "Multi-State Tax Calculation" job.audit_trail swap addto /Allocate_Income_By_State executetable }
@@ -9772,7 +9772,7 @@ ifelse
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>California state; state_period.state_code or job.state is equal to "CA"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 { state_period.state_code /CA streq }
 { job.state /CA streq }
@@ -9795,7 +9795,7 @@ ifelse
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Illinois state; state_period.state_code or job.state is equal to "IL"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 { state_period.state_code /IL streq }
 { job.state /IL streq }
@@ -9812,7 +9812,7 @@ ifelse
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>New Hampshire state; state_period.state_code or job.state is equal to "NH"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 { state_period.state_code /NH streq }
 { job.state /NH streq }
@@ -9829,7 +9829,7 @@ ifelse
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Colorado state; state_period.state_code or job.state is equal to "CO"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 { state_period.state_code /CO streq }
 { job.state /CO streq }
@@ -9847,7 +9847,7 @@ ifelse
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Montana state; state_period.state_code or job.state is equal to "MT"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 { state_period.state_code /MT streq }
 { job.state /MT streq }
@@ -9866,7 +9866,7 @@ ifelse
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>Pennsylvania state; state_period.state_code or job.state is equal to "PA"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 { state_period.state_code /PA streq }
 { job.state /PA streq }
@@ -9885,7 +9885,7 @@ ifelse
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>Delaware state; state_period.state_code or job.state is equal to "DE"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 { state_period.state_code /DE streq }
 { job.state /DE streq }
@@ -9907,7 +9907,7 @@ ifelse
 <condition_details>
 <condition_number>7</condition_number>
 <condition_comment>South Dakota state; state_period.state_code or job.state is equal to "SD"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 { state_period.state_code /SD streq }
 { job.state /SD streq }
@@ -9931,7 +9931,7 @@ ifelse
 <condition_comment>No state income tax (AK, FL, NV, TN, TX, WA, WY); State has no state income tax</condition_comment>
 
 <condition_comment>No state income tax (AK, FL, SD, TX, WA, WY)</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 {
   state_period.state_code /AK streq
@@ -9969,7 +9969,7 @@ ifelse
 <condition_details>
 <condition_number>10</condition_number>
 <condition_comment>Missouri state; state_period.state_code or job.state is equal to "MO"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 { state_period.state_code /MO streq }
 { job.state /MO streq }
@@ -9991,7 +9991,7 @@ ifelse
 <condition_details>
 <condition_number>10</condition_number>
 <condition_comment>Hawaii state; state_period.state_code or job.state is equal to "HI"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 { state_period.state_code /HI streq }
 { job.state /HI streq }
@@ -10014,7 +10014,7 @@ ifelse
 <condition_details>
 <condition_number>10</condition_number>
 <condition_comment>New Jersey state; state_period.state_code or job.state is equal to "NJ"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 { state_period.state_code /NJ streq }
 { job.state /NJ streq }
@@ -10037,7 +10037,7 @@ ifelse
 <condition_details>
 <condition_number>11</condition_number>
 <condition_comment>South Carolina state; state_period.state_code or job.state is equal to "SC"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 { state_period.state_code /SC streq }
 { job.state /SC streq }
@@ -10063,7 +10063,7 @@ ifelse
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate California state tax</action_comment>
-<action_description>perform Calculate_CA_Tax</action_description>
+<action_dsl>perform Calculate_CA_Tax</action_dsl>
 <action_postfix>
 /Calculate_CA_AGI executetable
 /Calculate_CA_Military_Retirement_Exemption executetable
@@ -10075,7 +10075,7 @@ ifelse
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Illinois state tax</action_comment>
-<action_description>perform Calculate_IL_Tax</action_description>
+<action_dsl>perform Calculate_IL_Tax</action_dsl>
 <action_postfix>
 Calculate_IL_Tax
 </action_postfix>
@@ -10084,7 +10084,7 @@ Calculate_IL_Tax
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate New Hampshire state tax</action_comment>
-<action_description>perform Calculate_NH_Tax</action_description>
+<action_dsl>perform Calculate_NH_Tax</action_dsl>
 <action_postfix>
 Calculate_NH_Tax
 </action_postfix>
@@ -10093,7 +10093,7 @@ Calculate_NH_Tax
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Colorado state tax</action_comment>
-<action_description>perform Calculate_CO_Tax</action_description>
+<action_dsl>perform Calculate_CO_Tax</action_dsl>
 <action_postfix>
 
 Calculate_CO_Military_Retirement_Exemption
@@ -10105,7 +10105,7 @@ Calculate_CO_Tax
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate Montana state tax</action_comment>
-<action_description>perform Calculate_MT_Tax</action_description>
+<action_dsl>perform Calculate_MT_Tax</action_dsl>
 <action_postfix>
 Calculate_MT_Tax
 </action_postfix>
@@ -10114,7 +10114,7 @@ Calculate_MT_Tax
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate Pennsylvania state tax</action_comment>
-<action_description>perform Calculate_PA_Tax</action_description>
+<action_dsl>perform Calculate_PA_Tax</action_dsl>
 <action_postfix>
 Calculate_PA_Tax
 </action_postfix>
@@ -10123,7 +10123,7 @@ Calculate_PA_Tax
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate Delaware state tax</action_comment>
-<action_description>perform Calculate_DE_Tax</action_description>
+<action_dsl>perform Calculate_DE_Tax</action_dsl>
 <action_postfix>
 Calculate_DE_Tax
 </action_postfix>
@@ -10132,7 +10132,7 @@ Calculate_DE_Tax
 <action_details>
 <action_number>7</action_number>
 <action_comment>Calculate South Dakota state tax</action_comment>
-<action_description>perform Calculate_SD_Tax</action_description>
+<action_dsl>perform Calculate_SD_Tax</action_dsl>
 <action_postfix>
 Calculate_SD_Tax
 </action_postfix>
@@ -10141,7 +10141,7 @@ Calculate_SD_Tax
 <action_details>
 <action_number>8</action_number>
 <action_comment>No state income tax; log "No state income tax for this state"</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 { "  No state income tax for " state_period.state_code strconcat job.audit_trail swap addto }
 { "  No state income tax for " job.state strconcat job.audit_trail swap addto }
@@ -10153,7 +10153,7 @@ ifelse
 <action_details>
 <action_number>7</action_number>
 <action_comment>Dynamically dispatch to state tax table; Construct table name Calculate_XX_Tax and execute</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 { state_period.state_code /state_code xdef }
 { job.state /state_code xdef }
@@ -10170,7 +10170,7 @@ ifelse
 <action_details>
 <action_number>10</action_number>
 <action_comment>Calculate Missouri state tax</action_comment>
-<action_description>perform Calculate_MO_Tax</action_description>
+<action_dsl>perform Calculate_MO_Tax</action_dsl>
 <action_postfix>
 Calculate_MO_Tax
 </action_postfix>
@@ -10179,7 +10179,7 @@ Calculate_MO_Tax
 <action_details>
 <action_number>10</action_number>
 <action_comment>Calculate Hawaii state tax</action_comment>
-<action_description>perform Calculate_HI_Tax</action_description>
+<action_dsl>perform Calculate_HI_Tax</action_dsl>
 <action_postfix>
 Calculate_HI_Tax
 </action_postfix>
@@ -10189,7 +10189,7 @@ Calculate_HI_Tax
 <action_details>
 <action_number>11</action_number>
 <action_comment>Calculate New Jersey state tax</action_comment>
-<action_description>perform Calculate_NJ_Tax</action_description>
+<action_dsl>perform Calculate_NJ_Tax</action_dsl>
 <action_postfix>
 Calculate_NJ_Tax
 </action_postfix>
@@ -10198,7 +10198,7 @@ Calculate_NJ_Tax
 <action_details>
 <action_number>13</action_number>
 <action_comment>Calculate South Carolina state tax</action_comment>
-<action_description>perform Calculate_SC_Tax</action_description>
+<action_dsl>perform Calculate_SC_Tax</action_dsl>
 <action_postfix>
 Calculate_SC_Tax
 </action_postfix>
@@ -10269,7 +10269,7 @@ Calculate_SC_Tax
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 { "US Territory Tax Calculation for " job.territory strconcat job.audit_trail swap addto }
 job.territory isnull not
@@ -10281,7 +10281,7 @@ if
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Puerto Rico territory</condition_comment>
-<condition_description>job.territory equals "PR"</condition_description>
+<condition_dsl>job.territory equals "PR"</condition_dsl>
 <condition_postfix>
 job.territory PR streq
 </condition_postfix>
@@ -10295,7 +10295,7 @@ job.territory PR streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>US Virgin Islands territory</condition_comment>
-<condition_description>job.territory equals "VI"</condition_description>
+<condition_dsl>job.territory equals "VI"</condition_dsl>
 <condition_postfix>
 job.territory VI streq
 </condition_postfix>
@@ -10309,7 +10309,7 @@ job.territory VI streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Guam territory</condition_comment>
-<condition_description>job.territory equals "GU"</condition_description>
+<condition_dsl>job.territory equals "GU"</condition_dsl>
 <condition_postfix>
 job.territory GU streq
 </condition_postfix>
@@ -10323,7 +10323,7 @@ job.territory GU streq
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>American Samoa territory</condition_comment>
-<condition_description>job.territory equals "AS"</condition_description>
+<condition_dsl>job.territory equals "AS"</condition_dsl>
 <condition_postfix>
 job.territory AS streq
 </condition_postfix>
@@ -10337,7 +10337,7 @@ job.territory AS streq
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>Northern Mariana Islands territory; job.territory equals "MP" or "CNMI"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 job.territory MP streq job.territory CNMI streq or
 </condition_postfix>
@@ -10351,7 +10351,7 @@ job.territory MP streq job.territory CNMI streq or
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>No territory or not applicable; No territory tax calculation needed</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 job.territory isnull job.territory "" streq or
 </condition_postfix>
@@ -10367,7 +10367,7 @@ job.territory isnull job.territory "" streq or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Puerto Rico territory tax</action_comment>
-<action_description>perform Calculate_PR_Tax</action_description>
+<action_dsl>perform Calculate_PR_Tax</action_dsl>
 <action_postfix>
 Calculate_PR_Tax
 </action_postfix>
@@ -10376,7 +10376,7 @@ Calculate_PR_Tax
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate US Virgin Islands territory tax</action_comment>
-<action_description>perform Calculate_VI_Tax</action_description>
+<action_dsl>perform Calculate_VI_Tax</action_dsl>
 <action_postfix>
 Calculate_VI_Tax
 </action_postfix>
@@ -10385,7 +10385,7 @@ Calculate_VI_Tax
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Guam territory tax</action_comment>
-<action_description>perform Calculate_GU_Tax</action_description>
+<action_dsl>perform Calculate_GU_Tax</action_dsl>
 <action_postfix>
 Calculate_GU_Tax
 </action_postfix>
@@ -10394,7 +10394,7 @@ Calculate_GU_Tax
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate American Samoa territory tax</action_comment>
-<action_description>perform Calculate_AS_Tax</action_description>
+<action_dsl>perform Calculate_AS_Tax</action_dsl>
 <action_postfix>
 Calculate_AS_Tax
 </action_postfix>
@@ -10403,7 +10403,7 @@ Calculate_AS_Tax
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate Northern Mariana Islands territory tax</action_comment>
-<action_description>perform Calculate_MP_Tax</action_description>
+<action_dsl>perform Calculate_MP_Tax</action_dsl>
 <action_postfix>
 Calculate_MP_Tax
 </action_postfix>
@@ -10412,7 +10412,7 @@ Calculate_MP_Tax
 <action_details>
 <action_number>6</action_number>
 <action_comment>No territory tax; log "No territory tax calculation needed"</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  No US territory tax calculation needed" job.audit_trail swap addto
 </action_postfix>
@@ -10462,7 +10462,7 @@ Calculate_MP_Tax
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize IL tax calculation</action_description>
+<action_dsl>Initialize IL tax calculation</action_dsl>
 <action_postfix>
 "ILLINOIS FORM IL-1040 - State Income Tax Calculation" job.audit_trail swap addto
 0 local@ num_people &gt;
@@ -10474,7 +10474,7 @@ result.agi /result.il_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Calculate number of people</condition_comment>
-<condition_description>Count taxpayers and dependents</condition_description>
+<condition_dsl>Count taxpayers and dependents</condition_dsl>
 <condition_postfix>
 job.taxpayers arraysize job.dependents arraysize + local@ num_people &gt;
 num_people 1 &gt;=
@@ -10487,7 +10487,7 @@ num_people 1 &gt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate IL tax with exemptions; Calculate Illinois AGI, apply exemptions, calculate tax at 4.95%</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 result.agi local@ il_retirement_subtraction &gt;
@@ -10510,7 +10510,7 @@ result.il_taxable_income il_tax_rate f* /result.il_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No exemptions - unlikely case; Calculate IL tax without exemptions</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Illinois AGI: $" result.il_agi cvs strconcat job.audit_trail swap addto
 result.il_agi 0 fmax /result.il_taxable_income xdef
@@ -10548,7 +10548,7 @@ result.il_taxable_income il_tax_rate f* /result.il_tax xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize HI tax calculation</action_description>
+<action_dsl>Initialize HI tax calculation</action_dsl>
 <action_postfix>
 "HAWAII FORM N-11 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.hi_agi xdef
@@ -10575,7 +10575,7 @@ result.hi_agi_after_deduction result.hi_exemption_total f- 0 fmax /result.hi_tax
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Single filer</condition_comment>
-<condition_description>Filing status is Single</condition_description>
+<condition_dsl>Filing status is Single</condition_dsl>
 <condition_postfix>
 job.filing_status Single streq
 </condition_postfix>
@@ -10586,7 +10586,7 @@ job.filing_status Single streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married filing jointly or QSS; Filing status is MFJ or QSS</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 job.filing_status MFJ streq job.filing_status QSS streq or
 </condition_postfix>
@@ -10597,7 +10597,7 @@ job.filing_status MFJ streq job.filing_status QSS streq or
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of household</condition_comment>
-<condition_description>Filing status is HOH</condition_description>
+<condition_dsl>Filing status is HOH</condition_dsl>
 <condition_postfix>
 job.filing_status HOH streq
 </condition_postfix>
@@ -10610,7 +10610,7 @@ job.filing_status HOH streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate HI tax for Single filers using progressive brackets; Calculate Hawaii tax for Single filers with 12 progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.hi_taxable_income hi_bracket_1_single f&amp;lt;= if
   result.hi_taxable_income hi_bracket_1_rate f* local@ hi_tax &gt;
@@ -10645,7 +10645,7 @@ hi_tax /result.hi_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate HI tax for MFJ/QSS filers using progressive brackets; Calculate Hawaii tax for MFJ/QSS filers with 12 progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.hi_taxable_income hi_bracket_1_mfj f&amp;lt;= if
   result.hi_taxable_income hi_bracket_1_rate f* local@ hi_tax &gt;
@@ -10680,7 +10680,7 @@ hi_tax /result.hi_tax xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate HI tax for HOH filers using progressive brackets; Calculate Hawaii tax for HOH filers with 12 progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.hi_taxable_income hi_bracket_1_hoh f&amp;lt;= if
   result.hi_taxable_income hi_bracket_1_rate f* local@ hi_tax &gt;
@@ -10743,7 +10743,7 @@ hi_tax /result.hi_tax xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize NH tax calculation</action_description>
+<action_dsl>Initialize NH tax calculation</action_dsl>
 <action_postfix>
 "NEW HAMPSHIRE FORM NH-1040 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.nh_agi xdef
@@ -10757,7 +10757,7 @@ result.agi /result.nh_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "married_filing_jointly"</condition_description>
+<condition_dsl>job.filing_status is equal to "married_filing_jointly"</condition_dsl>
 <condition_postfix>
 job.filing_status married_filing_jointly streq
 </condition_postfix>
@@ -10769,7 +10769,7 @@ job.filing_status married_filing_jointly streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate NH tax MFJ; Calculate NH tax with MFJ standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.nh_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 nh_standard_deduction_mfj /result.nh_standard_deduction xdef
@@ -10802,7 +10802,7 @@ result.nh_bracket_1_tax result.nh_bracket_2_tax f+ result.nh_bracket_3_tax f+ /r
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate NH tax Single/other; Calculate NH tax with Single standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.nh_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 nh_standard_deduction_single /result.nh_standard_deduction xdef
@@ -10860,7 +10860,7 @@ result.nh_bracket_1_tax result.nh_bracket_2_tax f+ result.nh_bracket_3_tax f+ /r
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize KS tax calculation</action_description>
+<action_dsl>Initialize KS tax calculation</action_dsl>
 <action_postfix>
 "KANSAS FORM K-40 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.ks_agi xdef
@@ -10873,7 +10873,7 @@ result.agi /result.ks_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "married_filing_jointly"</condition_description>
+<condition_dsl>job.filing_status is equal to "married_filing_jointly"</condition_dsl>
 <condition_postfix>
 job.filing_status married_filing_jointly streq
 </condition_postfix>
@@ -10885,7 +10885,7 @@ job.filing_status married_filing_jointly streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate KS tax MFJ; Calculate KS tax with MFJ standard deduction, personal exemptions, and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.ks_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 ks_standard_deduction_mfj /result.ks_standard_deduction xdef
@@ -10911,7 +10911,7 @@ result.ks_bracket_1_tax result.ks_bracket_2_tax f+ /result.ks_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate KS tax Single/other; Calculate KS tax with Single standard deduction, personal exemptions, and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.ks_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 ks_standard_deduction_single /result.ks_standard_deduction xdef
@@ -10963,7 +10963,7 @@ result.ks_bracket_1_tax result.ks_bracket_2_tax f+ /result.ks_tax xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize MT tax calculation</action_description>
+<action_dsl>Initialize MT tax calculation</action_dsl>
 <action_postfix>
 "MONTANA FORM 2 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.mt_agi xdef
@@ -10976,7 +10976,7 @@ result.agi /result.mt_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "married_filing_jointly"</condition_description>
+<condition_dsl>job.filing_status is equal to "married_filing_jointly"</condition_dsl>
 <condition_postfix>
 job.filing_status married_filing_jointly streq
 </condition_postfix>
@@ -10987,7 +10987,7 @@ job.filing_status married_filing_jointly streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single</condition_comment>
-<condition_description>job.filing_status is equal to "single"</condition_description>
+<condition_dsl>job.filing_status is equal to "single"</condition_dsl>
 <condition_postfix>
 job.filing_status single streq
 </condition_postfix>
@@ -10998,7 +10998,7 @@ job.filing_status single streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>job.filing_status is equal to "head_of_household"</condition_description>
+<condition_dsl>job.filing_status is equal to "head_of_household"</condition_dsl>
 <condition_postfix>
 job.filing_status head_of_household streq
 </condition_postfix>
@@ -11011,7 +11011,7 @@ job.filing_status head_of_household streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate MT tax MFJ; Calculate MT tax with MFJ standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.mt_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 mt_standard_deduction_mfj /result.mt_standard_deduction xdef
@@ -11035,7 +11035,7 @@ result.mt_bracket_1_tax result.mt_bracket_2_tax f+ /result.mt_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate MT tax Single; Calculate MT tax with Single standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.mt_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 mt_standard_deduction_single /result.mt_standard_deduction xdef
@@ -11059,7 +11059,7 @@ result.mt_bracket_1_tax result.mt_bracket_2_tax f+ /result.mt_tax xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate MT tax HOH; Calculate MT tax with HOH standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.mt_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 mt_standard_deduction_hoh /result.mt_standard_deduction xdef
@@ -11112,7 +11112,7 @@ result.mt_bracket_1_tax result.mt_bracket_2_tax f+ /result.mt_tax xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize NV tax calculation</action_description>
+<action_dsl>Initialize NV tax calculation</action_dsl>
 <action_postfix>
 "NEVADA - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.nv_agi xdef
@@ -11126,7 +11126,7 @@ result.agi /result.nv_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "married_filing_jointly"</condition_description>
+<condition_dsl>job.filing_status is equal to "married_filing_jointly"</condition_dsl>
 <condition_postfix>
 job.filing_status married_filing_jointly streq
 </condition_postfix>
@@ -11137,7 +11137,7 @@ job.filing_status married_filing_jointly streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single</condition_comment>
-<condition_description>job.filing_status is equal to "single"</condition_description>
+<condition_dsl>job.filing_status is equal to "single"</condition_dsl>
 <condition_postfix>
 job.filing_status single streq
 </condition_postfix>
@@ -11148,7 +11148,7 @@ job.filing_status single streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>job.filing_status is equal to "head_of_household"</condition_description>
+<condition_dsl>job.filing_status is equal to "head_of_household"</condition_dsl>
 <condition_postfix>
 job.filing_status head_of_household streq
 </condition_postfix>
@@ -11161,7 +11161,7 @@ job.filing_status head_of_household streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate NV tax MFJ; Calculate NV tax with MFJ standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.nv_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 nv_standard_deduction_mfj /result.nv_standard_deduction xdef
@@ -11194,7 +11194,7 @@ result.nv_bracket_1_tax result.nv_bracket_2_tax f+ result.nv_bracket_3_tax f+ /r
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate NV tax Single; Calculate NV tax with Single standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.nv_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 nv_standard_deduction_single /result.nv_standard_deduction xdef
@@ -11227,7 +11227,7 @@ result.nv_bracket_1_tax result.nv_bracket_2_tax f+ result.nv_bracket_3_tax f+ /r
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate NV tax HOH; Calculate NV tax with HOH standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.nv_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 nv_standard_deduction_hoh /result.nv_standard_deduction xdef
@@ -11289,7 +11289,7 @@ result.nv_bracket_1_tax result.nv_bracket_2_tax f+ result.nv_bracket_3_tax f+ /r
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize GBC calculation</action_description>
+<action_dsl>Initialize GBC calculation</action_dsl>
 <action_postfix>
 0.0 /result.general_business_credit_total xdef
 0.0 /result.general_business_credit_used xdef
@@ -11302,7 +11302,7 @@ result.nv_bracket_1_tax result.nv_bracket_2_tax f+ result.nv_bracket_3_tax f+ /r
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Any business credits present; Sum of business credits greater than 0</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.work_opportunity_credit result.research_credit f+ result.low_income_housing_credit f+
 result.disabled_access_credit f+ result.small_employer_pension_credit f+
@@ -11316,7 +11316,7 @@ result.small_employer_health_credit f+ result.employer_credit_paid_family_leave 
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate total GBC (Part I); Sum all component business credits</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.work_opportunity_credit result.research_credit f+ result.low_income_housing_credit f+
 result.disabled_access_credit f+ result.small_employer_pension_credit f+
@@ -11335,7 +11335,7 @@ result.employer_credit_paid_family_leave 0 &gt; { "    Employer Paid Family Leav
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate GBC limitation (Part II); Apply tax liability limitation</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 /tax_before_credits result.total_tax_before_credits def
 /threshold constants.gbc_threshold def
@@ -11354,7 +11354,7 @@ result.general_business_credit_carryforward 0 &gt; { "  GBC carryforward: $" res
 <action_details>
 <action_number>3</action_number>
 <action_comment>No business credits; Log no GBC applicable</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "No general business credits (Form 3800 not applicable)" job.audit_trail swap addto
 </action_postfix>
@@ -11379,7 +11379,7 @@ result.general_business_credit_carryforward 0 &gt; { "  GBC carryforward: $" res
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description />
+<action_dsl />
 <action_postfix>
 "KIDDIE TAX CALCULATION (Form 8615)" job.audit_trail swap addto
 </action_postfix>
@@ -11389,7 +11389,7 @@ result.general_business_credit_carryforward 0 &gt; { "  GBC carryforward: $" res
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always process kiddie tax for all dependents</condition_comment>
-<condition_description>always</condition_description>
+<condition_dsl>always</condition_dsl>
 <condition_postfix>
 always
 </condition_postfix>
@@ -11400,7 +11400,7 @@ always
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process kiddie tax for each dependent; Calculate_Kiddie_Tax_For_Dependent for each dependent</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 { /Calculate_Kiddie_Tax_For_Dependent executetable } job.dependents forall
 </action_postfix>
@@ -11428,7 +11428,7 @@ always
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Dependent is under 19 with unearned income over threshold; dependent.age lt 19 and dependent.unearned_income gt kiddie_tax_threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 dependent.age 19 &lt;
 dependent.unearned_income kiddie_tax_threshold &gt;
@@ -11439,7 +11439,7 @@ and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Dependent is 19-23 full-time student with unearned income over threshold; dependent.age between 19 and 23 and is_student and unearned_income gt threshold</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 dependent.age 19 &gt;=
 dependent.age 24 &lt;
@@ -11454,7 +11454,7 @@ and
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Kiddie tax does not apply</condition_comment>
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>
 otherwise
 </condition_postfix>
@@ -11465,7 +11465,7 @@ otherwise
 <action_details>
 <action_number>1</action_number>
 <action_comment>Mark dependent subject to kiddie tax; Set kiddie tax flag to true</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 true /dependent.subject_to_kiddie_tax xdef
 </action_postfix>
@@ -11475,7 +11475,7 @@ true /dependent.subject_to_kiddie_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate net unearned income subject to parent's tax rate; Net unearned income = unearned_income - kiddie_tax_threshold</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 dependent.unearned_income kiddie_tax_threshold f- 0 fmax /net_unearned_income local
 "  Dependent: " dependent.name strconcat job.audit_trail swap addto
@@ -11490,7 +11490,7 @@ dependent.unearned_income kiddie_tax_threshold f- 0 fmax /net_unearned_income lo
 <action_details>
 <action_number>3</action_number>
 <action_comment>Determine parent's marginal tax rate based on filing status; Calculate parent's marginal rate for MFJ filing status</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.10 /parent_marginal_rate local
 result.agi bracket_1_mfj &lt;={
@@ -11524,7 +11524,7 @@ net_unearned_income parent_marginal_rate f* /dependent.kiddie_tax_amount xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Add kiddie tax to total tax before credits; Add kiddie tax to total tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.total_tax_before_credits dependent.kiddie_tax_amount f+ /result.total_tax_before_credits xdef
 "    Total tax before credits increased to: $" result.total_tax_before_credits cvs strconcat job.audit_trail swap addto
@@ -11535,7 +11535,7 @@ result.total_tax_before_credits dependent.kiddie_tax_amount f+ /result.total_tax
 <action_details>
 <action_number>5</action_number>
 <action_comment>Kiddie tax does not apply - initialize to zero; No kiddie tax applicable</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 false /dependent.subject_to_kiddie_tax xdef
 0.0 /dependent.kiddie_tax_amount xdef
@@ -11563,7 +11563,7 @@ false /dependent.subject_to_kiddie_tax xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize Schedule H calculation</action_description>
+<action_dsl>Initialize Schedule H calculation</action_dsl>
 <action_postfix>
 "SCHEDULE H - Household Employment Taxes" job.audit_trail swap addto
 0.0 /result.schedule_h_social_security_tax xdef
@@ -11577,7 +11577,7 @@ false /dependent.subject_to_kiddie_tax xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has household employees; job.household_employees length greater than 0</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 job.household_employees length 0 &gt;
 </condition_postfix>
@@ -11589,7 +11589,7 @@ job.household_employees length 0 &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate employer FICA and FUTA for each employee; Process each household employee</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 {
   /employee xdef
@@ -11627,7 +11627,7 @@ result.schedule_h_social_security_tax result.schedule_h_medicare_tax f+ result.s
 <action_details>
 <action_number>2</action_number>
 <action_comment>No household employees; Skip Schedule H</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  No household employees - Schedule H not applicable" job.audit_trail swap addto
 </action_postfix>
@@ -11660,7 +11660,7 @@ result.schedule_h_social_security_tax result.schedule_h_medicare_tax f+ result.s
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each taxpayer for combat zone exclusion</context_comment>
-<context_description>for all taxpayers with military service</context_description>
+<context_dsl>for all taxpayers with military service</context_dsl>
 <context_postfix>
 0.0 /result.total_combat_zone_exclusion xdef
 "Processing Combat Zone Pay Exclusion (IRC § 112)" job.audit_trail swap addto
@@ -11673,7 +11673,7 @@ result.schedule_h_social_security_tax result.schedule_h_medicare_tax f+ result.s
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Served in combat zone</condition_comment>
-<condition_description>taxpayer.combat_zone_service == true</condition_description>
+<condition_dsl>taxpayer.combat_zone_service == true</condition_dsl>
 <condition_postfix>
 taxpayer.combat_zone_service true eq
 </condition_postfix>
@@ -11684,7 +11684,7 @@ taxpayer.combat_zone_service true eq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Enlisted rank</condition_comment>
-<condition_description>taxpayer.military_rank == "enlisted"</condition_description>
+<condition_dsl>taxpayer.military_rank == "enlisted"</condition_dsl>
 <condition_postfix>
 taxpayer.military_rank "enlisted" streq
 </condition_postfix>
@@ -11697,7 +11697,7 @@ taxpayer.military_rank "enlisted" streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Enlisted - exclude all combat zone pay; Entire combat zone pay excluded for enlisted</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  " taxpayer.name strconcat " - Enlisted combat zone service" strconcat job.audit_trail swap addto
 taxpayer.combat_zone_pay /taxpayer.combat_zone_exclusion xdef
@@ -11714,7 +11714,7 @@ result.total_combat_zone_exclusion taxpayer.combat_zone_exclusion f+ /result.tot
 <action_details>
 <action_number>2</action_number>
 <action_comment>Officer - limited exclusion; Officers limited to max enlisted pay + imminent danger pay</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  " taxpayer.name strconcat " - Officer combat zone service (limited exclusion)" strconcat job.audit_trail swap addto
 
@@ -11740,7 +11740,7 @@ result.total_combat_zone_exclusion taxpayer.combat_zone_exclusion f+ /result.tot
 <action_details>
 <action_number>3</action_number>
 <action_comment>No combat zone service; No exclusion</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /taxpayer.combat_zone_exclusion xdef
 </action_postfix>
@@ -11779,7 +11779,7 @@ result.total_combat_zone_exclusion taxpayer.combat_zone_exclusion f+ /result.tot
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process military moving expenses</context_comment>
-<context_description>for all military taxpayers</context_description>
+<context_dsl>for all military taxpayers</context_dsl>
 <context_postfix>
 0.0 /result.military_moving_expense_deduction xdef
 "Processing Military Moving Expense Deduction" job.audit_trail swap addto
@@ -11792,7 +11792,7 @@ result.total_combat_zone_exclusion taxpayer.combat_zone_exclusion f+ /result.tot
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Active duty military with PCS move</condition_comment>
-<condition_description>taxpayer.is_military == true AND taxpayer.pcs_move == true</condition_description>
+<condition_dsl>taxpayer.is_military == true AND taxpayer.pcs_move == true</condition_dsl>
 <condition_postfix>
 taxpayer.is_military true eq
 taxpayer.pcs_move true eq
@@ -11804,7 +11804,7 @@ and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Move meets distance test</condition_comment>
-<condition_description>taxpayer.moving_distance_miles &gt;= 50</condition_description>
+<condition_dsl>taxpayer.moving_distance_miles &gt;= 50</condition_dsl>
 <condition_postfix>
 taxpayer.moving_distance_miles 50 &gt;=
 </condition_postfix>
@@ -11816,7 +11816,7 @@ taxpayer.moving_distance_miles 50 &gt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Deduct qualifying military moving expenses; Military PCS moves are fully deductible</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  " taxpayer.name strconcat " - Qualified military PCS move" strconcat job.audit_trail swap addto
 
@@ -11836,7 +11836,7 @@ result.military_moving_expense_deduction taxpayer.moving_expense_deduction f+
 <action_details>
 <action_number>2</action_number>
 <action_comment>Not qualified or not military; No deduction</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /taxpayer.moving_expense_deduction xdef
 
@@ -11874,7 +11874,7 @@ taxpayer.is_military true eq {
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize coordination of military and foreign income</action_description>
+<action_dsl>Initialize coordination of military and foreign income</action_dsl>
 <action_postfix>
 "Coordinating Military Combat Zone and Foreign Earned Income Exclusions" job.audit_trail swap addto
 </action_postfix>
@@ -11884,7 +11884,7 @@ taxpayer.is_military true eq {
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Military with combat zone AND foreign earned income</condition_comment>
-<condition_description>Has both combat zone service and foreign earned income</condition_description>
+<condition_dsl>Has both combat zone service and foreign earned income</condition_dsl>
 <condition_postfix>
 result.total_combat_zone_exclusion 0 &gt;
 job.foreign_earned_incomes length 0 &gt;
@@ -11898,7 +11898,7 @@ and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Apply both exclusions (no double benefit); Combat zone exclusion + spouse FEIE</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Scenario: Military member in combat zone + spouse working abroad" job.audit_trail swap addto
 "  " job.audit_trail swap addto
@@ -11921,7 +11921,7 @@ result.total_combat_zone_exclusion result.foreign_earned_income_exclusion f+
 <action_details>
 <action_number>2</action_number>
 <action_comment>No coordination needed; Only one type of exclusion or none</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.combined_military_foreign_exclusion xdef
 </action_postfix>
@@ -11955,7 +11955,7 @@ result.total_combat_zone_exclusion result.foreign_earned_income_exclusion f+
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize OH tax calculation</action_description>
+<action_dsl>Initialize OH tax calculation</action_dsl>
 <action_postfix>
 "OHIO FORM IT-1040 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.oh_agi xdef
@@ -11969,7 +11969,7 @@ result.agi /result.oh_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Calculate number of people for exemptions</condition_comment>
-<condition_description>Count taxpayers and dependents</condition_description>
+<condition_dsl>Count taxpayers and dependents</condition_dsl>
 <condition_postfix>
 job.taxpayers arraysize job.dependents arraysize + local@ num_people &gt;
 num_people 1 &gt;=
@@ -11982,7 +11982,7 @@ num_people 1 &gt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate OH tax with exemptions; Calculate Ohio AGI, apply tiered exemptions, calculate progressive tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.oh_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 result.oh_agi oh_exemption_phaseout_threshold f&gt;= if
@@ -12030,7 +12030,7 @@ result.oh_bracket_1_tax result.oh_bracket_2_tax f+ result.oh_bracket_3_tax f+ /r
 <action_details>
 <action_number>2</action_number>
 <action_comment>No exemptions - unlikely case; Calculate OH tax without exemptions</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Ohio AGI: $" result.oh_agi cvs strconcat job.audit_trail swap addto
 result.oh_agi 0 fmax /result.oh_taxable_income xdef
@@ -12080,7 +12080,7 @@ result.oh_bracket_1_tax result.oh_bracket_2_tax f+ result.oh_bracket_3_tax f+ /r
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize Pennsylvania tax calculation</action_description>
+<action_dsl>Initialize Pennsylvania tax calculation</action_dsl>
 <action_postfix>
 "Pennsylvania Tax Calculation Started" job.audit_trail swap addto
 0.0 /result.pa_taxable_compensation xdef
@@ -12105,7 +12105,7 @@ result.oh_bracket_1_tax result.oh_bracket_2_tax f+ result.oh_bracket_3_tax f+ /r
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always execute</condition_comment>
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -12195,7 +12195,7 @@ result.pa_tax /result.state_tax_liability xdef
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize CA military retirement exemption calculation</action_description>
+<action_dsl>Initialize CA military retirement exemption calculation</action_dsl>
 <action_postfix>
 "CA Military Retirement Exemption Calculation Started" job.audit_trail swap addto
 0.0 /result.ca_military_retirement_exemption xdef
@@ -12209,7 +12209,7 @@ result.pa_tax /result.state_tax_liability xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has military retirement pay</condition_comment>
-<condition_description>military_retirement_pay &gt; 0</condition_description>
+<condition_dsl>military_retirement_pay &gt; 0</condition_dsl>
 <condition_postfix>
 result.military_retirement_pay 0 gt
 </condition_postfix>
@@ -12223,7 +12223,7 @@ result.military_retirement_pay 0 gt
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single filer, AGI ≤ $125k; Single AND AGI ≤ $125,000</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.filing_status "single" strcasecmp 0 eq
 result.agi result.ca_military_agi_limit_single le
@@ -12239,7 +12239,7 @@ and
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Joint filer, AGI ≤ $250k; Married Filing Jointly AND AGI ≤ $250,000</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.filing_status "married_filing_jointly" strcasecmp 0 eq
 result.filing_status "head_of_household" strcasecmp 0 eq or
@@ -12354,7 +12354,7 @@ job.audit_trail swap addto
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize CA AGI calculation</action_description>
+<action_dsl>Initialize CA AGI calculation</action_dsl>
 <action_postfix>
 "CALIFORNIA FORM 540 SCHEDULE CA - AGI Adjustments" job.audit_trail swap addto
 result.agi /result.ca_agi xdef
@@ -12367,7 +12367,7 @@ result.agi /result.ca_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has Social Security income</condition_comment>
-<condition_description>Any income item is type social_security</condition_description>
+<condition_dsl>Any income item is type social_security</condition_dsl>
 <condition_postfix>
 false local@ has_ss &gt;
 { dup type income_type &gt; income_type "social_security" streq if true local@ has_ss &gt; endif } job.incomes forall
@@ -12379,7 +12379,7 @@ has_ss
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has unemployment compensation</condition_comment>
-<condition_description>Any income item is type unemployment</condition_description>
+<condition_dsl>Any income item is type unemployment</condition_dsl>
 <condition_postfix>
 false local@ has_unemp &gt;
 { dup type income_type &gt; income_type "unemployment" streq if true local@ has_unemp &gt; endif } job.incomes forall
@@ -12393,7 +12393,7 @@ has_unemp
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Has military retirement income</condition_comment>
-<condition_description>Any income is pension from military</condition_description>
+<condition_dsl>Any income is pension from military</condition_dsl>
 <condition_postfix>
 false local@ has_military_retirement &gt;
 { dup type income_type &gt; income_type "pension" streq if
@@ -12413,7 +12413,7 @@ has_military_retirement
 <action_details>
 <action_number>1</action_number>
 <action_comment>CA AGI with SS, unemployment, and military retirement; Apply all major CA subtractions from federal AGI</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 0 local@ ss_total &gt;
@@ -12450,7 +12450,7 @@ endif
 <action_details>
 <action_number>2</action_number>
 <action_comment>CA AGI with SS and unemployment only; Apply SS and unemployment subtractions</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 0 local@ ss_total &gt;
@@ -12475,7 +12475,7 @@ endif
 <action_details>
 <action_number>3</action_number>
 <action_comment>CA AGI with SS and military retirement only; Apply SS and military retirement subtractions</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 0 local@ ss_total &gt;
@@ -12505,7 +12505,7 @@ endif
 <action_details>
 <action_number>4</action_number>
 <action_comment>CA AGI equals federal AGI; No CA-specific adjustments needed</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 "  California AGI: $" result.ca_agi cvs strconcat " (equals federal, no Schedule CA adjustments)" strconcat job.audit_trail swap addto
@@ -12545,7 +12545,7 @@ endif
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize California tax calculation</action_description>
+<action_dsl>Initialize California tax calculation</action_dsl>
 <action_postfix>
 "California Tax Calculation Started" job.audit_trail swap addto
 0.0 /result.ca_state_tax xdef
@@ -12560,7 +12560,7 @@ endif
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Filing status is Single</condition_comment>
-<condition_description>Filing Status is Single</condition_description>
+<condition_dsl>Filing Status is Single</condition_dsl>
 <condition_postfix>
 result.filing_status "single" strcasecmp 0 eq
 </condition_postfix>
@@ -12572,7 +12572,7 @@ result.filing_status "single" strcasecmp 0 eq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly or Head of Household; Filing Status is MFJ or HOH</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.filing_status "married_filing_jointly" strcasecmp 0 eq
 result.filing_status "head_of_household" strcasecmp 0 eq or
@@ -12835,7 +12835,7 @@ job.audit_trail swap addto
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize DE tax calculation</action_description>
+<action_dsl>Initialize DE tax calculation</action_dsl>
 <action_postfix>
 "DELAWARE FORM 200-01 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.de_agi xdef
@@ -12853,7 +12853,7 @@ result.agi /result.de_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "married_filing_jointly"</condition_description>
+<condition_dsl>job.filing_status is equal to "married_filing_jointly"</condition_dsl>
 <condition_postfix>
 job.filing_status married_filing_jointly streq
 </condition_postfix>
@@ -12865,7 +12865,7 @@ job.filing_status married_filing_jointly streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate DE tax MFJ; Calculate DE tax with MFJ standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.de_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 de_standard_deduction_mfj /result.de_standard_deduction xdef
@@ -12954,7 +12954,7 @@ result.de_bracket_1_tax result.de_bracket_2_tax f+ result.de_bracket_3_tax f+ re
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate DE tax Single/other; Calculate DE tax with Single standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.de_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 de_standard_deduction_single /result.de_standard_deduction xdef
@@ -13069,7 +13069,7 @@ result.de_bracket_1_tax result.de_bracket_2_tax f+ result.de_bracket_3_tax f+ re
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize Alabama tax calculation and compute AL taxable income</action_description>
+<action_dsl>Initialize Alabama tax calculation and compute AL taxable income</action_dsl>
 <action_postfix>
 0.0 /result.al_state_tax xdef
 "ALABAMA STATE TAX" job.audit_trail swap addto
@@ -13088,7 +13088,7 @@ result.al_taxable_income "  Alabama taxable income: $" swap f$ concat job.audit_
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>MFJ or HOH filing status; filing_status is MFJ or HOH</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 job.filing_status MFJ == job.filing_status HOH == or
 </condition_postfix>
@@ -13100,7 +13100,7 @@ job.filing_status MFJ == job.filing_status HOH == or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate AL tax using MFJ brackets; executeTable Calculate_AL_Tax_MFJ</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 Calculate_AL_Tax_MFJ
 </action_postfix>
@@ -13109,7 +13109,7 @@ Calculate_AL_Tax_MFJ
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate AL tax using Single brackets; executeTable Calculate_AL_Tax_Single</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 Calculate_AL_Tax_Single
 </action_postfix>
@@ -13136,7 +13136,7 @@ Calculate_AL_Tax_Single
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>In bracket 1 only; AL taxable income at or below $500</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.al_taxable_income al_bracket_1_single &lt;=
 </condition_postfix>
@@ -13147,7 +13147,7 @@ result.al_taxable_income al_bracket_1_single &lt;=
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>In bracket 2; AL taxable income at or below $3,000</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.al_taxable_income al_bracket_2_single &lt;=
 </condition_postfix>
@@ -13160,7 +13160,7 @@ result.al_taxable_income al_bracket_2_single &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Bracket 1 tax (2%)</action_comment>
-<action_description>set result.al_state_tax = result.al_taxable_income * 0.02</action_description>
+<action_dsl>set result.al_state_tax = result.al_taxable_income * 0.02</action_dsl>
 <action_postfix>
 result.al_taxable_income al_tax_rate_1 f* /result.al_state_tax xdef
 result.al_state_tax "  Alabama tax (2% bracket): $" swap f$ concat job.audit_trail swap addto
@@ -13170,7 +13170,7 @@ result.al_state_tax "  Alabama tax (2% bracket): $" swap f$ concat job.audit_tra
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bracket 2 tax (2% + 4%); set result.al_state_tax = ($500 * 0.02) + (excess * 0.04)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 al_bracket_1_single al_tax_rate_1 f*
 result.al_taxable_income al_bracket_1_single f- al_tax_rate_2 f* f+
@@ -13182,7 +13182,7 @@ result.al_state_tax "  Alabama tax (2% + 4% brackets): $" swap f$ concat job.aud
 <action_details>
 <action_number>3</action_number>
 <action_comment>Bracket 3 tax (2% + 4% + 5%); set result.al_state_tax = ($500 * 0.02) + ($2,500 * 0.04) + (excess * 0.05)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 al_bracket_1_single al_tax_rate_1 f*
 al_bracket_2_single al_bracket_1_single f- al_tax_rate_2 f* f+
@@ -13213,7 +13213,7 @@ result.al_state_tax "  Alabama tax (all brackets): $" swap f$ concat job.audit_t
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>In bracket 1 only; AL taxable income at or below $1,000</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.al_taxable_income al_bracket_1_mfj &lt;=
 </condition_postfix>
@@ -13224,7 +13224,7 @@ result.al_taxable_income al_bracket_1_mfj &lt;=
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>In bracket 2; AL taxable income at or below $6,000</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.al_taxable_income al_bracket_2_mfj &lt;=
 </condition_postfix>
@@ -13237,7 +13237,7 @@ result.al_taxable_income al_bracket_2_mfj &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Bracket 1 tax (2%)</action_comment>
-<action_description>set result.al_state_tax = result.al_taxable_income * 0.02</action_description>
+<action_dsl>set result.al_state_tax = result.al_taxable_income * 0.02</action_dsl>
 <action_postfix>
 result.al_taxable_income al_tax_rate_1 f* /result.al_state_tax xdef
 result.al_state_tax "  Alabama tax (2% bracket): $" swap f$ concat job.audit_trail swap addto
@@ -13247,7 +13247,7 @@ result.al_state_tax "  Alabama tax (2% bracket): $" swap f$ concat job.audit_tra
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bracket 2 tax (2% + 4%); set result.al_state_tax = ($1,000 * 0.02) + (excess * 0.04)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 al_bracket_1_mfj al_tax_rate_1 f*
 result.al_taxable_income al_bracket_1_mfj f- al_tax_rate_2 f* f+
@@ -13259,7 +13259,7 @@ result.al_state_tax "  Alabama tax (2% + 4% brackets): $" swap f$ concat job.aud
 <action_details>
 <action_number>3</action_number>
 <action_comment>Bracket 3 tax (2% + 4% + 5%); set result.al_state_tax = ($1,000 * 0.02) + ($5,000 * 0.04) + (excess * 0.05)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 al_bracket_1_mfj al_tax_rate_1 f*
 al_bracket_2_mfj al_bracket_1_mfj f- al_tax_rate_2 f* f+
@@ -13288,7 +13288,7 @@ result.al_state_tax "  Alabama tax (all brackets): $" swap f$ concat job.audit_t
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize SD tax calculation</action_description>
+<action_dsl>Initialize SD tax calculation</action_dsl>
 <action_postfix>
 "SOUTH DAKOTA FORM SD-1040 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.sd_agi xdef
@@ -13301,7 +13301,7 @@ result.agi /result.sd_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "married_filing_jointly"</condition_description>
+<condition_dsl>job.filing_status is equal to "married_filing_jointly"</condition_dsl>
 <condition_postfix>
 job.filing_status married_filing_jointly streq
 </condition_postfix>
@@ -13312,7 +13312,7 @@ job.filing_status married_filing_jointly streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single</condition_comment>
-<condition_description>job.filing_status is equal to "single"</condition_description>
+<condition_dsl>job.filing_status is equal to "single"</condition_dsl>
 <condition_postfix>
 job.filing_status single streq
 </condition_postfix>
@@ -13323,7 +13323,7 @@ job.filing_status single streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>job.filing_status is equal to "head_of_household"</condition_description>
+<condition_dsl>job.filing_status is equal to "head_of_household"</condition_dsl>
 <condition_postfix>
 job.filing_status head_of_household streq
 </condition_postfix>
@@ -13336,7 +13336,7 @@ job.filing_status head_of_household streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate SD tax MFJ; Calculate SD tax with MFJ standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.sd_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 sd_standard_deduction_mfj /result.sd_standard_deduction xdef
@@ -13360,7 +13360,7 @@ result.sd_bracket_1_tax result.sd_bracket_2_tax f+ /result.sd_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate SD tax Single; Calculate SD tax with Single standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.sd_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 sd_standard_deduction_single /result.sd_standard_deduction xdef
@@ -13384,7 +13384,7 @@ result.sd_bracket_1_tax result.sd_bracket_2_tax f+ /result.sd_tax xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate SD tax HOH; Calculate SD tax with HOH standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.sd_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 sd_standard_deduction_single /result.sd_standard_deduction xdef
@@ -13437,7 +13437,7 @@ result.sd_bracket_1_tax result.sd_bracket_2_tax f+ /result.sd_tax xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize GA tax calculation</action_description>
+<action_dsl>Initialize GA tax calculation</action_dsl>
 <action_postfix>
 "GEORGIA FORM 500 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.ga_agi xdef
@@ -13448,7 +13448,7 @@ result.agi /result.ga_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>Filing status is MFJ</condition_description>
+<condition_dsl>Filing status is MFJ</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -13460,7 +13460,7 @@ job.filing_status MFJ streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate GA tax for MFJ; Apply MFJ standard deduction ($24,000) and calculate tax at 5.19%</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.ga_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 ga_standard_deduction_mfj /result.ga_standard_deduction xdef
@@ -13475,7 +13475,7 @@ result.ga_taxable_income ga_tax_rate f* /result.ga_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate GA tax for Single/HOH; Apply Single/HOH standard deduction ($12,000) and calculate tax at 5.19%</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.ga_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 ga_standard_deduction_single /result.ga_standard_deduction xdef
@@ -13518,7 +13518,7 @@ result.ga_taxable_income ga_tax_rate f* /result.ga_tax xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize NE tax calculation</action_description>
+<action_dsl>Initialize NE tax calculation</action_dsl>
 <action_postfix>
 "NEBRASKA FORM 1040N - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.ne_agi xdef
@@ -13533,7 +13533,7 @@ result.agi /result.ne_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "married_filing_jointly"</condition_description>
+<condition_dsl>job.filing_status is equal to "married_filing_jointly"</condition_dsl>
 <condition_postfix>
 job.filing_status married_filing_jointly streq
 </condition_postfix>
@@ -13545,7 +13545,7 @@ job.filing_status married_filing_jointly streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate NE tax MFJ; Calculate NE tax with MFJ standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.ne_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 ne_standard_deduction_mfj /result.ne_standard_deduction xdef
@@ -13589,7 +13589,7 @@ result.ne_bracket_1_tax result.ne_bracket_2_tax f+ result.ne_bracket_3_tax f+ re
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate NE tax Single/other; Calculate NE tax with Single standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.ne_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 ne_standard_deduction_single /result.ne_standard_deduction xdef
@@ -13659,7 +13659,7 @@ result.ne_bracket_1_tax result.ne_bracket_2_tax f+ result.ne_bracket_3_tax f+ re
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize TN tax calculation</action_description>
+<action_dsl>Initialize TN tax calculation</action_dsl>
 <action_postfix>
 "TENNESSEE FORM TN-1040 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.tn_agi xdef
@@ -13673,7 +13673,7 @@ result.agi /result.tn_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "married_filing_jointly"</condition_description>
+<condition_dsl>job.filing_status is equal to "married_filing_jointly"</condition_dsl>
 <condition_postfix>
 job.filing_status married_filing_jointly streq
 </condition_postfix>
@@ -13685,7 +13685,7 @@ job.filing_status married_filing_jointly streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate TN tax MFJ; Calculate TN tax with MFJ standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.tn_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 tn_standard_deduction_mfj /result.tn_standard_deduction xdef
@@ -13718,7 +13718,7 @@ result.tn_bracket_1_tax result.tn_bracket_2_tax f+ result.tn_bracket_3_tax f+ /r
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate TN tax Single/other; Calculate TN tax with Single standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.tn_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 tn_standard_deduction_single /result.tn_standard_deduction xdef
@@ -13774,7 +13774,7 @@ result.tn_bracket_1_tax result.tn_bracket_2_tax f+ result.tn_bracket_3_tax f+ /r
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize MS tax calculation</action_description>
+<action_dsl>Initialize MS tax calculation</action_dsl>
 <action_postfix>
 "MISSISSIPPI FORM 80-105 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.ms_agi xdef
@@ -13787,7 +13787,7 @@ result.agi /result.ms_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "married_filing_jointly"</condition_description>
+<condition_dsl>job.filing_status is equal to "married_filing_jointly"</condition_dsl>
 <condition_postfix>
 job.filing_status married_filing_jointly streq
 </condition_postfix>
@@ -13798,7 +13798,7 @@ job.filing_status married_filing_jointly streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single</condition_comment>
-<condition_description>job.filing_status is equal to "single"</condition_description>
+<condition_dsl>job.filing_status is equal to "single"</condition_dsl>
 <condition_postfix>
 job.filing_status single streq
 </condition_postfix>
@@ -13809,7 +13809,7 @@ job.filing_status single streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>job.filing_status is equal to "head_of_household"</condition_description>
+<condition_dsl>job.filing_status is equal to "head_of_household"</condition_dsl>
 <condition_postfix>
 job.filing_status head_of_household streq
 </condition_postfix>
@@ -13822,7 +13822,7 @@ job.filing_status head_of_household streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate MS tax MFJ; Calculate MS tax with MFJ standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.ms_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 ms_standard_deduction_mfj /result.ms_standard_deduction xdef
@@ -13846,7 +13846,7 @@ result.ms_bracket_1_tax result.ms_bracket_2_tax f+ /result.ms_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate MS tax Single; Calculate MS tax with Single standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.ms_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 ms_standard_deduction_single /result.ms_standard_deduction xdef
@@ -13870,7 +13870,7 @@ result.ms_bracket_1_tax result.ms_bracket_2_tax f+ /result.ms_tax xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate MS tax HOH; Calculate MS tax with HOH standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.ms_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 ms_standard_deduction_hoh /result.ms_standard_deduction xdef
@@ -13924,7 +13924,7 @@ result.ms_bracket_1_tax result.ms_bracket_2_tax f+ /result.ms_tax xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize other state tax credit calculation</action_description>
+<action_dsl>Initialize other state tax credit calculation</action_dsl>
 <action_postfix>
 "CREDIT FOR TAXES PAID TO OTHER STATES (TABLE 45100)" job.audit_trail swap addto
 0.0 /total_other_state_income xdef
@@ -13938,7 +13938,7 @@ result.ms_bracket_1_tax result.ms_bracket_2_tax f+ /result.ms_tax xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has other state income and taxes</condition_comment>
-<condition_description>Has income from other states with taxes paid</condition_description>
+<condition_dsl>Has income from other states with taxes paid</condition_dsl>
 <condition_postfix>
 job.state_tax_results countof 1 &gt;
 </condition_postfix>
@@ -13948,7 +13948,7 @@ job.state_tax_results countof 1 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>No other state income; No multi-state taxation</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 otherwise
 </condition_postfix>
@@ -13960,7 +13960,7 @@ otherwise
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate credit for other state taxes; Sum other state income and taxes, calculate credit as lesser of taxes paid or resident state tax on that income</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Calculating credit for multi-state taxation" job.audit_trail swap addto
 job.state_tax_results forEach
@@ -13996,7 +13996,7 @@ endif
 <action_details>
 <action_number>2</action_number>
 <action_comment>No credit - single state only; No other state tax credit needed</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Single state filing - no other state tax credit needed" job.audit_trail swap addto
 </action_postfix>
@@ -14032,7 +14032,7 @@ endif
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize DC tax calculation</action_description>
+<action_dsl>Initialize DC tax calculation</action_dsl>
 <action_postfix>
 "WASHINGTON DC FORM D-40 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.dc_agi xdef
@@ -14043,7 +14043,7 @@ result.agi /result.dc_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Single or Married Filing Separately; job.filing_status is "Single" or "MFS"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 job.filing_status Single streq job.filing_status MFS streq or
 </condition_postfix>
@@ -14054,7 +14054,7 @@ job.filing_status Single streq job.filing_status MFS streq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>job.filing_status is "HOH"</condition_description>
+<condition_dsl>job.filing_status is "HOH"</condition_dsl>
 <condition_postfix>
 job.filing_status HOH streq
 </condition_postfix>
@@ -14065,7 +14065,7 @@ job.filing_status HOH streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Married Filing Jointly or Qualifying Widow(er); job.filing_status is "MFJ" or "QW"</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 job.filing_status MFJ streq job.filing_status QW streq or
 </condition_postfix>
@@ -14078,7 +14078,7 @@ job.filing_status MFJ streq job.filing_status QW streq or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate DC tax for Single/MFS; Apply DC standard deduction (Single/MFS) and calculate progressive tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.dc_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 dc_standard_deduction_single /result.dc_standard_deduction_amount xdef
@@ -14119,7 +14119,7 @@ dc_calculated_tax /result.dc_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate DC tax for HOH; Apply DC standard deduction (HOH) and calculate progressive tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.dc_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 dc_standard_deduction_hoh /result.dc_standard_deduction_amount xdef
@@ -14160,7 +14160,7 @@ dc_calculated_tax /result.dc_tax xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate DC tax for MFJ/QW; Apply DC standard deduction (MFJ/QW) and calculate progressive tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.dc_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 dc_standard_deduction_mfj /result.dc_standard_deduction_amount xdef
@@ -14234,7 +14234,7 @@ dc_calculated_tax /result.dc_tax xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Taxpayer is SC resident</condition_comment>
-<condition_description>job.state is equal to "SC"</condition_description>
+<condition_dsl>job.state is equal to "SC"</condition_dsl>
 <condition_postfix>
 job.state "SC" streq
 </condition_postfix>
@@ -14246,7 +14246,7 @@ job.state "SC" streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate SC state tax</action_comment>
-<action_description>perform Calculate_SC_Tax_Brackets</action_description>
+<action_dsl>perform Calculate_SC_Tax_Brackets</action_dsl>
 <action_postfix>
 Calculate_SC_Tax_Brackets
 "  South Carolina State Income Tax:" job.audit_trail swap addto
@@ -14258,7 +14258,7 @@ Calculate_SC_Tax_Brackets
 <action_details>
 <action_number>2</action_number>
 <action_comment>No SC tax for non-residents</action_comment>
-<action_description>set result.sc_state_tax = 0</action_description>
+<action_dsl>set result.sc_state_tax = 0</action_dsl>
 <action_postfix>
 0 /result.sc_state_tax xdef
 0 /result.sc_taxable_income xdef
@@ -14290,7 +14290,7 @@ Calculate_SC_Tax_Brackets
 <context_details>
 <context_number>1</context_number>
 <context_comment>Calculate SC taxable income with standard deduction</context_comment>
-<context_description>local double sc_std_deduction = SC standard deduction based on filing status</context_description>
+<context_dsl>local double sc_std_deduction = SC standard deduction based on filing status</context_dsl>
 <context_postfix>
 { sc_standard_deduction_mfj }
 { sc_standard_deduction_single }
@@ -14308,7 +14308,7 @@ deallocate pop
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>In bracket 1 only (0%); sc_taxable_income at or below sc_bracket_1</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.sc_taxable_income sc_bracket_1 &lt;=
 </condition_postfix>
@@ -14320,7 +14320,7 @@ result.sc_taxable_income sc_bracket_1 &lt;=
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>In bracket 2 (3%); sc_taxable_income at or below sc_bracket_2</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.sc_taxable_income sc_bracket_2 &lt;=
 </condition_postfix>
@@ -14332,7 +14332,7 @@ result.sc_taxable_income sc_bracket_2 &lt;=
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>In bracket 3 (6%)</condition_comment>
-<condition_description>sc_taxable_income above sc_bracket_2</condition_description>
+<condition_dsl>sc_taxable_income above sc_bracket_2</condition_dsl>
 <condition_postfix>
 result.sc_taxable_income sc_bracket_2 &gt;
 </condition_postfix>
@@ -14344,7 +14344,7 @@ result.sc_taxable_income sc_bracket_2 &gt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Zero or negative taxable income; sc_taxable_income at or below 0</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 result.sc_taxable_income 0 &lt;=
 </condition_postfix>
@@ -14358,7 +14358,7 @@ result.sc_taxable_income 0 &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Bracket 1 tax (0%); set result.sc_state_tax = 0 (below $3,560)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0 /result.sc_state_tax xdef
 </action_postfix>
@@ -14367,7 +14367,7 @@ result.sc_taxable_income 0 &lt;=
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bracket 2 tax (3%); set result.sc_state_tax = (income - $3,560) * 3%</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.sc_taxable_income sc_bracket_1 f- sc_rate_2 f* /result.sc_state_tax xdef
 </action_postfix>
@@ -14376,7 +14376,7 @@ result.sc_taxable_income sc_bracket_1 f- sc_rate_2 f* /result.sc_state_tax xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Bracket 3 tax (6%); set result.sc_state_tax = $428.10 + (income - $17,830) * 6%</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 sc_bracket_2 sc_bracket_1 f- sc_rate_2 f*
 result.sc_taxable_income sc_bracket_2 f- sc_rate_3 f* f+
@@ -14387,7 +14387,7 @@ result.sc_taxable_income sc_bracket_2 f- sc_rate_3 f* f+
 <action_details>
 <action_number>4</action_number>
 <action_comment>No tax (zero income)</action_comment>
-<action_description>set result.sc_state_tax = 0</action_description>
+<action_dsl>set result.sc_state_tax = 0</action_dsl>
 <action_postfix>
 0 /result.sc_state_tax xdef
 </action_postfix>
@@ -14425,7 +14425,7 @@ result.sc_taxable_income sc_bracket_2 f- sc_rate_3 f* f+
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize ID tax calculation</action_description>
+<action_dsl>Initialize ID tax calculation</action_dsl>
 <action_postfix>
 "IDAHO FORM 40 - State Income Tax Calculation" job.audit_trail swap addto
 0 local@ num_people &gt;
@@ -14437,7 +14437,7 @@ result.agi /result.id_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married filing status; Married filing jointly or separately</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 job.filing_status "married_filing_jointly" streq job.filing_status "married_filing_separately" streq or
 </condition_postfix>
@@ -14447,7 +14447,7 @@ job.filing_status "married_filing_jointly" streq job.filing_status "married_fili
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Calculate number of people</condition_comment>
-<condition_description>Count taxpayers and dependents</condition_description>
+<condition_dsl>Count taxpayers and dependents</condition_dsl>
 <condition_postfix>
 job.taxpayers arraysize job.dependents arraysize + local@ num_people &gt;
 num_people 1 &gt;=
@@ -14460,7 +14460,7 @@ num_people 1 &gt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate ID tax for married filers; Calculate Idaho tax with married threshold ($9,622)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 result.agi local@ id_retirement_subtraction &gt;
@@ -14490,7 +14490,7 @@ result.id_tax_before_credits result.id_food_tax_credit_total f- 0 fmax /result.i
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate ID tax for single/other filers; Calculate Idaho tax with single threshold ($4,811)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 result.agi local@ id_retirement_subtraction &gt;
@@ -14547,7 +14547,7 @@ result.id_tax_before_credits result.id_food_tax_credit_total f- 0 fmax /result.i
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize WI tax calculation</action_description>
+<action_dsl>Initialize WI tax calculation</action_dsl>
 <action_postfix>
 "WISCONSIN FORM 1 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.wi_agi xdef
@@ -14558,7 +14558,7 @@ result.agi /result.wi_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Filing status is MFJ</condition_comment>
-<condition_description>job.filing_status is equal to "married_joint"</condition_description>
+<condition_dsl>job.filing_status is equal to "married_joint"</condition_dsl>
 <condition_postfix>
 job.filing_status married_joint streq
 </condition_postfix>
@@ -14570,7 +14570,7 @@ job.filing_status married_joint streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate WI tax for Married Filing Jointly; Calculate Wisconsin tax using MFJ brackets and deductions</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 0 local@ wi_retirement_subtraction &gt;
@@ -14609,7 +14609,7 @@ wi_tax /result.wi_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate WI tax for Single or MFS; Calculate Wisconsin tax using Single/MFS brackets and deductions</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 0 local@ wi_retirement_subtraction &gt;
@@ -14680,7 +14680,7 @@ wi_tax /result.wi_tax xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize Michigan tax calculation</action_description>
+<action_dsl>Initialize Michigan tax calculation</action_dsl>
 <action_postfix>
 0.0 /result.mi_state_tax xdef
 0.0 /result.mi_taxable_income xdef
@@ -14695,7 +14695,7 @@ wi_tax /result.wi_tax xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Not a Michigan resident</condition_comment>
-<condition_description>job.state is not "MI"</condition_description>
+<condition_dsl>job.state is not "MI"</condition_dsl>
 <condition_postfix>
 job.state "MI" streq not
 </condition_postfix>
@@ -14707,7 +14707,7 @@ job.state "MI" streq not
 <action_details>
 <action_number>1</action_number>
 <action_comment>No Michigan tax (not a MI resident)</action_comment>
-<action_description>set result.mi_state_tax = 0</action_description>
+<action_dsl>set result.mi_state_tax = 0</action_dsl>
 <action_postfix>
 0.0 /result.mi_state_tax xdef
 "  Not a Michigan resident - no MI state tax" job.audit_trail swap addto
@@ -14717,7 +14717,7 @@ job.state "MI" streq not
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate MI tax with flat 4.25% rate; Calculate Michigan deductions, exemptions, and apply 4.25% flat tax rate</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 0.0 /result.mi_deduction xdef
 result.deduction_used "itemized" streq {
@@ -14784,7 +14784,7 @@ result.mi_taxable_income mi_tax_rate f* /result.mi_state_tax xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize MO tax calculation</action_description>
+<action_dsl>Initialize MO tax calculation</action_dsl>
 <action_postfix>
 "MISSOURI FORM MO-1040 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.mo_agi xdef
@@ -14796,7 +14796,7 @@ result.agi /result.mo_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "married_filing_jointly"</condition_description>
+<condition_dsl>job.filing_status is equal to "married_filing_jointly"</condition_dsl>
 <condition_postfix>
 job.filing_status married_filing_jointly streq
 </condition_postfix>
@@ -14807,7 +14807,7 @@ job.filing_status married_filing_jointly streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>job.filing_status is equal to "head_of_household"</condition_description>
+<condition_dsl>job.filing_status is equal to "head_of_household"</condition_dsl>
 <condition_postfix>
 job.filing_status head_of_household streq
 </condition_postfix>
@@ -14820,7 +14820,7 @@ job.filing_status head_of_household streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate MO tax MFJ; Calculate MO tax with MFJ standard deduction and 8 progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.mo_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 mo_standard_deduction_mfj /result.mo_standard_deduction xdef
@@ -14907,7 +14907,7 @@ endif
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate MO tax HOH; Calculate MO tax with HOH standard deduction</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.mo_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 mo_standard_deduction_hoh /result.mo_standard_deduction xdef
@@ -14994,7 +14994,7 @@ endif
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate MO tax Single; Calculate MO tax with Single standard deduction</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.mo_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 mo_standard_deduction_single /result.mo_standard_deduction xdef
@@ -15112,7 +15112,7 @@ endif
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Income exceeds bracket 8 threshold</condition_comment>
-<condition_description>Taxable income &gt; $25,000,000</condition_description>
+<condition_dsl>Taxable income &gt; $25,000,000</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket8_single f&gt;
 </condition_postfix>
@@ -15122,7 +15122,7 @@ result.ny_taxable_income ny_bracket8_single f&gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Income exceeds bracket 7 threshold</condition_comment>
-<condition_description>Taxable income &gt; $5,000,000</condition_description>
+<condition_dsl>Taxable income &gt; $5,000,000</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket7_single f&gt;
 </condition_postfix>
@@ -15132,7 +15132,7 @@ result.ny_taxable_income ny_bracket7_single f&gt;
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Income exceeds bracket 6 threshold</condition_comment>
-<condition_description>Taxable income &gt; $1,077,550</condition_description>
+<condition_dsl>Taxable income &gt; $1,077,550</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket6_single f&gt;
 </condition_postfix>
@@ -15142,7 +15142,7 @@ result.ny_taxable_income ny_bracket6_single f&gt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Income exceeds bracket 5 threshold</condition_comment>
-<condition_description>Taxable income &gt; $215,400</condition_description>
+<condition_dsl>Taxable income &gt; $215,400</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket5_single f&gt;
 </condition_postfix>
@@ -15152,7 +15152,7 @@ result.ny_taxable_income ny_bracket5_single f&gt;
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>Income exceeds bracket 4 threshold</condition_comment>
-<condition_description>Taxable income &gt; $80,650</condition_description>
+<condition_dsl>Taxable income &gt; $80,650</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket4_single f&gt;
 </condition_postfix>
@@ -15162,7 +15162,7 @@ result.ny_taxable_income ny_bracket4_single f&gt;
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>Income exceeds bracket 3 threshold</condition_comment>
-<condition_description>Taxable income &gt; $13,900</condition_description>
+<condition_dsl>Taxable income &gt; $13,900</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket3_single f&gt;
 </condition_postfix>
@@ -15172,7 +15172,7 @@ result.ny_taxable_income ny_bracket3_single f&gt;
 <condition_details>
 <condition_number>7</condition_number>
 <condition_comment>Income exceeds bracket 2 threshold</condition_comment>
-<condition_description>Taxable income &gt; $11,700</condition_description>
+<condition_dsl>Taxable income &gt; $11,700</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket2_single f&gt;
 </condition_postfix>
@@ -15182,7 +15182,7 @@ result.ny_taxable_income ny_bracket2_single f&gt;
 <condition_details>
 <condition_number>8</condition_number>
 <condition_comment>Income exceeds bracket 1 threshold</condition_comment>
-<condition_description>Taxable income &gt; $8,500</condition_description>
+<condition_dsl>Taxable income &gt; $8,500</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket1_single f&gt;
 </condition_postfix>
@@ -15194,7 +15194,7 @@ result.ny_taxable_income ny_bracket1_single f&gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Bracket 9: 10.9% on income over $25M; Calculate tax with 9 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_single ny_rate1 f*
 ny_bracket2_single ny_bracket1_single f- ny_rate2 f* f+
@@ -15212,7 +15212,7 @@ result.ny_taxable_income ny_bracket8_single f- ny_rate9 f* f+
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bracket 8: 10.3% on income over $5M; Calculate tax with 8 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_single ny_rate1 f*
 ny_bracket2_single ny_bracket1_single f- ny_rate2 f* f+
@@ -15229,7 +15229,7 @@ result.ny_taxable_income ny_bracket7_single f- ny_rate8 f* f+
 <action_details>
 <action_number>3</action_number>
 <action_comment>Bracket 7: 9.65% on income over $1,077,550; Calculate tax with 7 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_single ny_rate1 f*
 ny_bracket2_single ny_bracket1_single f- ny_rate2 f* f+
@@ -15245,7 +15245,7 @@ result.ny_taxable_income ny_bracket6_single f- ny_rate7 f* f+
 <action_details>
 <action_number>4</action_number>
 <action_comment>Bracket 6: 6.85% on income over $215,400; Calculate tax with 6 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_single ny_rate1 f*
 ny_bracket2_single ny_bracket1_single f- ny_rate2 f* f+
@@ -15260,7 +15260,7 @@ result.ny_taxable_income ny_bracket5_single f- ny_rate6 f* f+
 <action_details>
 <action_number>5</action_number>
 <action_comment>Bracket 5: 6% on income over $80,650; Calculate tax with 5 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_single ny_rate1 f*
 ny_bracket2_single ny_bracket1_single f- ny_rate2 f* f+
@@ -15274,7 +15274,7 @@ result.ny_taxable_income ny_bracket4_single f- ny_rate5 f* f+
 <action_details>
 <action_number>6</action_number>
 <action_comment>Bracket 4: 5.5% on income over $13,900; Calculate tax with 4 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_single ny_rate1 f*
 ny_bracket2_single ny_bracket1_single f- ny_rate2 f* f+
@@ -15287,7 +15287,7 @@ result.ny_taxable_income ny_bracket3_single f- ny_rate4 f* f+
 <action_details>
 <action_number>7</action_number>
 <action_comment>Bracket 3: 5.25% on income over $11,700; Calculate tax with 3 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_single ny_rate1 f*
 ny_bracket2_single ny_bracket1_single f- ny_rate2 f* f+
@@ -15299,7 +15299,7 @@ result.ny_taxable_income ny_bracket2_single f- ny_rate3 f* f+
 <action_details>
 <action_number>8</action_number>
 <action_comment>Bracket 2: 4.5% on income over $8,500; Calculate tax with 2 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_single ny_rate1 f*
 result.ny_taxable_income ny_bracket1_single f- ny_rate2 f* f+
@@ -15310,7 +15310,7 @@ result.ny_taxable_income ny_bracket1_single f- ny_rate2 f* f+
 <action_details>
 <action_number>9</action_number>
 <action_comment>Bracket 1: 4% on income up to $8,500; Calculate tax with 1 bracket</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.ny_taxable_income ny_rate1 f* /result.ny_tax xdef
 </action_postfix>
@@ -15375,7 +15375,7 @@ result.ny_taxable_income ny_rate1 f* /result.ny_tax xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Income exceeds bracket 8 threshold</condition_comment>
-<condition_description>Taxable income &gt; $25,000,000</condition_description>
+<condition_dsl>Taxable income &gt; $25,000,000</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket8_mfj f&gt;
 </condition_postfix>
@@ -15385,7 +15385,7 @@ result.ny_taxable_income ny_bracket8_mfj f&gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Income exceeds bracket 7 threshold</condition_comment>
-<condition_description>Taxable income &gt; $5,000,000</condition_description>
+<condition_dsl>Taxable income &gt; $5,000,000</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket7_mfj f&gt;
 </condition_postfix>
@@ -15395,7 +15395,7 @@ result.ny_taxable_income ny_bracket7_mfj f&gt;
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Income exceeds bracket 6 threshold</condition_comment>
-<condition_description>Taxable income &gt; $2,155,350</condition_description>
+<condition_dsl>Taxable income &gt; $2,155,350</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket6_mfj f&gt;
 </condition_postfix>
@@ -15405,7 +15405,7 @@ result.ny_taxable_income ny_bracket6_mfj f&gt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Income exceeds bracket 5 threshold</condition_comment>
-<condition_description>Taxable income &gt; $323,200</condition_description>
+<condition_dsl>Taxable income &gt; $323,200</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket5_mfj f&gt;
 </condition_postfix>
@@ -15415,7 +15415,7 @@ result.ny_taxable_income ny_bracket5_mfj f&gt;
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>Income exceeds bracket 4 threshold</condition_comment>
-<condition_description>Taxable income &gt; $161,550</condition_description>
+<condition_dsl>Taxable income &gt; $161,550</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket4_mfj f&gt;
 </condition_postfix>
@@ -15425,7 +15425,7 @@ result.ny_taxable_income ny_bracket4_mfj f&gt;
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>Income exceeds bracket 3 threshold</condition_comment>
-<condition_description>Taxable income &gt; $27,900</condition_description>
+<condition_dsl>Taxable income &gt; $27,900</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket3_mfj f&gt;
 </condition_postfix>
@@ -15435,7 +15435,7 @@ result.ny_taxable_income ny_bracket3_mfj f&gt;
 <condition_details>
 <condition_number>7</condition_number>
 <condition_comment>Income exceeds bracket 2 threshold</condition_comment>
-<condition_description>Taxable income &gt; $23,600</condition_description>
+<condition_dsl>Taxable income &gt; $23,600</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket2_mfj f&gt;
 </condition_postfix>
@@ -15445,7 +15445,7 @@ result.ny_taxable_income ny_bracket2_mfj f&gt;
 <condition_details>
 <condition_number>8</condition_number>
 <condition_comment>Income exceeds bracket 1 threshold</condition_comment>
-<condition_description>Taxable income &gt; $17,150</condition_description>
+<condition_dsl>Taxable income &gt; $17,150</condition_dsl>
 <condition_postfix>
 result.ny_taxable_income ny_bracket1_mfj f&gt;
 </condition_postfix>
@@ -15457,7 +15457,7 @@ result.ny_taxable_income ny_bracket1_mfj f&gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Bracket 9: 10.9% on income over $25M; Calculate tax with 9 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_mfj ny_rate1 f*
 ny_bracket2_mfj ny_bracket1_mfj f- ny_rate2 f* f+
@@ -15475,7 +15475,7 @@ result.ny_taxable_income ny_bracket8_mfj f- ny_rate9 f* f+
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bracket 8: 10.3% on income over $5M; Calculate tax with 8 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_mfj ny_rate1 f*
 ny_bracket2_mfj ny_bracket1_mfj f- ny_rate2 f* f+
@@ -15492,7 +15492,7 @@ result.ny_taxable_income ny_bracket7_mfj f- ny_rate8 f* f+
 <action_details>
 <action_number>3</action_number>
 <action_comment>Bracket 7: 9.65% on income over $2,155,350; Calculate tax with 7 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_mfj ny_rate1 f*
 ny_bracket2_mfj ny_bracket1_mfj f- ny_rate2 f* f+
@@ -15508,7 +15508,7 @@ result.ny_taxable_income ny_bracket6_mfj f- ny_rate7 f* f+
 <action_details>
 <action_number>4</action_number>
 <action_comment>Bracket 6: 6.85% on income over $323,200; Calculate tax with 6 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_mfj ny_rate1 f*
 ny_bracket2_mfj ny_bracket1_mfj f- ny_rate2 f* f+
@@ -15523,7 +15523,7 @@ result.ny_taxable_income ny_bracket5_mfj f- ny_rate6 f* f+
 <action_details>
 <action_number>5</action_number>
 <action_comment>Bracket 5: 6% on income over $161,550; Calculate tax with 5 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_mfj ny_rate1 f*
 ny_bracket2_mfj ny_bracket1_mfj f- ny_rate2 f* f+
@@ -15537,7 +15537,7 @@ result.ny_taxable_income ny_bracket4_mfj f- ny_rate5 f* f+
 <action_details>
 <action_number>6</action_number>
 <action_comment>Bracket 4: 5.5% on income over $27,900; Calculate tax with 4 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_mfj ny_rate1 f*
 ny_bracket2_mfj ny_bracket1_mfj f- ny_rate2 f* f+
@@ -15550,7 +15550,7 @@ result.ny_taxable_income ny_bracket3_mfj f- ny_rate4 f* f+
 <action_details>
 <action_number>7</action_number>
 <action_comment>Bracket 3: 5.25% on income over $23,600; Calculate tax with 3 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_mfj ny_rate1 f*
 ny_bracket2_mfj ny_bracket1_mfj f- ny_rate2 f* f+
@@ -15562,7 +15562,7 @@ result.ny_taxable_income ny_bracket2_mfj f- ny_rate3 f* f+
 <action_details>
 <action_number>8</action_number>
 <action_comment>Bracket 2: 4.5% on income over $17,150; Calculate tax with 2 brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 ny_bracket1_mfj ny_rate1 f*
 result.ny_taxable_income ny_bracket1_mfj f- ny_rate2 f* f+
@@ -15573,7 +15573,7 @@ result.ny_taxable_income ny_bracket1_mfj f- ny_rate2 f* f+
 <action_details>
 <action_number>9</action_number>
 <action_comment>Bracket 1: 4% on income up to $17,150; Calculate tax with 1 bracket</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 result.ny_taxable_income ny_rate1 f* /result.ny_tax xdef
 </action_postfix>
@@ -15635,7 +15635,7 @@ result.ny_taxable_income ny_rate1 f* /result.ny_tax xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize NY tax calculation</action_description>
+<action_dsl>Initialize NY tax calculation</action_dsl>
 <action_postfix>
 "NEW YORK FORM IT-201 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.ny_agi xdef
@@ -15646,7 +15646,7 @@ result.agi /result.ny_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Filing status is Single</condition_comment>
-<condition_description>job.filing_status is equal to "single"</condition_description>
+<condition_dsl>job.filing_status is equal to "single"</condition_dsl>
 <condition_postfix>
 job.filing_status single streq
 </condition_postfix>
@@ -15658,7 +15658,7 @@ job.filing_status single streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate NY tax for single filer; Calculate NY AGI, apply single standard deduction and exemptions, apply progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 0 local@ ny_pension_subtraction &gt;
@@ -15688,7 +15688,7 @@ Apply_NY_Tax_Brackets_Single
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate NY tax for married filing jointly; Calculate NY AGI, apply MFJ standard deduction and exemptions, apply progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 0 local@ ny_pension_subtraction &gt;
@@ -15743,7 +15743,7 @@ Apply_NY_Tax_Brackets_MFJ
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize ME tax calculation</action_description>
+<action_dsl>Initialize ME tax calculation</action_dsl>
 <action_postfix>
 "MAINE FORM 1040ME - State Income Tax Calculation" job.audit_trail swap addto
 0 local@ num_people &gt;
@@ -15755,7 +15755,7 @@ result.agi /result.me_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Filing status is Single</condition_comment>
-<condition_description>Filing status is Single</condition_description>
+<condition_dsl>Filing status is Single</condition_dsl>
 <condition_postfix>
 job.filing_status Single streq
 </condition_postfix>
@@ -15767,7 +15767,7 @@ job.filing_status Single streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is MFJ</condition_comment>
-<condition_description>Filing status is MFJ</condition_description>
+<condition_dsl>Filing status is MFJ</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -15779,7 +15779,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Filing status is MFS</condition_comment>
-<condition_description>Filing status is MFS</condition_description>
+<condition_dsl>Filing status is MFS</condition_dsl>
 <condition_postfix>
 job.filing_status MFS streq
 </condition_postfix>
@@ -15791,7 +15791,7 @@ job.filing_status MFS streq
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Filing status is HOH</condition_comment>
-<condition_description>Filing status is HOH</condition_description>
+<condition_dsl>Filing status is HOH</condition_dsl>
 <condition_postfix>
 job.filing_status HOH streq
 </condition_postfix>
@@ -15805,7 +15805,7 @@ job.filing_status HOH streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate ME tax for Single filer; Apply ME deductions and calculate tax using Single brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 job.taxpayers arraysize job.dependents arraysize + local@ num_people &gt;
@@ -15846,7 +15846,7 @@ endif
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate ME tax for MFJ filer; Apply ME deductions and calculate tax using MFJ brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 job.taxpayers arraysize job.dependents arraysize + local@ num_people &gt;
@@ -15887,7 +15887,7 @@ endif
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate ME tax for MFS filer; Apply ME deductions and calculate tax using Single brackets (MFS uses same as Single)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 job.taxpayers arraysize job.dependents arraysize + local@ num_people &gt;
@@ -15928,7 +15928,7 @@ endif
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate ME tax for HOH filer; Apply ME deductions and calculate tax using MFJ brackets (HOH uses same as MFJ)</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 job.taxpayers arraysize job.dependents arraysize + local@ num_people &gt;
@@ -16003,7 +16003,7 @@ endif
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize ND tax calculation</action_description>
+<action_dsl>Initialize ND tax calculation</action_dsl>
 <action_postfix>
 "NORTH DAKOTA FORM ND-1 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.nd_agi xdef
@@ -16017,7 +16017,7 @@ result.agi /result.nd_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "married_filing_jointly"</condition_description>
+<condition_dsl>job.filing_status is equal to "married_filing_jointly"</condition_dsl>
 <condition_postfix>
 job.filing_status married_filing_jointly streq
 </condition_postfix>
@@ -16029,7 +16029,7 @@ job.filing_status married_filing_jointly streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single filer</condition_comment>
-<condition_description>job.filing_status is equal to "single"</condition_description>
+<condition_dsl>job.filing_status is equal to "single"</condition_dsl>
 <condition_postfix>
 job.filing_status single streq
 </condition_postfix>
@@ -16041,7 +16041,7 @@ job.filing_status single streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>job.filing_status is equal to "head_of_household"</condition_description>
+<condition_dsl>job.filing_status is equal to "head_of_household"</condition_dsl>
 <condition_postfix>
 job.filing_status head_of_household streq
 </condition_postfix>
@@ -16055,7 +16055,7 @@ job.filing_status head_of_household streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate ND tax MFJ; Calculate ND tax with MFJ standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.nd_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 nd_standard_deduction_mfj /result.nd_standard_deduction xdef
@@ -16088,7 +16088,7 @@ result.nd_bracket_1_tax result.nd_bracket_2_tax f+ result.nd_bracket_3_tax f+ /r
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate ND tax Single; Calculate ND tax with Single standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.nd_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 nd_standard_deduction_single /result.nd_standard_deduction xdef
@@ -16121,7 +16121,7 @@ result.nd_bracket_1_tax result.nd_bracket_2_tax f+ result.nd_bracket_3_tax f+ /r
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate ND tax HOH; Calculate ND tax with HOH standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.nd_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 nd_standard_deduction_hoh /result.nd_standard_deduction xdef
@@ -16154,7 +16154,7 @@ result.nd_bracket_1_tax result.nd_bracket_2_tax f+ result.nd_bracket_3_tax f+ /r
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate ND tax MFS/other; Calculate ND tax with MFS standard deduction and progressive brackets</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.nd_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 nd_standard_deduction_mfs /result.nd_standard_deduction xdef
@@ -16220,7 +16220,7 @@ result.nd_bracket_1_tax result.nd_bracket_2_tax f+ result.nd_bracket_3_tax f+ /r
 <contexts />
 <initial_actions>
 <initial_action>
-<action_description>Initialize NJ tax calculation</action_description>
+<action_dsl>Initialize NJ tax calculation</action_dsl>
 <action_postfix>
 "NEW JERSEY FORM NJ-1040 - State Income Tax Calculation" job.audit_trail swap addto
 0 local@ num_taxpayers &gt;
@@ -16233,7 +16233,7 @@ result.agi /result.nj_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Count taxpayers and dependents; Get number of taxpayers and dependents for exemptions</condition_comment>
-<condition_description />
+<condition_dsl />
 <condition_postfix>
 job.taxpayers arraysize local@ num_taxpayers &gt;
 job.dependents arraysize local@ num_dependents &gt;
@@ -16247,7 +16247,7 @@ num_taxpayers 1 &gt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate NJ tax with progressive brackets; Calculate NJ AGI, apply exemptions, calculate progressive tax</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 result.agi local@ nj_retirement_subtraction &gt;
@@ -16306,7 +16306,7 @@ nj_calculated_tax /result.nj_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No taxpayers - unlikely case; Calculate NJ tax without exemptions</action_comment>
-<action_description />
+<action_dsl />
 <action_postfix>
 "  New Jersey Gross Income: $" result.nj_agi cvs strconcat job.audit_trail swap addto
 result.nj_agi 0 fmax /result.nj_taxable_income xdef

--- a/sampleprojects/TaxReturn/xml/TaxReturn_dt_core.xml
+++ b/sampleprojects/TaxReturn/xml/TaxReturn_dt_core.xml
@@ -20,7 +20,7 @@
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>new result entity</action_description>
+<action_dsl>new result entity</action_dsl>
 <action_postfix>
 /result createentity entitypush
 result job.results swap addto
@@ -33,7 +33,7 @@ no_income_tax_states job.state memberof not /job.has_state_income_tax xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -42,7 +42,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single filer</condition_comment>
-<condition_description>job.filing_status is equal to "Single"</condition_description>
+<condition_dsl>job.filing_status is equal to "Single"</condition_dsl>
 <condition_postfix>
 job.filing_status SINGLE streq
 </condition_postfix>
@@ -51,7 +51,7 @@ job.filing_status SINGLE streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>job.filing_status is equal to "HOH"</condition_description>
+<condition_dsl>job.filing_status is equal to "HOH"</condition_dsl>
 <condition_postfix>
 job.filing_status HOH streq
 </condition_postfix>
@@ -60,7 +60,7 @@ job.filing_status HOH streq
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Default case</condition_comment>
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>
 otherwise
 </condition_postfix>
@@ -71,7 +71,7 @@ otherwise
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log filing status per Form 1040 Line 1</action_comment>
-<action_description>add "Filing as MFJ per Form 1040 Line 1" to job.audit_trail</action_description>
+<action_dsl>add "Filing as MFJ per Form 1040 Line 1" to job.audit_trail</action_dsl>
 <action_postfix>
 "Filing as Married Filing Jointly per Form 1040 Line 1, Publication 17 Chapter 2, IRC Section 1(a)" job.audit_trail swap addto
 </action_postfix>
@@ -80,7 +80,7 @@ otherwise
 <action_details>
 <action_number>2</action_number>
 <action_comment>Log Single filing status</action_comment>
-<action_description>add "Filing as Single per Form 1040 Line 1" to job.audit_trail</action_description>
+<action_dsl>add "Filing as Single per Form 1040 Line 1" to job.audit_trail</action_dsl>
 <action_postfix>
 "Filing as Single per Form 1040 Line 1, Publication 17 Chapter 2, IRC Section 1(c)" job.audit_trail swap addto
 </action_postfix>
@@ -89,7 +89,7 @@ otherwise
 <action_details>
 <action_number>3</action_number>
 <action_comment>Log HOH filing status</action_comment>
-<action_description>add "Filing as HOH per Form 1040 Line 1" to job.audit_trail</action_description>
+<action_dsl>add "Filing as HOH per Form 1040 Line 1" to job.audit_trail</action_dsl>
 <action_postfix>
 "Filing as Head of Household per Form 1040 Line 1, Publication 17 Chapter 2, IRC Section 1(b)" job.audit_trail swap addto
 </action_postfix>
@@ -98,7 +98,7 @@ otherwise
 <action_details>
 <action_number>4</action_number>
 <action_comment>Log MFS or QSS status</action_comment>
-<action_description>add "Filing as " + job.filing_status + " per Form 1040" to job.audit_trail</action_description>
+<action_dsl>add "Filing as " + job.filing_status + " per Form 1040" to job.audit_trail</action_dsl>
 <action_postfix>
 "Filing as " job.filing_status strconcat " per Form 1040 Line 1, Publication 17 Chapter 2" strconcat job.audit_trail swap addto
 </action_postfix>
@@ -107,7 +107,7 @@ otherwise
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate gross income (Form 1040 Lines 1-9)</action_comment>
-<action_description>Calculate_Gross_Income</action_description>
+<action_dsl>Calculate_Gross_Income</action_dsl>
 <action_postfix>
 Calculate_Gross_Income
 </action_postfix>
@@ -119,7 +119,7 @@ Calculate_Gross_Income
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate deductions (Form 1040 Line 12)</action_comment>
-<action_description>Calculate_Deductions</action_description>
+<action_dsl>Calculate_Deductions</action_dsl>
 <action_postfix>
 Calculate_Deductions
 </action_postfix>
@@ -131,7 +131,7 @@ Calculate_Deductions
 <action_details>
 <action_number>7</action_number>
 <action_comment>Calculate taxable income (Form 1040 Line 15)</action_comment>
-<action_description>Calculate_Taxable_Income</action_description>
+<action_dsl>Calculate_Taxable_Income</action_dsl>
 <action_postfix>
 Calculate_Taxable_Income
 </action_postfix>
@@ -143,7 +143,7 @@ Calculate_Taxable_Income
 <action_details>
 <action_number>8</action_number>
 <action_comment>Calculate tax liability (Form 1040 Lines 16-24)</action_comment>
-<action_description>Calculate_Tax_Liability</action_description>
+<action_dsl>Calculate_Tax_Liability</action_dsl>
 <action_postfix>
 Calculate_Tax_Liability
 </action_postfix>
@@ -155,7 +155,7 @@ Calculate_Tax_Liability
 <action_details>
 <action_number>9</action_number>
 <action_comment>Calculate Alternative Minimum Tax (Form 6251)</action_comment>
-<action_description>Calculate_AMT</action_description>
+<action_dsl>Calculate_AMT</action_dsl>
 <action_postfix>
 Calculate_AMT
 </action_postfix>
@@ -167,7 +167,7 @@ Calculate_AMT
 <action_details>
 <action_number>10</action_number>
 <action_comment>Calculate kiddie tax for dependents with unearned income (Form 8615)</action_comment>
-<action_description>Calculate_Kiddie_Tax</action_description>
+<action_dsl>Calculate_Kiddie_Tax</action_dsl>
 <action_postfix>
 Calculate_Kiddie_Tax
 </action_postfix>
@@ -179,7 +179,7 @@ Calculate_Kiddie_Tax
 <action_details>
 <action_number>11</action_number>
 <action_comment>Calculate credits (Form 1040 Lines 19-21)</action_comment>
-<action_description>Calculate_Credits</action_description>
+<action_dsl>Calculate_Credits</action_dsl>
 <action_postfix>
 Calculate_Credits
 </action_postfix>
@@ -191,7 +191,7 @@ Calculate_Credits
 <action_details>
 <action_number>12</action_number>
 <action_comment>Calculate final balance (Form 1040 Lines 33-37)</action_comment>
-<action_description>Calculate_Final_Balance</action_description>
+<action_dsl>Calculate_Final_Balance</action_dsl>
 <action_postfix>
 Calculate_Final_Balance
 </action_postfix>
@@ -202,7 +202,7 @@ Calculate_Final_Balance
 <action_details>
 <action_number>12</action_number>
 <action_comment>Calculate state income tax if applicable</action_comment>
-<action_description>Dispatch_State_Tax</action_description>
+<action_dsl>Dispatch_State_Tax</action_dsl>
 <action_postfix>
 job.has_state_income_tax if
   Dispatch_State_Tax
@@ -247,7 +247,7 @@ endif
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.total_w2_wages = 0</action_description>
+<action_dsl>set result.total_w2_wages = 0</action_dsl>
 <action_postfix>
 0.0 /result.total_w2_wages xdef
 0.0 /result.total_se_income xdef
@@ -261,7 +261,7 @@ endif
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always execute</condition_comment>
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -272,7 +272,7 @@ perform when called
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process W-2 income for all taxpayers</action_comment>
-<action_description>Process_W2_Income</action_description>
+<action_dsl>Process_W2_Income</action_dsl>
 <action_postfix>
 Process_W2_Income
 </action_postfix>
@@ -281,7 +281,7 @@ Process_W2_Income
 <action_details>
 <action_number>2</action_number>
 <action_comment>Process self-employment income (Schedule C)</action_comment>
-<action_description>Process_Self_Employment</action_description>
+<action_dsl>Process_Self_Employment</action_dsl>
 <action_postfix>
 Process_Self_Employment
 </action_postfix>
@@ -290,7 +290,7 @@ Process_Self_Employment
 <action_details>
 <action_number>3</action_number>
 <action_comment>Process rental income (Schedule E)</action_comment>
-<action_description>Process_Rental_Income</action_description>
+<action_dsl>Process_Rental_Income</action_dsl>
 <action_postfix>
 Process_Rental_Income
 Calculate_Passive_Activity_Loss
@@ -300,7 +300,7 @@ Calculate_Passive_Activity_Loss
 <action_details>
 <action_number>4</action_number>
 <action_comment>Process other income (pension, interest, dividends)</action_comment>
-<action_description>Process_Other_Income</action_description>
+<action_dsl>Process_Other_Income</action_dsl>
 <action_postfix>
 Process_Other_Income
 </action_postfix>
@@ -309,7 +309,7 @@ Process_Other_Income
 <action_details>
 <action_number>5</action_number>
 <action_comment>Process capital gains and qualified dividends</action_comment>
-<action_description>Process_Capital_Gains</action_description>
+<action_dsl>Process_Capital_Gains</action_dsl>
 <action_postfix>
 Process_Capital_Gains
 </action_postfix>
@@ -318,7 +318,7 @@ Process_Capital_Gains
 <action_details>
 <action_number>6</action_number>
 <action_comment>Process Schedule K-1 income (partnerships, S-corps, trusts)</action_comment>
-<action_description>Process_K1_Income</action_description>
+<action_dsl>Process_K1_Income</action_dsl>
 <action_postfix>
 Process_K1_Income
 Calculate_K1_SE_Tax
@@ -328,7 +328,7 @@ Calculate_K1_SE_Tax
 <action_details>
 <action_number>7</action_number>
 <action_comment>Process IRA accounts (Form 8606)</action_comment>
-<action_description>Process_IRA_Accounts</action_description>
+<action_dsl>Process_IRA_Accounts</action_dsl>
 <action_postfix>
 Process_IRA_Accounts
 Calculate_Roth_Conversion_Tax
@@ -338,7 +338,7 @@ Calculate_Roth_Conversion_Tax
 <action_details>
 <action_number>8</action_number>
 <action_comment>Process Schedule F farm income</action_comment>
-<action_description>Process_Farm_Income</action_description>
+<action_dsl>Process_Farm_Income</action_dsl>
 <action_postfix>
 Process_Farm_Income
 Calculate_Farm_SE_Tax
@@ -348,7 +348,7 @@ Calculate_Farm_SE_Tax
 <action_details>
 <action_number>9</action_number>
 <action_comment>Process Form 4797 business property sales</action_comment>
-<action_description>Process_Property_Sales</action_description>
+<action_dsl>Process_Property_Sales</action_dsl>
 <action_postfix>
 Process_Property_Sales
 Calculate_Section_1231
@@ -358,7 +358,7 @@ Calculate_Section_1231
 <action_details>
 <action_number>10</action_number>
 <action_comment>Process Form 1116 foreign income</action_comment>
-<action_description>Process_Foreign_Income</action_description>
+<action_dsl>Process_Foreign_Income</action_dsl>
 <action_postfix>
 Process_Foreign_Income
 </action_postfix>
@@ -367,7 +367,7 @@ Process_Foreign_Income
 <action_details>
 <action_number>11</action_number>
 <action_comment>Calculate total gross income FIRST (for OBBBA phase-out calculations)</action_comment>
-<action_description>set result.gross_income = result.total_w2_wages + result.total_se_income + result.total_rental_income + result.total_other_income</action_description>
+<action_dsl>set result.gross_income = result.total_w2_wages + result.total_se_income + result.total_rental_income + result.total_other_income</action_dsl>
 <action_postfix>
 result.total_w2_wages result.total_se_income f+ result.total_rental_income f+ result.total_other_income f+ result.total_tip_income f+ result.total_overtime_income f+ result.total_social_security f+ result.total_long_term_gains f+ result.total_short_term_gains f+ result.total_k1_ordinary_income f+ result.total_k1_rental_income f+ result.net_farm_profit f+ result.total_depreciation_recapture f+ result.total_foreign_income f+ /result.gross_income xdef
 "Line 9 - Total Income: $" result.gross_income cvs strconcat " per Form 1040 Line 9" strconcat job.audit_trail swap addto
@@ -377,7 +377,7 @@ result.total_w2_wages result.total_se_income f+ result.total_rental_income f+ re
 <action_details>
 <action_number>12</action_number>
 <action_comment>Calculate AGI adjustments (Schedule 1 Part II)</action_comment>
-<action_description>Calculate_AGI_Adjustments</action_description>
+<action_dsl>Calculate_AGI_Adjustments</action_dsl>
 <action_postfix>
 Calculate_AGI_Adjustments
 </action_postfix>
@@ -386,7 +386,7 @@ Calculate_AGI_Adjustments
 <action_details>
 <action_number>13</action_number>
 <action_comment>Calculate AGI</action_comment>
-<action_description>set result.agi = result.gross_income - result.total_adjustments</action_description>
+<action_dsl>set result.agi = result.gross_income - result.total_adjustments</action_dsl>
 <action_postfix>
 result.gross_income result.total_adjustments f- /result.agi xdef
 "Line 11 - Adjusted Gross Income (AGI): $" result.agi cvs strconcat " per Form 1040 Line 11" strconcat job.audit_trail swap addto
@@ -396,7 +396,7 @@ result.gross_income result.total_adjustments f- /result.agi xdef
 <action_details>
 <action_number>14</action_number>
 <action_comment>Calculate Social Security taxability after AGI is known</action_comment>
-<action_description>Calculate_SS_Taxability</action_description>
+<action_dsl>Calculate_SS_Taxability</action_dsl>
 <action_postfix>
 Calculate_SS_Taxability
 </action_postfix>
@@ -419,7 +419,7 @@ Calculate_SS_Taxability
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each taxpayer</context_comment>
-<context_description>for all taxpayers</context_description>
+<context_dsl>for all taxpayers</context_dsl>
 <context_postfix>
 { /Process_W2_Income executetable } job.taxpayers forall
 </context_postfix>
@@ -430,7 +430,7 @@ Calculate_SS_Taxability
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Taxpayer has W-2 wages</condition_comment>
-<condition_description>taxpayer.w2_wages &gt; 0</condition_description>
+<condition_dsl>taxpayer.w2_wages &gt; 0</condition_dsl>
 <condition_postfix>taxpayer.w2_wages 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="Y"></condition_column>
@@ -440,7 +440,7 @@ Calculate_SS_Taxability
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxpayer is senior</condition_comment>
-<condition_description>taxpayer.is_senior == true</condition_description>
+<condition_dsl>taxpayer.is_senior == true</condition_dsl>
 <condition_postfix>taxpayer.is_senior true beq</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -452,7 +452,7 @@ Calculate_SS_Taxability
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add W-2 wages to total</action_comment>
-<action_description>add taxpayer.w2_wages to result.total_w2_wages</action_description>
+<action_dsl>add taxpayer.w2_wages to result.total_w2_wages</action_dsl>
 <action_postfix>
 taxpayer.w2_wages result.total_w2_wages f+ /result.total_w2_wages xdef
 "  W-2 Wages for " taxpayer.name strconcat ": $" strconcat taxpayer.w2_wages cvs strconcat " (Form W-2, IRC 61(a)(1))" strconcat job.audit_trail swap addto
@@ -463,7 +463,7 @@ taxpayer.w2_wages result.total_w2_wages f+ /result.total_w2_wages xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Track withholding for payments</action_comment>
-<action_description>add taxpayer.w2_withholding to result.total_payments</action_description>
+<action_dsl>add taxpayer.w2_withholding to result.total_payments</action_dsl>
 <action_postfix>
 taxpayer.w2_withholding result.total_payments f+ /result.total_payments xdef
 taxpayer.estimated_payments result.total_payments f+ /result.total_payments xdef
@@ -476,7 +476,7 @@ taxpayer.estimated_payments result.total_payments f+ /result.total_payments xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Process OBBBA income sources (tips, overtime, SS)</action_comment>
-<action_description>add taxpayer.tip_income to result.total_tip_income</action_description>
+<action_dsl>add taxpayer.tip_income to result.total_tip_income</action_dsl>
 <action_postfix>
 taxpayer.tip_income result.total_tip_income f+ /result.total_tip_income xdef
 taxpayer.overtime_income result.total_overtime_income f+ /result.total_overtime_income xdef
@@ -490,7 +490,7 @@ taxpayer.social_security_income result.total_social_security f+ /result.total_so
 <action_details>
 <action_number>4</action_number>
 <action_comment>Count senior taxpayer</action_comment>
-<action_description>add 1 to result.senior_count</action_description>
+<action_dsl>add 1 to result.senior_count</action_dsl>
 <action_postfix>
 result.senior_count 1 + /result.senior_count xdef
 </action_postfix>
@@ -531,7 +531,7 @@ result.senior_count 1 + /result.senior_count xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each self-employed taxpayer</context_comment>
-<context_description>for all taxpayers whose is_self_employed == true</context_description>
+<context_dsl>for all taxpayers whose is_self_employed == true</context_dsl>
 <context_postfix>
 { Filter_Self_Employed_Taxpayer performaliased } job.taxpayers forall
 </context_postfix>
@@ -542,7 +542,7 @@ result.senior_count 1 + /result.senior_count xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has self-employment income</condition_comment>
-<condition_description>taxpayer.se_gross_income &gt; 0</condition_description>
+<condition_dsl>taxpayer.se_gross_income &gt; 0</condition_dsl>
 <condition_postfix>taxpayer.se_gross_income 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -552,7 +552,7 @@ result.senior_count 1 + /result.senior_count xdef
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log gross receipts</action_comment>
-<action_description>add "Gross Receipts: $" + taxpayer.se_gross_income to job.audit_trail</action_description>
+<action_dsl>add "Gross Receipts: $" + taxpayer.se_gross_income to job.audit_trail</action_dsl>
 <action_postfix>
 "SCHEDULE C - " taxpayer.name strconcat " (" strconcat taxpayer.occupation strconcat ")" strconcat job.audit_trail swap addto
 "  Gross Receipts: $" taxpayer.se_gross_income cvs strconcat " (Schedule C Line 1, IRC 61)" strconcat job.audit_trail swap addto
@@ -562,7 +562,7 @@ result.senior_count 1 + /result.senior_count xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate vehicle deduction</action_comment>
-<action_description>Calculate_Vehicle_Deduction</action_description>
+<action_dsl>Calculate_Vehicle_Deduction</action_dsl>
 <action_postfix>
 Calculate_Vehicle_Deduction
 </action_postfix>
@@ -571,7 +571,7 @@ Calculate_Vehicle_Deduction
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate net profit</action_comment>
-<action_description>set taxpayer.se_net_profit = taxpayer.se_gross_income - taxpayer.se_expenses</action_description>
+<action_dsl>set taxpayer.se_net_profit = taxpayer.se_gross_income - taxpayer.se_expenses</action_dsl>
 <action_postfix>
 taxpayer.se_gross_income taxpayer.se_expenses f- /taxpayer.se_net_profit xdef
 "  Net Profit: $" taxpayer.se_net_profit cvs strconcat " (Schedule C Line 31)" strconcat job.audit_trail swap addto
@@ -582,7 +582,7 @@ taxpayer.se_net_profit result.total_se_income f+ /result.total_se_income xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate SE tax after net profit is known</action_comment>
-<action_description>Calculate_SE_Tax</action_description>
+<action_dsl>Calculate_SE_Tax</action_dsl>
 <action_postfix>
 Calculate_SE_Tax
 </action_postfix>
@@ -616,7 +616,7 @@ Calculate_SE_Tax
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>SE net profit meets threshold for SE tax</condition_comment>
-<condition_description>taxpayer.se_net_profit &gt;= se_threshold</condition_description>
+<condition_dsl>taxpayer.se_net_profit &gt;= se_threshold</condition_dsl>
 <condition_postfix>taxpayer.se_net_profit se_threshold >=</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -626,7 +626,7 @@ Calculate_SE_Tax
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate SE tax - net profit exceeds threshold</action_comment>
-<action_description>set taxpayer.se_tax = taxpayer.se_net_profit * se_income_multiplier * se_tax_rate</action_description>
+<action_dsl>set taxpayer.se_tax = taxpayer.se_net_profit * se_income_multiplier * se_tax_rate</action_dsl>
 <action_postfix>
 taxpayer.se_net_profit se_income_multiplier f* se_tax_rate f* /taxpayer.se_tax xdef
 taxpayer.se_tax se_deduction_rate f* /taxpayer.se_tax_deduction xdef
@@ -640,7 +640,7 @@ taxpayer.se_tax se_deduction_rate f* /taxpayer.se_tax_deduction xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No SE tax required - net profit below threshold</action_comment>
-<action_description>set taxpayer.se_tax = 0</action_description>
+<action_dsl>set taxpayer.se_tax = 0</action_dsl>
 <action_postfix>
 "  SE Tax: Not required - net SE income below $400 threshold (IRC 1402(b)(2))" job.audit_trail swap addto
 0 /taxpayer.se_tax xdef
@@ -674,7 +674,7 @@ taxpayer.se_tax se_deduction_rate f* /taxpayer.se_tax_deduction xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process vehicles for current taxpayer</context_comment>
-<context_description>for all vehicles where taxpayer_id matches current taxpayer</context_description>
+<context_dsl>for all vehicles where taxpayer_id matches current taxpayer</context_dsl>
 <context_postfix>
 { Filter_Taxpayer_Vehicle performaliased } job.vehicles forall
 </context_postfix>
@@ -685,7 +685,7 @@ taxpayer.se_tax se_deduction_rate f* /taxpayer.se_tax_deduction xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has business miles</condition_comment>
-<condition_description>vehicle.business_miles &gt; 0</condition_description>
+<condition_dsl>vehicle.business_miles &gt; 0</condition_dsl>
 <condition_postfix>
 vehicle.business_miles 0 >
 </condition_postfix>
@@ -696,7 +696,7 @@ vehicle.business_miles 0 >
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Using standard mileage method</condition_comment>
-<condition_description>vehicle.method is equal to "standard_mileage"</condition_description>
+<condition_dsl>vehicle.method is equal to "standard_mileage"</condition_dsl>
 <condition_postfix>
 vehicle.method "standard_mileage" streq
 </condition_postfix>
@@ -708,7 +708,7 @@ vehicle.method "standard_mileage" streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate business use percentage</action_comment>
-<action_description>set business_use_percentage = business_miles / total_miles</action_description>
+<action_dsl>set business_use_percentage = business_miles / total_miles</action_dsl>
 <action_postfix>
 business_miles cvr total_miles cvr fdiv /business_use_percentage xdef
 </action_postfix>
@@ -718,7 +718,7 @@ business_miles cvr total_miles cvr fdiv /business_use_percentage xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate standard mileage deduction</action_comment>
-<action_description>set vehicle.vehicle_deduction = vehicle.business_miles * mileage_rate</action_description>
+<action_dsl>set vehicle.vehicle_deduction = vehicle.business_miles * mileage_rate</action_dsl>
 <action_postfix>
 vehicle.business_miles cvr mileage_rate f* /vehicle.standard_mileage_deduction xdef
 vehicle.standard_mileage_deduction /vehicle.vehicle_deduction xdef
@@ -732,7 +732,7 @@ vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate actual expense deduction</action_comment>
-<action_description>set vehicle.vehicle_deduction = (vehicle.actual_expenses + vehicle.vehicle_depreciation) * vehicle.business_use_percentage</action_description>
+<action_dsl>set vehicle.vehicle_deduction = (vehicle.actual_expenses + vehicle.vehicle_depreciation) * vehicle.business_use_percentage</action_dsl>
 <action_postfix>
 vehicle.actual_expenses vehicle.vehicle_depreciation f+ vehicle.business_use_percentage f* /vehicle.vehicle_deduction xdef
 vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
@@ -772,7 +772,7 @@ vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each rental property</context_comment>
-<context_description>for all properties where property.type is equal to "rental"</context_description>
+<context_dsl>for all properties where property.type is equal to "rental"</context_dsl>
 <context_postfix>
 { /Process_Rental_Income executetable } job.properties forall
 </context_postfix>
@@ -783,7 +783,7 @@ vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is rental property</condition_comment>
-<condition_description>property.type is equal to "rental"</condition_description>
+<condition_dsl>property.type is equal to "rental"</condition_dsl>
 <condition_postfix>property.type "rental" streq</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="Y"></condition_column>
@@ -792,7 +792,7 @@ vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has rental income</condition_comment>
-<condition_description>property.rental_income &gt; 0</condition_description>
+<condition_dsl>property.rental_income &gt; 0</condition_dsl>
 <condition_postfix>property.rental_income 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="Y"></condition_column>
@@ -800,7 +800,7 @@ vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Net income is positive (income not loss)</condition_comment>
-<condition_description>property.rental_net_income &gt;= 0</condition_description>
+<condition_dsl>property.rental_net_income &gt;= 0</condition_dsl>
 <condition_postfix>property.rental_net_income 0 >=</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -810,7 +810,7 @@ vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log rental property header</action_comment>
-<action_description>add "SCHEDULE E - Rental Property: " + property.address to job.audit_trail</action_description>
+<action_dsl>add "SCHEDULE E - Rental Property: " + property.address to job.audit_trail</action_dsl>
 <action_postfix>
 "SCHEDULE E Part I - Rental Property: " property.address strconcat job.audit_trail swap addto
 "  Rental Income: $" property.rental_income cvs strconcat " (Schedule E Line 3, IRC 61(a)(5))" strconcat job.audit_trail swap addto
@@ -821,7 +821,7 @@ vehicle.vehicle_deduction taxpayer.se_expenses f+ /taxpayer.se_expenses xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate total rental expenses</action_comment>
-<action_description>set property.rental_expenses = property.rental_advertising + property.rental_insurance + property.mortgage_interest + property.property_taxes + property.rental_repairs + property.rental_utilities + property.depreciation</action_description>
+<action_dsl>set property.rental_expenses = property.rental_advertising + property.rental_insurance + property.mortgage_interest + property.property_taxes + property.rental_repairs + property.rental_utilities + property.depreciation</action_dsl>
 <action_postfix>
 property.rental_advertising property.rental_insurance f+ property.mortgage_interest f+ property.property_taxes f+ property.rental_repairs f+ property.rental_utilities f+ property.rental_management f+ property.depreciation f+ /property.rental_expenses xdef
 "  Expenses:" job.audit_trail swap addto
@@ -840,7 +840,7 @@ property.rental_advertising property.rental_insurance f+ property.mortgage_inter
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate net rental income</action_comment>
-<action_description>set property.rental_net_income = property.rental_income - property.rental_expenses</action_description>
+<action_dsl>set property.rental_net_income = property.rental_income - property.rental_expenses</action_dsl>
 <action_postfix>
 property.rental_income property.rental_expenses f- /property.rental_net_income xdef
 property.rental_net_income result.total_rental_income f+ /result.total_rental_income xdef
@@ -851,7 +851,7 @@ property.rental_net_income result.total_rental_income f+ /result.total_rental_in
 <action_details>
 <action_number>4</action_number>
 <action_comment>Log net income</action_comment>
-<action_description>add "Net Rental Income: $" + property.rental_net_income to job.audit_trail</action_description>
+<action_dsl>add "Net Rental Income: $" + property.rental_net_income to job.audit_trail</action_dsl>
 <action_postfix>
 "  Net Rental Income: $" property.rental_net_income cvs strconcat " (Schedule E Line 21)" strconcat job.audit_trail swap addto
 </action_postfix>
@@ -860,7 +860,7 @@ property.rental_net_income result.total_rental_income f+ /result.total_rental_in
 <action_details>
 <action_number>5</action_number>
 <action_comment>Log net loss</action_comment>
-<action_description>add "Net Rental Loss: $" + property.rental_net_income to job.audit_trail</action_description>
+<action_dsl>add "Net Rental Loss: $" + property.rental_net_income to job.audit_trail</action_dsl>
 <action_postfix>
 "  Net Rental Loss: $" property.rental_net_income cvs strconcat " (Schedule E Line 21)" strconcat job.audit_trail swap addto
 "  Note: Rental loss may be subject to passive activity limitations per Form 8582, IRC 469" job.audit_trail swap addto
@@ -897,7 +897,7 @@ property.rental_net_income result.total_rental_income f+ /result.total_rental_in
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each income entity</context_comment>
-<context_description>for all income entities</context_description>
+<context_dsl>for all income entities</context_dsl>
 <context_postfix>
 { /Process_Other_Income executetable } job.incomes forall
 </context_postfix>
@@ -908,7 +908,7 @@ property.rental_net_income result.total_rental_income f+ /result.total_rental_in
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has gross amount</condition_comment>
-<condition_description>income.gross_amount &gt; 0</condition_description>
+<condition_dsl>income.gross_amount &gt; 0</condition_dsl>
 <condition_postfix>
 income.gross_amount 0 >
 </condition_postfix>
@@ -920,7 +920,7 @@ income.gross_amount 0 >
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add income to total other income</action_comment>
-<action_description>add income.gross_amount to result.total_other_income</action_description>
+<action_dsl>add income.gross_amount to result.total_other_income</action_dsl>
 <action_postfix>
 income.gross_amount result.total_other_income f+ /result.total_other_income xdef
 "  Other Income (" income.type strconcat "): $" strconcat income.gross_amount cvs strconcat " from " strconcat income.source strconcat job.audit_trail swap addto
@@ -930,7 +930,7 @@ income.gross_amount result.total_other_income f+ /result.total_other_income xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Track withholding</action_comment>
-<action_description>add income.tax_withheld to result.total_payments</action_description>
+<action_dsl>add income.tax_withheld to result.total_payments</action_dsl>
 <action_postfix>
 income.tax_withheld result.total_payments f+ /result.total_payments xdef
 </action_postfix>
@@ -958,7 +958,7 @@ income.tax_withheld result.total_payments f+ /result.total_payments xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each taxpayer for adjustments</context_comment>
-<context_description>for all taxpayers</context_description>
+<context_dsl>for all taxpayers</context_dsl>
 <context_postfix>
 0.0 /result.total_adjustments xdef
 "ADJUSTMENTS TO INCOME (Schedule 1 Part II)" job.audit_trail swap addto
@@ -977,7 +977,7 @@ result.total_obbba_deductions result.ira_deduction f+ result.hsa_deduction f+ re
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has SE tax to deduct</condition_comment>
-<condition_description>taxpayer.se_tax_deduction &gt; 0</condition_description>
+<condition_dsl>taxpayer.se_tax_deduction &gt; 0</condition_dsl>
 <condition_postfix>
 taxpayer.se_tax_deduction 0 >
 </condition_postfix>
@@ -989,7 +989,7 @@ taxpayer.se_tax_deduction 0 >
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add SE tax deduction to adjustments</action_comment>
-<action_description>add taxpayer.se_tax_deduction to result.total_adjustments</action_description>
+<action_dsl>add taxpayer.se_tax_deduction to result.total_adjustments</action_dsl>
 <action_postfix>
 taxpayer.se_tax_deduction result.total_adjustments f+ /result.total_adjustments xdef
 "  Line 15 - SE Tax Deduction for " taxpayer.name strconcat ": $" strconcat taxpayer.se_tax_deduction cvs strconcat " (IRC 164(f))" strconcat job.audit_trail swap addto
@@ -999,7 +999,7 @@ taxpayer.se_tax_deduction result.total_adjustments f+ /result.total_adjustments 
 <action_details>
 <action_number>2</action_number>
 <action_comment>Log total adjustments</action_comment>
-<action_description>add "Total Adjustments: $" + result.total_adjustments to job.audit_trail</action_description>
+<action_dsl>add "Total Adjustments: $" + result.total_adjustments to job.audit_trail</action_dsl>
 <action_postfix>
 "  Line 26 - Total Adjustments: $" result.total_adjustments cvs strconcat job.audit_trail swap addto
 </action_postfix>
@@ -1022,7 +1022,7 @@ taxpayer.se_tax_deduction result.total_adjustments f+ /result.total_adjustments 
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Calculate_Standard_Deduction</action_description>
+<action_dsl>Calculate_Standard_Deduction</action_dsl>
 <action_postfix>
 "DEDUCTIONS (Form 1040 Line 12)" job.audit_trail swap addto
 /Calculate_Standard_Deduction executetable
@@ -1034,7 +1034,7 @@ taxpayer.se_tax_deduction result.total_adjustments f+ /result.total_adjustments 
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Itemized deductions exceed standard deduction</condition_comment>
-<condition_description>result.total_itemized &gt; result.standard_deduction</condition_description>
+<condition_dsl>result.total_itemized &gt; result.standard_deduction</condition_dsl>
 <condition_postfix>
 result.total_itemized result.standard_deduction >
 </condition_postfix>
@@ -1046,7 +1046,7 @@ result.total_itemized result.standard_deduction >
 <action_details>
 <action_number>1</action_number>
 <action_comment>Use itemized deductions</action_comment>
-<action_description>set result.deduction_used = result.total_itemized</action_description>
+<action_dsl>set result.deduction_used = result.total_itemized</action_dsl>
 <action_postfix>
 result.total_itemized /result.total_deduction xdef
 "itemized" /result.deduction_used xdef
@@ -1057,7 +1057,7 @@ result.total_itemized /result.total_deduction xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Use standard deduction</action_comment>
-<action_description>set result.deduction_used = result.standard_deduction</action_description>
+<action_dsl>set result.deduction_used = result.standard_deduction</action_dsl>
 <action_postfix>
 result.standard_deduction /result.total_deduction xdef
 "standard" /result.deduction_used xdef
@@ -1094,7 +1094,7 @@ result.standard_deduction /result.total_deduction xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly or Qualifying Surviving Spouse</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ" or job.filing_status is equal to "QSS"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ" or job.filing_status is equal to "QSS"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq job.filing_status QSS streq or
 </condition_postfix>
@@ -1108,7 +1108,7 @@ job.filing_status MFJ streq job.filing_status QSS streq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>job.filing_status is equal to "HOH"</condition_description>
+<condition_dsl>job.filing_status is equal to "HOH"</condition_dsl>
 <condition_postfix>
 job.filing_status HOH streq
 </condition_postfix>
@@ -1122,7 +1122,7 @@ job.filing_status HOH streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Has seniors age 65+</condition_comment>
-<condition_description>result.senior_count &gt; 0</condition_description>
+<condition_dsl>result.senior_count &gt; 0</condition_dsl>
 <condition_postfix>
 result.senior_count 0 >
 </condition_postfix>
@@ -1138,7 +1138,7 @@ result.senior_count 0 >
 <action_details>
 <action_number>1</action_number>
 <action_comment>MFJ/QSS standard deduction</action_comment>
-<action_description>set result.standard_deduction = standard_deduction_mfj</action_description>
+<action_dsl>set result.standard_deduction = standard_deduction_mfj</action_dsl>
 <action_postfix>
 constants.standard_deduction_mfj /result.standard_deduction xdef
 "Standard Deduction (MFJ): $" result.standard_deduction cvs strconcat " per IRC 63(c)(2)(A)" strconcat job.audit_trail swap addto
@@ -1149,7 +1149,7 @@ constants.standard_deduction_mfj /result.standard_deduction xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>HOH standard deduction</action_comment>
-<action_description>set result.standard_deduction = standard_deduction_hoh</action_description>
+<action_dsl>set result.standard_deduction = standard_deduction_hoh</action_dsl>
 <action_postfix>
 constants.standard_deduction_hoh /result.standard_deduction xdef
 "Standard Deduction (HOH): $" result.standard_deduction cvs strconcat " per IRC 63(c)(2)(B)" strconcat job.audit_trail swap addto
@@ -1160,7 +1160,7 @@ constants.standard_deduction_hoh /result.standard_deduction xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Single/MFS standard deduction</action_comment>
-<action_description>set result.standard_deduction = standard_deduction_single</action_description>
+<action_dsl>set result.standard_deduction = standard_deduction_single</action_dsl>
 <action_postfix>
 constants.standard_deduction_single /result.standard_deduction xdef
 "Standard Deduction (Single/MFS): $" result.standard_deduction cvs strconcat " per IRC 63(c)(2)(C)" strconcat job.audit_trail swap addto
@@ -1171,7 +1171,7 @@ constants.standard_deduction_single /result.standard_deduction xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Add additional standard deduction for married seniors age 65+</action_comment>
-<action_description>add senior_extra_deduction_married to result.standard_deduction</action_description>
+<action_dsl>add senior_extra_deduction_married to result.standard_deduction</action_dsl>
 <action_postfix>
 result.senior_count 1.0 f* constants.additional_std_deduction_married f* result.standard_deduction f+ /result.standard_deduction xdef
 "  Additional for seniors (65+): $" result.senior_count 1.0 f* constants.additional_std_deduction_married f* cvs strconcat " (" strconcat result.senior_count cvs strconcat " x $" strconcat constants.additional_std_deduction_married cvs strconcat ")" strconcat job.audit_trail swap addto
@@ -1181,7 +1181,7 @@ result.senior_count 1.0 f* constants.additional_std_deduction_married f* result.
 <action_details>
 <action_number>5</action_number>
 <action_comment>Add additional standard deduction for single/HOH seniors age 65+</action_comment>
-<action_description>add senior_extra_deduction_single to result.standard_deduction</action_description>
+<action_dsl>add senior_extra_deduction_single to result.standard_deduction</action_dsl>
 <action_postfix>
 result.senior_count 1.0 f* constants.additional_std_deduction_single f* result.standard_deduction f+ /result.standard_deduction xdef
 "  Additional for seniors (65+): $" result.senior_count 1.0 f* constants.additional_std_deduction_single f* cvs strconcat " (" strconcat result.senior_count cvs strconcat " x $" strconcat constants.additional_std_deduction_single cvs strconcat ")" strconcat job.audit_trail swap addto
@@ -1230,7 +1230,7 @@ result.senior_count 1.0 f* constants.additional_std_deduction_single f* result.s
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.total_itemized = 0</action_description>
+<action_dsl>set result.total_itemized = 0</action_dsl>
 <action_postfix>
 0.0 /result.total_itemized xdef
 "SCHEDULE A - Itemized Deductions" job.audit_trail swap addto
@@ -1241,7 +1241,7 @@ result.senior_count 1.0 f* constants.additional_std_deduction_single f* result.s
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always calculate itemized for comparison</condition_comment>
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -1252,7 +1252,7 @@ perform when called
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate medical expense deduction (Schedule A Lines 1-4)</action_comment>
-<action_description>Calculate_Medical_Expense_Deduction</action_description>
+<action_dsl>Calculate_Medical_Expense_Deduction</action_dsl>
 <action_postfix>
 Calculate_Medical_Expense_Deduction
 result.medical_expense_deduction result.total_itemized f+ /result.total_itemized xdef
@@ -1262,7 +1262,7 @@ result.medical_expense_deduction result.total_itemized f+ /result.total_itemized
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate SALT deduction</action_comment>
-<action_description>Calculate_SALT_Deduction</action_description>
+<action_dsl>Calculate_SALT_Deduction</action_dsl>
 <action_postfix>
 Calculate_SALT_Deduction
 </action_postfix>
@@ -1271,7 +1271,7 @@ Calculate_SALT_Deduction
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate mortgage interest deduction</action_comment>
-<action_description>Calculate_Mortgage_Interest</action_description>
+<action_dsl>Calculate_Mortgage_Interest</action_dsl>
 <action_postfix>
 Calculate_Mortgage_Interest
 </action_postfix>
@@ -1280,7 +1280,7 @@ Calculate_Mortgage_Interest
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate charitable contributions</action_comment>
-<action_description>Calculate_Charitable_Deduction</action_description>
+<action_dsl>Calculate_Charitable_Deduction</action_dsl>
 <action_postfix>
 Calculate_Charitable_Deduction
 </action_postfix>
@@ -1289,7 +1289,7 @@ Calculate_Charitable_Deduction
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate noncash charitable contributions (Form 8283)</action_comment>
-<action_description>Calculate_Noncash_Charitable</action_description>
+<action_dsl>Calculate_Noncash_Charitable</action_dsl>
 <action_postfix>
 /Calculate_Noncash_Charitable executetable
 </action_postfix>
@@ -1298,7 +1298,7 @@ Calculate_Charitable_Deduction
 <action_details>
 <action_number>6</action_number>
 <action_comment>Log total itemized</action_comment>
-<action_description>add "Total Itemized Deductions: $" + result.total_itemized to job.audit_trail</action_description>
+<action_dsl>add "Total Itemized Deductions: $" + result.total_itemized to job.audit_trail</action_dsl>
 <action_postfix>
 "  Total Itemized Deductions: $" result.total_itemized cvs strconcat job.audit_trail swap addto
 </action_postfix>
@@ -1321,7 +1321,7 @@ Calculate_Charitable_Deduction
 <context_details>
 <context_number>1</context_number>
 <context_comment>Calculate total SALT from property taxes and deductions</context_comment>
-<context_description>local double salt_total = sum of property_taxes + state/local tax deductions</context_description>
+<context_dsl>local double salt_total = sum of property_taxes + state/local tax deductions</context_dsl>
 <context_postfix>
 0.0 allocate
 { Sum_Primary_Residence_Tax performaliased } job.properties forall
@@ -1335,7 +1335,7 @@ Calculate_Charitable_Deduction
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>State has income tax</condition_comment>
-<condition_description>job.has_state_income_tax == true</condition_description>
+<condition_dsl>job.has_state_income_tax == true</condition_dsl>
 <condition_postfix>
 job.has_state_income_tax true beq
 </condition_postfix>
@@ -1347,7 +1347,7 @@ job.has_state_income_tax true beq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Total SALT exceeds cap</condition_comment>
-<condition_description>salt_total &gt; salt_cap</condition_description>
+<condition_dsl>salt_total &gt; salt_cap</condition_dsl>
 <condition_postfix>
 0 local@ salt_cap >
 </condition_postfix>
@@ -1361,7 +1361,7 @@ job.has_state_income_tax true beq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Apply SALT cap with state income tax</action_comment>
-<action_description>set result.salt_deduction = salt_cap</action_description>
+<action_dsl>set result.salt_deduction = salt_cap</action_dsl>
 <action_postfix>
 "  State and Local Taxes (SALT):" job.audit_trail swap addto
 "    State Income Tax: (applicable)" job.audit_trail swap addto
@@ -1375,7 +1375,7 @@ salt_cap result.total_itemized f+ /result.total_itemized xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No state income tax, apply cap if needed</action_comment>
-<action_description>set result.salt_deduction = salt_cap</action_description>
+<action_dsl>set result.salt_deduction = salt_cap</action_dsl>
 <action_postfix>
 "  State and Local Taxes (SALT) - " job.state strconcat " (No State Income Tax):" strconcat job.audit_trail swap addto
 "    Real Estate Taxes: $" 0 local@ cvs strconcat " (Line 5b, IRC 164(a)(1))" strconcat job.audit_trail swap addto
@@ -1388,7 +1388,7 @@ salt_cap result.total_itemized f+ /result.total_itemized xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Full SALT with state income tax (under cap)</action_comment>
-<action_description>set result.salt_deduction = salt_total</action_description>
+<action_dsl>set result.salt_deduction = salt_total</action_dsl>
 <action_postfix>
 "  State and Local Taxes (SALT):" job.audit_trail swap addto
 "    Total SALT: $" 0 local@ cvs strconcat " (under $" strconcat salt_cap cvs strconcat " cap)" strconcat job.audit_trail swap addto
@@ -1400,7 +1400,7 @@ salt_cap result.total_itemized f+ /result.total_itemized xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Full SALT no state income tax (under cap)</action_comment>
-<action_description>set result.salt_deduction = property_tax_total</action_description>
+<action_dsl>set result.salt_deduction = property_tax_total</action_dsl>
 <action_postfix>
 "  State and Local Taxes (SALT) - " job.state strconcat " (No State Income Tax):" strconcat job.audit_trail swap addto
 "    Property Taxes: $" 0 local@ cvs strconcat " (under $" strconcat salt_cap cvs strconcat " cap)" strconcat job.audit_trail swap addto
@@ -1437,7 +1437,7 @@ salt_cap result.total_itemized f+ /result.total_itemized xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Property is primary residence</condition_comment>
-<condition_description>property.type is equal to "primary_residence"</condition_description>
+<condition_dsl>property.type is equal to "primary_residence"</condition_dsl>
 <condition_postfix>
 type "primary_residence" streq
 </condition_postfix>
@@ -1449,7 +1449,7 @@ type "primary_residence" streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add property tax to total</action_comment>
-<action_description>add property.property_taxes to salt_total</action_description>
+<action_dsl>add property.property_taxes to salt_total</action_dsl>
 <action_postfix>
 property_taxes 0 local@ f+ 0 local!
 </action_postfix>
@@ -1458,7 +1458,7 @@ property_taxes 0 local@ f+ 0 local!
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-primary residence</action_comment>
-<action_description>otherwise</action_description>
+<action_dsl>otherwise</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X"></action_column>
@@ -1482,7 +1482,7 @@ property_taxes 0 local@ f+ 0 local!
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Deduction is state or local tax</condition_comment>
-<condition_description>deduction.category is state_income_tax or local_tax</condition_description>
+<condition_dsl>deduction.category is state_income_tax or local_tax</condition_dsl>
 <condition_postfix>
 category "state_income_tax" streq category "local_tax" streq or
 </condition_postfix>
@@ -1494,7 +1494,7 @@ category "state_income_tax" streq category "local_tax" streq or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add SALT deduction to total</action_comment>
-<action_description>add taxpayer.state_tax_paid to salt_total</action_description>
+<action_dsl>add taxpayer.state_tax_paid to salt_total</action_dsl>
 <action_postfix>
 amount 0 local@ f+ 0 local!
 </action_postfix>
@@ -1503,7 +1503,7 @@ amount 0 local@ f+ 0 local!
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-SALT deduction</action_comment>
-<action_description>otherwise</action_description>
+<action_dsl>otherwise</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X"></action_column>
@@ -1525,7 +1525,7 @@ amount 0 local@ f+ 0 local!
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process primary residence properties</context_comment>
-<context_description>for all properties where property.type is equal to "primary_residence"</context_description>
+<context_dsl>for all properties where property.type is equal to "primary_residence"</context_dsl>
 <context_postfix>
 { Filter_Primary_Residence performaliased } job.properties forall
 </context_postfix>
@@ -1536,7 +1536,7 @@ amount 0 local@ f+ 0 local!
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has mortgage interest</condition_comment>
-<condition_description>property.mortgage_interest &gt; 0</condition_description>
+<condition_dsl>property.mortgage_interest &gt; 0</condition_dsl>
 <condition_postfix>
 property.mortgage_interest 0 >
 </condition_postfix>
@@ -1547,7 +1547,7 @@ property.mortgage_interest 0 >
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Mortgage balance within limit</condition_comment>
-<condition_description>mortgage_balance &lt;= mortgage_limit_post_tcja</condition_description>
+<condition_dsl>mortgage_balance &lt;= mortgage_limit_post_tcja</condition_dsl>
 <condition_postfix>
 property.mortgage_balance mortgage_limit_post_tcja &lt;=
 </condition_postfix>
@@ -1559,7 +1559,7 @@ property.mortgage_balance mortgage_limit_post_tcja &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full mortgage interest deduction</action_comment>
-<action_description>add property.mortgage_interest to result.total_itemized</action_description>
+<action_dsl>add property.mortgage_interest to result.total_itemized</action_dsl>
 <action_postfix>
 property.mortgage_interest /property.mortgage_interest_deductible xdef
 property.mortgage_interest_deductible result.total_itemized f+ /result.total_itemized xdef
@@ -1573,7 +1573,7 @@ property.mortgage_interest_deductible result.total_itemized f+ /result.total_ite
 <action_details>
 <action_number>2</action_number>
 <action_comment>Limited mortgage interest deduction</action_comment>
-<action_description>add property.mortgage_interest * (mortgage_limit_post_tcja / property.mortgage_balance) to result.total_itemized</action_description>
+<action_dsl>add property.mortgage_interest * (mortgage_limit_post_tcja / property.mortgage_balance) to result.total_itemized</action_dsl>
 <action_postfix>
 property.mortgage_interest mortgage_limit_post_tcja * property.mortgage_balance / /property.mortgage_interest_deductible xdef
 property.mortgage_interest_deductible result.total_itemized f+ /result.total_itemized xdef
@@ -1617,7 +1617,7 @@ property.mortgage_interest_deductible result.total_itemized f+ /result.total_ite
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Property is primary residence</condition_comment>
-<condition_description>property.type is equal to "primary_residence"</condition_description>
+<condition_dsl>property.type is equal to "primary_residence"</condition_dsl>
 <condition_postfix>
 type "primary_residence" streq
 </condition_postfix>
@@ -1629,7 +1629,7 @@ type "primary_residence" streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process primary residence</action_comment>
-<action_description>otherwise</action_description>
+<action_dsl>otherwise</action_dsl>
 <action_postfix>
 Calculate_Mortgage_Interest_For_Property
 </action_postfix>
@@ -1638,7 +1638,7 @@ Calculate_Mortgage_Interest_For_Property
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-primary residence</action_comment>
-<action_description>otherwise</action_description>
+<action_dsl>otherwise</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X"></action_column>
@@ -1660,7 +1660,7 @@ Calculate_Mortgage_Interest_For_Property
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process charitable deductions</context_comment>
-<context_description>for all deductions where deduction.category is equal to "charity"</context_description>
+<context_dsl>for all deductions where deduction.category is equal to "charity"</context_dsl>
 <context_postfix>
 { Filter_Charity_Deduction performaliased } job.deductions forall
 </context_postfix>
@@ -1671,7 +1671,7 @@ Calculate_Mortgage_Interest_For_Property
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has charitable contribution</condition_comment>
-<condition_description>deduction.amount &gt; 0</condition_description>
+<condition_dsl>deduction.amount &gt; 0</condition_dsl>
 <condition_postfix>
 deduction.amount 0 >
 </condition_postfix>
@@ -1683,7 +1683,7 @@ deduction.amount 0 >
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add charitable contribution</action_comment>
-<action_description>add deduction.amount to result.total_itemized</action_description>
+<action_dsl>add deduction.amount to result.total_itemized</action_dsl>
 <action_postfix>
 deduction.amount /deduction.allowed_amount xdef
 deduction.allowed_amount result.total_itemized f+ /result.total_itemized xdef
@@ -1715,7 +1715,7 @@ deduction.allowed_amount result.total_itemized f+ /result.total_itemized xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Deduction is charity category</condition_comment>
-<condition_description>deduction.category is charity or charitable_cash</condition_description>
+<condition_dsl>deduction.category is charity or charitable_cash</condition_dsl>
 <condition_postfix>
 category "charity" streq category "charitable_cash" streq or
 </condition_postfix>
@@ -1727,7 +1727,7 @@ category "charity" streq category "charitable_cash" streq or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process charity deduction</action_comment>
-<action_description>add deduction.allowed_amount to result.total_itemized</action_description>
+<action_dsl>add deduction.allowed_amount to result.total_itemized</action_dsl>
 <action_postfix>
 amount /deduction.allowed_amount xdef
 deduction.allowed_amount result.total_itemized f+ /result.total_itemized xdef
@@ -1738,7 +1738,7 @@ deduction.allowed_amount result.total_itemized f+ /result.total_itemized xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-charity deduction</action_comment>
-<action_description>otherwise</action_description>
+<action_dsl>otherwise</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X"></action_column>
@@ -1760,7 +1760,7 @@ deduction.allowed_amount result.total_itemized f+ /result.total_itemized xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each noncash contribution</context_comment>
-<context_description>for all noncash contributions</context_description>
+<context_dsl>for all noncash contributions</context_dsl>
 <context_postfix>
 "NONCASH CHARITABLE CONTRIBUTIONS (Form 8283, IRC 170)" job.audit_trail swap addto
 0.0 /result.total_noncash_charitable xdef
@@ -1773,7 +1773,7 @@ deduction.allowed_amount result.total_itemized f+ /result.total_itemized xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has noncash contributions</condition_comment>
-<condition_description>length of job.noncash_contributions &gt; 0</condition_description>
+<condition_dsl>length of job.noncash_contributions &gt; 0</condition_dsl>
 <condition_postfix>
 job.noncash_contributions length 0 >
 </condition_postfix>
@@ -1785,7 +1785,7 @@ job.noncash_contributions length 0 >
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log total noncash charitable</action_comment>
-<action_description>add result.total_noncash_charitable to result.total_itemized</action_description>
+<action_dsl>add result.total_noncash_charitable to result.total_itemized</action_dsl>
 <action_postfix>
 result.total_noncash_charitable result.total_itemized f+ /result.total_itemized xdef
 "  Total Noncash Charitable: $" result.total_noncash_charitable cvs strconcat " (Form 8283)" strconcat job.audit_trail swap addto
@@ -1795,7 +1795,7 @@ result.total_noncash_charitable result.total_itemized f+ /result.total_itemized 
 <action_details>
 <action_number>2</action_number>
 <action_comment>No noncash contributions</action_comment>
-<action_description>set result.total_noncash_charitable = 0</action_description>
+<action_dsl>set result.total_noncash_charitable = 0</action_dsl>
 <action_postfix>
 0.0 /result.total_noncash_charitable xdef
 </action_postfix>
@@ -1825,7 +1825,7 @@ result.total_noncash_charitable result.total_itemized f+ /result.total_itemized 
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Requires Section B (appraisal required for over $5,000)</condition_comment>
-<condition_description>fair_market_value &gt; 5000</condition_description>
+<condition_dsl>fair_market_value &gt; 5000</condition_dsl>
 <condition_postfix>
 fair_market_value 5000 >
 </condition_postfix>
@@ -1835,7 +1835,7 @@ fair_market_value 5000 >
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Is appreciated capital gain property (long-term)</condition_comment>
-<condition_description>is_appreciated_property == true and holding_period is equal to "long_term"</condition_description>
+<condition_dsl>is_appreciated_property == true and holding_period is equal to "long_term"</condition_dsl>
 <condition_postfix>
 is_appreciated_property true eq holding_period "long_term" streq and
 </condition_postfix>
@@ -1849,7 +1849,7 @@ is_appreciated_property true eq holding_period "long_term" streq and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Capital gain property - use FMV with 30% AGI limit</action_comment>
-<action_description>set noncash_contribution.deduction_amount = fair_market_value, set noncash_contribution.agi_limitation = 0.30</action_description>
+<action_dsl>set noncash_contribution.deduction_amount = fair_market_value, set noncash_contribution.agi_limitation = 0.30</action_dsl>
 <action_postfix>
 fair_market_value /noncash_contribution.deduction_amount xdef
 0.30 /noncash_contribution.agi_limitation xdef
@@ -1861,7 +1861,7 @@ noncash_contribution.deduction_amount result.total_noncash_charitable f+ /result
 <action_details>
 <action_number>2</action_number>
 <action_comment>Ordinary income property or short-term - use lesser of FMV or basis</action_comment>
-<action_description>set noncash_contribution.deduction_amount = the minimum of fair_market_value and cost_basis</action_description>
+<action_dsl>set noncash_contribution.deduction_amount = the minimum of fair_market_value and cost_basis</action_dsl>
 <action_postfix>
 fair_market_value cost_basis min /noncash_contribution.deduction_amount xdef
 0.50 /noncash_contribution.agi_limitation xdef
@@ -1873,7 +1873,7 @@ noncash_contribution.deduction_amount result.total_noncash_charitable f+ /result
 <action_details>
 <action_number>3</action_number>
 <action_comment>Section A - under $5,000, use FMV</action_comment>
-<action_description>set noncash_contribution.deduction_amount = fair_market_value</action_description>
+<action_dsl>set noncash_contribution.deduction_amount = fair_market_value</action_dsl>
 <action_postfix>
 fair_market_value /noncash_contribution.deduction_amount xdef
 0.50 /noncash_contribution.agi_limitation xdef
@@ -1915,7 +1915,7 @@ noncash_contribution.deduction_amount result.total_noncash_charitable f+ /result
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has self-employment income for QBI</condition_comment>
-<condition_description>result.total_se_income &gt; 0</condition_description>
+<condition_dsl>result.total_se_income &gt; 0</condition_dsl>
 <condition_postfix>
 result.total_se_income 0 >
 </condition_postfix>
@@ -1927,7 +1927,7 @@ result.total_se_income 0 >
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate QBI deduction</action_comment>
-<action_description>set result.qbi_deduction = the minimum of (result.total_se_income * qbi_rate) and ((result.agi - result.total_deduction) * qbi_rate)</action_description>
+<action_dsl>set result.qbi_deduction = the minimum of (result.total_se_income * qbi_rate) and ((result.agi - result.total_deduction) * qbi_rate)</action_dsl>
 <action_postfix>
 result.total_se_income qbi_rate f* /result.qbi_from_income xdef
 result.agi result.total_deduction f- qbi_rate f* /result.qbi_taxable_limit xdef
@@ -1940,7 +1940,7 @@ result.qbi_from_income result.qbi_taxable_limit fmin /result.qbi_deduction xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No QBI deduction</action_comment>
-<action_description>set result.qbi_deduction = 0</action_description>
+<action_dsl>set result.qbi_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.qbi_deduction xdef
 "TAXABLE INCOME CALCULATION" job.audit_trail swap addto
@@ -1950,7 +1950,7 @@ result.qbi_from_income result.qbi_taxable_limit fmin /result.qbi_deduction xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate taxable income (floor at zero)</action_comment>
-<action_description>set result.taxable_income = the maximum of (result.agi - result.total_deduction - result.qbi_deduction) and 0</action_description>
+<action_dsl>set result.taxable_income = the maximum of (result.agi - result.total_deduction - result.qbi_deduction) and 0</action_dsl>
 <action_postfix>
 result.agi result.total_deduction f- result.qbi_deduction f- 0.0 fmax /result.taxable_income xdef
 "  Line 15 - Taxable Income: $" result.taxable_income cvs strconcat " per Form 1040 Line 15" strconcat job.audit_trail swap addto
@@ -1983,7 +1983,7 @@ result.agi result.total_deduction f- result.qbi_deduction f- 0.0 fmax /result.ta
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add "TAX CALCULATION (Form 1040 Lines 16-24)" to job.audit_trail</action_description>
+<action_dsl>add "TAX CALCULATION (Form 1040 Lines 16-24)" to job.audit_trail</action_dsl>
 <action_postfix>
 "TAX CALCULATION (Form 1040 Lines 16-24)" job.audit_trail swap addto
 </action_postfix>
@@ -1993,7 +1993,7 @@ result.agi result.total_deduction f- result.qbi_deduction f- 0.0 fmax /result.ta
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always calculate</condition_comment>
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -2004,7 +2004,7 @@ perform when called
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate regular tax using brackets</action_comment>
-<action_description>Apply_Tax_Brackets</action_description>
+<action_dsl>Apply_Tax_Brackets</action_dsl>
 <action_postfix>
 Apply_Tax_Brackets
 </action_postfix>
@@ -2013,7 +2013,7 @@ Apply_Tax_Brackets
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate capital gains tax</action_comment>
-<action_description>Calculate_Capital_Gains_Tax</action_description>
+<action_dsl>Calculate_Capital_Gains_Tax</action_dsl>
 <action_postfix>
 Calculate_Capital_Gains_Tax
 </action_postfix>
@@ -2022,7 +2022,7 @@ Calculate_Capital_Gains_Tax
 <action_details>
 <action_number>3</action_number>
 <action_comment>Add SE tax from all taxpayers</action_comment>
-<action_description>set result.se_tax = the sum of taxpayer.se_tax for all taxpayers</action_description>
+<action_dsl>set result.se_tax = the sum of taxpayer.se_tax for all taxpayers</action_dsl>
 <action_postfix>
 0.0 { se_tax + } job.taxpayers forall /result.se_tax xdef
 "  SE Tax (Schedule SE): $" result.se_tax cvs strconcat job.audit_trail swap addto
@@ -2032,7 +2032,7 @@ Calculate_Capital_Gains_Tax
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate NIIT</action_comment>
-<action_description>Calculate_NIIT</action_description>
+<action_dsl>Calculate_NIIT</action_dsl>
 <action_postfix>
 Calculate_NIIT
 </action_postfix>
@@ -2041,7 +2041,7 @@ Calculate_NIIT
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate Additional Medicare Tax</action_comment>
-<action_description>Calculate_Additional_Medicare_Tax</action_description>
+<action_dsl>Calculate_Additional_Medicare_Tax</action_dsl>
 <action_postfix>
 Calculate_Additional_Medicare_Tax
 </action_postfix>
@@ -2050,7 +2050,7 @@ Calculate_Additional_Medicare_Tax
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate Schedule H (household employment taxes)</action_comment>
-<action_description>Calculate_Schedule_H</action_description>
+<action_dsl>Calculate_Schedule_H</action_dsl>
 <action_postfix>
 Calculate_Schedule_H
 </action_postfix>
@@ -2059,7 +2059,7 @@ Calculate_Schedule_H
 <action_details>
 <action_number>7</action_number>
 <action_comment>Calculate total tax before credits</action_comment>
-<action_description>set result.total_tax_before_credits = result.regular_tax + result.capital_gains_tax + result.se_tax + result.niit_tax + result.additional_medicare_tax</action_description>
+<action_dsl>set result.total_tax_before_credits = result.regular_tax + result.capital_gains_tax + result.se_tax + result.niit_tax + result.additional_medicare_tax</action_dsl>
 <action_postfix>
 result.regular_tax result.capital_gains_tax f+ result.se_tax f+ result.niit_tax f+ result.additional_medicare_tax f+ result.schedule_h_total_tax f+ /result.total_tax_before_credits xdef
 "  Total Tax Before Credits: $" result.total_tax_before_credits cvs strconcat job.audit_trail swap addto
@@ -2085,7 +2085,7 @@ result.regular_tax result.capital_gains_tax f+ result.se_tax f+ result.niit_tax 
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ" or job.filing_status is equal to "QSS"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ" or job.filing_status is equal to "QSS"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq job.filing_status QSS streq or
 </condition_postfix>
@@ -2094,7 +2094,7 @@ job.filing_status MFJ streq job.filing_status QSS streq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single or other</condition_comment>
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>
 otherwise
 </condition_postfix>
@@ -2105,7 +2105,7 @@ otherwise
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate MFJ tax</action_comment>
-<action_description>Apply_Tax_Brackets_MFJ</action_description>
+<action_dsl>Apply_Tax_Brackets_MFJ</action_dsl>
 <action_postfix>
 Apply_Tax_Brackets_MFJ
 "  Line 16 - Regular Tax (MFJ brackets): $" result.regular_tax cvs strconcat " per IRC 1(a)" strconcat job.audit_trail swap addto
@@ -2115,7 +2115,7 @@ Apply_Tax_Brackets_MFJ
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate Single tax</action_comment>
-<action_description>Apply_Tax_Brackets_Single</action_description>
+<action_dsl>Apply_Tax_Brackets_Single</action_dsl>
 <action_postfix>
 Apply_Tax_Brackets_Single
 "  Line 16 - Regular Tax (Single brackets): $" result.regular_tax cvs strconcat " per IRC 1(c)" strconcat job.audit_trail swap addto
@@ -2150,7 +2150,7 @@ Apply_Tax_Brackets_Single
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>In bracket 1 only</condition_comment>
-<condition_description>taxable_income at or below bracket_1_mfj</condition_description>
+<condition_dsl>taxable_income at or below bracket_1_mfj</condition_dsl>
 <condition_postfix>
 result.taxable_income bracket_1_mfj &lt;=
 </condition_postfix>
@@ -2163,7 +2163,7 @@ result.taxable_income bracket_1_mfj &lt;=
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>In bracket 2</condition_comment>
-<condition_description>taxable_income at or below bracket_2_mfj</condition_description>
+<condition_dsl>taxable_income at or below bracket_2_mfj</condition_dsl>
 <condition_postfix>
 result.taxable_income bracket_2_mfj &lt;=
 </condition_postfix>
@@ -2176,7 +2176,7 @@ result.taxable_income bracket_2_mfj &lt;=
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>In bracket 3</condition_comment>
-<condition_description>taxable_income at or below bracket_3_mfj</condition_description>
+<condition_dsl>taxable_income at or below bracket_3_mfj</condition_dsl>
 <condition_postfix>
 result.taxable_income bracket_3_mfj &lt;=
 </condition_postfix>
@@ -2189,7 +2189,7 @@ result.taxable_income bracket_3_mfj &lt;=
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>In bracket 4</condition_comment>
-<condition_description>taxable_income at or below bracket_4_mfj</condition_description>
+<condition_dsl>taxable_income at or below bracket_4_mfj</condition_dsl>
 <condition_postfix>
 result.taxable_income bracket_4_mfj &lt;=
 </condition_postfix>
@@ -2204,7 +2204,7 @@ result.taxable_income bracket_4_mfj &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Bracket 1 tax</action_comment>
-<action_description>set result.regular_tax = result.taxable_income * bracket_1_rate</action_description>
+<action_dsl>set result.regular_tax = result.taxable_income * bracket_1_rate</action_dsl>
 <action_postfix>
 result.taxable_income bracket_1_rate f* /result.regular_tax xdef
 </action_postfix>
@@ -2213,7 +2213,7 @@ result.taxable_income bracket_1_rate f* /result.regular_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bracket 2 tax</action_comment>
-<action_description>set result.regular_tax = tax at bracket_1 + excess taxed at bracket_2_rate</action_description>
+<action_dsl>set result.regular_tax = tax at bracket_1 + excess taxed at bracket_2_rate</action_dsl>
 <action_postfix>
 bracket_1_mfj bracket_1_rate f*
 result.taxable_income bracket_1_mfj f- bracket_2_rate f* f+
@@ -2224,7 +2224,7 @@ result.taxable_income bracket_1_mfj f- bracket_2_rate f* f+
 <action_details>
 <action_number>3</action_number>
 <action_comment>Bracket 3 tax</action_comment>
-<action_description>set result.regular_tax = tax at brackets 1-2 + excess taxed at bracket_3_rate</action_description>
+<action_dsl>set result.regular_tax = tax at brackets 1-2 + excess taxed at bracket_3_rate</action_dsl>
 <action_postfix>
 bracket_1_mfj bracket_1_rate f*
 bracket_2_mfj bracket_1_mfj f- bracket_2_rate f* f+
@@ -2236,7 +2236,7 @@ result.taxable_income bracket_2_mfj f- bracket_3_rate f* f+
 <action_details>
 <action_number>4</action_number>
 <action_comment>Bracket 4 tax</action_comment>
-<action_description>set result.regular_tax = tax at brackets 1-3 + excess taxed at bracket_4_rate</action_description>
+<action_dsl>set result.regular_tax = tax at brackets 1-3 + excess taxed at bracket_4_rate</action_dsl>
 <action_postfix>
 bracket_1_mfj bracket_1_rate f*
 bracket_2_mfj bracket_1_mfj f- bracket_2_rate f* f+
@@ -2249,7 +2249,7 @@ result.taxable_income bracket_3_mfj f- bracket_4_rate f* f+
 <action_details>
 <action_number>5</action_number>
 <action_comment>Bracket 5 tax</action_comment>
-<action_description>set result.regular_tax = tax at brackets 1-4 + excess taxed at bracket_5_rate</action_description>
+<action_dsl>set result.regular_tax = tax at brackets 1-4 + excess taxed at bracket_5_rate</action_dsl>
 <action_postfix>
 bracket_1_mfj bracket_1_rate f*
 bracket_2_mfj bracket_1_mfj f- bracket_2_rate f* f+
@@ -2279,7 +2279,7 @@ result.taxable_income bracket_4_mfj f- bracket_5_rate f* f+
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>In bracket 1 only</condition_comment>
-<condition_description>taxable_income at or below bracket_1_single</condition_description>
+<condition_dsl>taxable_income at or below bracket_1_single</condition_dsl>
 <condition_postfix>
 result.taxable_income bracket_1_single &lt;=
 </condition_postfix>
@@ -2292,7 +2292,7 @@ result.taxable_income bracket_1_single &lt;=
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>In bracket 2</condition_comment>
-<condition_description>taxable_income at or below bracket_2_single</condition_description>
+<condition_dsl>taxable_income at or below bracket_2_single</condition_dsl>
 <condition_postfix>
 result.taxable_income bracket_2_single &lt;=
 </condition_postfix>
@@ -2305,7 +2305,7 @@ result.taxable_income bracket_2_single &lt;=
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>In bracket 3</condition_comment>
-<condition_description>taxable_income at or below bracket_3_single</condition_description>
+<condition_dsl>taxable_income at or below bracket_3_single</condition_dsl>
 <condition_postfix>
 result.taxable_income bracket_3_single &lt;=
 </condition_postfix>
@@ -2318,7 +2318,7 @@ result.taxable_income bracket_3_single &lt;=
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>In bracket 4</condition_comment>
-<condition_description>taxable_income at or below bracket_4_single</condition_description>
+<condition_dsl>taxable_income at or below bracket_4_single</condition_dsl>
 <condition_postfix>
 result.taxable_income bracket_4_single &lt;=
 </condition_postfix>
@@ -2333,7 +2333,7 @@ result.taxable_income bracket_4_single &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Bracket 1 tax</action_comment>
-<action_description>set result.regular_tax = result.taxable_income * bracket_1_rate</action_description>
+<action_dsl>set result.regular_tax = result.taxable_income * bracket_1_rate</action_dsl>
 <action_postfix>
 result.taxable_income bracket_1_rate f* /result.regular_tax xdef
 </action_postfix>
@@ -2342,7 +2342,7 @@ result.taxable_income bracket_1_rate f* /result.regular_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bracket 2 tax</action_comment>
-<action_description>set result.regular_tax = tax at bracket_1 + excess taxed at bracket_2_rate</action_description>
+<action_dsl>set result.regular_tax = tax at bracket_1 + excess taxed at bracket_2_rate</action_dsl>
 <action_postfix>
 bracket_1_single bracket_1_rate f*
 result.taxable_income bracket_1_single f- bracket_2_rate f* f+
@@ -2353,7 +2353,7 @@ result.taxable_income bracket_1_single f- bracket_2_rate f* f+
 <action_details>
 <action_number>3</action_number>
 <action_comment>Bracket 3 tax</action_comment>
-<action_description>set result.regular_tax = tax at brackets 1-2 + excess taxed at bracket_3_rate</action_description>
+<action_dsl>set result.regular_tax = tax at brackets 1-2 + excess taxed at bracket_3_rate</action_dsl>
 <action_postfix>
 bracket_1_single bracket_1_rate f*
 bracket_2_single bracket_1_single f- bracket_2_rate f* f+
@@ -2365,7 +2365,7 @@ result.taxable_income bracket_2_single f- bracket_3_rate f* f+
 <action_details>
 <action_number>4</action_number>
 <action_comment>Bracket 4 tax</action_comment>
-<action_description>set result.regular_tax = tax at brackets 1-3 + excess taxed at bracket_4_rate</action_description>
+<action_dsl>set result.regular_tax = tax at brackets 1-3 + excess taxed at bracket_4_rate</action_dsl>
 <action_postfix>
 bracket_1_single bracket_1_rate f*
 bracket_2_single bracket_1_single f- bracket_2_rate f* f+
@@ -2378,7 +2378,7 @@ result.taxable_income bracket_3_single f- bracket_4_rate f* f+
 <action_details>
 <action_number>5</action_number>
 <action_comment>Bracket 5 tax</action_comment>
-<action_description>set result.regular_tax = tax at brackets 1-4 + excess taxed at bracket_5_rate</action_description>
+<action_dsl>set result.regular_tax = tax at brackets 1-4 + excess taxed at bracket_5_rate</action_dsl>
 <action_postfix>
 bracket_1_single bracket_1_rate f*
 bracket_2_single bracket_1_single f- bracket_2_rate f* f+
@@ -2405,7 +2405,7 @@ result.taxable_income bracket_4_single f- bracket_5_rate f* f+
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.total_ctc = 0, set result.total_odc = 0, set result.total_actc = 0, set result.total_credits = 0</action_description>
+<action_dsl>set result.total_ctc = 0, set result.total_odc = 0, set result.total_actc = 0, set result.total_credits = 0</action_dsl>
 <action_postfix>
 0.0 /result.total_ctc xdef
 0.0 /result.total_odc xdef
@@ -2419,7 +2419,7 @@ result.taxable_income bracket_4_single f- bracket_5_rate f* f+
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always process credits</condition_comment>
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -2430,7 +2430,7 @@ perform when called
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate child tax credits for all dependents</action_comment>
-<action_description>for all dependents perform Calculate_Child_Tax_Credit</action_description>
+<action_dsl>for all dependents perform Calculate_Child_Tax_Credit</action_dsl>
 <action_postfix>
 { /Calculate_Child_Tax_Credit executetable } job.dependents forall
 </action_postfix>
@@ -2439,7 +2439,7 @@ perform when called
 <action_details>
 <action_number>2</action_number>
 <action_comment>Apply CTC phase-out per IRC 24(b)</action_comment>
-<action_description>Calculate_CTC_Phase_Out</action_description>
+<action_dsl>Calculate_CTC_Phase_Out</action_dsl>
 <action_postfix>
 result.total_ctc result.total_odc f+ /result.ctc_before_phaseout xdef
 /Calculate_CTC_Phase_Out executetable
@@ -2449,7 +2449,7 @@ result.total_ctc result.total_odc f+ /result.ctc_before_phaseout xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate EITC</action_comment>
-<action_description>Calculate_EITC</action_description>
+<action_dsl>Calculate_EITC</action_dsl>
 <action_postfix>
 /Calculate_EITC executetable
 </action_postfix>
@@ -2458,7 +2458,7 @@ result.total_ctc result.total_odc f+ /result.ctc_before_phaseout xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate education credits</action_comment>
-<action_description>Calculate_Education_Credits</action_description>
+<action_dsl>Calculate_Education_Credits</action_dsl>
 <action_postfix>
 /Calculate_Education_Credits executetable
 </action_postfix>
@@ -2467,7 +2467,7 @@ result.total_ctc result.total_odc f+ /result.ctc_before_phaseout xdef
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate Child and Dependent Care Credit</action_comment>
-<action_description>Calculate_CDCC</action_description>
+<action_dsl>Calculate_CDCC</action_dsl>
 <action_postfix>
 /Calculate_CDCC executetable
 </action_postfix>
@@ -2476,7 +2476,7 @@ result.total_ctc result.total_odc f+ /result.ctc_before_phaseout xdef
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate Saver's Credit</action_comment>
-<action_description>Calculate_Savers_Credit</action_description>
+<action_dsl>Calculate_Savers_Credit</action_dsl>
 <action_postfix>
 /Calculate_Savers_Credit executetable
 </action_postfix>
@@ -2485,7 +2485,7 @@ result.total_ctc result.total_odc f+ /result.ctc_before_phaseout xdef
 <action_details>
 <action_number>7</action_number>
 <action_comment>Calculate Energy Credits</action_comment>
-<action_description>Calculate_Energy_Credits</action_description>
+<action_dsl>Calculate_Energy_Credits</action_dsl>
 <action_postfix>
 /Calculate_Energy_Credits executetable
 </action_postfix>
@@ -2494,7 +2494,7 @@ result.total_ctc result.total_odc f+ /result.ctc_before_phaseout xdef
 <action_details>
 <action_number>8</action_number>
 <action_comment>Calculate Premium Tax Credit</action_comment>
-<action_description>Calculate_Premium_Tax_Credit</action_description>
+<action_dsl>Calculate_Premium_Tax_Credit</action_dsl>
 <action_postfix>
 /Calculate_Premium_Tax_Credit executetable
 </action_postfix>
@@ -2503,7 +2503,7 @@ result.total_ctc result.total_odc f+ /result.ctc_before_phaseout xdef
 <action_details>
 <action_number>9</action_number>
 <action_comment>Calculate Foreign Tax Credit (Form 1116)</action_comment>
-<action_description>Calculate_Foreign_Tax_Credit</action_description>
+<action_dsl>Calculate_Foreign_Tax_Credit</action_dsl>
 <action_postfix>
 Calculate_Foreign_Tax_Credit
 </action_postfix>
@@ -2512,7 +2512,7 @@ Calculate_Foreign_Tax_Credit
 <action_details>
 <action_number>10</action_number>
 <action_comment>Calculate DC First-Time Homebuyer Credit (Form 8859)</action_comment>
-<action_description>Calculate_DC_Homebuyer_Credit</action_description>
+<action_dsl>Calculate_DC_Homebuyer_Credit</action_dsl>
 <action_postfix>
 /Calculate_DC_Homebuyer_Credit executetable
 </action_postfix>
@@ -2521,7 +2521,7 @@ Calculate_Foreign_Tax_Credit
 <action_details>
 <action_number>11</action_number>
 <action_comment>Calculate Mortgage Interest Credit (Form 8396)</action_comment>
-<action_description>Calculate_Mortgage_Interest_Credit</action_description>
+<action_dsl>Calculate_Mortgage_Interest_Credit</action_dsl>
 <action_postfix>
 Calculate_Mortgage_Interest_Credit
 </action_postfix>
@@ -2530,7 +2530,7 @@ Calculate_Mortgage_Interest_Credit
 <action_details>
 <action_number>12</action_number>
 <action_comment>Calculate Energy Efficient Appliance Credit (Form 8909)</action_comment>
-<action_description>Calculate_Energy_Appliance_Credit</action_description>
+<action_dsl>Calculate_Energy_Appliance_Credit</action_dsl>
 <action_postfix>
 Calculate_Energy_Appliance_Credit
 </action_postfix>
@@ -2539,7 +2539,7 @@ Calculate_Energy_Appliance_Credit
 <action_details>
 <action_number>13</action_number>
 <action_comment>Calculate General Business Credit (Form 3800)</action_comment>
-<action_description>Calculate_General_Business_Credit</action_description>
+<action_dsl>Calculate_General_Business_Credit</action_dsl>
 <action_postfix>
 /Calculate_General_Business_Credit executetable
 </action_postfix>
@@ -2548,7 +2548,7 @@ Calculate_Energy_Appliance_Credit
 <action_details>
 <action_number>14</action_number>
 <action_comment>Sum total credits</action_comment>
-<action_description>set result.total_credits = sum of all credit amounts</action_description>
+<action_dsl>set result.total_credits = sum of all credit amounts</action_dsl>
 <action_postfix>
 result.total_ctc result.total_odc f+ result.education_credit f+
 result.cdcc_credit f+ result.savers_credit f+ result.energy_efficiency_credit f+ result.clean_energy_credit f+
@@ -2592,7 +2592,7 @@ result.general_business_credit_used f+ /result.total_credits xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly or Qualifying Surviving Spouse</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ" or job.filing_status is equal to "QSS"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ" or job.filing_status is equal to "QSS"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq job.filing_status QSS streq or
 </condition_postfix>
@@ -2606,7 +2606,7 @@ job.filing_status MFJ streq job.filing_status QSS streq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>AGI exceeds MFJ phase-out threshold</condition_comment>
-<condition_description>result.agi &gt; ctc_phaseout_mfj</condition_description>
+<condition_dsl>result.agi &gt; ctc_phaseout_mfj</condition_dsl>
 <condition_postfix>
 result.agi constants.ctc_phase_out_mfj >
 </condition_postfix>
@@ -2620,7 +2620,7 @@ result.agi constants.ctc_phase_out_mfj >
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>AGI exceeds Single phase-out threshold</condition_comment>
-<condition_description>result.agi &gt; ctc_phaseout_single</condition_description>
+<condition_dsl>result.agi &gt; ctc_phaseout_single</condition_dsl>
 <condition_postfix>
 result.agi constants.ctc_phase_out_single >
 </condition_postfix>
@@ -2634,7 +2634,7 @@ result.agi constants.ctc_phase_out_single >
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Has credits to phase out</condition_comment>
-<condition_description>result.ctc_before_phaseout &gt; 0</condition_description>
+<condition_dsl>result.ctc_before_phaseout &gt; 0</condition_dsl>
 <condition_postfix>
 result.ctc_before_phaseout 0 >
 </condition_postfix>
@@ -2650,7 +2650,7 @@ result.ctc_before_phaseout 0 >
 <action_details>
 <action_number>1</action_number>
 <action_comment>Set MFJ threshold and calculate values</action_comment>
-<action_description>set result.ctc_threshold = constants.ctc_phase_out_mfj</action_description>
+<action_dsl>set result.ctc_threshold = constants.ctc_phase_out_mfj</action_dsl>
 <action_postfix>
 constants.ctc_phase_out_mfj /result.ctc_threshold xdef
 result.agi result.ctc_threshold f- /result.agi_over_threshold xdef
@@ -2662,7 +2662,7 @@ result.agi result.ctc_threshold f- /result.agi_over_threshold xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Set Single threshold and calculate values</action_comment>
-<action_description>set result.ctc_threshold = constants.ctc_phase_out_single</action_description>
+<action_dsl>set result.ctc_threshold = constants.ctc_phase_out_single</action_dsl>
 <action_postfix>
 constants.ctc_phase_out_single /result.ctc_threshold xdef
 result.agi result.ctc_threshold f- /result.agi_over_threshold xdef
@@ -2674,7 +2674,7 @@ result.agi result.ctc_threshold f- /result.agi_over_threshold xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate phase-out reduction for MFJ with credits over threshold</action_comment>
-<action_description>set result.ctc_phase_out_reduction = ($50 per $1000 over threshold), reduce credits proportionally</action_description>
+<action_dsl>set result.ctc_phase_out_reduction = ($50 per $1000 over threshold), reduce credits proportionally</action_dsl>
 <action_postfix>
 result.agi_over_threshold 1000.0 fdiv ceiling constants.ctc_phase_out_rate f* result.ctc_before_phaseout fmin /result.ctc_phase_out_reduction xdef
 result.ctc_before_phaseout result.ctc_phase_out_reduction f- 0.0 fmax /result.ctc_after_phaseout xdef
@@ -2689,7 +2689,7 @@ result.ctc_after_phaseout result.ctc_before_phaseout fdiv result.total_odc f* fl
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate phase-out reduction for Single with credits over threshold</action_comment>
-<action_description>set result.ctc_phase_out_reduction = ($50 per $1000 over threshold), reduce credits proportionally</action_description>
+<action_dsl>set result.ctc_phase_out_reduction = ($50 per $1000 over threshold), reduce credits proportionally</action_dsl>
 <action_postfix>
 result.agi_over_threshold 1000.0 fdiv ceiling constants.ctc_phase_out_rate f* result.ctc_before_phaseout fmin /result.ctc_phase_out_reduction xdef
 result.ctc_before_phaseout result.ctc_phase_out_reduction f- 0.0 fmax /result.ctc_after_phaseout xdef
@@ -2704,7 +2704,7 @@ result.ctc_after_phaseout result.ctc_before_phaseout fdiv result.total_odc f* fl
 <action_details>
 <action_number>5</action_number>
 <action_comment>AGI over threshold but no credits to reduce</action_comment>
-<action_description>set result.ctc_phase_out_reduction = 0, set result.ctc_after_phaseout = 0</action_description>
+<action_dsl>set result.ctc_phase_out_reduction = 0, set result.ctc_after_phaseout = 0</action_dsl>
 <action_postfix>
 result.agi_over_threshold 1000.0 fdiv ceiling constants.ctc_phase_out_rate f* 0.0 fmin /result.ctc_phase_out_reduction xdef
 0.0 /result.ctc_after_phaseout xdef
@@ -2715,7 +2715,7 @@ result.agi_over_threshold 1000.0 fdiv ceiling constants.ctc_phase_out_rate f* 0.
 <action_details>
 <action_number>6</action_number>
 <action_comment>AGI does not exceed threshold</action_comment>
-<action_description>set result.ctc_after_phaseout = result.ctc_before_phaseout</action_description>
+<action_dsl>set result.ctc_after_phaseout = result.ctc_before_phaseout</action_dsl>
 <action_postfix>
 0.0 /result.agi_over_threshold xdef
 0.0 /result.ctc_phase_out_reduction xdef
@@ -2768,7 +2768,7 @@ result.ctc_before_phaseout /result.ctc_after_phaseout xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is a qualifying child (relationship)</condition_comment>
-<condition_description>dependent.relationship is equal to "child"</condition_description>
+<condition_dsl>dependent.relationship is equal to "child"</condition_dsl>
 <condition_postfix>
 dependent.relationship "child" streq
 </condition_postfix>
@@ -2779,7 +2779,7 @@ dependent.relationship "child" streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Under age 17 at end of year</condition_comment>
-<condition_description>dependent.age &lt; ctc_age_limit</condition_description>
+<condition_dsl>dependent.age &lt; ctc_age_limit</condition_dsl>
 <condition_postfix>
 dependent.age ctc_age_limit &lt;
 </condition_postfix>
@@ -2789,7 +2789,7 @@ dependent.age ctc_age_limit &lt;
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Has valid SSN</condition_comment>
-<condition_description>dependent.has_ssn == true</condition_description>
+<condition_dsl>dependent.has_ssn == true</condition_dsl>
 <condition_postfix>
 dependent.has_ssn true beq
 </condition_postfix>
@@ -2801,7 +2801,7 @@ dependent.has_ssn true beq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Award Child Tax Credit</action_comment>
-<action_description>add constants.ctc_amount to result.total_ctc</action_description>
+<action_dsl>add constants.ctc_amount to result.total_ctc</action_dsl>
 <action_postfix>
 true /dependent.qualifies_for_ctc xdef
 constants.ctc_amount /dependent.ctc_amount xdef
@@ -2814,7 +2814,7 @@ dependent.ctc_amount result.total_ctc f+ /result.total_ctc xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Award Other Dependent Credit (age 17)</action_comment>
-<action_description>add constants.odc_amount to result.total_odc</action_description>
+<action_dsl>add constants.odc_amount to result.total_odc</action_dsl>
 <action_postfix>
 true /dependent.qualifies_for_odc xdef
 constants.odc_amount /dependent.odc_amount xdef
@@ -2828,7 +2828,7 @@ dependent.odc_amount result.total_odc f+ /result.total_odc xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Non-child dependent gets ODC</action_comment>
-<action_description>add constants.odc_amount to result.total_odc</action_description>
+<action_dsl>add constants.odc_amount to result.total_odc</action_dsl>
 <action_postfix>
 true /dependent.qualifies_for_odc xdef
 constants.odc_amount /dependent.odc_amount xdef
@@ -2867,7 +2867,7 @@ dependent.odc_amount result.total_odc f+ /result.total_odc xdef
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.total_tax = tax_before_credits - nonrefundable_credits + ptc_repayment, add refundable credits to payments</action_description>
+<action_dsl>set result.total_tax = tax_before_credits - nonrefundable_credits + ptc_repayment, add refundable credits to payments</action_dsl>
 <action_postfix>
 "FINAL CALCULATION (Form 1040 Lines 33-37)" job.audit_trail swap addto
 result.total_tax_before_credits result.amt_owed f+ /result.tax_before_nonrefundable_credits xdef
@@ -2890,7 +2890,7 @@ result.total_actc result.total_payments f+ /result.total_payments xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Total tax is negative (floor at zero)</condition_comment>
-<condition_description>result.total_tax &lt; 0</condition_description>
+<condition_dsl>result.total_tax &lt; 0</condition_dsl>
 <condition_postfix>
 result.total_tax 0 &lt;
 </condition_postfix>
@@ -2901,7 +2901,7 @@ result.total_tax 0 &lt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Payments exceed tax (refund)</condition_comment>
-<condition_description>result.total_payments &gt; result.total_tax</condition_description>
+<condition_dsl>result.total_payments &gt; result.total_tax</condition_dsl>
 <condition_postfix>
 result.total_payments result.total_tax >
 </condition_postfix>
@@ -2914,7 +2914,7 @@ result.total_payments result.total_tax >
 <action_details>
 <action_number>1</action_number>
 <action_comment>Floor total tax at zero</action_comment>
-<action_description>set result.total_tax = 0</action_description>
+<action_dsl>set result.total_tax = 0</action_dsl>
 <action_postfix>
 0.0 /result.total_tax xdef
 "  Total Tax floored at $0 (credits exceeded tax liability)" job.audit_trail swap addto
@@ -2924,7 +2924,7 @@ result.total_payments result.total_tax >
 <action_details>
 <action_number>2</action_number>
 <action_comment>Log total tax and payments</action_comment>
-<action_description>add tax summary to job.audit_trail</action_description>
+<action_dsl>add tax summary to job.audit_trail</action_dsl>
 <action_postfix>
 "  Line 24 - Total Tax: $" result.total_tax cvs strconcat job.audit_trail swap addto
 "  Line 33 - Total Payments: $" result.total_payments cvs strconcat job.audit_trail swap addto
@@ -2936,7 +2936,7 @@ result.total_payments result.total_tax >
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate refund</action_comment>
-<action_description>set result.refund_or_owed = result.total_payments - result.total_tax</action_description>
+<action_dsl>set result.refund_or_owed = result.total_payments - result.total_tax</action_dsl>
 <action_postfix>
 result.total_payments result.total_tax f- /result.refund_or_owed xdef
 "  Line 34 - REFUND: $" result.refund_or_owed cvs strconcat job.audit_trail swap addto
@@ -2953,7 +2953,7 @@ result.total_payments result.total_tax f- /result.refund_or_owed xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate amount owed</action_comment>
-<action_description>set result.refund_or_owed = result.total_tax - result.total_payments</action_description>
+<action_dsl>set result.refund_or_owed = result.total_tax - result.total_payments</action_dsl>
 <action_postfix>
 result.total_tax result.total_payments f- /result.refund_or_owed xdef
 "  Line 37 - AMOUNT OWED: $" result.refund_or_owed cvs strconcat job.audit_trail swap addto
@@ -2995,7 +2995,7 @@ result.total_tax result.total_payments f- /result.refund_or_owed xdef
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>for all dependents perform Count_EITC_Qualifying_Child</action_description>
+<action_dsl>for all dependents perform Count_EITC_Qualifying_Child</action_dsl>
 <action_postfix>
 0 allocate
 { Count_EITC_Qualifying_Child performaliased } job.dependents forall
@@ -3008,7 +3008,7 @@ deallocate pop
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has earned income</condition_comment>
-<condition_description>result.total_earned_income &gt; 0</condition_description>
+<condition_dsl>result.total_earned_income &gt; 0</condition_dsl>
 <condition_postfix>
 result.total_w2_wages result.total_se_income f+ 0 &gt;
 </condition_postfix>
@@ -3025,7 +3025,7 @@ result.total_w2_wages result.total_se_income f+ 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>3+ qualifying children</condition_comment>
-<condition_description>EITC qualifying children 3 or more</condition_description>
+<condition_dsl>EITC qualifying children 3 or more</condition_dsl>
 <condition_postfix>
 result.eitc_qualifying_children 3 &gt;=
 </condition_postfix>
@@ -3042,7 +3042,7 @@ result.eitc_qualifying_children 3 &gt;=
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>2 qualifying children</condition_comment>
-<condition_description>result.eitc_qualifying_children == 2</condition_description>
+<condition_dsl>result.eitc_qualifying_children == 2</condition_dsl>
 <condition_postfix>
 result.eitc_qualifying_children 2 ==
 </condition_postfix>
@@ -3059,7 +3059,7 @@ result.eitc_qualifying_children 2 ==
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>1 qualifying child</condition_comment>
-<condition_description>result.eitc_qualifying_children == 1</condition_description>
+<condition_dsl>result.eitc_qualifying_children == 1</condition_dsl>
 <condition_postfix>
 result.eitc_qualifying_children 1 ==
 </condition_postfix>
@@ -3076,7 +3076,7 @@ result.eitc_qualifying_children 1 ==
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>0 qualifying children</condition_comment>
-<condition_description>result.eitc_qualifying_children == 0</condition_description>
+<condition_dsl>result.eitc_qualifying_children == 0</condition_dsl>
 <condition_postfix>
 result.eitc_qualifying_children 0 ==
 </condition_postfix>
@@ -3093,7 +3093,7 @@ result.eitc_qualifying_children 0 ==
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>AGI below phase-out threshold (3+ children)</condition_comment>
-<condition_description>AGI at or below threshold for 3+ children</condition_description>
+<condition_dsl>AGI at or below threshold for 3+ children</condition_dsl>
 <condition_postfix>
 result.agi eitc_threshold_mfj_3 &lt;=
 </condition_postfix>
@@ -3110,7 +3110,7 @@ result.agi eitc_threshold_mfj_3 &lt;=
 <condition_details>
 <condition_number>7</condition_number>
 <condition_comment>AGI below phase-out threshold (2 children)</condition_comment>
-<condition_description>AGI at or below threshold for 2 children</condition_description>
+<condition_dsl>AGI at or below threshold for 2 children</condition_dsl>
 <condition_postfix>
 result.agi eitc_threshold_mfj_2 &lt;=
 </condition_postfix>
@@ -3127,7 +3127,7 @@ result.agi eitc_threshold_mfj_2 &lt;=
 <condition_details>
 <condition_number>8</condition_number>
 <condition_comment>AGI below phase-out threshold (1 child)</condition_comment>
-<condition_description>AGI at or below threshold for 1 child</condition_description>
+<condition_dsl>AGI at or below threshold for 1 child</condition_dsl>
 <condition_postfix>
 result.agi eitc_threshold_mfj_1 &lt;=
 </condition_postfix>
@@ -3144,7 +3144,7 @@ result.agi eitc_threshold_mfj_1 &lt;=
 <condition_details>
 <condition_number>9</condition_number>
 <condition_comment>AGI below phase-out threshold (0 children)</condition_comment>
-<condition_description>AGI at or below threshold for 0 children</condition_description>
+<condition_dsl>AGI at or below threshold for 0 children</condition_dsl>
 <condition_postfix>
 result.agi eitc_threshold_mfj_0 &lt;=
 </condition_postfix>
@@ -3163,7 +3163,7 @@ result.agi eitc_threshold_mfj_0 &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>EITC 3+ children - full amount</action_comment>
-<action_description>set result.eitc = eitc_max_3_children</action_description>
+<action_dsl>set result.eitc = eitc_max_3_children</action_dsl>
 <action_postfix>
 eitc_max_3_children /result.eitc xdef
 "  EITC (3+ children): $" result.eitc cvs strconcat " (maximum) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3173,7 +3173,7 @@ eitc_max_3_children /result.eitc xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>EITC 3+ children - phase-out</action_comment>
-<action_description>EITC for 3+ children with phase-out per IRC 32</action_description>
+<action_dsl>EITC for 3+ children with phase-out per IRC 32</action_dsl>
 <action_postfix>
 eitc_max_3_children result.agi eitc_threshold_mfj_3 f- 0.2106 f* f- 0 fmax /result.eitc xdef
 "  EITC (3+ children): $" result.eitc cvs strconcat " (phase-out applied) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3183,7 +3183,7 @@ eitc_max_3_children result.agi eitc_threshold_mfj_3 f- 0.2106 f* f- 0 fmax /resu
 <action_details>
 <action_number>3</action_number>
 <action_comment>EITC 2 children - full amount</action_comment>
-<action_description>set result.eitc = eitc_max_2_children</action_description>
+<action_dsl>set result.eitc = eitc_max_2_children</action_dsl>
 <action_postfix>
 eitc_max_2_children /result.eitc xdef
 "  EITC (2 children): $" result.eitc cvs strconcat " (maximum) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3193,7 +3193,7 @@ eitc_max_2_children /result.eitc xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>EITC 2 children - phase-out</action_comment>
-<action_description>EITC for 2 children with phase-out per IRC 32</action_description>
+<action_dsl>EITC for 2 children with phase-out per IRC 32</action_dsl>
 <action_postfix>
 eitc_max_2_children result.agi eitc_threshold_mfj_2 f- 0.2106 f* f- 0 fmax /result.eitc xdef
 "  EITC (2 children): $" result.eitc cvs strconcat " (phase-out applied) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3203,7 +3203,7 @@ eitc_max_2_children result.agi eitc_threshold_mfj_2 f- 0.2106 f* f- 0 fmax /resu
 <action_details>
 <action_number>5</action_number>
 <action_comment>EITC 1 child - full amount</action_comment>
-<action_description>set result.eitc = eitc_max_1_child</action_description>
+<action_dsl>set result.eitc = eitc_max_1_child</action_dsl>
 <action_postfix>
 eitc_max_1_child /result.eitc xdef
 "  EITC (1 child): $" result.eitc cvs strconcat " (maximum) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3213,7 +3213,7 @@ eitc_max_1_child /result.eitc xdef
 <action_details>
 <action_number>6</action_number>
 <action_comment>EITC 1 child - phase-out</action_comment>
-<action_description>EITC for 1 child with phase-out per IRC 32</action_description>
+<action_dsl>EITC for 1 child with phase-out per IRC 32</action_dsl>
 <action_postfix>
 eitc_max_1_child result.agi eitc_threshold_mfj_1 f- 0.1598 f* f- 0 fmax /result.eitc xdef
 "  EITC (1 child): $" result.eitc cvs strconcat " (phase-out applied) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3223,7 +3223,7 @@ eitc_max_1_child result.agi eitc_threshold_mfj_1 f- 0.1598 f* f- 0 fmax /result.
 <action_details>
 <action_number>7</action_number>
 <action_comment>EITC 0 children - full amount</action_comment>
-<action_description>set result.eitc = eitc_max_0_children</action_description>
+<action_dsl>set result.eitc = eitc_max_0_children</action_dsl>
 <action_postfix>
 eitc_max_0_children /result.eitc xdef
 "  EITC (0 children): $" result.eitc cvs strconcat " (maximum) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3233,7 +3233,7 @@ eitc_max_0_children /result.eitc xdef
 <action_details>
 <action_number>8</action_number>
 <action_comment>EITC 0 children - phase-out</action_comment>
-<action_description>EITC for 0 children with phase-out per IRC 32</action_description>
+<action_dsl>EITC for 0 children with phase-out per IRC 32</action_dsl>
 <action_postfix>
 eitc_max_0_children result.agi eitc_threshold_mfj_0 f- 0.0765 f* f- 0 fmax /result.eitc xdef
 "  EITC (0 children): $" result.eitc cvs strconcat " (phase-out applied) per Schedule EIC, IRC 32" strconcat job.audit_trail swap addto
@@ -3243,7 +3243,7 @@ eitc_max_0_children result.agi eitc_threshold_mfj_0 f- 0.0765 f* f- 0 fmax /resu
 <action_details>
 <action_number>9</action_number>
 <action_comment>No EITC - no earned income</action_comment>
-<action_description>set result.eitc = 0</action_description>
+<action_dsl>set result.eitc = 0</action_dsl>
 <action_postfix>
 0.0 /result.eitc xdef
 "  EITC: $0 - No earned income" job.audit_trail swap addto
@@ -3266,7 +3266,7 @@ eitc_max_0_children result.agi eitc_threshold_mfj_0 f- 0.0765 f* f- 0 fmax /resu
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.education_credit = 0, for all dependents perform Calculate_Education_Credit_Per_Dependent</action_description>
+<action_dsl>set result.education_credit = 0, for all dependents perform Calculate_Education_Credit_Per_Dependent</action_dsl>
 <action_postfix>
 0.0 /result.education_credit xdef
 { Calculate_Education_Credit_Per_Dependent performaliased } job.dependents forall
@@ -3277,7 +3277,7 @@ eitc_max_0_children result.agi eitc_threshold_mfj_0 f- 0.0765 f* f- 0 fmax /resu
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always process</condition_comment>
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -3288,7 +3288,7 @@ perform when called
 <action_details>
 <action_number>1</action_number>
 <action_comment>Log education credit total</action_comment>
-<action_description>add education credit summary to job.audit_trail</action_description>
+<action_dsl>add education credit summary to job.audit_trail</action_dsl>
 <action_postfix>
 "  Total Education Credits: $" result.education_credit cvs strconcat job.audit_trail swap addto
 </action_postfix>
@@ -3313,7 +3313,7 @@ perform when called
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is college student</condition_comment>
-<condition_description>dependent.is_college_student == true</condition_description>
+<condition_dsl>dependent.is_college_student == true</condition_dsl>
 <condition_postfix>
 dependent.is_college_student true beq
 </condition_postfix>
@@ -3326,7 +3326,7 @@ dependent.is_college_student true beq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Eligible for AOTC (years 1-4, not exhausted)</condition_comment>
-<condition_description>dependent.college_year &gt;= 1 and dependent.college_year &lt;= 4 and dependent.aotc_used_years &lt; 4</condition_description>
+<condition_dsl>dependent.college_year &gt;= 1 and dependent.college_year &lt;= 4 and dependent.aotc_used_years &lt; 4</condition_dsl>
 <condition_postfix>
 dependent.college_year 1 &gt;= dependent.college_year 4 &lt;= and dependent.aotc_used_years 4 &lt; and
 </condition_postfix>
@@ -3339,7 +3339,7 @@ dependent.college_year 1 &gt;= dependent.college_year 4 &lt;= and dependent.aotc
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>AGI in AOTC phase-out range</condition_comment>
-<condition_description>result.agi &gt; aotc_phase_out_mfj</condition_description>
+<condition_dsl>result.agi &gt; aotc_phase_out_mfj</condition_dsl>
 <condition_postfix>
 result.agi aotc_phase_out_mfj &gt;
 </condition_postfix>
@@ -3352,7 +3352,7 @@ result.agi aotc_phase_out_mfj &gt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>AGI in LLC phase-out range</condition_comment>
-<condition_description>result.agi &gt; llc_phase_out_mfj</condition_description>
+<condition_dsl>result.agi &gt; llc_phase_out_mfj</condition_dsl>
 <condition_postfix>
 result.agi llc_phase_out_mfj &gt;
 </condition_postfix>
@@ -3367,7 +3367,7 @@ result.agi llc_phase_out_mfj &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate AOTC (full amount)</action_comment>
-<action_description>AOTC: 100% of first $2000 + 25% of next $2000</action_description>
+<action_dsl>AOTC: 100% of first $2000 + 25% of next $2000</action_dsl>
 <action_postfix>
 dependent.qualified_expenses 2000.0 fmin dependent.qualified_expenses 2000.0 f- 0.0 fmax 0.25 f* f+ aotc_max fmin /dependent.education_credit xdef
 dependent.education_credit result.education_credit f+ /result.education_credit xdef
@@ -3378,7 +3378,7 @@ dependent.education_credit result.education_credit f+ /result.education_credit x
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate AOTC with phase-out</action_comment>
-<action_description>AOTC with AGI phase-out reduction</action_description>
+<action_dsl>AOTC with AGI phase-out reduction</action_dsl>
 <action_postfix>
 dependent.qualified_expenses 2000.0 fmin dependent.qualified_expenses 2000.0 f- 0.0 fmax 0.25 f* f+ aotc_max fmin /dependent.education_credit xdef
 dependent.education_credit aotc_phase_out_end_mfj result.agi f- aotc_phase_out_end_mfj aotc_phase_out_mfj f- fdiv f* /dependent.education_credit xdef
@@ -3390,7 +3390,7 @@ dependent.education_credit result.education_credit f+ /result.education_credit x
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate LLC (full amount)</action_comment>
-<action_description>LLC: 20% of qualified expenses up to $2000</action_description>
+<action_dsl>LLC: 20% of qualified expenses up to $2000</action_dsl>
 <action_postfix>
 dependent.qualified_expenses 0.20 f* llc_max fmin /dependent.education_credit xdef
 dependent.education_credit result.education_credit f+ /result.education_credit xdef
@@ -3401,7 +3401,7 @@ dependent.education_credit result.education_credit f+ /result.education_credit x
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate LLC with phase-out</action_comment>
-<action_description>LLC with AGI phase-out reduction</action_description>
+<action_dsl>LLC with AGI phase-out reduction</action_dsl>
 <action_postfix>
 dependent.qualified_expenses 0.20 f* llc_max fmin /dependent.education_credit xdef
 dependent.education_credit llc_phase_out_end_mfj result.agi f- llc_phase_out_end_mfj llc_phase_out_mfj f- fdiv f* /dependent.education_credit xdef
@@ -3413,7 +3413,7 @@ dependent.education_credit result.education_credit f+ /result.education_credit x
 <action_details>
 <action_number>5</action_number>
 <action_comment>Not a college student</action_comment>
-<action_description>otherwise</action_description>
+<action_dsl>otherwise</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="5" column_value="X"></action_column>
@@ -3458,7 +3458,7 @@ dependent.education_credit result.education_credit f+ /result.education_credit x
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has qualified business income</condition_comment>
-<condition_description>result.total_se_income &gt; 0</condition_description>
+<condition_dsl>result.total_se_income &gt; 0</condition_dsl>
 <condition_postfix>
 result.total_se_income 0 &gt;
 </condition_postfix>
@@ -3468,7 +3468,7 @@ result.total_se_income 0 &gt;
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxable income below threshold (simplified calculation)</condition_comment>
-<condition_description>taxable_income before QBI below $394,600 MFJ threshold (2025)</condition_description>
+<condition_dsl>taxable_income before QBI below $394,600 MFJ threshold (2025)</condition_dsl>
 <condition_postfix>
 result.agi result.total_deduction f- 394600 &lt;=
 </condition_postfix>
@@ -3479,7 +3479,7 @@ result.agi result.total_deduction f- 394600 &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate QBI deduction at 20%</action_comment>
-<action_description>set result.qbi_deduction = result.total_se_income * qbi_rate</action_description>
+<action_dsl>set result.qbi_deduction = result.total_se_income * qbi_rate</action_dsl>
 <action_postfix>
 result.total_se_income qbi_rate f* /result.qbi_deduction xdef
 result.agi result.total_deduction f- result.qbi_deduction f- 0.20 f* result.qbi_deduction fmin /result.qbi_deduction xdef
@@ -3491,7 +3491,7 @@ result.agi result.total_deduction f- result.qbi_deduction f- 0.20 f* result.qbi_
 <action_details>
 <action_number>2</action_number>
 <action_comment>No QBI - no qualified business income</action_comment>
-<action_description>set result.qbi_deduction = 0</action_description>
+<action_dsl>set result.qbi_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.qbi_deduction xdef
 "  QBI Deduction: $0 - No qualified business income" job.audit_trail swap addto
@@ -3514,7 +3514,7 @@ result.agi result.total_deduction f- result.qbi_deduction f- 0.20 f* result.qbi_
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.validation_passed = true</action_description>
+<action_dsl>set result.validation_passed = true</action_dsl>
 <action_postfix>
 "VALIDATION RESULTS" job.audit_trail swap addto
 true /result.validation_passed xdef
@@ -3525,7 +3525,7 @@ true /result.validation_passed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Expected values exist</condition_comment>
-<condition_description>job has expected values for validation</condition_description>
+<condition_dsl>job has expected values for validation</condition_dsl>
 <condition_postfix>
 job.expected_agi null neq
 </condition_postfix>
@@ -3537,7 +3537,7 @@ job.expected_agi null neq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Run all validations</action_comment>
-<action_description>Validate_AGI, Validate_Taxable_Income, Validate_Total_Tax, Validate_Summary</action_description>
+<action_dsl>Validate_AGI, Validate_Taxable_Income, Validate_Total_Tax, Validate_Summary</action_dsl>
 <action_postfix>
 Validate_AGI
 Validate_Taxable_Income
@@ -3549,7 +3549,7 @@ Validate_Summary
 <action_details>
 <action_number>2</action_number>
 <action_comment>No expected values</action_comment>
-<action_description>add "No expected values provided" to job.audit_trail</action_description>
+<action_dsl>add "No expected values provided" to job.audit_trail</action_dsl>
 <action_postfix>
 "  No expected values provided - validation skipped" job.audit_trail swap addto
 </action_postfix>
@@ -3574,7 +3574,7 @@ Validate_Summary
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>AGI matches expected (within tolerance)</condition_comment>
-<condition_description>agi_difference &lt;= 1.0</condition_description>
+<condition_dsl>agi_difference &lt;= 1.0</condition_dsl>
 <condition_postfix>
 result.agi job.expected_agi f- fabs 1.0 &lt;=
 </condition_postfix>
@@ -3586,7 +3586,7 @@ result.agi job.expected_agi f- fabs 1.0 &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>AGI validation passed</action_comment>
-<action_description>add AGI pass message to job.audit_trail</action_description>
+<action_dsl>add AGI pass message to job.audit_trail</action_dsl>
 <action_postfix>
 "  PASS: AGI = $" result.agi cvs strconcat job.audit_trail swap addto
 </action_postfix>
@@ -3595,7 +3595,7 @@ result.agi job.expected_agi f- fabs 1.0 &lt;=
 <action_details>
 <action_number>2</action_number>
 <action_comment>AGI validation failed</action_comment>
-<action_description>add AGI mismatch to job.audit_trail, set result.validation_passed = false</action_description>
+<action_dsl>add AGI mismatch to job.audit_trail, set result.validation_passed = false</action_dsl>
 <action_postfix>
 "  FAIL: AGI mismatch - calculated $" result.agi cvs strconcat " vs expected $" strconcat job.expected_agi cvs strconcat job.audit_trail swap addto
 false /result.validation_passed xdef
@@ -3621,7 +3621,7 @@ false /result.validation_passed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Taxable income matches expected</condition_comment>
-<condition_description>taxable_income_difference &lt;= 1.0</condition_description>
+<condition_dsl>taxable_income_difference &lt;= 1.0</condition_dsl>
 <condition_postfix>
 result.taxable_income job.expected_taxable_income f- fabs 1.0 &lt;=
 </condition_postfix>
@@ -3633,7 +3633,7 @@ result.taxable_income job.expected_taxable_income f- fabs 1.0 &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Taxable income validation passed</action_comment>
-<action_description>add taxable income pass message to job.audit_trail</action_description>
+<action_dsl>add taxable income pass message to job.audit_trail</action_dsl>
 <action_postfix>
 "  PASS: Taxable Income = $" result.taxable_income cvs strconcat job.audit_trail swap addto
 </action_postfix>
@@ -3642,7 +3642,7 @@ result.taxable_income job.expected_taxable_income f- fabs 1.0 &lt;=
 <action_details>
 <action_number>2</action_number>
 <action_comment>Taxable income validation failed</action_comment>
-<action_description>add taxable income mismatch to job.audit_trail, set result.validation_passed = false</action_description>
+<action_dsl>add taxable income mismatch to job.audit_trail, set result.validation_passed = false</action_dsl>
 <action_postfix>
 "  FAIL: Taxable income mismatch - calculated $" result.taxable_income cvs strconcat " vs expected $" strconcat job.expected_taxable_income cvs strconcat job.audit_trail swap addto
 false /result.validation_passed xdef
@@ -3668,7 +3668,7 @@ false /result.validation_passed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Total tax matches expected</condition_comment>
-<condition_description>total_tax_difference &lt;= 1.0</condition_description>
+<condition_dsl>total_tax_difference &lt;= 1.0</condition_dsl>
 <condition_postfix>
 result.total_tax job.expected_total_tax f- fabs 1.0 &lt;=
 </condition_postfix>
@@ -3680,7 +3680,7 @@ result.total_tax job.expected_total_tax f- fabs 1.0 &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Total tax validation passed</action_comment>
-<action_description>add total tax pass message to job.audit_trail</action_description>
+<action_dsl>add total tax pass message to job.audit_trail</action_dsl>
 <action_postfix>
 "  PASS: Total Tax = $" result.total_tax cvs strconcat job.audit_trail swap addto
 </action_postfix>
@@ -3689,7 +3689,7 @@ result.total_tax job.expected_total_tax f- fabs 1.0 &lt;=
 <action_details>
 <action_number>2</action_number>
 <action_comment>Total tax validation failed</action_comment>
-<action_description>add total tax mismatch to job.audit_trail, set result.validation_passed = false</action_description>
+<action_dsl>add total tax mismatch to job.audit_trail, set result.validation_passed = false</action_dsl>
 <action_postfix>
 "  FAIL: Total tax mismatch - calculated $" result.total_tax cvs strconcat " vs expected $" strconcat job.expected_total_tax cvs strconcat job.audit_trail swap addto
 false /result.validation_passed xdef
@@ -3715,7 +3715,7 @@ false /result.validation_passed xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>All validations passed</condition_comment>
-<condition_description>result.validation_passed == true</condition_description>
+<condition_dsl>result.validation_passed == true</condition_dsl>
 <condition_postfix>
 result.validation_passed true beq
 </condition_postfix>
@@ -3727,7 +3727,7 @@ result.validation_passed true beq
 <action_details>
 <action_number>1</action_number>
 <action_comment>All tests passed</action_comment>
-<action_description>add "VALIDATION: ALL TESTS PASSED" to job.audit_trail</action_description>
+<action_dsl>add "VALIDATION: ALL TESTS PASSED" to job.audit_trail</action_dsl>
 <action_postfix>
 "VALIDATION: ALL TESTS PASSED" job.audit_trail swap addto
 </action_postfix>
@@ -3736,7 +3736,7 @@ result.validation_passed true beq
 <action_details>
 <action_number>2</action_number>
 <action_comment>Some tests failed</action_comment>
-<action_description>add "VALIDATION: SOME TESTS FAILED" to job.audit_trail</action_description>
+<action_dsl>add "VALIDATION: SOME TESTS FAILED" to job.audit_trail</action_dsl>
 <action_postfix>
 "VALIDATION: SOME TESTS FAILED - Review audit trail" job.audit_trail swap addto
 </action_postfix>
@@ -3761,7 +3761,7 @@ result.validation_passed true beq
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Taxpayer is self-employed</condition_comment>
-<condition_description>taxpayer.is_self_employed == true</condition_description>
+<condition_dsl>taxpayer.is_self_employed == true</condition_dsl>
 <condition_postfix>
 is_self_employed true beq
 </condition_postfix>
@@ -3773,7 +3773,7 @@ is_self_employed true beq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process self-employed taxpayer</action_comment>
-<action_description>Process_Self_Employment</action_description>
+<action_dsl>Process_Self_Employment</action_dsl>
 <action_postfix>
 /Process_Self_Employment executetable
 </action_postfix>
@@ -3782,7 +3782,7 @@ is_self_employed true beq
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-self-employed</action_comment>
-<action_description>otherwise</action_description>
+<action_dsl>otherwise</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X"></action_column>
@@ -3806,7 +3806,7 @@ is_self_employed true beq
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Vehicle belongs to current taxpayer</condition_comment>
-<condition_description>vehicle.taxpayer_id is equal to taxpayer.id</condition_description>
+<condition_dsl>vehicle.taxpayer_id is equal to taxpayer.id</condition_dsl>
 <condition_postfix>
 taxpayer_id taxpayer.id ==
 </condition_postfix>
@@ -3818,7 +3818,7 @@ taxpayer_id taxpayer.id ==
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process vehicle</action_comment>
-<action_description>Calculate_Vehicle_Deduction</action_description>
+<action_dsl>Calculate_Vehicle_Deduction</action_dsl>
 <action_postfix>
 /Calculate_Vehicle_Deduction executetable
 </action_postfix>
@@ -3827,7 +3827,7 @@ taxpayer_id taxpayer.id ==
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip vehicle</action_comment>
-<action_description>otherwise</action_description>
+<action_dsl>otherwise</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X"></action_column>
@@ -3851,7 +3851,7 @@ taxpayer_id taxpayer.id ==
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Property is rental</condition_comment>
-<condition_description>property.type is equal to "rental"</condition_description>
+<condition_dsl>property.type is equal to "rental"</condition_dsl>
 <condition_postfix>
 type "rental" streq
 </condition_postfix>
@@ -3863,7 +3863,7 @@ type "rental" streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process rental</action_comment>
-<action_description>Process_Rental_Income</action_description>
+<action_dsl>Process_Rental_Income</action_dsl>
 <action_postfix>
 /Process_Rental_Income executetable
 </action_postfix>
@@ -3872,7 +3872,7 @@ type "rental" streq
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-rental</action_comment>
-<action_description>otherwise</action_description>
+<action_dsl>otherwise</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X"></action_column>
@@ -3896,7 +3896,7 @@ type "rental" streq
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is qualifying child</condition_comment>
-<condition_description>relationship is child AND age under 19</condition_description>
+<condition_dsl>relationship is child AND age under 19</condition_dsl>
 <condition_postfix>
 relationship "child" streq age 19 &lt; and
 </condition_postfix>
@@ -3908,7 +3908,7 @@ relationship "child" streq age 19 &lt; and
 <action_details>
 <action_number>1</action_number>
 <action_comment>Increment counter</action_comment>
-<action_description>increment qualifying children count</action_description>
+<action_dsl>increment qualifying children count</action_dsl>
 <action_postfix>
 0 local@ 1 + 0 local!
 </action_postfix>
@@ -3917,7 +3917,7 @@ relationship "child" streq age 19 &lt; and
 <action_details>
 <action_number>2</action_number>
 <action_comment>Skip non-qualifying</action_comment>
-<action_description>otherwise</action_description>
+<action_dsl>otherwise</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="2" column_value="X"></action_column>
@@ -3941,7 +3941,7 @@ relationship "child" streq age 19 &lt; and
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has mortgage interest</condition_comment>
-<condition_description>property.mortgage_interest &gt; 0</condition_description>
+<condition_dsl>property.mortgage_interest &gt; 0</condition_dsl>
 <condition_postfix>
 dup mortgage_interest 0 &gt;
 </condition_postfix>
@@ -3953,7 +3953,7 @@ dup mortgage_interest 0 &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process mortgage interest</action_comment>
-<action_description>add property.mortgage_interest to result.total_itemized</action_description>
+<action_dsl>add property.mortgage_interest to result.total_itemized</action_dsl>
 <action_postfix>
 dup mortgage_interest result.total_itemized f+ /result.total_itemized xdef
 "  Mortgage Interest: $" over mortgage_interest cvs strconcat " (Schedule A Line 8a)" strconcat job.audit_trail swap addto
@@ -3964,7 +3964,7 @@ pop
 <action_details>
 <action_number>2</action_number>
 <action_comment>No mortgage interest</action_comment>
-<action_description>otherwise</action_description>
+<action_dsl>otherwise</action_dsl>
 <action_postfix>
 pop
 </action_postfix>
@@ -3986,7 +3986,7 @@ pop
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.tips_deduction = 0, set result.overtime_deduction = 0, set result.senior_deduction = 0</action_description>
+<action_dsl>set result.tips_deduction = 0, set result.overtime_deduction = 0, set result.senior_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.tips_deduction xdef
 0.0 /result.overtime_deduction xdef
@@ -4000,7 +4000,7 @@ pop
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always calculate OBBBA deductions</condition_comment>
-<condition_description>perform when called</condition_description>
+<condition_dsl>perform when called</condition_dsl>
 <condition_postfix>
 perform when called
 </condition_postfix>
@@ -4011,7 +4011,7 @@ perform when called
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate No Tax on Tips deduction</action_comment>
-<action_description>Calculate_Tips_Deduction</action_description>
+<action_dsl>Calculate_Tips_Deduction</action_dsl>
 <action_postfix>
 Calculate_Tips_Deduction
 </action_postfix>
@@ -4020,7 +4020,7 @@ Calculate_Tips_Deduction
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate No Tax on Overtime deduction</action_comment>
-<action_description>Calculate_Overtime_Deduction</action_description>
+<action_dsl>Calculate_Overtime_Deduction</action_dsl>
 <action_postfix>
 Calculate_Overtime_Deduction
 </action_postfix>
@@ -4029,7 +4029,7 @@ Calculate_Overtime_Deduction
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Senior Additional deduction</action_comment>
-<action_description>Calculate_Senior_Deduction</action_description>
+<action_dsl>Calculate_Senior_Deduction</action_dsl>
 <action_postfix>
 Calculate_Senior_Deduction
 </action_postfix>
@@ -4038,7 +4038,7 @@ Calculate_Senior_Deduction
 <action_details>
 <action_number>4</action_number>
 <action_comment>Sum total OBBBA deductions</action_comment>
-<action_description>set result.total_obbba_deductions = result.tips_deduction + result.overtime_deduction + result.senior_deduction</action_description>
+<action_dsl>set result.total_obbba_deductions = result.tips_deduction + result.overtime_deduction + result.senior_deduction</action_dsl>
 <action_postfix>
 result.tips_deduction result.overtime_deduction f+ result.senior_deduction f+ /result.total_obbba_deductions xdef
 "  Total OBBBA Deductions: $" result.total_obbba_deductions cvs strconcat job.audit_trail swap addto
@@ -4064,7 +4064,7 @@ result.tips_deduction result.overtime_deduction f+ result.senior_deduction f+ /r
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has tip income</condition_comment>
-<condition_description>result.total_tip_income &gt; 0</condition_description>
+<condition_dsl>result.total_tip_income &gt; 0</condition_dsl>
 <condition_postfix>
 result.total_tip_income 0 >
 </condition_postfix>
@@ -4077,7 +4077,7 @@ result.total_tip_income 0 >
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -4090,7 +4090,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ income below phase-out threshold ($300k)</condition_comment>
-<condition_description>gross income below MFJ tips phase-out threshold</condition_description>
+<condition_dsl>gross income below MFJ tips phase-out threshold</condition_dsl>
 <condition_postfix>
 result.gross_income constants.tips_phaseout_joint &lt;
 </condition_postfix>
@@ -4103,7 +4103,7 @@ result.gross_income constants.tips_phaseout_joint &lt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Single income below phase-out threshold ($150k)</condition_comment>
-<condition_description>gross income below Single tips phase-out threshold</condition_description>
+<condition_dsl>gross income below Single tips phase-out threshold</condition_dsl>
 <condition_postfix>
 result.gross_income constants.tips_phaseout_single &lt;
 </condition_postfix>
@@ -4118,7 +4118,7 @@ result.gross_income constants.tips_phaseout_single &lt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full tips deduction (below phase-out)</action_comment>
-<action_description>set result.tips_deduction = the minimum of result.total_tip_income and constants.tips_deduction_max</action_description>
+<action_dsl>set result.tips_deduction = the minimum of result.total_tip_income and constants.tips_deduction_max</action_dsl>
 <action_postfix>
 result.total_tip_income constants.tips_deduction_max fmin /result.tips_deduction xdef
 "  Tips Deduction: $" result.tips_deduction cvs strconcat " (OBBBA No Tax on Tips)" strconcat job.audit_trail swap addto
@@ -4129,7 +4129,7 @@ result.total_tip_income constants.tips_deduction_max fmin /result.tips_deduction
 <action_details>
 <action_number>2</action_number>
 <action_comment>Tips deduction phased out (high income)</action_comment>
-<action_description>set result.tips_deduction = 0</action_description>
+<action_dsl>set result.tips_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.tips_deduction xdef
 "  Tips Deduction: $0 (phased out - income exceeds threshold)" job.audit_trail swap addto
@@ -4140,7 +4140,7 @@ result.total_tip_income constants.tips_deduction_max fmin /result.tips_deduction
 <action_details>
 <action_number>3</action_number>
 <action_comment>No tip income</action_comment>
-<action_description>set result.tips_deduction = 0</action_description>
+<action_dsl>set result.tips_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.tips_deduction xdef
 </action_postfix>
@@ -4186,7 +4186,7 @@ result.total_tip_income constants.tips_deduction_max fmin /result.tips_deduction
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has overtime income</condition_comment>
-<condition_description>result.total_overtime_income &gt; 0</condition_description>
+<condition_dsl>result.total_overtime_income &gt; 0</condition_dsl>
 <condition_postfix>
 result.total_overtime_income 0 >
 </condition_postfix>
@@ -4199,7 +4199,7 @@ result.total_overtime_income 0 >
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -4212,7 +4212,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ income below phase-out threshold ($300k)</condition_comment>
-<condition_description>gross income below MFJ overtime phase-out threshold</condition_description>
+<condition_dsl>gross income below MFJ overtime phase-out threshold</condition_dsl>
 <condition_postfix>
 result.gross_income constants.tips_phaseout_joint &lt;
 </condition_postfix>
@@ -4225,7 +4225,7 @@ result.gross_income constants.tips_phaseout_joint &lt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Single income below phase-out threshold ($150k)</condition_comment>
-<condition_description>gross income below Single overtime phase-out threshold</condition_description>
+<condition_dsl>gross income below Single overtime phase-out threshold</condition_dsl>
 <condition_postfix>
 result.gross_income constants.tips_phaseout_single &lt;
 </condition_postfix>
@@ -4240,7 +4240,7 @@ result.gross_income constants.tips_phaseout_single &lt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full overtime deduction MFJ (below phase-out)</action_comment>
-<action_description>set result.overtime_deduction = the minimum of result.total_overtime_income and constants.overtime_deduction_max_joint</action_description>
+<action_dsl>set result.overtime_deduction = the minimum of result.total_overtime_income and constants.overtime_deduction_max_joint</action_dsl>
 <action_postfix>
 result.total_overtime_income constants.overtime_deduction_max_joint fmin /result.overtime_deduction xdef
 "  Overtime Deduction: $" result.overtime_deduction cvs strconcat " (OBBBA No Tax on Overtime - MFJ cap)" strconcat job.audit_trail swap addto
@@ -4250,7 +4250,7 @@ result.total_overtime_income constants.overtime_deduction_max_joint fmin /result
 <action_details>
 <action_number>2</action_number>
 <action_comment>Full overtime deduction Single (below phase-out)</action_comment>
-<action_description>set result.overtime_deduction = the minimum of result.total_overtime_income and constants.overtime_deduction_max_single</action_description>
+<action_dsl>set result.overtime_deduction = the minimum of result.total_overtime_income and constants.overtime_deduction_max_single</action_dsl>
 <action_postfix>
 result.total_overtime_income constants.overtime_deduction_max_single fmin /result.overtime_deduction xdef
 "  Overtime Deduction: $" result.overtime_deduction cvs strconcat " (OBBBA No Tax on Overtime - Single cap)" strconcat job.audit_trail swap addto
@@ -4260,7 +4260,7 @@ result.total_overtime_income constants.overtime_deduction_max_single fmin /resul
 <action_details>
 <action_number>3</action_number>
 <action_comment>Overtime deduction phased out (high income)</action_comment>
-<action_description>set result.overtime_deduction = 0</action_description>
+<action_dsl>set result.overtime_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.overtime_deduction xdef
 "  Overtime Deduction: $0 (phased out - income exceeds threshold)" job.audit_trail swap addto
@@ -4271,7 +4271,7 @@ result.total_overtime_income constants.overtime_deduction_max_single fmin /resul
 <action_details>
 <action_number>4</action_number>
 <action_comment>No overtime income</action_comment>
-<action_description>set result.overtime_deduction = 0</action_description>
+<action_dsl>set result.overtime_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.overtime_deduction xdef
 </action_postfix>
@@ -4317,7 +4317,7 @@ result.total_overtime_income constants.overtime_deduction_max_single fmin /resul
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has seniors</condition_comment>
-<condition_description>result.senior_count &gt; 0</condition_description>
+<condition_dsl>result.senior_count &gt; 0</condition_dsl>
 <condition_postfix>
 result.senior_count 0 >
 </condition_postfix>
@@ -4330,7 +4330,7 @@ result.senior_count 0 >
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -4343,7 +4343,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ income below phase-out threshold ($150k)</condition_comment>
-<condition_description>gross income below MFJ senior phase-out threshold</condition_description>
+<condition_dsl>gross income below MFJ senior phase-out threshold</condition_dsl>
 <condition_postfix>
 result.gross_income constants.senior_phaseout_joint &lt;
 </condition_postfix>
@@ -4356,7 +4356,7 @@ result.gross_income constants.senior_phaseout_joint &lt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Single income below phase-out threshold ($75k)</condition_comment>
-<condition_description>gross income below Single senior phase-out threshold</condition_description>
+<condition_dsl>gross income below Single senior phase-out threshold</condition_dsl>
 <condition_postfix>
 result.gross_income constants.senior_phaseout_single &lt;
 </condition_postfix>
@@ -4371,7 +4371,7 @@ result.gross_income constants.senior_phaseout_single &lt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full senior deduction (below phase-out)</action_comment>
-<action_description>set result.senior_deduction = result.senior_count * constants.senior_deduction_amount</action_description>
+<action_dsl>set result.senior_deduction = result.senior_count * constants.senior_deduction_amount</action_dsl>
 <action_postfix>
 result.senior_count 1.0 f* constants.senior_deduction_amount f* /result.senior_deduction xdef
 "  Senior Deduction: $" result.senior_deduction cvs strconcat " (" strconcat result.senior_count cvs strconcat " senior(s) x $6,000 - OBBBA)" strconcat job.audit_trail swap addto
@@ -4382,7 +4382,7 @@ result.senior_count 1.0 f* constants.senior_deduction_amount f* /result.senior_d
 <action_details>
 <action_number>2</action_number>
 <action_comment>Senior deduction phased out (high income)</action_comment>
-<action_description>set result.senior_deduction = 0</action_description>
+<action_dsl>set result.senior_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.senior_deduction xdef
 "  Senior Deduction: $0 (phased out - income exceeds threshold)" job.audit_trail swap addto
@@ -4393,7 +4393,7 @@ result.senior_count 1.0 f* constants.senior_deduction_amount f* /result.senior_d
 <action_details>
 <action_number>3</action_number>
 <action_comment>No seniors</action_comment>
-<action_description>set result.senior_deduction = 0</action_description>
+<action_dsl>set result.senior_deduction = 0</action_dsl>
 <action_postfix>
 0.0 /result.senior_deduction xdef
 </action_postfix>
@@ -4436,7 +4436,7 @@ result.senior_count 1.0 f* constants.senior_deduction_amount f* /result.senior_d
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.provisional_income = result.agi + (result.total_social_security * 0.5)</action_description>
+<action_dsl>set result.provisional_income = result.agi + (result.total_social_security * 0.5)</action_dsl>
 <action_postfix>
 result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xdef
 "SOCIAL SECURITY TAXABILITY (Publication 915)" job.audit_trail swap addto
@@ -4449,7 +4449,7 @@ result.agi result.total_social_security 0.5 f* f+ /result.provisional_income xde
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has Social Security income</condition_comment>
-<condition_description>result.total_social_security &gt; 0</condition_description>
+<condition_dsl>result.total_social_security &gt; 0</condition_dsl>
 <condition_postfix>
 result.total_social_security 0 >
 </condition_postfix>
@@ -4464,7 +4464,7 @@ result.total_social_security 0 >
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -4479,7 +4479,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ provisional income at or below base amount ($32k)</condition_comment>
-<condition_description>provisional_income at or below MFJ base amount</condition_description>
+<condition_dsl>provisional_income at or below MFJ base amount</condition_dsl>
 <condition_postfix>
 result.provisional_income ss_base_amount_mfj le
 </condition_postfix>
@@ -4494,7 +4494,7 @@ result.provisional_income ss_base_amount_mfj le
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>MFJ provisional income at or below additional amount ($44k)</condition_comment>
-<condition_description>provisional_income at or below MFJ additional amount</condition_description>
+<condition_dsl>provisional_income at or below MFJ additional amount</condition_dsl>
 <condition_postfix>
 result.provisional_income ss_additional_amount_mfj le
 </condition_postfix>
@@ -4509,7 +4509,7 @@ result.provisional_income ss_additional_amount_mfj le
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>Single provisional income at or below base amount ($25k)</condition_comment>
-<condition_description>provisional_income at or below Single base amount</condition_description>
+<condition_dsl>provisional_income at or below Single base amount</condition_dsl>
 <condition_postfix>
 result.provisional_income ss_base_amount_single le
 </condition_postfix>
@@ -4524,7 +4524,7 @@ result.provisional_income ss_base_amount_single le
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>Single provisional income at or below additional amount ($34k)</condition_comment>
-<condition_description>provisional_income at or below Single additional amount</condition_description>
+<condition_dsl>provisional_income at or below Single additional amount</condition_dsl>
 <condition_postfix>
 result.provisional_income ss_additional_amount_single le
 </condition_postfix>
@@ -4541,7 +4541,7 @@ result.provisional_income ss_additional_amount_single le
 <action_details>
 <action_number>1</action_number>
 <action_comment>0% SS taxable - below base amount</action_comment>
-<action_description>set result.taxable_social_security = 0</action_description>
+<action_dsl>set result.taxable_social_security = 0</action_dsl>
 <action_postfix>
 0.0 /result.ss_taxable_percentage xdef
 0.0 /result.taxable_social_security xdef
@@ -4553,7 +4553,7 @@ result.provisional_income ss_additional_amount_single le
 <action_details>
 <action_number>2</action_number>
 <action_comment>Up to 50% SS taxable MFJ - between base and additional</action_comment>
-<action_description>50% SS taxable per Pub 915 Worksheet 1 (MFJ thresholds)</action_description>
+<action_dsl>50% SS taxable per Pub 915 Worksheet 1 (MFJ thresholds)</action_dsl>
 <action_postfix>
 0.50 /result.ss_taxable_percentage xdef
 result.provisional_income ss_base_amount_mfj f- 0.5 f* result.total_social_security 0.5 f* fmin /result.taxable_social_security xdef
@@ -4565,7 +4565,7 @@ result.provisional_income ss_base_amount_mfj f- 0.5 f* result.total_social_secur
 <action_details>
 <action_number>3</action_number>
 <action_comment>Up to 50% SS taxable Single - between base and additional</action_comment>
-<action_description>50% SS taxable per Pub 915 Worksheet 1 (Single thresholds)</action_description>
+<action_dsl>50% SS taxable per Pub 915 Worksheet 1 (Single thresholds)</action_dsl>
 <action_postfix>
 0.50 /result.ss_taxable_percentage xdef
 result.provisional_income ss_base_amount_single f- 0.5 f* result.total_social_security 0.5 f* fmin /result.taxable_social_security xdef
@@ -4577,7 +4577,7 @@ result.provisional_income ss_base_amount_single f- 0.5 f* result.total_social_se
 <action_details>
 <action_number>4</action_number>
 <action_comment>Up to 85% SS taxable - above additional amount</action_comment>
-<action_description>85% SS taxable per Pub 915 Worksheet 2</action_description>
+<action_dsl>85% SS taxable per Pub 915 Worksheet 2</action_dsl>
 <action_postfix>
 0.85 /result.ss_taxable_percentage xdef
 result.total_social_security 0.85 f* /result.taxable_social_security xdef
@@ -4590,7 +4590,7 @@ result.total_social_security 0.85 f* /result.taxable_social_security xdef
 <action_details>
 <action_number>5</action_number>
 <action_comment>No SS income</action_comment>
-<action_description>set result.taxable_social_security = 0</action_description>
+<action_dsl>set result.taxable_social_security = 0</action_dsl>
 <action_postfix>
 0.0 /result.ss_taxable_percentage xdef
 0.0 /result.taxable_social_security xdef
@@ -4643,7 +4643,7 @@ result.total_social_security 0.85 f* /result.taxable_social_security xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each income entity for capital gains</context_comment>
-<context_description>for all income entities</context_description>
+<context_dsl>for all income entities</context_dsl>
 <context_postfix>
 0.0 /result.total_long_term_gains xdef
 0.0 /result.total_short_term_gains xdef
@@ -4658,7 +4658,7 @@ result.total_social_security 0.85 f* /result.taxable_social_security xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is capital gain type</condition_comment>
-<condition_description>income.type is equal to "capital_gain"</condition_description>
+<condition_dsl>income.type is equal to "capital_gain"</condition_dsl>
 <condition_postfix>
 income.type "capital_gain" streq
 </condition_postfix>
@@ -4670,7 +4670,7 @@ income.type "capital_gain" streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Is long-term holding period</condition_comment>
-<condition_description>income.holding_period is equal to "long_term"</condition_description>
+<condition_dsl>income.holding_period is equal to "long_term"</condition_dsl>
 <condition_postfix>
 income.holding_period "long_term" streq
 </condition_postfix>
@@ -4682,7 +4682,7 @@ income.holding_period "long_term" streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Is dividend type</condition_comment>
-<condition_description>income.type is equal to "dividend"</condition_description>
+<condition_dsl>income.type is equal to "dividend"</condition_dsl>
 <condition_postfix>
 income.type "dividend" streq
 </condition_postfix>
@@ -4694,7 +4694,7 @@ income.type "dividend" streq
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Is qualified dividend</condition_comment>
-<condition_description>income.is_qualified_dividend == true</condition_description>
+<condition_dsl>income.is_qualified_dividend == true</condition_dsl>
 <condition_postfix>
 income.is_qualified_dividend true beq
 </condition_postfix>
@@ -4708,7 +4708,7 @@ income.is_qualified_dividend true beq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add to long-term gains</action_comment>
-<action_description>add gain.amount to result.total_long_term_gains</action_description>
+<action_dsl>add gain.amount to result.total_long_term_gains</action_dsl>
 <action_postfix>
 income.gross_amount result.total_long_term_gains f+ /result.total_long_term_gains xdef
 "  Long-Term Capital Gain: $" income.gross_amount cvs strconcat " from " strconcat income.source strconcat " (Schedule D Part II)" strconcat job.audit_trail swap addto
@@ -4718,7 +4718,7 @@ income.gross_amount result.total_long_term_gains f+ /result.total_long_term_gain
 <action_details>
 <action_number>2</action_number>
 <action_comment>Add to short-term gains</action_comment>
-<action_description>add gain.amount to result.total_short_term_gains</action_description>
+<action_dsl>add gain.amount to result.total_short_term_gains</action_dsl>
 <action_postfix>
 income.gross_amount result.total_short_term_gains f+ /result.total_short_term_gains xdef
 "  Short-Term Capital Gain: $" income.gross_amount cvs strconcat " from " strconcat income.source strconcat " (Schedule D Part I)" strconcat job.audit_trail swap addto
@@ -4728,7 +4728,7 @@ income.gross_amount result.total_short_term_gains f+ /result.total_short_term_ga
 <action_details>
 <action_number>3</action_number>
 <action_comment>Add qualified dividend</action_comment>
-<action_description>add dividend.amount to result.qualified_dividends</action_description>
+<action_dsl>add dividend.amount to result.qualified_dividends</action_dsl>
 <action_postfix>
 income.gross_amount result.total_qualified_dividends f+ /result.total_qualified_dividends xdef
 "  Qualified Dividend: $" income.gross_amount cvs strconcat " from " strconcat income.source strconcat " (Form 1040 Line 3a)" strconcat job.audit_trail swap addto
@@ -4751,7 +4751,7 @@ income.gross_amount result.total_qualified_dividends f+ /result.total_qualified_
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.preferential_rate_income = result.total_long_term_gains + result.qualified_dividends</action_description>
+<action_dsl>set result.preferential_rate_income = result.total_long_term_gains + result.qualified_dividends</action_dsl>
 <action_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ allocate
 result.taxable_income 0 local@ f- /result.ordinary_income_for_cg xdef
@@ -4765,7 +4765,7 @@ result.taxable_income 0 local@ f- /result.ordinary_income_for_cg xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has preferential rate income</condition_comment>
-<condition_description>result.ltcg_and_qualified_dividends &gt; 0</condition_description>
+<condition_dsl>result.ltcg_and_qualified_dividends &gt; 0</condition_dsl>
 <condition_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ 0 >
 </condition_postfix>
@@ -4775,7 +4775,7 @@ result.total_long_term_gains result.total_qualified_dividends f+ 0 >
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -4786,7 +4786,7 @@ job.filing_status MFJ streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate CG tax for MFJ</action_comment>
-<action_description>Calculate_Capital_Gains_Tax_MFJ</action_description>
+<action_dsl>Calculate_Capital_Gains_Tax_MFJ</action_dsl>
 <action_postfix>
 Apply_CG_Brackets_MFJ
 </action_postfix>
@@ -4795,7 +4795,7 @@ Apply_CG_Brackets_MFJ
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate CG tax for Single/Other</action_comment>
-<action_description>Calculate_Capital_Gains_Tax_Single</action_description>
+<action_dsl>Calculate_Capital_Gains_Tax_Single</action_dsl>
 <action_postfix>
 Apply_CG_Brackets_Single
 </action_postfix>
@@ -4825,7 +4825,7 @@ Apply_CG_Brackets_Single
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Ordinary income fills 0% bracket</condition_comment>
-<condition_description>ordinary_income_for_cg at or below 0% ceiling</condition_description>
+<condition_dsl>ordinary_income_for_cg at or below 0% ceiling</condition_dsl>
 <condition_postfix>
 result.ordinary_income_for_cg cg_0_percent_mfj le
 </condition_postfix>
@@ -4836,7 +4836,7 @@ result.ordinary_income_for_cg cg_0_percent_mfj le
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxable income in 15% bracket</condition_comment>
-<condition_description>taxable_income at or below 15% ceiling</condition_description>
+<condition_dsl>taxable_income at or below 15% ceiling</condition_dsl>
 <condition_postfix>
 result.taxable_income cg_15_percent_mfj le
 </condition_postfix>
@@ -4849,7 +4849,7 @@ result.taxable_income cg_15_percent_mfj le
 <action_details>
 <action_number>1</action_number>
 <action_comment>0% rate applies to all preferential income</action_comment>
-<action_description>set result.capital_gains_tax = 0</action_description>
+<action_dsl>set result.capital_gains_tax = 0</action_dsl>
 <action_postfix>
 0.0 /result.capital_gains_tax xdef
 "  Capital Gains Rate: 0% - Taxable income within 0% bracket ($94,050 MFJ)" job.audit_trail swap addto
@@ -4860,7 +4860,7 @@ deallocate pop
 <action_details>
 <action_number>2</action_number>
 <action_comment>15% rate applies</action_comment>
-<action_description>LTCG/QD at 15%</action_description>
+<action_dsl>LTCG/QD at 15%</action_dsl>
 <action_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ 0.15 f* /result.capital_gains_tax xdef
 "  Capital Gains Rate: 15% - Taxable income within 15% bracket" job.audit_trail swap addto
@@ -4872,7 +4872,7 @@ deallocate pop
 <action_details>
 <action_number>3</action_number>
 <action_comment>20% rate applies</action_comment>
-<action_description>LTCG/QD at 20%</action_description>
+<action_dsl>LTCG/QD at 20%</action_dsl>
 <action_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ 0.20 f* /result.capital_gains_tax xdef
 "  Capital Gains Rate: 20% - Taxable income above 15% bracket ($583,750 MFJ)" job.audit_trail swap addto
@@ -4900,7 +4900,7 @@ deallocate pop
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Ordinary income fills 0% bracket</condition_comment>
-<condition_description>ordinary_income_for_cg at or below 0% ceiling</condition_description>
+<condition_dsl>ordinary_income_for_cg at or below 0% ceiling</condition_dsl>
 <condition_postfix>
 result.ordinary_income_for_cg cg_0_percent_single le
 </condition_postfix>
@@ -4911,7 +4911,7 @@ result.ordinary_income_for_cg cg_0_percent_single le
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxable income in 15% bracket</condition_comment>
-<condition_description>taxable_income at or below 15% ceiling</condition_description>
+<condition_dsl>taxable_income at or below 15% ceiling</condition_dsl>
 <condition_postfix>
 result.taxable_income cg_15_percent_single le
 </condition_postfix>
@@ -4924,7 +4924,7 @@ result.taxable_income cg_15_percent_single le
 <action_details>
 <action_number>1</action_number>
 <action_comment>0% rate applies to all preferential income</action_comment>
-<action_description>set result.capital_gains_tax = 0</action_description>
+<action_dsl>set result.capital_gains_tax = 0</action_dsl>
 <action_postfix>
 0.0 /result.capital_gains_tax xdef
 "  Capital Gains Rate: 0% - Taxable income within 0% bracket ($47,025 Single)" job.audit_trail swap addto
@@ -4935,7 +4935,7 @@ deallocate pop
 <action_details>
 <action_number>2</action_number>
 <action_comment>15% rate applies</action_comment>
-<action_description>LTCG/QD at 15%</action_description>
+<action_dsl>LTCG/QD at 15%</action_dsl>
 <action_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ 0.15 f* /result.capital_gains_tax xdef
 "  Capital Gains Rate: 15% - Taxable income within 15% bracket" job.audit_trail swap addto
@@ -4947,7 +4947,7 @@ deallocate pop
 <action_details>
 <action_number>3</action_number>
 <action_comment>20% rate applies</action_comment>
-<action_description>LTCG/QD at 20%</action_description>
+<action_dsl>LTCG/QD at 20%</action_dsl>
 <action_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ 0.20 f* /result.capital_gains_tax xdef
 "  Capital Gains Rate: 20% - Taxable income above 15% bracket ($518,900 Single)" job.audit_trail swap addto
@@ -4972,7 +4972,7 @@ deallocate pop
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.net_investment_income = sum of investment income</action_description>
+<action_dsl>set result.net_investment_income = sum of investment income</action_dsl>
 <action_postfix>
 result.total_other_income result.total_long_term_gains f+ result.total_short_term_gains f+ result.total_rental_income f+ result.total_qualified_dividends f+ /result.net_investment_income xdef
 result.agi /result.magi_for_niit xdef
@@ -4986,7 +4986,7 @@ result.agi /result.magi_for_niit xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has NII</condition_comment>
-<condition_description>result.net_investment_income &gt; 0</condition_description>
+<condition_dsl>result.net_investment_income &gt; 0</condition_dsl>
 <condition_postfix>
 result.net_investment_income 0 >
 </condition_postfix>
@@ -5001,7 +5001,7 @@ result.net_investment_income 0 >
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -5016,7 +5016,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Married Filing Separately</condition_comment>
-<condition_description>job.filing_status is equal to "MFS"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFS"</condition_dsl>
 <condition_postfix>
 job.filing_status MFS streq
 </condition_postfix>
@@ -5031,7 +5031,7 @@ job.filing_status MFS streq
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>MAGI exceeds MFJ threshold ($250k)</condition_comment>
-<condition_description>result.magi &gt; niit_threshold_mfj</condition_description>
+<condition_dsl>result.magi &gt; niit_threshold_mfj</condition_dsl>
 <condition_postfix>
 result.magi_for_niit niit_threshold_mfj >
 </condition_postfix>
@@ -5046,7 +5046,7 @@ result.magi_for_niit niit_threshold_mfj >
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>MAGI exceeds MFS threshold ($125k)</condition_comment>
-<condition_description>result.magi &gt; niit_threshold_mfs</condition_description>
+<condition_dsl>result.magi &gt; niit_threshold_mfs</condition_dsl>
 <condition_postfix>
 result.magi_for_niit niit_threshold_mfs >
 </condition_postfix>
@@ -5061,7 +5061,7 @@ result.magi_for_niit niit_threshold_mfs >
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>MAGI exceeds Single threshold ($200k)</condition_comment>
-<condition_description>result.magi &gt; niit_threshold_single</condition_description>
+<condition_dsl>result.magi &gt; niit_threshold_single</condition_dsl>
 <condition_postfix>
 result.magi_for_niit niit_threshold_single >
 </condition_postfix>
@@ -5078,7 +5078,7 @@ result.magi_for_niit niit_threshold_single >
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate NIIT for MFJ</action_comment>
-<action_description>NIIT = 3.8% x MIN(NII, MAGI - $250k)</action_description>
+<action_dsl>NIIT = 3.8% x MIN(NII, MAGI - $250k)</action_dsl>
 <action_postfix>
 result.magi_for_niit niit_threshold_mfj f- result.net_investment_income fmin niit_rate f* /result.niit_tax xdef
 "  Threshold (MFJ): $" niit_threshold_mfj cvs strconcat job.audit_trail swap addto
@@ -5089,7 +5089,7 @@ result.magi_for_niit niit_threshold_mfj f- result.net_investment_income fmin nii
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate NIIT for MFS</action_comment>
-<action_description>NIIT = 3.8% x MIN(NII, MAGI - $125k)</action_description>
+<action_dsl>NIIT = 3.8% x MIN(NII, MAGI - $125k)</action_dsl>
 <action_postfix>
 result.magi_for_niit niit_threshold_mfs f- result.net_investment_income fmin niit_rate f* /result.niit_tax xdef
 "  Threshold (MFS): $" niit_threshold_mfs cvs strconcat job.audit_trail swap addto
@@ -5100,7 +5100,7 @@ result.magi_for_niit niit_threshold_mfs f- result.net_investment_income fmin nii
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate NIIT for Single</action_comment>
-<action_description>NIIT = 3.8% x MIN(NII, MAGI - $200k)</action_description>
+<action_dsl>NIIT = 3.8% x MIN(NII, MAGI - $200k)</action_dsl>
 <action_postfix>
 result.magi_for_niit niit_threshold_single f- result.net_investment_income fmin niit_rate f* /result.niit_tax xdef
 "  Threshold (Single): $" niit_threshold_single cvs strconcat job.audit_trail swap addto
@@ -5111,7 +5111,7 @@ result.magi_for_niit niit_threshold_single f- result.net_investment_income fmin 
 <action_details>
 <action_number>4</action_number>
 <action_comment>No NIIT - below threshold</action_comment>
-<action_description>MAGI below threshold - no NIIT</action_description>
+<action_dsl>MAGI below threshold - no NIIT</action_dsl>
 <action_postfix>
 0.0 /result.niit_tax xdef
 "  NIIT: $0 - MAGI below threshold" job.audit_trail swap addto
@@ -5123,7 +5123,7 @@ result.magi_for_niit niit_threshold_single f- result.net_investment_income fmin 
 <action_details>
 <action_number>5</action_number>
 <action_comment>No NII</action_comment>
-<action_description>set result.niit_tax = 0</action_description>
+<action_dsl>set result.niit_tax = 0</action_dsl>
 <action_postfix>
 0.0 /result.niit_tax xdef
 "  NIIT: $0 - No net investment income" job.audit_trail swap addto
@@ -5175,7 +5175,7 @@ result.magi_for_niit niit_threshold_single f- result.net_investment_income fmin 
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.medicare_wages = sum of taxpayer wages</action_description>
+<action_dsl>set result.medicare_wages = sum of taxpayer wages</action_dsl>
 <action_postfix>
 result.total_w2_wages result.total_se_income f+ /result.wages_for_additional_medicare xdef
 "ADDITIONAL MEDICARE TAX (Form 8959, IRC 3101(b)(2))" job.audit_trail swap addto
@@ -5187,7 +5187,7 @@ result.total_w2_wages result.total_se_income f+ /result.wages_for_additional_med
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -5201,7 +5201,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Separately</condition_comment>
-<condition_description>job.filing_status is equal to "MFS"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFS"</condition_dsl>
 <condition_postfix>
 job.filing_status MFS streq
 </condition_postfix>
@@ -5215,7 +5215,7 @@ job.filing_status MFS streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Wages exceed MFJ threshold ($250k)</condition_comment>
-<condition_description>result.total_w2_wages &gt; additional_medicare_threshold_mfj</condition_description>
+<condition_dsl>result.total_w2_wages &gt; additional_medicare_threshold_mfj</condition_dsl>
 <condition_postfix>
 result.wages_for_additional_medicare additional_medicare_threshold_mfj >
 </condition_postfix>
@@ -5229,7 +5229,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_mfj >
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Wages exceed MFS threshold ($125k)</condition_comment>
-<condition_description>result.total_w2_wages &gt; additional_medicare_threshold_mfs</condition_description>
+<condition_dsl>result.total_w2_wages &gt; additional_medicare_threshold_mfs</condition_dsl>
 <condition_postfix>
 result.wages_for_additional_medicare additional_medicare_threshold_mfs >
 </condition_postfix>
@@ -5243,7 +5243,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_mfs >
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>Wages exceed Single threshold ($200k)</condition_comment>
-<condition_description>result.total_w2_wages &gt; additional_medicare_threshold_single</condition_description>
+<condition_dsl>result.total_w2_wages &gt; additional_medicare_threshold_single</condition_dsl>
 <condition_postfix>
 result.wages_for_additional_medicare additional_medicare_threshold_single >
 </condition_postfix>
@@ -5259,7 +5259,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_single >
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate Additional Medicare Tax for MFJ</action_comment>
-<action_description>0.9% on wages over $250k</action_description>
+<action_dsl>0.9% on wages over $250k</action_dsl>
 <action_postfix>
 result.wages_for_additional_medicare additional_medicare_threshold_mfj f- additional_medicare_rate f* /result.additional_medicare_tax xdef
 "  Threshold (MFJ): $" additional_medicare_threshold_mfj cvs strconcat job.audit_trail swap addto
@@ -5270,7 +5270,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_mfj f- additi
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate Additional Medicare Tax for MFS</action_comment>
-<action_description>0.9% on wages over $125k</action_description>
+<action_dsl>0.9% on wages over $125k</action_dsl>
 <action_postfix>
 result.wages_for_additional_medicare additional_medicare_threshold_mfs f- additional_medicare_rate f* /result.additional_medicare_tax xdef
 "  Threshold (MFS): $" additional_medicare_threshold_mfs cvs strconcat job.audit_trail swap addto
@@ -5281,7 +5281,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_mfs f- additi
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Additional Medicare Tax for Single</action_comment>
-<action_description>0.9% on wages over $200k</action_description>
+<action_dsl>0.9% on wages over $200k</action_dsl>
 <action_postfix>
 result.wages_for_additional_medicare additional_medicare_threshold_single f- additional_medicare_rate f* /result.additional_medicare_tax xdef
 "  Threshold (Single): $" additional_medicare_threshold_single cvs strconcat job.audit_trail swap addto
@@ -5292,7 +5292,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_single f- add
 <action_details>
 <action_number>4</action_number>
 <action_comment>No Additional Medicare Tax</action_comment>
-<action_description>set result.additional_medicare_tax = 0</action_description>
+<action_dsl>set result.additional_medicare_tax = 0</action_dsl>
 <action_postfix>
 0.0 /result.additional_medicare_tax xdef
 "  Additional Medicare Tax: $0 - Wages below threshold" job.audit_trail swap addto
@@ -5343,7 +5343,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_single f- add
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each taxpayer for IRA deduction</context_comment>
-<context_description>for all taxpayers</context_description>
+<context_dsl>for all taxpayers</context_dsl>
 <context_postfix>
 0.0 /result.ira_deduction xdef
 "IRA DEDUCTION (Publication 590-A, IRC 219)" job.audit_trail swap addto
@@ -5356,7 +5356,7 @@ result.wages_for_additional_medicare additional_medicare_threshold_single f- add
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has IRA contribution</condition_comment>
-<condition_description>taxpayer.traditional_ira_contribution &gt; 0</condition_description>
+<condition_dsl>taxpayer.traditional_ira_contribution &gt; 0</condition_dsl>
 <condition_postfix>
 taxpayer.traditional_ira_contribution 0 >
 </condition_postfix>
@@ -5371,7 +5371,7 @@ taxpayer.traditional_ira_contribution 0 >
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Covered by employer plan</condition_comment>
-<condition_description>taxpayer.covered_by_employer_plan == true</condition_description>
+<condition_dsl>taxpayer.covered_by_employer_plan == true</condition_dsl>
 <condition_postfix>
 taxpayer.covered_by_employer_plan true beq
 </condition_postfix>
@@ -5386,7 +5386,7 @@ taxpayer.covered_by_employer_plan true beq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Age 50 or over (catchup eligible)</condition_comment>
-<condition_description>taxpayer.age_50_or_over == true</condition_description>
+<condition_dsl>taxpayer.age_50_or_over == true</condition_dsl>
 <condition_postfix>
 taxpayer.age_50_or_over true beq
 </condition_postfix>
@@ -5401,7 +5401,7 @@ taxpayer.age_50_or_over true beq
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Married Filing Jointly (for phase-out)</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -5418,7 +5418,7 @@ job.filing_status MFJ streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full IRA deduction with catchup (not covered, age 50+)</action_comment>
-<action_description>set taxpayer.ira_deduction = the minimum of contribution and ira_catchup_limit</action_description>
+<action_dsl>set taxpayer.ira_deduction = the minimum of contribution and ira_catchup_limit</action_dsl>
 <action_postfix>
 taxpayer.traditional_ira_contribution ira_contribution_limit ira_catchup_limit f+ fmin result.ira_deduction f+ /result.ira_deduction xdef
 "  IRA Deduction for " taxpayer.name strconcat ": $" strconcat result.ira_deduction cvs strconcat " (full with catchup - not covered)" strconcat job.audit_trail swap addto
@@ -5428,7 +5428,7 @@ taxpayer.traditional_ira_contribution ira_contribution_limit ira_catchup_limit f
 <action_details>
 <action_number>2</action_number>
 <action_comment>Full IRA deduction no catchup (not covered, age under 50)</action_comment>
-<action_description>set taxpayer.ira_deduction = the minimum of contribution and ira_standard_limit</action_description>
+<action_dsl>set taxpayer.ira_deduction = the minimum of contribution and ira_standard_limit</action_dsl>
 <action_postfix>
 taxpayer.traditional_ira_contribution ira_contribution_limit fmin result.ira_deduction f+ /result.ira_deduction xdef
 "  IRA Deduction for " taxpayer.name strconcat ": $" strconcat result.ira_deduction cvs strconcat " (full - not covered)" strconcat job.audit_trail swap addto
@@ -5438,7 +5438,7 @@ taxpayer.traditional_ira_contribution ira_contribution_limit fmin result.ira_ded
 <action_details>
 <action_number>3</action_number>
 <action_comment>IRA deduction with MFJ phase-out and catchup</action_comment>
-<action_description>set taxpayer.ira_deduction = phased out deduction with catchup (MFJ)</action_description>
+<action_dsl>set taxpayer.ira_deduction = phased out deduction with catchup (MFJ)</action_dsl>
 <action_postfix>
 taxpayer.traditional_ira_contribution ira_contribution_limit ira_catchup_limit f+ fmin /ira_max allocate
 result.agi ira_phaseout_start_mfj f- ira_phaseout_end_mfj ira_phaseout_start_mfj f- fdiv 1 fmin 0 fmax /phaseout_pct allocate
@@ -5451,7 +5451,7 @@ deallocate pop deallocate pop
 <action_details>
 <action_number>4</action_number>
 <action_comment>IRA deduction with MFJ phase-out no catchup</action_comment>
-<action_description>set taxpayer.ira_deduction = phased out deduction standard (MFJ)</action_description>
+<action_dsl>set taxpayer.ira_deduction = phased out deduction standard (MFJ)</action_dsl>
 <action_postfix>
 taxpayer.traditional_ira_contribution ira_contribution_limit fmin /ira_max allocate
 result.agi ira_phaseout_start_mfj f- ira_phaseout_end_mfj ira_phaseout_start_mfj f- fdiv 1 fmin 0 fmax /phaseout_pct allocate
@@ -5464,7 +5464,7 @@ deallocate pop deallocate pop
 <action_details>
 <action_number>5</action_number>
 <action_comment>IRA deduction with Single phase-out and catchup</action_comment>
-<action_description>set taxpayer.ira_deduction = phased out deduction with catchup (Single)</action_description>
+<action_dsl>set taxpayer.ira_deduction = phased out deduction with catchup (Single)</action_dsl>
 <action_postfix>
 taxpayer.traditional_ira_contribution ira_contribution_limit ira_catchup_limit f+ fmin /ira_max allocate
 result.agi ira_phaseout_start_single f- ira_phaseout_end_single ira_phaseout_start_single f- fdiv 1 fmin 0 fmax /phaseout_pct allocate
@@ -5477,7 +5477,7 @@ deallocate pop deallocate pop
 <action_details>
 <action_number>6</action_number>
 <action_comment>IRA deduction with Single phase-out no catchup</action_comment>
-<action_description>set taxpayer.ira_deduction = phased out deduction standard (Single)</action_description>
+<action_dsl>set taxpayer.ira_deduction = phased out deduction standard (Single)</action_dsl>
 <action_postfix>
 taxpayer.traditional_ira_contribution ira_contribution_limit fmin /ira_max allocate
 result.agi ira_phaseout_start_single f- ira_phaseout_end_single ira_phaseout_start_single f- fdiv 1 fmin 0 fmax /phaseout_pct allocate
@@ -5490,7 +5490,7 @@ deallocate pop deallocate pop
 <action_details>
 <action_number>7</action_number>
 <action_comment>No IRA contribution</action_comment>
-<action_description>set taxpayer.ira_deduction = 0</action_description>
+<action_dsl>set taxpayer.ira_deduction = 0</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="7" column_value="X"></action_column>
@@ -5541,7 +5541,7 @@ deallocate pop deallocate pop
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each taxpayer for HSA deduction</context_comment>
-<context_description>for all taxpayers</context_description>
+<context_dsl>for all taxpayers</context_dsl>
 <context_postfix>
 0.0 /result.hsa_deduction xdef
 "HSA DEDUCTION (Form 8889, IRC 223)" job.audit_trail swap addto
@@ -5554,7 +5554,7 @@ deallocate pop deallocate pop
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has HSA contribution</condition_comment>
-<condition_description>taxpayer.hsa_contribution &gt; 0</condition_description>
+<condition_dsl>taxpayer.hsa_contribution &gt; 0</condition_dsl>
 <condition_postfix>
 taxpayer.hsa_contribution 0 >
 </condition_postfix>
@@ -5567,7 +5567,7 @@ taxpayer.hsa_contribution 0 >
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Family coverage</condition_comment>
-<condition_description>taxpayer.hsa_coverage_type is equal to "family"</condition_description>
+<condition_dsl>taxpayer.hsa_coverage_type is equal to "family"</condition_dsl>
 <condition_postfix>
 taxpayer.hsa_coverage_type "family" streq
 </condition_postfix>
@@ -5580,7 +5580,7 @@ taxpayer.hsa_coverage_type "family" streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Age 55 or over (catchup eligible)</condition_comment>
-<condition_description>taxpayer.age_50_or_over == true</condition_description>
+<condition_dsl>taxpayer.age_50_or_over == true</condition_dsl>
 <condition_postfix>
 taxpayer.age_50_or_over true beq
 </condition_postfix>
@@ -5595,7 +5595,7 @@ taxpayer.age_50_or_over true beq
 <action_details>
 <action_number>1</action_number>
 <action_comment>HSA deduction - family coverage with catchup</action_comment>
-<action_description>set taxpayer.hsa_deduction = the minimum of contribution and hsa_family_catchup_limit</action_description>
+<action_dsl>set taxpayer.hsa_deduction = the minimum of contribution and hsa_family_catchup_limit</action_dsl>
 <action_postfix>
 taxpayer.hsa_contribution hsa_limit_family hsa_catchup f+ fmin result.hsa_deduction f+ /result.hsa_deduction xdef
 "  HSA Deduction for " taxpayer.name strconcat ": $" strconcat result.hsa_deduction cvs strconcat " (family with catchup)" strconcat job.audit_trail swap addto
@@ -5605,7 +5605,7 @@ taxpayer.hsa_contribution hsa_limit_family hsa_catchup f+ fmin result.hsa_deduct
 <action_details>
 <action_number>2</action_number>
 <action_comment>HSA deduction - family coverage no catchup</action_comment>
-<action_description>set taxpayer.hsa_deduction = the minimum of contribution and hsa_family_limit</action_description>
+<action_dsl>set taxpayer.hsa_deduction = the minimum of contribution and hsa_family_limit</action_dsl>
 <action_postfix>
 taxpayer.hsa_contribution hsa_limit_family fmin result.hsa_deduction f+ /result.hsa_deduction xdef
 "  HSA Deduction for " taxpayer.name strconcat ": $" strconcat result.hsa_deduction cvs strconcat " (family coverage)" strconcat job.audit_trail swap addto
@@ -5615,7 +5615,7 @@ taxpayer.hsa_contribution hsa_limit_family fmin result.hsa_deduction f+ /result.
 <action_details>
 <action_number>3</action_number>
 <action_comment>HSA deduction - self coverage with catchup</action_comment>
-<action_description>set taxpayer.hsa_deduction = the minimum of contribution and hsa_self_catchup_limit</action_description>
+<action_dsl>set taxpayer.hsa_deduction = the minimum of contribution and hsa_self_catchup_limit</action_dsl>
 <action_postfix>
 taxpayer.hsa_contribution hsa_limit_self hsa_catchup f+ fmin result.hsa_deduction f+ /result.hsa_deduction xdef
 "  HSA Deduction for " taxpayer.name strconcat ": $" strconcat result.hsa_deduction cvs strconcat " (self with catchup)" strconcat job.audit_trail swap addto
@@ -5625,7 +5625,7 @@ taxpayer.hsa_contribution hsa_limit_self hsa_catchup f+ fmin result.hsa_deductio
 <action_details>
 <action_number>4</action_number>
 <action_comment>HSA deduction - self coverage no catchup</action_comment>
-<action_description>set taxpayer.hsa_deduction = the minimum of contribution and hsa_self_limit</action_description>
+<action_dsl>set taxpayer.hsa_deduction = the minimum of contribution and hsa_self_limit</action_dsl>
 <action_postfix>
 taxpayer.hsa_contribution hsa_limit_self fmin result.hsa_deduction f+ /result.hsa_deduction xdef
 "  HSA Deduction for " taxpayer.name strconcat ": $" strconcat result.hsa_deduction cvs strconcat " (self-only coverage)" strconcat job.audit_trail swap addto
@@ -5635,7 +5635,7 @@ taxpayer.hsa_contribution hsa_limit_self fmin result.hsa_deduction f+ /result.hs
 <action_details>
 <action_number>5</action_number>
 <action_comment>No HSA contribution</action_comment>
-<action_description>set taxpayer.hsa_deduction = 0</action_description>
+<action_dsl>set taxpayer.hsa_deduction = 0</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="5" column_value="X"></action_column>
@@ -5678,7 +5678,7 @@ taxpayer.hsa_contribution hsa_limit_self fmin result.hsa_deduction f+ /result.hs
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each taxpayer for student loan deduction</context_comment>
-<context_description>for all taxpayers</context_description>
+<context_dsl>for all taxpayers</context_dsl>
 <context_postfix>
 0.0 /result.student_loan_deduction xdef
 "STUDENT LOAN INTEREST DEDUCTION (Schedule 1 Line 21, IRC 221)" job.audit_trail swap addto
@@ -5691,7 +5691,7 @@ taxpayer.hsa_contribution hsa_limit_self fmin result.hsa_deduction f+ /result.hs
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has student loan interest</condition_comment>
-<condition_description>taxpayer.student_loan_interest_paid &gt; 0</condition_description>
+<condition_dsl>taxpayer.student_loan_interest_paid &gt; 0</condition_dsl>
 <condition_postfix>
 taxpayer.student_loan_interest_paid 0 >
 </condition_postfix>
@@ -5704,7 +5704,7 @@ taxpayer.student_loan_interest_paid 0 >
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -5717,7 +5717,7 @@ job.filing_status MFJ streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>MFJ AGI below phase-out start</condition_comment>
-<condition_description>AGI below MFJ phase-out start</condition_description>
+<condition_dsl>AGI below MFJ phase-out start</condition_dsl>
 <condition_postfix>
 result.agi student_loan_phaseout_start_mfj &lt;
 </condition_postfix>
@@ -5730,7 +5730,7 @@ result.agi student_loan_phaseout_start_mfj &lt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Single AGI below phase-out start</condition_comment>
-<condition_description>AGI below Single phase-out start</condition_description>
+<condition_dsl>AGI below Single phase-out start</condition_dsl>
 <condition_postfix>
 result.agi student_loan_phaseout_start_single &lt;
 </condition_postfix>
@@ -5745,7 +5745,7 @@ result.agi student_loan_phaseout_start_single &lt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Full student loan deduction</action_comment>
-<action_description>set result.student_loan_deduction = the minimum of interest_paid and 2500</action_description>
+<action_dsl>set result.student_loan_deduction = the minimum of interest_paid and 2500</action_dsl>
 <action_postfix>
 taxpayer.student_loan_interest_paid student_loan_max_deduction fmin result.student_loan_deduction f+ /result.student_loan_deduction xdef
 "  Student Loan Interest for " taxpayer.name strconcat ": $" strconcat result.student_loan_deduction cvs strconcat " (full - MAGI below phase-out)" strconcat job.audit_trail swap addto
@@ -5756,7 +5756,7 @@ taxpayer.student_loan_interest_paid student_loan_max_deduction fmin result.stude
 <action_details>
 <action_number>2</action_number>
 <action_comment>Student loan deduction with MFJ phase-out</action_comment>
-<action_description>set result.student_loan_deduction = phased out deduction (MFJ)</action_description>
+<action_dsl>set result.student_loan_deduction = phased out deduction (MFJ)</action_dsl>
 <action_postfix>
 taxpayer.student_loan_interest_paid student_loan_max_deduction fmin /sl_max allocate
 result.agi student_loan_phaseout_start_mfj f- student_loan_phaseout_end_mfj student_loan_phaseout_start_mfj f- fdiv 1 fmin 0 fmax /phaseout_pct allocate
@@ -5769,7 +5769,7 @@ deallocate pop deallocate pop
 <action_details>
 <action_number>3</action_number>
 <action_comment>Student loan deduction with Single phase-out</action_comment>
-<action_description>set result.student_loan_deduction = phased out deduction (Single)</action_description>
+<action_dsl>set result.student_loan_deduction = phased out deduction (Single)</action_dsl>
 <action_postfix>
 taxpayer.student_loan_interest_paid student_loan_max_deduction fmin /sl_max allocate
 result.agi student_loan_phaseout_start_single f- student_loan_phaseout_end_single student_loan_phaseout_start_single f- fdiv 1 fmin 0 fmax /phaseout_pct allocate
@@ -5782,7 +5782,7 @@ deallocate pop deallocate pop
 <action_details>
 <action_number>4</action_number>
 <action_comment>No student loan interest</action_comment>
-<action_description>set result.student_loan_deduction = 0</action_description>
+<action_dsl>set result.student_loan_deduction = 0</action_dsl>
 <action_postfix>
 </action_postfix>
 <action_column column_number="5" column_value="X"></action_column>
@@ -5820,13 +5820,13 @@ deallocate pop deallocate pop
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<initial_action_description>set result.educator_deduction = 0</initial_action_description>
+<initial_action_dsl>set result.educator_deduction = 0</initial_action_dsl>
 <initial_action_postfix>0 /result.educator_expense_deduction xdef</initial_action_postfix>
 </initial_action>
 </initial_actions>
 <conditions>
 <condition_details>
-<condition_description>Is taxpayer an eligible K-12 educator?</condition_description>
+<condition_dsl>Is taxpayer an eligible K-12 educator?</condition_dsl>
 <condition_postfix>taxpayer.is_educator</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -5834,7 +5834,7 @@ deallocate pop deallocate pop
 </conditions>
 <actions>
 <action_details>
-<action_description>set result.educator_deduction = taxpayer.educator_expenses (max $300)</action_description>
+<action_dsl>set result.educator_deduction = taxpayer.educator_expenses (max $300)</action_dsl>
 <action_postfix>
 taxpayer.educator_expenses constants.educator_expense_limit fmin result.educator_expense_deduction f+ /result.educator_expense_deduction xdef
 result.total_adjustments result.educator_expense_deduction f+ /result.total_adjustments xdef
@@ -5859,7 +5859,7 @@ result.total_adjustments result.educator_expense_deduction f+ /result.total_adju
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<initial_action_description>set result.total_medical_expenses = sum of taxpayer medical expenses</initial_action_description>
+<initial_action_dsl>set result.total_medical_expenses = sum of taxpayer medical expenses</initial_action_dsl>
 <initial_action_postfix>
 0.0 { medical_expenses + } job.taxpayers forall /result.total_medical_expenses xdef
 </initial_action_postfix>
@@ -5867,7 +5867,7 @@ result.total_adjustments result.educator_expense_deduction f+ /result.total_adju
 </initial_actions>
 <conditions>
 <condition_details>
-<condition_description>Are there medical expenses?</condition_description>
+<condition_dsl>Are there medical expenses?</condition_dsl>
 <condition_postfix>result.total_medical_expenses 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -5875,7 +5875,7 @@ result.total_adjustments result.educator_expense_deduction f+ /result.total_adju
 </conditions>
 <actions>
 <action_details>
-<action_description>set result.medical_deduction = medical_expenses - (result.agi * 0.075)</action_description>
+<action_dsl>set result.medical_deduction = medical_expenses - (result.agi * 0.075)</action_dsl>
 <action_postfix>
 result.agi constants.medical_floor_percentage f* /result.medical_expense_floor xdef
 result.total_medical_expenses result.medical_expense_floor f- 0 fmax /result.medical_expense_deduction xdef
@@ -5905,7 +5905,7 @@ result.total_medical_expenses result.medical_expense_floor f- 0 fmax /result.med
 <context_details>
 <context_number>1</context_number>
 <context_comment>Count qualifying persons and sum expenses</context_comment>
-<context_description>for all dependents</context_description>
+<context_dsl>for all dependents</context_dsl>
 <context_postfix>
 0 /result.qualifying_care_persons xdef
 0.0 /result.total_care_expenses xdef
@@ -5921,7 +5921,7 @@ result.total_medical_expenses result.medical_expense_floor f- 0 fmax /result.med
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has 2+ qualifying persons</condition_comment>
-<condition_description>result.qualifying_care_persons &gt; 1</condition_description>
+<condition_dsl>result.qualifying_care_persons &gt; 1</condition_dsl>
 <condition_postfix>result.qualifying_care_persons 1 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -5930,7 +5930,7 @@ result.total_medical_expenses result.medical_expense_floor f- 0 fmax /result.med
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has 1 qualifying person</condition_comment>
-<condition_description>result.qualifying_care_persons == 1</condition_description>
+<condition_dsl>result.qualifying_care_persons == 1</condition_dsl>
 <condition_postfix>result.qualifying_care_persons 1 ==</condition_postfix>
 <condition_column column_number="1" column_value="-"></condition_column>
 <condition_column column_number="2" column_value="Y"></condition_column>
@@ -5940,7 +5940,7 @@ result.total_medical_expenses result.medical_expense_floor f- 0 fmax /result.med
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.cdcc_expense_limit = 6000</action_description>
+<action_dsl>set result.cdcc_expense_limit = 6000</action_dsl>
 <action_postfix>
 constants.cdcc_expense_limit_2 /result.cdcc_expense_limit xdef
 </action_postfix>
@@ -5948,7 +5948,7 @@ constants.cdcc_expense_limit_2 /result.cdcc_expense_limit xdef
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.cdcc_expense_limit = 3000</action_description>
+<action_dsl>set result.cdcc_expense_limit = 3000</action_dsl>
 <action_postfix>
 constants.cdcc_expense_limit_1 /result.cdcc_expense_limit xdef
 </action_postfix>
@@ -5956,7 +5956,7 @@ constants.cdcc_expense_limit_1 /result.cdcc_expense_limit xdef
 </action_details>
 <action_details>
 <action_number>3</action_number>
-<action_description>set result.cdcc_credit = qualified_expenses * credit_rate</action_description>
+<action_dsl>set result.cdcc_credit = qualified_expenses * credit_rate</action_dsl>
 <action_postfix>
 result.total_care_expenses result.cdcc_expense_limit fmin /result.cdcc_allowed_expenses xdef
 result.agi constants.cdcc_rate_reduction_start f- constants.cdcc_rate_reduction_increment fdiv 0 fmax floor /result.cdcc_rate_reductions xdef
@@ -5975,7 +5975,7 @@ result.cdcc_credit result.total_credits f+ /result.total_credits xdef
 </action_details>
 <action_details>
 <action_number>4</action_number>
-<action_description>set result.cdcc_credit = 0</action_description>
+<action_dsl>set result.cdcc_credit = 0</action_dsl>
 <action_postfix>
 "  No qualifying persons for CDCC" job.audit_trail swap addto
 </action_postfix>
@@ -6013,7 +6013,7 @@ result.cdcc_credit result.total_credits f+ /result.total_credits xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Child under 13</condition_comment>
-<condition_description>dependent.age &lt; 13</condition_description>
+<condition_dsl>dependent.age &lt; 13</condition_dsl>
 <condition_postfix>dependent.age 13 &lt;</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -6022,7 +6022,7 @@ result.cdcc_credit result.total_credits f+ /result.total_credits xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Disabled dependent</condition_comment>
-<condition_description>dependent.is_disabled == true</condition_description>
+<condition_dsl>dependent.is_disabled == true</condition_dsl>
 <condition_postfix>dependent.is_disabled true beq</condition_postfix>
 <condition_column column_number="1" column_value="-"></condition_column>
 <condition_column column_number="2" column_value="Y"></condition_column>
@@ -6032,7 +6032,7 @@ result.cdcc_credit result.total_credits f+ /result.total_credits xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>increment qualifying_person_count, add dependent.care_expenses to total</action_description>
+<action_dsl>increment qualifying_person_count, add dependent.care_expenses to total</action_dsl>
 <action_postfix>
 result.qualifying_care_persons 1 + /result.qualifying_care_persons xdef
 dependent.care_expenses result.total_care_expenses f+ /result.total_care_expenses xdef
@@ -6043,7 +6043,7 @@ true /dependent.qualifies_for_cdcc xdef
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>otherwise</action_description>
+<action_dsl>otherwise</action_dsl>
 <action_postfix>
 false /dependent.qualifies_for_cdcc xdef
 </action_postfix>
@@ -6075,7 +6075,7 @@ false /dependent.qualifies_for_cdcc xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Sum eligible contributions</context_comment>
-<context_description>for all taxpayers</context_description>
+<context_dsl>for all taxpayers</context_dsl>
 <context_postfix>
 0.0 /result.total_savers_contribution xdef
 0.0 /result.savers_credit xdef
@@ -6090,7 +6090,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has contributions</condition_comment>
-<condition_description>result.total_savers_contribution &gt; 0</condition_description>
+<condition_dsl>result.total_savers_contribution &gt; 0</condition_dsl>
 <condition_postfix>result.total_savers_contribution 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="Y"></condition_column>
@@ -6109,7 +6109,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status MFJ</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>job.filing_status MFJ streq</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="Y"></condition_column>
@@ -6127,7 +6127,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Filing status HOH</condition_comment>
-<condition_description>job.filing_status is equal to "HOH"</condition_description>
+<condition_dsl>job.filing_status is equal to "HOH"</condition_dsl>
 <condition_postfix>job.filing_status HOH streq</condition_postfix>
 <condition_column column_number="5" column_value="Y"></condition_column>
 <condition_column column_number="6" column_value="Y"></condition_column>
@@ -6141,7 +6141,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>AGI at 50% tier for MFJ</condition_comment>
-<condition_description>result.agi &lt;= savers_credit_50pct_threshold_mfj</condition_description>
+<condition_dsl>result.agi &lt;= savers_credit_50pct_threshold_mfj</condition_dsl>
 <condition_postfix>result.agi constants.savers_50_percent_mfj &lt;=</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -6151,7 +6151,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>AGI at 20% tier for MFJ</condition_comment>
-<condition_description>result.agi &lt;= savers_credit_20pct_threshold_mfj</condition_description>
+<condition_dsl>result.agi &lt;= savers_credit_20pct_threshold_mfj</condition_dsl>
 <condition_postfix>result.agi constants.savers_20_percent_mfj &lt;=</condition_postfix>
 <condition_column column_number="2" column_value="Y"></condition_column>
 <condition_column column_number="3" column_value="N"></condition_column>
@@ -6160,7 +6160,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>AGI at 10% tier for MFJ</condition_comment>
-<condition_description>result.agi &lt;= savers_credit_10pct_threshold_mfj</condition_description>
+<condition_dsl>result.agi &lt;= savers_credit_10pct_threshold_mfj</condition_dsl>
 <condition_postfix>result.agi constants.savers_10_percent_mfj &lt;=</condition_postfix>
 <condition_column column_number="3" column_value="Y"></condition_column>
 <condition_column column_number="4" column_value="N"></condition_column>
@@ -6168,7 +6168,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>7</condition_number>
 <condition_comment>AGI at 50% tier for HOH</condition_comment>
-<condition_description>result.agi &lt;= savers_credit_50pct_threshold_hoh</condition_description>
+<condition_dsl>result.agi &lt;= savers_credit_50pct_threshold_hoh</condition_dsl>
 <condition_postfix>result.agi constants.savers_50_percent_hoh &lt;=</condition_postfix>
 <condition_column column_number="5" column_value="Y"></condition_column>
 <condition_column column_number="6" column_value="N"></condition_column>
@@ -6178,7 +6178,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>8</condition_number>
 <condition_comment>AGI at 20% tier for HOH</condition_comment>
-<condition_description>result.agi &lt;= savers_credit_20pct_threshold_hoh</condition_description>
+<condition_dsl>result.agi &lt;= savers_credit_20pct_threshold_hoh</condition_dsl>
 <condition_postfix>result.agi constants.savers_20_percent_hoh &lt;=</condition_postfix>
 <condition_column column_number="6" column_value="Y"></condition_column>
 <condition_column column_number="7" column_value="N"></condition_column>
@@ -6187,7 +6187,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>9</condition_number>
 <condition_comment>AGI at 10% tier for HOH</condition_comment>
-<condition_description>result.agi &lt;= savers_credit_10pct_threshold_hoh</condition_description>
+<condition_dsl>result.agi &lt;= savers_credit_10pct_threshold_hoh</condition_dsl>
 <condition_postfix>result.agi constants.savers_10_percent_hoh &lt;=</condition_postfix>
 <condition_column column_number="7" column_value="Y"></condition_column>
 <condition_column column_number="8" column_value="N"></condition_column>
@@ -6195,7 +6195,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>10</condition_number>
 <condition_comment>AGI at 50% tier for Single</condition_comment>
-<condition_description>result.agi &lt;= savers_credit_50pct_threshold_single</condition_description>
+<condition_dsl>result.agi &lt;= savers_credit_50pct_threshold_single</condition_dsl>
 <condition_postfix>result.agi constants.savers_50_percent_single &lt;=</condition_postfix>
 <condition_column column_number="9" column_value="Y"></condition_column>
 <condition_column column_number="10" column_value="N"></condition_column>
@@ -6205,7 +6205,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>11</condition_number>
 <condition_comment>AGI at 20% tier for Single</condition_comment>
-<condition_description>result.agi &lt;= savers_credit_20pct_threshold_single</condition_description>
+<condition_dsl>result.agi &lt;= savers_credit_20pct_threshold_single</condition_dsl>
 <condition_postfix>result.agi constants.savers_20_percent_single &lt;=</condition_postfix>
 <condition_column column_number="10" column_value="Y"></condition_column>
 <condition_column column_number="11" column_value="N"></condition_column>
@@ -6214,7 +6214,7 @@ false /dependent.qualifies_for_cdcc xdef
 <condition_details>
 <condition_number>12</condition_number>
 <condition_comment>AGI at 10% tier for Single</condition_comment>
-<condition_description>result.agi &lt;= savers_credit_10pct_threshold_single</condition_description>
+<condition_dsl>result.agi &lt;= savers_credit_10pct_threshold_single</condition_dsl>
 <condition_postfix>result.agi constants.savers_10_percent_single &lt;=</condition_postfix>
 <condition_column column_number="11" column_value="Y"></condition_column>
 <condition_column column_number="12" column_value="N"></condition_column>
@@ -6223,7 +6223,7 @@ false /dependent.qualifies_for_cdcc xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.savers_credit_rate = 0.50</action_description>
+<action_dsl>set result.savers_credit_rate = 0.50</action_dsl>
 <action_postfix>0.50 /result.savers_credit_rate xdef</action_postfix>
 <action_column column_number="1" column_value="X"></action_column>
 <action_column column_number="5" column_value="X"></action_column>
@@ -6231,7 +6231,7 @@ false /dependent.qualifies_for_cdcc xdef
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.savers_credit_rate = 0.20</action_description>
+<action_dsl>set result.savers_credit_rate = 0.20</action_dsl>
 <action_postfix>0.20 /result.savers_credit_rate xdef</action_postfix>
 <action_column column_number="2" column_value="X"></action_column>
 <action_column column_number="6" column_value="X"></action_column>
@@ -6239,7 +6239,7 @@ false /dependent.qualifies_for_cdcc xdef
 </action_details>
 <action_details>
 <action_number>3</action_number>
-<action_description>set result.savers_credit_rate = 0.10</action_description>
+<action_dsl>set result.savers_credit_rate = 0.10</action_dsl>
 <action_postfix>0.10 /result.savers_credit_rate xdef</action_postfix>
 <action_column column_number="3" column_value="X"></action_column>
 <action_column column_number="7" column_value="X"></action_column>
@@ -6247,7 +6247,7 @@ false /dependent.qualifies_for_cdcc xdef
 </action_details>
 <action_details>
 <action_number>4</action_number>
-<action_description>set result.savers_credit_rate = 0</action_description>
+<action_dsl>set result.savers_credit_rate = 0</action_dsl>
 <action_postfix>0.0 /result.savers_credit_rate xdef</action_postfix>
 <action_column column_number="4" column_value="X"></action_column>
 <action_column column_number="8" column_value="X"></action_column>
@@ -6255,7 +6255,7 @@ false /dependent.qualifies_for_cdcc xdef
 </action_details>
 <action_details>
 <action_number>5</action_number>
-<action_description>set result.savers_credit = eligible_contributions * result.savers_credit_rate</action_description>
+<action_dsl>set result.savers_credit = eligible_contributions * result.savers_credit_rate</action_dsl>
 <action_postfix>
 result.total_savers_contribution result.savers_credit_rate f* /result.savers_credit xdef
 "  Eligible contributions: $" result.total_savers_contribution cvs strconcat job.audit_trail swap addto
@@ -6278,7 +6278,7 @@ result.savers_credit result.total_credits f+ /result.total_credits xdef
 </action_details>
 <action_details>
 <action_number>6</action_number>
-<action_description>set result.savers_credit = 0</action_description>
+<action_dsl>set result.savers_credit = 0</action_dsl>
 <action_postfix>
 "  No eligible retirement contributions for Saver's Credit" job.audit_trail swap addto
 </action_postfix>
@@ -6356,7 +6356,7 @@ result.savers_credit result.total_credits f+ /result.total_credits xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has any IRA contribution</condition_comment>
-<condition_description>taxpayer has IRA contributions</condition_description>
+<condition_dsl>taxpayer has IRA contributions</condition_dsl>
 <condition_postfix>taxpayer.traditional_ira_contribution taxpayer.roth_ira_contribution f+ 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -6365,7 +6365,7 @@ result.savers_credit result.total_credits f+ /result.total_credits xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add contribution.amount to result.eligible_contributions (up to limit)</action_description>
+<action_dsl>add contribution.amount to result.eligible_contributions (up to limit)</action_dsl>
 <action_postfix>
 taxpayer.traditional_ira_contribution taxpayer.roth_ira_contribution f+ constants.savers_credit_max_contribution fmin result.total_savers_contribution f+ /result.total_savers_contribution xdef
 </action_postfix>
@@ -6393,7 +6393,7 @@ taxpayer.traditional_ira_contribution taxpayer.roth_ira_contribution f+ constant
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each energy improvement</context_comment>
-<context_description>for all energy improvements</context_description>
+<context_dsl>for all energy improvements</context_dsl>
 <context_postfix>
 0.0 /result.clean_energy_credit xdef
 0.0 /result.energy_efficiency_credit xdef
@@ -6405,7 +6405,7 @@ taxpayer.traditional_ira_contribution taxpayer.roth_ira_contribution f+ constant
 <initial_actions>
 <initial_action>
 <action_number>1</action_number>
-<action_description>set result.energy_efficiency_credit = the minimum of credit and annual_limit</action_description>
+<action_dsl>set result.energy_efficiency_credit = the minimum of credit and annual_limit</action_dsl>
 <action_postfix>
 result.energy_efficiency_credit constants.energy_efficiency_annual_limit fmin /result.energy_efficiency_credit xdef
 </action_postfix>
@@ -6415,7 +6415,7 @@ result.energy_efficiency_credit constants.energy_efficiency_annual_limit fmin /r
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has energy credits</condition_comment>
-<condition_description>result.total_credits &gt; 0</condition_description>
+<condition_dsl>result.total_credits &gt; 0</condition_dsl>
 <condition_postfix>result.clean_energy_credit result.energy_efficiency_credit f+ 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -6424,7 +6424,7 @@ result.energy_efficiency_credit constants.energy_efficiency_annual_limit fmin /r
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add energy credit summary to job.audit_trail</action_description>
+<action_dsl>add energy credit summary to job.audit_trail</action_dsl>
 <action_postfix>
 "  Clean Energy Credit (25D): $" result.clean_energy_credit cvs strconcat job.audit_trail swap addto
 "  Energy Efficiency Credit (25C): $" result.energy_efficiency_credit cvs strconcat job.audit_trail swap addto
@@ -6434,7 +6434,7 @@ result.clean_energy_credit result.energy_efficiency_credit f+ result.total_credi
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.energy_efficiency_credit = 0, set result.clean_energy_credit = 0</action_description>
+<action_dsl>set result.energy_efficiency_credit = 0, set result.clean_energy_credit = 0</action_dsl>
 <action_postfix>
 "  No qualifying energy improvements" job.audit_trail swap addto
 </action_postfix>
@@ -6464,7 +6464,7 @@ result.clean_energy_credit result.energy_efficiency_credit f+ result.total_credi
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Clean energy improvement (25D)</condition_comment>
-<condition_description>category is clean_energy</condition_description>
+<condition_dsl>category is clean_energy</condition_dsl>
 <condition_postfix>energy_improvement.category clean_energy streq</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -6473,7 +6473,7 @@ result.clean_energy_credit result.energy_efficiency_credit f+ result.total_credi
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add (improvement.cost * 0.30) to result.clean_energy_credit</action_description>
+<action_dsl>add (improvement.cost * 0.30) to result.clean_energy_credit</action_dsl>
 <action_postfix>
 energy_improvement.cost constants.clean_energy_rate f* result.clean_energy_credit f+ /result.clean_energy_credit xdef
 "    " energy_improvement.type strconcat ": $" strconcat energy_improvement.cost cvs strconcat " (25D 30%)" strconcat job.audit_trail swap addto
@@ -6482,7 +6482,7 @@ energy_improvement.cost constants.clean_energy_rate f* result.clean_energy_credi
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>add (improvement.cost * 0.30) to result.energy_efficiency_credit</action_description>
+<action_dsl>add (improvement.cost * 0.30) to result.energy_efficiency_credit</action_dsl>
 <action_postfix>
 energy_improvement.cost constants.energy_efficiency_rate f* result.energy_efficiency_credit f+ /result.energy_efficiency_credit xdef
 "    " energy_improvement.type strconcat ": $" strconcat energy_improvement.cost cvs strconcat " (25C 30%)" strconcat job.audit_trail swap addto
@@ -6515,7 +6515,7 @@ energy_improvement.cost constants.energy_efficiency_rate f* result.energy_effici
 <context_details>
 <context_number>1</context_number>
 <context_comment>Sum rental losses from all properties</context_comment>
-<context_description>for all properties</context_description>
+<context_dsl>for all properties</context_dsl>
 <context_postfix>
 0.0 /result.total_rental_loss xdef
 0.0 /result.rental_loss_allowed xdef
@@ -6530,7 +6530,7 @@ energy_improvement.cost constants.energy_efficiency_rate f* result.energy_effici
 <initial_actions>
 <initial_action>
 <action_number>1</action_number>
-<action_description>set result.pal_allowance = ($25k - phaseout_reduction)</action_description>
+<action_dsl>set result.pal_allowance = ($25k - phaseout_reduction)</action_dsl>
 <action_postfix>
 result.agi constants.rental_loss_phaseout_start f- 0 fmax constants.rental_loss_phaseout_rate f* /result.pal_phaseout_reduction xdef
 constants.rental_loss_allowance result.pal_phaseout_reduction f- 0 fmax /result.pal_reduced_allowance xdef
@@ -6543,7 +6543,7 @@ result.total_rental_loss result.rental_loss_allowed f- /result.suspended_passive
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has rental losses</condition_comment>
-<condition_description>result.total_rental_loss &gt; 0</condition_description>
+<condition_dsl>result.total_rental_loss &gt; 0</condition_dsl>
 <condition_postfix>result.total_rental_loss 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -6552,7 +6552,7 @@ result.total_rental_loss result.rental_loss_allowed f- /result.suspended_passive
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add PAL summary to job.audit_trail</action_description>
+<action_dsl>add PAL summary to job.audit_trail</action_dsl>
 <action_postfix>
 "  Total rental loss: $" result.total_rental_loss cvs strconcat job.audit_trail swap addto
 "  Allowance after phaseout: $" result.pal_reduced_allowance cvs strconcat job.audit_trail swap addto
@@ -6563,7 +6563,7 @@ result.total_rental_loss result.rental_loss_allowed f- /result.suspended_passive
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.pal_deduction = 0</action_description>
+<action_dsl>set result.pal_deduction = 0</action_dsl>
 <action_postfix>
 "  No rental losses to analyze" job.audit_trail swap addto
 </action_postfix>
@@ -6593,7 +6593,7 @@ result.total_rental_loss result.rental_loss_allowed f- /result.suspended_passive
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Property has loss (negative net income)</condition_comment>
-<condition_description>property.rental_net_income &lt; 0</condition_description>
+<condition_dsl>property.rental_net_income &lt; 0</condition_dsl>
 <condition_postfix>property.rental_net_income 0 &lt;</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -6602,7 +6602,7 @@ result.total_rental_loss result.rental_loss_allowed f- /result.suspended_passive
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add (-rental.net_loss) to result.total_rental_losses</action_description>
+<action_dsl>add (-rental.net_loss) to result.total_rental_losses</action_dsl>
 <action_postfix>
 property.rental_net_income fnegate result.total_rental_loss f+ /result.total_rental_loss xdef
 </action_postfix>
@@ -6630,7 +6630,7 @@ property.rental_net_income fnegate result.total_rental_loss f+ /result.total_ren
 <initial_actions>
 <initial_action>
 <action_number>1</action_number>
-<action_description>set result.amti = result.taxable_income + amt_adjustments</action_description>
+<action_dsl>set result.amti = result.taxable_income + amt_adjustments</action_dsl>
 <action_postfix>
 result.taxable_income result.salt_deduction f+ /result.amti xdef
 "ALTERNATIVE MINIMUM TAX (Form 6251, IRC 55-59)" job.audit_trail swap addto
@@ -6644,7 +6644,7 @@ result.taxable_income result.salt_deduction f+ /result.amti xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Filing status MFJ</condition_comment>
-<condition_description>job.filing_status is equal to "MFJ"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>job.filing_status MFJ streq</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -6653,7 +6653,7 @@ result.taxable_income result.salt_deduction f+ /result.amti xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status MFS</condition_comment>
-<condition_description>job.filing_status is equal to "MFS"</condition_description>
+<condition_dsl>job.filing_status is equal to "MFS"</condition_dsl>
 <condition_postfix>job.filing_status MFS streq</condition_postfix>
 <condition_column column_number="2" column_value="Y"></condition_column>
 <condition_column column_number="3" column_value="N"></condition_column>
@@ -6662,7 +6662,7 @@ result.taxable_income result.salt_deduction f+ /result.amti xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.amt_owed = (amti - exemption) * amt_rate (MFJ)</action_description>
+<action_dsl>set result.amt_owed = (amti - exemption) * amt_rate (MFJ)</action_dsl>
 <action_postfix>
 result.amti amt_phaseout_mfj f- 0.25 f* 0 fmax /result.amt_exemption_reduction xdef
 amt_exemption_mfj result.amt_exemption_reduction f- 0 fmax /result.amt_exemption xdef
@@ -6677,7 +6677,7 @@ result.amt_tax result.total_tax_before_credits f- 0 fmax /result.amt_owed xdef
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.amt_owed = (amti - exemption) * amt_rate (MFS)</action_description>
+<action_dsl>set result.amt_owed = (amti - exemption) * amt_rate (MFS)</action_dsl>
 <action_postfix>
 result.amti amt_phaseout_mfs f- 0.25 f* 0 fmax /result.amt_exemption_reduction xdef
 amt_exemption_mfs result.amt_exemption_reduction f- 0 fmax /result.amt_exemption xdef
@@ -6692,7 +6692,7 @@ result.amt_tax result.total_tax_before_credits f- 0 fmax /result.amt_owed xdef
 </action_details>
 <action_details>
 <action_number>3</action_number>
-<action_description>set result.amt_owed = (amti - exemption) * amt_rate (Single/HOH)</action_description>
+<action_dsl>set result.amt_owed = (amti - exemption) * amt_rate (Single/HOH)</action_dsl>
 <action_postfix>
 result.amti amt_phaseout_single f- 0.25 f* 0 fmax /result.amt_exemption_reduction xdef
 amt_exemption_single result.amt_exemption_reduction f- 0 fmax /result.amt_exemption xdef
@@ -6735,7 +6735,7 @@ result.amt_tax result.total_tax_before_credits f- 0 fmax /result.amt_owed xdef
 <initial_actions>
 <initial_action>
 <action_number>1</action_number>
-<action_description>set result.premium_tax_credit = max_ptc - required_contribution</action_description>
+<action_dsl>set result.premium_tax_credit = max_ptc - required_contribution</action_dsl>
 <action_postfix>
 0.0 /result.premium_tax_credit xdef
 0.0 /result.ptc_repayment xdef
@@ -6753,7 +6753,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has marketplace coverage</condition_comment>
-<condition_description>job.has_marketplace_coverage == true</condition_description>
+<condition_dsl>job.has_marketplace_coverage == true</condition_dsl>
 <condition_postfix>job.has_marketplace_coverage true beq</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="Y"></condition_column>
@@ -6763,7 +6763,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Eligible for PTC (FPL 100-400%)</condition_comment>
-<condition_description>FPL between 100 and 400</condition_description>
+<condition_dsl>FPL between 100 and 400</condition_dsl>
 <condition_postfix>result.fpl_percentage 100 >= result.fpl_percentage 400 &lt;= and</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="Y"></condition_column>
@@ -6772,7 +6772,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Net PTC is positive (credit owed)</condition_comment>
-<condition_description>result.net_ptc &gt;= 0</condition_description>
+<condition_dsl>result.net_ptc &gt;= 0</condition_dsl>
 <condition_postfix>result.net_ptc 0 >=</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -6781,7 +6781,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add PTC summary to job.audit_trail</action_description>
+<action_dsl>add PTC summary to job.audit_trail</action_dsl>
 <action_postfix>
 "  Household size: " job.household_size cvs strconcat job.audit_trail swap addto
 "  FPL: $" result.fpl_amount cvs strconcat job.audit_trail swap addto
@@ -6795,7 +6795,7 @@ result.max_ptc job.advance_ptc_received f- /result.net_ptc xdef
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>add result.premium_tax_credit to result.total_credits</action_description>
+<action_dsl>add result.premium_tax_credit to result.total_credits</action_dsl>
 <action_postfix>
 result.net_ptc /result.premium_tax_credit xdef
 result.premium_tax_credit result.total_credits f+ /result.total_credits xdef
@@ -6805,7 +6805,7 @@ result.premium_tax_credit result.total_credits f+ /result.total_credits xdef
 </action_details>
 <action_details>
 <action_number>3</action_number>
-<action_description>set result.ptc_repayment = excess_advance_ptc</action_description>
+<action_dsl>set result.ptc_repayment = excess_advance_ptc</action_dsl>
 <action_postfix>
 result.net_ptc fnegate /result.ptc_repayment xdef
 "  PTC Repayment required: $" result.ptc_repayment cvs strconcat job.audit_trail swap addto
@@ -6814,7 +6814,7 @@ result.net_ptc fnegate /result.ptc_repayment xdef
 </action_details>
 <action_details>
 <action_number>4</action_number>
-<action_description>set result.ptc_repayment = total_advance_ptc</action_description>
+<action_dsl>set result.ptc_repayment = total_advance_ptc</action_dsl>
 <action_postfix>
 job.advance_ptc_received /result.ptc_repayment xdef
 "  FPL percentage: " result.fpl_percentage cvs strconcat "% (outside 100-400% range)" strconcat job.audit_trail swap addto
@@ -6824,7 +6824,7 @@ job.advance_ptc_received /result.ptc_repayment xdef
 </action_details>
 <action_details>
 <action_number>5</action_number>
-<action_description>set result.premium_tax_credit = 0</action_description>
+<action_dsl>set result.premium_tax_credit = 0</action_dsl>
 <action_postfix>
 "  No marketplace coverage - PTC not applicable" job.audit_trail swap addto
 </action_postfix>
@@ -6865,7 +6865,7 @@ job.advance_ptc_received /result.ptc_repayment xdef
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>add "K-1 PROCESSING" to job.audit_trail</action_description>
+<action_dsl>add "K-1 PROCESSING" to job.audit_trail</action_dsl>
 <action_postfix>
 "Processing Schedule K-1 Income (Schedule E Part II)" job.audit_trail swap addto
 </action_postfix>
@@ -6875,7 +6875,7 @@ job.advance_ptc_received /result.ptc_repayment xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has K-1 to process</condition_comment>
-<condition_description>K-1 entity exists in context</condition_description>
+<condition_dsl>K-1 entity exists in context</condition_dsl>
 <condition_postfix>k1 isnull not</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 </condition_details>
@@ -6883,7 +6883,7 @@ job.advance_ptc_received /result.ptc_repayment xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add k1.income to appropriate category totals</action_description>
+<action_dsl>add k1.income to appropriate category totals</action_dsl>
 <action_postfix>
 "  K-1 from: " k1.entity_name strconcat " (" strconcat k1.source_type strconcat ")" strconcat job.audit_trail swap addto
 k1.ordinary_income result.total_k1_ordinary_income f+ /result.total_k1_ordinary_income xdef
@@ -6917,7 +6917,7 @@ k1.qbi_income result.total_k1_qbi f+ /result.total_k1_qbi xdef
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add K-1 SE tax summary to job.audit_trail</action_description>
+<action_dsl>add K-1 SE tax summary to job.audit_trail</action_dsl>
 <action_postfix>
 "Calculating K-1 Self-Employment Tax (Schedule SE)" job.audit_trail swap addto
 </action_postfix>
@@ -6927,7 +6927,7 @@ k1.qbi_income result.total_k1_qbi f+ /result.total_k1_qbi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has K-1 SE earnings</condition_comment>
-<condition_description>result.total_k1_se_earnings &gt; se_threshold</condition_description>
+<condition_dsl>result.total_k1_se_earnings &gt; se_threshold</condition_dsl>
 <condition_postfix>result.total_k1_se_earnings se_threshold ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -6936,7 +6936,7 @@ k1.qbi_income result.total_k1_qbi f+ /result.total_k1_qbi xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set taxpayer.k1_se_tax = k1_se_earnings * se_tax_rate</action_description>
+<action_dsl>set taxpayer.k1_se_tax = k1_se_earnings * se_tax_rate</action_dsl>
 <action_postfix>
 result.total_k1_se_earnings se_income_multiplier f* /k1_se_base xdef
 k1_se_base se_tax_rate f* /k1_se_tax xdef
@@ -6949,7 +6949,7 @@ k1_se_tax se_deduction_rate f* result.total_adjustments f+ /result.total_adjustm
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set taxpayer.k1_se_tax = 0</action_description>
+<action_dsl>set taxpayer.k1_se_tax = 0</action_dsl>
 <action_postfix>
 "  No K-1 SE earnings or below threshold" job.audit_trail swap addto
 </action_postfix>
@@ -6977,7 +6977,7 @@ k1_se_tax se_deduction_rate f* result.total_adjustments f+ /result.total_adjustm
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>add "IRA PROCESSING" to job.audit_trail</action_description>
+<action_dsl>add "IRA PROCESSING" to job.audit_trail</action_dsl>
 <action_postfix>
 "Processing IRA Accounts (Form 8606)" job.audit_trail swap addto
 </action_postfix>
@@ -6987,14 +6987,14 @@ k1_se_tax se_deduction_rate f* result.total_adjustments f+ /result.total_adjustm
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has IRA account to process</condition_comment>
-<condition_description>IRA account exists in context</condition_description>
+<condition_dsl>IRA account exists in context</condition_dsl>
 <condition_postfix>ira isnull not</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 </condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Is traditional IRA</condition_comment>
-<condition_description>Account type is traditional</condition_description>
+<condition_dsl>Account type is traditional</condition_dsl>
 <condition_postfix>ira.account_type traditional streq</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 </condition_details>
@@ -7002,7 +7002,7 @@ k1_se_tax se_deduction_rate f* result.total_adjustments f+ /result.total_adjustm
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>for all IRA accounts perform Process_IRA_Basis</action_description>
+<action_dsl>for all IRA accounts perform Process_IRA_Basis</action_dsl>
 <action_postfix>
 "  Traditional IRA at: " ira.institution strconcat job.audit_trail swap addto
 ira.year_end_balance result.total_ira_balance f+ /result.total_ira_balance xdef
@@ -7031,7 +7031,7 @@ ira.distribution_amount result.total_ira_distributions f+ /result.total_ira_dist
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add Roth conversion summary to job.audit_trail</action_description>
+<action_dsl>add Roth conversion summary to job.audit_trail</action_dsl>
 <action_postfix>
 "Calculating Roth Conversion Tax (Form 8606 Part II)" job.audit_trail swap addto
 </action_postfix>
@@ -7041,7 +7041,7 @@ ira.distribution_amount result.total_ira_distributions f+ /result.total_ira_dist
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has Roth conversions</condition_comment>
-<condition_description>result.total_roth_conversions &gt; 0</condition_description>
+<condition_dsl>result.total_roth_conversions &gt; 0</condition_dsl>
 <condition_postfix>result.total_roth_conversions 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -7049,7 +7049,7 @@ ira.distribution_amount result.total_ira_distributions f+ /result.total_ira_dist
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has basis to recover</condition_comment>
-<condition_description>result.total_ira_basis &gt; 0</condition_description>
+<condition_dsl>result.total_ira_basis &gt; 0</condition_dsl>
 <condition_postfix>result.total_ira_basis 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 </condition_details>
@@ -7057,7 +7057,7 @@ ira.distribution_amount result.total_ira_distributions f+ /result.total_ira_dist
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set conversion.taxable_amount = conversion_amount * taxable_ratio</action_description>
+<action_dsl>set conversion.taxable_amount = conversion_amount * taxable_ratio</action_dsl>
 <action_postfix>
 result.total_ira_balance result.total_ira_basis f- result.total_ira_balance f/ /taxable_pct xdef
 result.total_roth_conversions taxable_pct f* /result.taxable_conversions xdef
@@ -7072,7 +7072,7 @@ result.taxable_conversions result.total_other_income f+ /result.total_other_inco
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set conversion.taxable_amount = 0</action_description>
+<action_dsl>set conversion.taxable_amount = 0</action_dsl>
 <action_postfix>
 "  No Roth conversions this year" job.audit_trail swap addto
 </action_postfix>
@@ -7100,7 +7100,7 @@ result.taxable_conversions result.total_other_income f+ /result.total_other_inco
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>add "FARM INCOME PROCESSING" to job.audit_trail</action_description>
+<action_dsl>add "FARM INCOME PROCESSING" to job.audit_trail</action_dsl>
 <action_postfix>
 "Processing Schedule F Farm Income (Publication 225)" job.audit_trail swap addto
 </action_postfix>
@@ -7110,7 +7110,7 @@ result.taxable_conversions result.total_other_income f+ /result.total_other_inco
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has farm to process</condition_comment>
-<condition_description>Farm entity exists in context</condition_description>
+<condition_dsl>Farm entity exists in context</condition_dsl>
 <condition_postfix>farm isnull not</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 </condition_details>
@@ -7118,7 +7118,7 @@ result.taxable_conversions result.total_other_income f+ /result.total_other_inco
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.farm_net_income = farm.gross_income - farm.expenses</action_description>
+<action_dsl>set result.farm_net_income = farm.gross_income - farm.expenses</action_dsl>
 <action_postfix>
 "  Farm: " farm.farm_name strconcat job.audit_trail swap addto
 farm.sales_livestock_raised farm.sales_crops f+ farm.coop_distributions f+ farm.agricultural_payments f+ farm.ccc_loans f+ farm.crop_insurance f+ farm.custom_hire f+ farm.other_farm_income f+ farm.sales_livestock_bought f- /farm.gross_income xdef
@@ -7149,7 +7149,7 @@ farm.net_profit result.net_farm_profit f+ /result.net_farm_profit xdef
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add farm SE tax summary to job.audit_trail</action_description>
+<action_dsl>add farm SE tax summary to job.audit_trail</action_dsl>
 <action_postfix>
 "Calculating Farm Self-Employment Tax (Schedule SE)" job.audit_trail swap addto
 </action_postfix>
@@ -7159,7 +7159,7 @@ farm.net_profit result.net_farm_profit f+ /result.net_farm_profit xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has farm profit subject to SE tax</condition_comment>
-<condition_description>result.net_farm_profit &gt; se_threshold</condition_description>
+<condition_dsl>result.net_farm_profit &gt; se_threshold</condition_dsl>
 <condition_postfix>result.net_farm_profit se_threshold ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -7168,7 +7168,7 @@ farm.net_profit result.net_farm_profit f+ /result.net_farm_profit xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set taxpayer.farm_se_tax = farm_net_income * se_tax_rate</action_description>
+<action_dsl>set taxpayer.farm_se_tax = farm_net_income * se_tax_rate</action_dsl>
 <action_postfix>
 result.net_farm_profit se_income_multiplier f* /farm_se_base xdef
 farm_se_base se_tax_rate f* /result.farm_se_tax xdef
@@ -7181,7 +7181,7 @@ result.farm_se_tax se_deduction_rate f* result.total_adjustments f+ /result.tota
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set taxpayer.farm_se_tax = 0</action_description>
+<action_dsl>set taxpayer.farm_se_tax = 0</action_dsl>
 <action_postfix>
 "  No farm profit or below SE threshold" job.audit_trail swap addto
 </action_postfix>
@@ -7209,7 +7209,7 @@ result.farm_se_tax se_deduction_rate f* result.total_adjustments f+ /result.tota
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>add "PROPERTY SALE PROCESSING" to job.audit_trail</action_description>
+<action_dsl>add "PROPERTY SALE PROCESSING" to job.audit_trail</action_dsl>
 <action_postfix>
 "Processing Form 4797 Business Property Sales" job.audit_trail swap addto
 </action_postfix>
@@ -7219,7 +7219,7 @@ result.farm_se_tax se_deduction_rate f* result.total_adjustments f+ /result.tota
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has property sale to process</condition_comment>
-<condition_description>Property sale exists in context</condition_description>
+<condition_dsl>Property sale exists in context</condition_dsl>
 <condition_postfix>sale isnull not</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="Y"></condition_column>
@@ -7228,7 +7228,7 @@ result.farm_se_tax se_deduction_rate f* result.total_adjustments f+ /result.tota
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Is Section 1245 property (personal property)</condition_comment>
-<condition_description>Property type is 1245</condition_description>
+<condition_dsl>Property type is 1245</condition_dsl>
 <condition_postfix>sale.property_type 1245 streq</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -7237,7 +7237,7 @@ result.farm_se_tax se_deduction_rate f* result.total_adjustments f+ /result.tota
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Is Section 1250 property (real property)</condition_comment>
-<condition_description>Property type is 1250 or is real property</condition_description>
+<condition_dsl>Property type is 1250 or is real property</condition_dsl>
 <condition_postfix>sale.property_type 1250 streq sale.is_real_property or</condition_postfix>
 <condition_column column_number="2" column_value="Y"></condition_column>
 <condition_column column_number="3" column_value="N"></condition_column>
@@ -7246,7 +7246,7 @@ result.farm_se_tax se_deduction_rate f* result.total_adjustments f+ /result.tota
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set sale.gain = sale.proceeds - sale.adjusted_basis</action_description>
+<action_dsl>set sale.gain = sale.proceeds - sale.adjusted_basis</action_dsl>
 <action_postfix>
 "  Property: " sale.description strconcat job.audit_trail swap addto
 sale.cost_basis sale.improvements f+ sale.depreciation_allowed f- /sale.adjusted_basis xdef
@@ -7262,7 +7262,7 @@ sale.amount_realized sale.adjusted_basis f- /sale.total_gain_loss xdef
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>add sale.depreciation to result.ordinary_income (Section 1245)</action_description>
+<action_dsl>add sale.depreciation to result.ordinary_income (Section 1245)</action_dsl>
 <action_postfix>
 sale.total_gain_loss 0 > { sale.depreciation_allowed sale.total_gain_loss fmin /sale.ordinary_income_recapture xdef } if
 sale.total_gain_loss sale.ordinary_income_recapture f- /sale.section_1231_gain xdef
@@ -7273,7 +7273,7 @@ sale.ordinary_income_recapture result.total_depreciation_recapture f+ /result.to
 </action_details>
 <action_details>
 <action_number>3</action_number>
-<action_description>add sale.depreciation to result.section_1250_gain (25% max rate)</action_description>
+<action_dsl>add sale.depreciation to result.section_1250_gain (25% max rate)</action_dsl>
 <action_postfix>
 sale.total_gain_loss 0 > { sale.depreciation_allowed sale.total_gain_loss fmin /sale.unrecaptured_1250_gain xdef } if
 sale.total_gain_loss sale.unrecaptured_1250_gain f- /sale.section_1231_gain xdef
@@ -7284,7 +7284,7 @@ sale.unrecaptured_1250_gain result.total_unrecaptured_1250 f+ /result.total_unre
 </action_details>
 <action_details>
 <action_number>4</action_number>
-<action_description>add sale.gain to result.section_1231_gain</action_description>
+<action_dsl>add sale.gain to result.section_1231_gain</action_dsl>
 <action_postfix>
 sale.total_gain_loss /sale.section_1231_gain xdef
 "    Section 1231 gain/loss: $" sale.section_1231_gain cvs strconcat job.audit_trail swap addto
@@ -7293,7 +7293,7 @@ sale.total_gain_loss /sale.section_1231_gain xdef
 </action_details>
 <action_details>
 <action_number>5</action_number>
-<action_description>add sale.section_1231_gain to result.total_section_1231</action_description>
+<action_dsl>add sale.section_1231_gain to result.total_section_1231</action_dsl>
 <action_postfix>
 sale.section_1231_gain 0 > { sale.section_1231_gain result.total_1231_gains f+ /result.total_1231_gains xdef } if
 sale.section_1231_gain 0 &lt; { sale.section_1231_gain fnegate result.total_1231_losses f+ /result.total_1231_losses xdef } if
@@ -7318,7 +7318,7 @@ sale.section_1231_gain 0 &lt; { sale.section_1231_gain fnegate result.total_1231
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>set result.net_section_1231 = total_gains - total_losses</action_description>
+<action_dsl>set result.net_section_1231 = total_gains - total_losses</action_dsl>
 <action_postfix>
 "Calculating Net Section 1231 Treatment (IRC 1231)" job.audit_trail swap addto
 result.total_1231_gains result.total_1231_losses f- /result.net_1231_gain_loss xdef
@@ -7329,7 +7329,7 @@ result.total_1231_gains result.total_1231_losses f- /result.net_1231_gain_loss x
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has net Section 1231 gain</condition_comment>
-<condition_description>result.net_1231_gain &gt; 0</condition_description>
+<condition_dsl>result.net_1231_gain &gt; 0</condition_dsl>
 <condition_postfix>result.net_1231_gain_loss 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -7338,7 +7338,7 @@ result.total_1231_gains result.total_1231_losses f- /result.net_1231_gain_loss x
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has net Section 1231 loss</condition_comment>
-<condition_description>Net 1231 loss (negative)</condition_description>
+<condition_dsl>Net 1231 loss (negative)</condition_dsl>
 <condition_postfix>result.net_1231_gain_loss 0 &lt;</condition_postfix>
 <condition_column column_number="2" column_value="Y"></condition_column>
 <condition_column column_number="3" column_value="N"></condition_column>
@@ -7347,7 +7347,7 @@ result.total_1231_gains result.total_1231_losses f- /result.net_1231_gain_loss x
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add result.net_section_1231 to result.total_long_term_gains</action_description>
+<action_dsl>add result.net_section_1231 to result.total_long_term_gains</action_dsl>
 <action_postfix>
 result.net_1231_gain_loss result.total_long_term_gains f+ /result.total_long_term_gains xdef
 "  Net Section 1231 gain: $" result.net_1231_gain_loss cvs strconcat job.audit_trail swap addto
@@ -7357,7 +7357,7 @@ result.net_1231_gain_loss result.total_long_term_gains f+ /result.total_long_ter
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>add result.net_section_1231 to result.ordinary_loss</action_description>
+<action_dsl>add result.net_section_1231 to result.ordinary_loss</action_dsl>
 <action_postfix>
 result.net_1231_gain_loss result.total_other_income f+ /result.total_other_income xdef
 "  Net Section 1231 loss: $" result.net_1231_gain_loss cvs strconcat job.audit_trail swap addto
@@ -7367,7 +7367,7 @@ result.net_1231_gain_loss result.total_other_income f+ /result.total_other_incom
 </action_details>
 <action_details>
 <action_number>3</action_number>
-<action_description>set result.net_section_1231 = 0</action_description>
+<action_dsl>set result.net_section_1231 = 0</action_dsl>
 <action_postfix>
 "  No Section 1231 gains or losses" job.audit_trail swap addto
 </action_postfix>
@@ -7395,7 +7395,7 @@ result.net_1231_gain_loss result.total_other_income f+ /result.total_other_incom
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>add "FOREIGN INCOME PROCESSING" to job.audit_trail</action_description>
+<action_dsl>add "FOREIGN INCOME PROCESSING" to job.audit_trail</action_dsl>
 <action_postfix>
 "Processing Form 1116 Foreign Income (IRC 901)" job.audit_trail swap addto
 </action_postfix>
@@ -7405,7 +7405,7 @@ result.net_1231_gain_loss result.total_other_income f+ /result.total_other_incom
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has foreign income to process</condition_comment>
-<condition_description>Foreign income entity exists in context</condition_description>
+<condition_dsl>Foreign income entity exists in context</condition_dsl>
 <condition_postfix>foreign isnull not</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 </condition_details>
@@ -7413,7 +7413,7 @@ result.net_1231_gain_loss result.total_other_income f+ /result.total_other_incom
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add foreign_income.amount to result.total_foreign_income</action_description>
+<action_dsl>add foreign_income.amount to result.total_foreign_income</action_dsl>
 <action_postfix>
 "  Country: " foreign.country strconcat " (" strconcat foreign.income_category strconcat ")" strconcat job.audit_trail swap addto
 foreign.gross_income foreign.directly_allocable_deductions f- /foreign.foreign_source_taxable xdef
@@ -7441,7 +7441,7 @@ foreign.foreign_taxes_paid foreign.foreign_taxes_withheld f+ result.total_foreig
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>add FTC calculation summary to job.audit_trail</action_description>
+<action_dsl>add FTC calculation summary to job.audit_trail</action_dsl>
 <action_postfix>
 "Calculating Foreign Tax Credit (Form 1116, IRC 904)" job.audit_trail swap addto
 </action_postfix>
@@ -7451,7 +7451,7 @@ foreign.foreign_taxes_paid foreign.foreign_taxes_withheld f+ result.total_foreig
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has foreign taxes paid</condition_comment>
-<condition_description>result.total_foreign_taxes_paid &gt; 0</condition_description>
+<condition_dsl>result.total_foreign_taxes_paid &gt; 0</condition_dsl>
 <condition_postfix>result.total_foreign_taxes_paid 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -7459,7 +7459,7 @@ foreign.foreign_taxes_paid foreign.foreign_taxes_withheld f+ result.total_foreig
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has taxable income</condition_comment>
-<condition_description>result.taxable_income &gt; 0</condition_description>
+<condition_dsl>result.taxable_income &gt; 0</condition_dsl>
 <condition_postfix>result.taxable_income 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 </condition_details>
@@ -7467,7 +7467,7 @@ foreign.foreign_taxes_paid foreign.foreign_taxes_withheld f+ result.total_foreig
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.foreign_tax_credit = the minimum of taxes_paid and ftc_limitation</action_description>
+<action_dsl>set result.foreign_tax_credit = the minimum of taxes_paid and ftc_limitation</action_dsl>
 <action_postfix>
 result.total_foreign_income result.taxable_income f/ result.regular_tax f* /result.foreign_tax_credit_limit xdef
 result.total_foreign_taxes_paid result.foreign_tax_credit_limit fmin /result.foreign_tax_credit xdef
@@ -7480,7 +7480,7 @@ result.total_foreign_taxes_paid result.foreign_tax_credit_limit fmin /result.for
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.foreign_tax_credit = 0</action_description>
+<action_dsl>set result.foreign_tax_credit = 0</action_dsl>
 <action_postfix>
 "  No foreign taxes paid - FTC not applicable" job.audit_trail swap addto
 </action_postfix>
@@ -7513,7 +7513,7 @@ result.total_foreign_taxes_paid result.foreign_tax_credit_limit fmin /result.for
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each property for MCC</context_comment>
-<context_description>for all properties</context_description>
+<context_dsl>for all properties</context_dsl>
 <context_postfix>
 { /Calculate_Mortgage_Interest_Credit executetable } job.properties forall
 </context_postfix>
@@ -7521,7 +7521,7 @@ result.total_foreign_taxes_paid result.foreign_tax_credit_limit fmin /result.for
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize mortgage interest credit</action_description>
+<action_dsl>Initialize mortgage interest credit</action_dsl>
 <action_postfix>
 0.0 /result.mortgage_interest_credit xdef
 0.0 /result.carryforward_mortgage_credit xdef
@@ -7533,21 +7533,21 @@ result.total_foreign_taxes_paid result.foreign_tax_credit_limit fmin /result.for
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Property has MCC</condition_comment>
-<condition_description>property.has_mortgage_credit_certificate equals true</condition_description>
+<condition_dsl>property.has_mortgage_credit_certificate equals true</condition_dsl>
 <condition_postfix>property.has_mortgage_credit_certificate</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 </condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>MCC rate is valid</condition_comment>
-<condition_description>property.mcc_rate &gt; 0 and &lt;= 0.50</condition_description>
+<condition_dsl>property.mcc_rate &gt; 0 and &lt;= 0.50</condition_dsl>
 <condition_postfix>property.mcc_rate 0 &gt; property.mcc_rate 0.50 &lt;= and</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 </condition_details>
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Has mortgage interest paid</condition_comment>
-<condition_description>Mortgage interest paid &gt; 0 (use mortgage_interest_paid if set, else mortgage_interest)</condition_description>
+<condition_dsl>Mortgage interest paid &gt; 0 (use mortgage_interest_paid if set, else mortgage_interest)</condition_dsl>
 <condition_postfix>
 property.mortgage_interest_paid 0 &gt; property.mortgage_interest_paid property.mortgage_interest if 0 &gt;
 </condition_postfix>
@@ -7557,7 +7557,7 @@ property.mortgage_interest_paid 0 &gt; property.mortgage_interest_paid property.
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>Calculate mortgage interest credit and reduce itemized deduction</action_description>
+<action_dsl>Calculate mortgage interest credit and reduce itemized deduction</action_dsl>
 <action_postfix>
 property.mcc_rate property.mortgage_interest_paid f* /result.mortgage_interest_credit xdef
 result.mortgage_interest_credit result.mcc_credit_limit f> if
@@ -7591,7 +7591,7 @@ result.mortgage_interest_credit /result.mortgage_interest_deduction_reduction xd
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each installment sale</context_comment>
-<context_description>for all installment sales</context_description>
+<context_dsl>for all installment sales</context_dsl>
 <context_postfix>
 0.0 /result.total_installment_gain xdef
 0.0 /result.total_installment_interest xdef
@@ -7605,7 +7605,7 @@ result.mortgage_interest_credit /result.mortgage_interest_deduction_reduction xd
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has payments this year</condition_comment>
-<condition_description>result.payments_received &gt; 0</condition_description>
+<condition_dsl>result.payments_received &gt; 0</condition_dsl>
 <condition_postfix>installment_sale.payments_received 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 </condition_details>
@@ -7613,7 +7613,7 @@ result.mortgage_interest_credit /result.mortgage_interest_deduction_reduction xd
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.installment_gain = payments_received * gross_profit_ratio</action_description>
+<action_dsl>set result.installment_gain = payments_received * gross_profit_ratio</action_dsl>
 <action_postfix>
 installment_sale.selling_price installment_sale.adjusted_basis f- installment_sale.selling_expenses f- /installment_sale.gross_profit xdef
 installment_sale.selling_price installment_sale.selling_expenses f- /installment_sale.contract_price xdef
@@ -7644,7 +7644,7 @@ installment_sale.interest_received result.total_installment_interest f+ /result.
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each like-kind exchange</context_comment>
-<context_description>for all like-kind exchanges</context_description>
+<context_dsl>for all like-kind exchanges</context_dsl>
 <context_postfix>
 0.0 /result.total_like_kind_recognized xdef
 0.0 /result.total_like_kind_deferred xdef
@@ -7658,7 +7658,7 @@ installment_sale.interest_received result.total_installment_interest f+ /result.
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has exchange to process</condition_comment>
-<condition_description>Exchange entity exists</condition_description>
+<condition_dsl>Exchange entity exists</condition_dsl>
 <condition_postfix>like_kind_exchange isnull not</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 </condition_details>
@@ -7666,7 +7666,7 @@ installment_sale.interest_received result.total_installment_interest f+ /result.
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.recognized_gain = total_gain * recognition_ratio</action_description>
+<action_dsl>set result.recognized_gain = total_gain * recognition_ratio</action_dsl>
 <action_postfix>
 like_kind_exchange.cash_received like_kind_exchange.other_property_fmv f+ like_kind_exchange.mortgage_relieved f+ like_kind_exchange.mortgage_assumed f- like_kind_exchange.cash_paid f- /like_kind_exchange.boot_received xdef
 like_kind_exchange.boot_received 0 fmax /like_kind_exchange.boot_received xdef
@@ -7700,7 +7700,7 @@ like_kind_exchange.deferred_gain result.total_like_kind_deferred f+ /result.tota
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each early distribution</context_comment>
-<context_description>for all early distributions</context_description>
+<context_dsl>for all early distributions</context_dsl>
 <context_postfix>
 0.0 /result.total_early_withdrawal_penalty xdef
 "Processing Form 5329 Early Distributions (IRC 72(t))" job.audit_trail swap addto
@@ -7713,7 +7713,7 @@ like_kind_exchange.deferred_gain result.total_like_kind_deferred f+ /result.tota
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Subject to penalty</condition_comment>
-<condition_description>Early distribution with no exception</condition_description>
+<condition_dsl>Early distribution with no exception</condition_dsl>
 <condition_postfix>
 early_distribution.age_at_distribution early_withdrawal_age_limit &lt;
 early_distribution.exception_code "" streq
@@ -7726,7 +7726,7 @@ and
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.early_withdrawal_penalty = distribution.amount * 0.10</action_description>
+<action_dsl>set result.early_withdrawal_penalty = distribution.amount * 0.10</action_dsl>
 <action_postfix>
 true /early_distribution.subject_to_penalty xdef
 early_distribution.taxable_amount early_withdrawal_penalty_rate f* /early_distribution.penalty_amount xdef
@@ -7738,7 +7738,7 @@ early_distribution.penalty_amount result.total_early_withdrawal_penalty f+ /resu
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.early_withdrawal_penalty = 0</action_description>
+<action_dsl>set result.early_withdrawal_penalty = 0</action_dsl>
 <action_postfix>
 false /early_distribution.subject_to_penalty xdef
 0 /early_distribution.penalty_amount xdef
@@ -7763,7 +7763,7 @@ false /early_distribution.subject_to_penalty xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each child unearned income record</context_comment>
-<context_description>for all child unearned income records</context_description>
+<context_dsl>for all child unearned income records</context_dsl>
 <context_postfix>
 0.0 /result.total_kiddie_tax xdef
 "Processing Form 8615 Kiddie Tax (IRC 1(g))" job.audit_trail swap addto
@@ -7776,7 +7776,7 @@ false /early_distribution.subject_to_penalty xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Subject to kiddie tax</condition_comment>
-<condition_description>Child under age limit with unearned income over threshold</condition_description>
+<condition_dsl>Child under age limit with unearned income over threshold</condition_dsl>
 <condition_postfix>
 child_unearned_income.child_age kiddie_tax_age_limit &lt;
 child_unearned_income.is_student child_unearned_income.child_age kiddie_tax_student_age &lt; and or
@@ -7790,7 +7790,7 @@ and
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.kiddie_tax = unearned_income * parent_marginal_rate</action_description>
+<action_dsl>set result.kiddie_tax = unearned_income * parent_marginal_rate</action_dsl>
 <action_postfix>
 true /child_unearned_income.subject_to_kiddie_tax xdef
 child_unearned_income.unearned_income_amount kiddie_tax_threshold f- /child_unearned_income.net_unearned_income xdef
@@ -7804,7 +7804,7 @@ child_unearned_income.kiddie_tax result.total_kiddie_tax f+ /result.total_kiddie
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.kiddie_tax = 0</action_description>
+<action_dsl>set result.kiddie_tax = 0</action_dsl>
 <action_postfix>
 false /child_unearned_income.subject_to_kiddie_tax xdef
 0.0 /child_unearned_income.kiddie_tax xdef
@@ -7829,7 +7829,7 @@ false /child_unearned_income.subject_to_kiddie_tax xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process elderly/disabled records</context_comment>
-<context_description>for all elderly/disabled records</context_description>
+<context_dsl>for all elderly/disabled records</context_dsl>
 <context_postfix>
 0.0 /result.elderly_disabled_credit xdef
 "Processing Schedule R Credit for Elderly/Disabled (IRC 22)" job.audit_trail swap addto
@@ -7842,7 +7842,7 @@ false /child_unearned_income.subject_to_kiddie_tax xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Qualifies for credit</condition_comment>
-<condition_description>Age 65+ or permanently disabled</condition_description>
+<condition_dsl>Age 65+ or permanently disabled</condition_dsl>
 <condition_postfix>elderly_disabled.age_65_or_older elderly_disabled.permanently_disabled or</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -7851,7 +7851,7 @@ false /child_unearned_income.subject_to_kiddie_tax xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.elderly_disabled_credit = credit_calculation</action_description>
+<action_dsl>set result.elderly_disabled_credit = credit_calculation</action_dsl>
 <action_postfix>
 true /elderly_disabled.qualifies xdef
 elderly_credit_single /elderly_disabled.initial_amount xdef
@@ -7868,7 +7868,7 @@ elderly_disabled.credit_amount result.elderly_disabled_credit f+ /result.elderly
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.elderly_disabled_credit = 0</action_description>
+<action_dsl>set result.elderly_disabled_credit = 0</action_dsl>
 <action_postfix>
 false /elderly_disabled.qualifies xdef
 "  Does not qualify for Schedule R credit" job.audit_trail swap addto
@@ -7892,7 +7892,7 @@ false /elderly_disabled.qualifies xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process estimated payments</context_comment>
-<context_description>for all estimated payments</context_description>
+<context_dsl>for all estimated payments</context_dsl>
 <context_postfix>
 0.0 /result.total_estimated_payments xdef
 0.0 /result.estimated_tax_penalty xdef
@@ -7907,7 +7907,7 @@ false /result.safe_harbor_met xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has estimated payment</condition_comment>
-<condition_description>result.payment_amount &gt; 0</condition_description>
+<condition_dsl>result.payment_amount &gt; 0</condition_dsl>
 <condition_postfix>estimated_payment.payment_amount 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 </condition_details>
@@ -7915,7 +7915,7 @@ false /result.safe_harbor_met xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>add estimated_payment.amount to result.total_estimated_payments</action_description>
+<action_dsl>add estimated_payment.amount to result.total_estimated_payments</action_dsl>
 <action_postfix>
 estimated_payment.payment_amount result.total_estimated_payments f+ /result.total_estimated_payments xdef
 result.total_tax 4 f/ /estimated_payment.required_payment xdef
@@ -7941,7 +7941,7 @@ estimated_payment.required_payment estimated_payment.payment_amount f- 0 fmax /e
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process casualty losses</context_comment>
-<context_description>for all casualty losses</context_description>
+<context_dsl>for all casualty losses</context_dsl>
 <context_postfix>
 0.0 /result.total_casualty_loss xdef
 false /result.is_disaster_loss xdef
@@ -7955,7 +7955,7 @@ false /result.is_disaster_loss xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is disaster loss (deductible)</condition_comment>
-<condition_description>Federally declared disaster</condition_description>
+<condition_dsl>Federally declared disaster</condition_dsl>
 <condition_postfix>casualty_loss.disaster_designation "" streq not</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -7964,7 +7964,7 @@ false /result.is_disaster_loss xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.disaster_loss_deduction = (loss - $500 floor) - (10% of AGI)</action_description>
+<action_dsl>set result.disaster_loss_deduction = (loss - $500 floor) - (10% of AGI)</action_dsl>
 <action_postfix>
 true /result.is_disaster_loss xdef
 casualty_loss.fmv_before casualty_loss.fmv_after f- /casualty_loss.decrease_in_fmv xdef
@@ -7979,7 +7979,7 @@ casualty_loss.deductible_loss result.total_casualty_loss f+ /result.total_casual
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.casualty_deduction = 0</action_description>
+<action_dsl>set result.casualty_deduction = 0</action_dsl>
 <action_postfix>
 0 /casualty_loss.deductible_loss xdef
 "  Personal casualty loss not from federally declared disaster - not deductible (TCJA)" job.audit_trail swap addto
@@ -8003,7 +8003,7 @@ casualty_loss.deductible_loss result.total_casualty_loss f+ /result.total_casual
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process clean vehicles</context_comment>
-<context_description>for all clean vehicles</context_description>
+<context_dsl>for all clean vehicles</context_dsl>
 <context_postfix>
 0.0 /result.total_clean_vehicle_credit xdef
 "Processing Form 8936 Clean Vehicle Credit (IRC 30D)" job.audit_trail swap addto
@@ -8016,7 +8016,7 @@ casualty_loss.deductible_loss result.total_casualty_loss f+ /result.total_casual
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>New vehicle meeting requirements</condition_comment>
-<condition_description>Final assembly in NA and meets MSRP limit</condition_description>
+<condition_dsl>Final assembly in NA and meets MSRP limit</condition_dsl>
 <condition_postfix>
 clean_vehicle.vehicle_type "new" streq
 clean_vehicle.final_assembly_us
@@ -8030,7 +8030,7 @@ and and
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.clean_vehicle_credit = credit_amount (up to $7,500)</action_description>
+<action_dsl>set result.clean_vehicle_credit = credit_amount (up to $7,500)</action_dsl>
 <action_postfix>
 true /clean_vehicle.qualifies xdef
 clean_vehicle.critical_minerals_pct 0.4 >= { 3750 } { 0 } ifelse /clean_vehicle.critical_minerals_credit xdef
@@ -8044,7 +8044,7 @@ clean_vehicle.total_credit result.total_clean_vehicle_credit f+ /result.total_cl
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.clean_vehicle_credit = 0</action_description>
+<action_dsl>set result.clean_vehicle_credit = 0</action_dsl>
 <action_postfix>
 false /clean_vehicle.qualifies xdef
 0 /clean_vehicle.total_credit xdef
@@ -8069,7 +8069,7 @@ false /clean_vehicle.qualifies xdef
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process adoptions</context_comment>
-<context_description>for all adoptions</context_description>
+<context_dsl>for all adoptions</context_dsl>
 <context_postfix>
 0.0 /result.total_adoption_credit xdef
 0.0 /result.adoption_credit_carryforward xdef
@@ -8083,7 +8083,7 @@ false /clean_vehicle.qualifies xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has qualified expenses</condition_comment>
-<condition_description>result.qualified_adoption_expenses &gt; 0</condition_description>
+<condition_dsl>result.qualified_adoption_expenses &gt; 0</condition_dsl>
 <condition_postfix>adoption.qualified_expenses 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 </condition_details>
@@ -8091,7 +8091,7 @@ false /clean_vehicle.qualifies xdef
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.adoption_credit = qualified_expenses (up to limit)</action_description>
+<action_dsl>set result.adoption_credit = qualified_expenses (up to limit)</action_dsl>
 <action_postfix>
 adoption_credit_max /adoption.max_credit xdef
 adoption.qualified_expenses adoption.employer_assistance f- adoption.prior_year_expenses f- adoption.max_credit fmin /adoption.credit_before_limit xdef
@@ -8120,7 +8120,7 @@ adoption.credit_allowed result.total_adoption_credit f+ /result.total_adoption_c
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process household employees</context_comment>
-<context_description>for all household employees</context_description>
+<context_dsl>for all household employees</context_dsl>
 <context_postfix>
 0.0 /result.total_household_tax xdef
 "Processing Schedule H Household Employment Taxes" job.audit_trail swap addto
@@ -8133,7 +8133,7 @@ adoption.credit_allowed result.total_adoption_credit f+ /result.total_adoption_c
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Wages meet threshold</condition_comment>
-<condition_description>Cash wages at or above threshold</condition_description>
+<condition_dsl>Cash wages at or above threshold</condition_dsl>
 <condition_postfix>household_employee.cash_wages household_ss_threshold >=</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -8142,7 +8142,7 @@ adoption.credit_allowed result.total_adoption_credit f+ /result.total_adoption_c
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.household_employment_tax = wages * combined_rate</action_description>
+<action_dsl>set result.household_employment_tax = wages * combined_rate</action_dsl>
 <action_postfix>
 household_employee.ss_wages 0.062 f* /household_employee.ss_tax_employer xdef
 household_employee.medicare_wages 0.0145 f* /household_employee.medicare_tax_employer xdef
@@ -8156,7 +8156,7 @@ household_employee.total_household_tax result.total_household_tax f+ /result.tot
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.household_employment_tax = 0</action_description>
+<action_dsl>set result.household_employment_tax = 0</action_dsl>
 <action_postfix>
 0 /household_employee.total_household_tax xdef
 "  Household employee wages below threshold - no tax due" job.audit_trail swap addto
@@ -8180,7 +8180,7 @@ household_employee.total_household_tax result.total_household_tax f+ /result.tot
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process NOL carryovers</context_comment>
-<context_description>for all NOL carryovers</context_description>
+<context_dsl>for all NOL carryovers</context_dsl>
 <context_postfix>
 0.0 /result.nol_deduction xdef
 0.0 /result.nol_carryforward_remaining xdef
@@ -8194,7 +8194,7 @@ household_employee.total_household_tax result.total_household_tax f+ /result.tot
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has NOL available</condition_comment>
-<condition_description>result.nol_amount_available &gt; 0</condition_description>
+<condition_dsl>result.nol_amount_available &gt; 0</condition_dsl>
 <condition_postfix>nol_carryover.amount_available 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 </condition_details>
@@ -8202,7 +8202,7 @@ household_employee.total_household_tax result.total_household_tax f+ /result.tot
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.nol_deduction = carryforward_amount (80% of taxable income limit)</action_description>
+<action_dsl>set result.nol_deduction = carryforward_amount (80% of taxable income limit)</action_dsl>
 <action_postfix>
 result.taxable_income result.nol_deduction f+ nol_limitation_rate f* /nol_carryover.deduction_limit xdef
 nol_carryover.amount_available nol_carryover.deduction_limit fmin /nol_carryover.amount_used xdef
@@ -8230,7 +8230,7 @@ nol_carryover.remaining_carryover result.nol_carryforward_remaining f+ /result.n
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process mortgage credit certificates</context_comment>
-<context_description>for all mortgage credit certificates</context_description>
+<context_dsl>for all mortgage credit certificates</context_dsl>
 <context_postfix>
 0.0 /result.mortgage_interest_credit xdef
 0.0 /result.mortgage_credit_carryforward xdef
@@ -8244,7 +8244,7 @@ nol_carryover.remaining_carryover result.nol_carryforward_remaining f+ /result.n
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Credit rate exceeds 20%</condition_comment>
-<condition_description>result.mcc_credit_rate &gt; 0.20</condition_description>
+<condition_dsl>result.mcc_credit_rate &gt; 0.20</condition_dsl>
 <condition_postfix>mortgage_credit_certificate.credit_rate 0.20 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -8253,7 +8253,7 @@ nol_carryover.remaining_carryover result.nol_carryforward_remaining f+ /result.n
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.credit_amount = the minimum of credit and 2000</action_description>
+<action_dsl>set result.credit_amount = the minimum of credit and 2000</action_dsl>
 <action_postfix>
 mortgage_credit_certificate.mortgage_interest_paid mortgage_credit_certificate.credit_rate f* /mortgage_credit_certificate.tentative_credit xdef
 2000.0 /mortgage_credit_certificate.credit_limit xdef
@@ -8268,7 +8268,7 @@ mortgage_credit_certificate.carryforward_to_next result.mortgage_credit_carryfor
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.credit_amount = full_credit_amount</action_description>
+<action_dsl>set result.credit_amount = full_credit_amount</action_dsl>
 <action_postfix>
 mortgage_credit_certificate.mortgage_interest_paid mortgage_credit_certificate.credit_rate f* /mortgage_credit_certificate.tentative_credit xdef
 mortgage_credit_certificate.tentative_credit mortgage_credit_certificate.prior_year_carryforward f+ /mortgage_credit_certificate.current_year_credit xdef
@@ -8296,7 +8296,7 @@ mortgage_credit_certificate.current_year_credit result.mortgage_interest_credit 
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process prior year AMT credits</context_comment>
-<context_description>for all prior year AMT credits</context_description>
+<context_dsl>for all prior year AMT credits</context_dsl>
 <context_postfix>
 0.0 /result.prior_year_amt_credit xdef
 0.0 /result.amt_credit_carryforward xdef
@@ -8310,7 +8310,7 @@ mortgage_credit_certificate.current_year_credit result.mortgage_interest_credit 
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Credit available</condition_comment>
-<condition_description>Prior year AMT credit is available</condition_description>
+<condition_dsl>Prior year AMT credit is available</condition_dsl>
 <condition_postfix>prior_year_amt.credit_available 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -8319,7 +8319,7 @@ mortgage_credit_certificate.current_year_credit result.mortgage_interest_credit 
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.amt_credit_used = the minimum of available_credit and (regular_tax - tentative_minimum_tax)</action_description>
+<action_dsl>set result.amt_credit_used = the minimum of available_credit and (regular_tax - tentative_minimum_tax)</action_dsl>
 <action_postfix>
 result.regular_tax result.amt_owed f- /prior_year_amt.net_regular_tax xdef
 result.tentative_minimum_tax /prior_year_amt.tentative_minimum_tax xdef
@@ -8334,7 +8334,7 @@ prior_year_amt.carryforward_remaining result.amt_credit_carryforward f+ /result.
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.amt_credit_used = 0</action_description>
+<action_dsl>set result.amt_credit_used = 0</action_dsl>
 <action_postfix>
 "  No prior year AMT credit available" job.audit_trail swap addto
 </action_postfix>
@@ -8357,7 +8357,7 @@ prior_year_amt.carryforward_remaining result.amt_credit_carryforward f+ /result.
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process partnership audit adjustments</context_comment>
-<context_description>for all partnership audit adjustments</context_description>
+<context_dsl>for all partnership audit adjustments</context_dsl>
 <context_postfix>
 0.0 /result.partnership_audit_tax xdef
 "Calculating Partnership Audit Additional Tax (Form 8978, IRC 6226)" job.audit_trail swap addto
@@ -8370,7 +8370,7 @@ prior_year_amt.carryforward_remaining result.amt_credit_carryforward f+ /result.
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has income adjustments</condition_comment>
-<condition_description>Partnership audit has income adjustments</condition_description>
+<condition_dsl>Partnership audit has income adjustments</condition_dsl>
 <condition_postfix>
 partnership_audit.ordinary_income_adjustment partnership_audit.capital_gain_adjustment f+
 partnership_audit.dividend_adjustment f+ partnership_audit.interest_adjustment f+
@@ -8382,7 +8382,7 @@ partnership_audit.rental_adjustment f+ partnership_audit.other_adjustment f+ 0 !
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>Calculate additional tax from partnership audit adjustments</action_description>
+<action_dsl>Calculate additional tax from partnership audit adjustments</action_dsl>
 <action_postfix>
 partnership_audit.ordinary_income_adjustment partnership_audit.capital_gain_adjustment f+
 partnership_audit.dividend_adjustment f+ partnership_audit.interest_adjustment f+
@@ -8414,7 +8414,7 @@ partnership_audit.total_amount_due result.partnership_audit_tax f+ /result.partn
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process each taxpayer for energy appliance credit</context_comment>
-<context_description>for all taxpayers</context_description>
+<context_dsl>for all taxpayers</context_dsl>
 <context_postfix>
 { /Calculate_Energy_Appliance_Credit executetable } job.taxpayers forall
 </context_postfix>
@@ -8422,11 +8422,11 @@ partnership_audit.total_amount_due result.partnership_audit_tax f+ /result.partn
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize energy appliance credit</action_description>
+<action_dsl>Initialize energy appliance credit</action_dsl>
 <action_postfix>
 0.0 /result.energy_appliance_credit xdef
 <context_comment>Process unreported tips</context_comment>
-<context_description>for all unreported tips records</context_description>
+<context_dsl>for all unreported tips records</context_dsl>
 <context_postfix>
 0.0 /result.unreported_tips_tax xdef
 "Calculating Unreported Tips Tax (Form 4137, IRC 3121(q))" job.audit_trail swap addto
@@ -8439,7 +8439,7 @@ partnership_audit.total_amount_due result.partnership_audit_tax f+ /result.partn
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has unreported tips</condition_comment>
-<condition_description>Taxpayer has unreported tip income</condition_description>
+<condition_dsl>Taxpayer has unreported tip income</condition_dsl>
 <condition_postfix>unreported_tips.unreported_tips_amount 0 ></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -8448,7 +8448,7 @@ partnership_audit.total_amount_due result.partnership_audit_tax f+ /result.partn
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.unreported_tips_tax = unreported_tips * fica_rate</action_description>
+<action_dsl>set result.unreported_tips_tax = unreported_tips * fica_rate</action_dsl>
 <action_postfix>
 unreported_tips.w2_wages unreported_tips.w2_ss_tips f+ unreported_tips.unreported_tips_amount f+ /unreported_tips.ss_wages_and_tips xdef
 unreported_tips.ss_wages_and_tips ss_wage_base fmin unreported_tips.w2_wages unreported_tips.w2_ss_tips f+ f- 0 fmax /unreported_tips.ss_tax_on_tips xdef
@@ -8463,7 +8463,7 @@ unreported_tips.total_fica_on_tips result.unreported_tips_tax f+ /result.unrepor
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.unreported_tips_tax = 0</action_description>
+<action_dsl>set result.unreported_tips_tax = 0</action_dsl>
 <action_postfix>
 0 /unreported_tips.total_fica_on_tips xdef
 </action_postfix>
@@ -8486,7 +8486,7 @@ unreported_tips.total_fica_on_tips result.unreported_tips_tax f+ /result.unrepor
 <context_details>
 <context_number>1</context_number>
 <context_comment>Process LIHTC recaptures</context_comment>
-<context_description>for all LIHTC recapture events</context_description>
+<context_dsl>for all LIHTC recapture events</context_dsl>
 <context_postfix>
 0.0 /result.lihtc_recapture_tax xdef
 "Calculating LIHTC Recapture (Form 8611, IRC 42(j))" job.audit_trail swap addto
@@ -8499,7 +8499,7 @@ unreported_tips.total_fica_on_tips result.unreported_tips_tax f+ /result.unrepor
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has recapture event</condition_comment>
-<condition_description>LIHTC property has recapture event</condition_description>
+<condition_dsl>LIHTC property has recapture event</condition_dsl>
 <condition_postfix>lihtc_recapture.accelerated_portion 0 > lihtc_recapture.percentage_decrease 0 > or</condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
@@ -8508,7 +8508,7 @@ unreported_tips.total_fica_on_tips result.unreported_tips_tax f+ /result.unrepor
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_description>set result.recapture_tax = recapture_amount + interest</action_description>
+<action_dsl>set result.recapture_tax = recapture_amount + interest</action_dsl>
 <action_postfix>
 lihtc_recapture.accelerated_portion lihtc_recapture.percentage_decrease f* /lihtc_recapture.recapture_amount xdef
 lihtc_recapture.recapture_amount 0.0 f= if
@@ -8524,7 +8524,7 @@ lihtc_recapture.total_recapture_tax result.lihtc_recapture_tax f+ /result.lihtc_
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_description>set result.recapture_tax = 0</action_description>
+<action_dsl>set result.recapture_tax = 0</action_dsl>
 <action_postfix>
 0 /lihtc_recapture.total_recapture_tax xdef
 "  No LIHTC recapture required" job.audit_trail swap addto
@@ -8549,7 +8549,7 @@ lihtc_recapture.total_recapture_tax result.lihtc_recapture_tax f+ /result.lihtc_
 </contexts>
 <initial_actions>
 <initial_action>
-<action_description>Log multi-state allocation start</action_description>
+<action_dsl>Log multi-state allocation start</action_dsl>
 <action_postfix>
 "Multi-State Income Allocation" job.audit_trail swap addto
 </action_postfix>
@@ -8559,10 +8559,10 @@ lihtc_recapture.total_recapture_tax result.lihtc_recapture_tax f+ /result.lihtc_
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Produced energy efficient appliances</condition_comment>
-<condition_description>taxpayer.energy_efficient_appliances_produced &gt; 0</condition_description>
+<condition_dsl>taxpayer.energy_efficient_appliances_produced &gt; 0</condition_dsl>
 <condition_postfix>taxpayer.energy_efficient_appliances_produced 0 &gt;</condition_postfix>
 <condition_comment>State period exists</condition_comment>
-<condition_description>state_period is not null</condition_description>
+<condition_dsl>state_period is not null</condition_dsl>
 <condition_postfix>
 state_period isnull not
 </condition_postfix>
@@ -8573,7 +8573,7 @@ state_period isnull not
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate days in state</action_comment>
-<action_description>Calculate days between start_date and end_date</action_description>
+<action_dsl>Calculate days between start_date and end_date</action_dsl>
 <action_postfix>
 state_period.end_date state_period.start_date daysbetween state_period.days_in_state !
 </action_postfix>
@@ -8582,7 +8582,7 @@ state_period.end_date state_period.start_date daysbetween state_period.days_in_s
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate allocation percentage</action_comment>
-<action_description>Calculate allocation percentage based on days in state</action_description>
+<action_dsl>Calculate allocation percentage based on days in state</action_dsl>
 <action_postfix>
 state_period.days_in_state cvt:d 365.0 div state_period.allocation_percentage !
 </action_postfix>
@@ -8591,7 +8591,7 @@ state_period.days_in_state cvt:d 365.0 div state_period.allocation_percentage !
 <action_details>
 <action_number>3</action_number>
 <action_comment>Allocate income for this state</action_comment>
-<action_description>Allocate income to this state based on state_code match or allocation percentage</action_description>
+<action_dsl>Allocate income to this state based on state_code match or allocation percentage</action_dsl>
 <action_postfix>
 0 state_period.allocated_income !
 0 state_period.allocated_withholding !
@@ -8609,7 +8609,7 @@ done
 <action_details>
 <action_number>4</action_number>
 <action_comment>Log allocation results</action_comment>
-<action_description>Log the allocation results for audit trail</action_description>
+<action_dsl>Log the allocation results for audit trail</action_dsl>
 <action_postfix>
 "  Allocated " state_period.allocated_income formatnumber strconcat " to " strconcat state_period.state_code strconcat
 " (" strconcat state_period.days_in_state cvt:s strconcat " days)" strconcat job.audit_trail swap addto
@@ -8640,7 +8640,7 @@ done
 
 <initial_actions>
 <initial_action>
-<action_description>Log state tax dispatcher invocation</action_description>
+<action_dsl>Log state tax dispatcher invocation</action_dsl>
 <action_postfix>
 "State Tax Dispatcher: Processing state " job.state cvs strconcat job.audit_trail swap addto
 </action_postfix>
@@ -8653,7 +8653,7 @@ done
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Alabama</condition_comment>
-<condition_description>job.state == "AL"</condition_description>
+<condition_dsl>job.state == "AL"</condition_dsl>
 <condition_postfix>
 job.state "AL" streq
 </condition_postfix>
@@ -8664,7 +8664,7 @@ job.state "AL" streq
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Alaska</condition_comment>
-<condition_description>job.state == "AK"</condition_description>
+<condition_dsl>job.state == "AK"</condition_dsl>
 <condition_postfix>
 job.state "AK" streq
 </condition_postfix>
@@ -8675,7 +8675,7 @@ job.state "AK" streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Arkansas</condition_comment>
-<condition_description>job.state == "AR"</condition_description>
+<condition_dsl>job.state == "AR"</condition_dsl>
 <condition_postfix>
 job.state "AR" streq
 </condition_postfix>
@@ -8686,7 +8686,7 @@ job.state "AR" streq
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Arizona</condition_comment>
-<condition_description>job.state == "AZ"</condition_description>
+<condition_dsl>job.state == "AZ"</condition_dsl>
 <condition_postfix>
 job.state "AZ" streq
 </condition_postfix>
@@ -8697,7 +8697,7 @@ job.state "AZ" streq
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>California</condition_comment>
-<condition_description>job.state == "CA"</condition_description>
+<condition_dsl>job.state == "CA"</condition_dsl>
 <condition_postfix>
 job.state "CA" streq
 </condition_postfix>
@@ -8708,7 +8708,7 @@ job.state "CA" streq
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>Colorado</condition_comment>
-<condition_description>job.state == "CO"</condition_description>
+<condition_dsl>job.state == "CO"</condition_dsl>
 <condition_postfix>
 job.state "CO" streq
 </condition_postfix>
@@ -8719,7 +8719,7 @@ job.state "CO" streq
 <condition_details>
 <condition_number>7</condition_number>
 <condition_comment>Connecticut</condition_comment>
-<condition_description>job.state == "CT"</condition_description>
+<condition_dsl>job.state == "CT"</condition_dsl>
 <condition_postfix>
 job.state "CT" streq
 </condition_postfix>
@@ -8730,7 +8730,7 @@ job.state "CT" streq
 <condition_details>
 <condition_number>8</condition_number>
 <condition_comment>District of Columbia</condition_comment>
-<condition_description>job.state == "DC"</condition_description>
+<condition_dsl>job.state == "DC"</condition_dsl>
 <condition_postfix>
 job.state "DC" streq
 </condition_postfix>
@@ -8741,7 +8741,7 @@ job.state "DC" streq
 <condition_details>
 <condition_number>9</condition_number>
 <condition_comment>Delaware</condition_comment>
-<condition_description>job.state == "DE"</condition_description>
+<condition_dsl>job.state == "DE"</condition_dsl>
 <condition_postfix>
 job.state "DE" streq
 </condition_postfix>
@@ -8752,7 +8752,7 @@ job.state "DE" streq
 <condition_details>
 <condition_number>10</condition_number>
 <condition_comment>Florida</condition_comment>
-<condition_description>job.state == "FL"</condition_description>
+<condition_dsl>job.state == "FL"</condition_dsl>
 <condition_postfix>
 job.state "FL" streq
 </condition_postfix>
@@ -8763,7 +8763,7 @@ job.state "FL" streq
 <condition_details>
 <condition_number>11</condition_number>
 <condition_comment>Georgia</condition_comment>
-<condition_description>job.state == "GA"</condition_description>
+<condition_dsl>job.state == "GA"</condition_dsl>
 <condition_postfix>
 job.state "GA" streq
 </condition_postfix>
@@ -8774,7 +8774,7 @@ job.state "GA" streq
 <condition_details>
 <condition_number>12</condition_number>
 <condition_comment>Hawaii</condition_comment>
-<condition_description>job.state == "HI"</condition_description>
+<condition_dsl>job.state == "HI"</condition_dsl>
 <condition_postfix>
 job.state "HI" streq
 </condition_postfix>
@@ -8785,7 +8785,7 @@ job.state "HI" streq
 <condition_details>
 <condition_number>13</condition_number>
 <condition_comment>Iowa</condition_comment>
-<condition_description>job.state == "IA"</condition_description>
+<condition_dsl>job.state == "IA"</condition_dsl>
 <condition_postfix>
 job.state "IA" streq
 </condition_postfix>
@@ -8796,7 +8796,7 @@ job.state "IA" streq
 <condition_details>
 <condition_number>14</condition_number>
 <condition_comment>Idaho</condition_comment>
-<condition_description>job.state == "ID"</condition_description>
+<condition_dsl>job.state == "ID"</condition_dsl>
 <condition_postfix>
 job.state "ID" streq
 </condition_postfix>
@@ -8807,7 +8807,7 @@ job.state "ID" streq
 <condition_details>
 <condition_number>15</condition_number>
 <condition_comment>Illinois</condition_comment>
-<condition_description>job.state == "IL"</condition_description>
+<condition_dsl>job.state == "IL"</condition_dsl>
 <condition_postfix>
 job.state "IL" streq
 </condition_postfix>
@@ -8818,7 +8818,7 @@ job.state "IL" streq
 <condition_details>
 <condition_number>16</condition_number>
 <condition_comment>Indiana</condition_comment>
-<condition_description>job.state == "IN"</condition_description>
+<condition_dsl>job.state == "IN"</condition_dsl>
 <condition_postfix>
 job.state "IN" streq
 </condition_postfix>
@@ -8829,7 +8829,7 @@ job.state "IN" streq
 <condition_details>
 <condition_number>17</condition_number>
 <condition_comment>Kansas</condition_comment>
-<condition_description>job.state == "KS"</condition_description>
+<condition_dsl>job.state == "KS"</condition_dsl>
 <condition_postfix>
 job.state "KS" streq
 </condition_postfix>
@@ -8840,7 +8840,7 @@ job.state "KS" streq
 <condition_details>
 <condition_number>18</condition_number>
 <condition_comment>Kentucky</condition_comment>
-<condition_description>job.state == "KY"</condition_description>
+<condition_dsl>job.state == "KY"</condition_dsl>
 <condition_postfix>
 job.state "KY" streq
 </condition_postfix>
@@ -8851,7 +8851,7 @@ job.state "KY" streq
 <condition_details>
 <condition_number>19</condition_number>
 <condition_comment>Louisiana</condition_comment>
-<condition_description>job.state == "LA"</condition_description>
+<condition_dsl>job.state == "LA"</condition_dsl>
 <condition_postfix>
 job.state "LA" streq
 </condition_postfix>
@@ -8862,7 +8862,7 @@ job.state "LA" streq
 <condition_details>
 <condition_number>20</condition_number>
 <condition_comment>Massachusetts</condition_comment>
-<condition_description>job.state == "MA"</condition_description>
+<condition_dsl>job.state == "MA"</condition_dsl>
 <condition_postfix>
 job.state "MA" streq
 </condition_postfix>
@@ -8873,7 +8873,7 @@ job.state "MA" streq
 <condition_details>
 <condition_number>21</condition_number>
 <condition_comment>Maryland</condition_comment>
-<condition_description>job.state == "MD"</condition_description>
+<condition_dsl>job.state == "MD"</condition_dsl>
 <condition_postfix>
 job.state "MD" streq
 </condition_postfix>
@@ -8884,7 +8884,7 @@ job.state "MD" streq
 <condition_details>
 <condition_number>22</condition_number>
 <condition_comment>Maine</condition_comment>
-<condition_description>job.state == "ME"</condition_description>
+<condition_dsl>job.state == "ME"</condition_dsl>
 <condition_postfix>
 job.state "ME" streq
 </condition_postfix>
@@ -8895,7 +8895,7 @@ job.state "ME" streq
 <condition_details>
 <condition_number>23</condition_number>
 <condition_comment>Michigan</condition_comment>
-<condition_description>job.state == "MI"</condition_description>
+<condition_dsl>job.state == "MI"</condition_dsl>
 <condition_postfix>
 job.state "MI" streq
 </condition_postfix>
@@ -8906,7 +8906,7 @@ job.state "MI" streq
 <condition_details>
 <condition_number>24</condition_number>
 <condition_comment>Minnesota</condition_comment>
-<condition_description>job.state == "MN"</condition_description>
+<condition_dsl>job.state == "MN"</condition_dsl>
 <condition_postfix>
 job.state "MN" streq
 </condition_postfix>
@@ -8917,7 +8917,7 @@ job.state "MN" streq
 <condition_details>
 <condition_number>25</condition_number>
 <condition_comment>Missouri</condition_comment>
-<condition_description>job.state == "MO"</condition_description>
+<condition_dsl>job.state == "MO"</condition_dsl>
 <condition_postfix>
 job.state "MO" streq
 </condition_postfix>
@@ -8928,7 +8928,7 @@ job.state "MO" streq
 <condition_details>
 <condition_number>26</condition_number>
 <condition_comment>Mississippi</condition_comment>
-<condition_description>job.state == "MS"</condition_description>
+<condition_dsl>job.state == "MS"</condition_dsl>
 <condition_postfix>
 job.state "MS" streq
 </condition_postfix>
@@ -8939,7 +8939,7 @@ job.state "MS" streq
 <condition_details>
 <condition_number>27</condition_number>
 <condition_comment>Montana</condition_comment>
-<condition_description>job.state == "MT"</condition_description>
+<condition_dsl>job.state == "MT"</condition_dsl>
 <condition_postfix>
 job.state "MT" streq
 </condition_postfix>
@@ -8950,7 +8950,7 @@ job.state "MT" streq
 <condition_details>
 <condition_number>28</condition_number>
 <condition_comment>North Carolina</condition_comment>
-<condition_description>job.state == "NC"</condition_description>
+<condition_dsl>job.state == "NC"</condition_dsl>
 <condition_postfix>
 job.state "NC" streq
 </condition_postfix>
@@ -8961,7 +8961,7 @@ job.state "NC" streq
 <condition_details>
 <condition_number>29</condition_number>
 <condition_comment>North Dakota</condition_comment>
-<condition_description>job.state == "ND"</condition_description>
+<condition_dsl>job.state == "ND"</condition_dsl>
 <condition_postfix>
 job.state "ND" streq
 </condition_postfix>
@@ -8972,7 +8972,7 @@ job.state "ND" streq
 <condition_details>
 <condition_number>30</condition_number>
 <condition_comment>Nebraska</condition_comment>
-<condition_description>job.state == "NE"</condition_description>
+<condition_dsl>job.state == "NE"</condition_dsl>
 <condition_postfix>
 job.state "NE" streq
 </condition_postfix>
@@ -8983,7 +8983,7 @@ job.state "NE" streq
 <condition_details>
 <condition_number>31</condition_number>
 <condition_comment>New Hampshire</condition_comment>
-<condition_description>job.state == "NH"</condition_description>
+<condition_dsl>job.state == "NH"</condition_dsl>
 <condition_postfix>
 job.state "NH" streq
 </condition_postfix>
@@ -8994,7 +8994,7 @@ job.state "NH" streq
 <condition_details>
 <condition_number>32</condition_number>
 <condition_comment>New Jersey</condition_comment>
-<condition_description>job.state == "NJ"</condition_description>
+<condition_dsl>job.state == "NJ"</condition_dsl>
 <condition_postfix>
 job.state "NJ" streq
 </condition_postfix>
@@ -9005,7 +9005,7 @@ job.state "NJ" streq
 <condition_details>
 <condition_number>33</condition_number>
 <condition_comment>New Mexico</condition_comment>
-<condition_description>job.state == "NM"</condition_description>
+<condition_dsl>job.state == "NM"</condition_dsl>
 <condition_postfix>
 job.state "NM" streq
 </condition_postfix>
@@ -9016,7 +9016,7 @@ job.state "NM" streq
 <condition_details>
 <condition_number>34</condition_number>
 <condition_comment>Nevada</condition_comment>
-<condition_description>job.state == "NV"</condition_description>
+<condition_dsl>job.state == "NV"</condition_dsl>
 <condition_postfix>
 job.state "NV" streq
 </condition_postfix>
@@ -9027,7 +9027,7 @@ job.state "NV" streq
 <condition_details>
 <condition_number>35</condition_number>
 <condition_comment>New York</condition_comment>
-<condition_description>job.state == "NY"</condition_description>
+<condition_dsl>job.state == "NY"</condition_dsl>
 <condition_postfix>
 job.state "NY" streq
 </condition_postfix>
@@ -9038,7 +9038,7 @@ job.state "NY" streq
 <condition_details>
 <condition_number>36</condition_number>
 <condition_comment>Ohio</condition_comment>
-<condition_description>job.state == "OH"</condition_description>
+<condition_dsl>job.state == "OH"</condition_dsl>
 <condition_postfix>
 job.state "OH" streq
 </condition_postfix>
@@ -9049,7 +9049,7 @@ job.state "OH" streq
 <condition_details>
 <condition_number>37</condition_number>
 <condition_comment>Oklahoma</condition_comment>
-<condition_description>job.state == "OK"</condition_description>
+<condition_dsl>job.state == "OK"</condition_dsl>
 <condition_postfix>
 job.state "OK" streq
 </condition_postfix>
@@ -9060,7 +9060,7 @@ job.state "OK" streq
 <condition_details>
 <condition_number>38</condition_number>
 <condition_comment>Oregon</condition_comment>
-<condition_description>job.state == "OR"</condition_description>
+<condition_dsl>job.state == "OR"</condition_dsl>
 <condition_postfix>
 job.state "OR" streq
 </condition_postfix>
@@ -9071,7 +9071,7 @@ job.state "OR" streq
 <condition_details>
 <condition_number>39</condition_number>
 <condition_comment>Pennsylvania</condition_comment>
-<condition_description>job.state == "PA"</condition_description>
+<condition_dsl>job.state == "PA"</condition_dsl>
 <condition_postfix>
 job.state "PA" streq
 </condition_postfix>
@@ -9082,7 +9082,7 @@ job.state "PA" streq
 <condition_details>
 <condition_number>40</condition_number>
 <condition_comment>Rhode Island</condition_comment>
-<condition_description>job.state == "RI"</condition_description>
+<condition_dsl>job.state == "RI"</condition_dsl>
 <condition_postfix>
 job.state "RI" streq
 </condition_postfix>
@@ -9093,7 +9093,7 @@ job.state "RI" streq
 <condition_details>
 <condition_number>41</condition_number>
 <condition_comment>South Carolina</condition_comment>
-<condition_description>job.state == "SC"</condition_description>
+<condition_dsl>job.state == "SC"</condition_dsl>
 <condition_postfix>
 job.state "SC" streq
 </condition_postfix>
@@ -9104,7 +9104,7 @@ job.state "SC" streq
 <condition_details>
 <condition_number>42</condition_number>
 <condition_comment>South Dakota</condition_comment>
-<condition_description>job.state == "SD"</condition_description>
+<condition_dsl>job.state == "SD"</condition_dsl>
 <condition_postfix>
 job.state "SD" streq
 </condition_postfix>
@@ -9115,7 +9115,7 @@ job.state "SD" streq
 <condition_details>
 <condition_number>43</condition_number>
 <condition_comment>Tennessee</condition_comment>
-<condition_description>job.state == "TN"</condition_description>
+<condition_dsl>job.state == "TN"</condition_dsl>
 <condition_postfix>
 job.state "TN" streq
 </condition_postfix>
@@ -9126,7 +9126,7 @@ job.state "TN" streq
 <condition_details>
 <condition_number>44</condition_number>
 <condition_comment>Texas</condition_comment>
-<condition_description>job.state == "TX"</condition_description>
+<condition_dsl>job.state == "TX"</condition_dsl>
 <condition_postfix>
 job.state "TX" streq
 </condition_postfix>
@@ -9137,7 +9137,7 @@ job.state "TX" streq
 <condition_details>
 <condition_number>45</condition_number>
 <condition_comment>Utah</condition_comment>
-<condition_description>job.state == "UT"</condition_description>
+<condition_dsl>job.state == "UT"</condition_dsl>
 <condition_postfix>
 job.state "UT" streq
 </condition_postfix>
@@ -9148,7 +9148,7 @@ job.state "UT" streq
 <condition_details>
 <condition_number>46</condition_number>
 <condition_comment>Virginia</condition_comment>
-<condition_description>job.state == "VA"</condition_description>
+<condition_dsl>job.state == "VA"</condition_dsl>
 <condition_postfix>
 job.state "VA" streq
 </condition_postfix>
@@ -9159,7 +9159,7 @@ job.state "VA" streq
 <condition_details>
 <condition_number>47</condition_number>
 <condition_comment>Vermont</condition_comment>
-<condition_description>job.state == "VT"</condition_description>
+<condition_dsl>job.state == "VT"</condition_dsl>
 <condition_postfix>
 job.state "VT" streq
 </condition_postfix>
@@ -9170,7 +9170,7 @@ job.state "VT" streq
 <condition_details>
 <condition_number>48</condition_number>
 <condition_comment>Washington</condition_comment>
-<condition_description>job.state == "WA"</condition_description>
+<condition_dsl>job.state == "WA"</condition_dsl>
 <condition_postfix>
 job.state "WA" streq
 </condition_postfix>
@@ -9181,7 +9181,7 @@ job.state "WA" streq
 <condition_details>
 <condition_number>49</condition_number>
 <condition_comment>Wisconsin</condition_comment>
-<condition_description>job.state == "WI"</condition_description>
+<condition_dsl>job.state == "WI"</condition_dsl>
 <condition_postfix>
 job.state "WI" streq
 </condition_postfix>
@@ -9192,7 +9192,7 @@ job.state "WI" streq
 <condition_details>
 <condition_number>50</condition_number>
 <condition_comment>West Virginia</condition_comment>
-<condition_description>job.state == "WV"</condition_description>
+<condition_dsl>job.state == "WV"</condition_dsl>
 <condition_postfix>
 job.state "WV" streq
 </condition_postfix>
@@ -9203,7 +9203,7 @@ job.state "WV" streq
 <condition_details>
 <condition_number>51</condition_number>
 <condition_comment>Wyoming</condition_comment>
-<condition_description>job.state == "WY"</condition_description>
+<condition_dsl>job.state == "WY"</condition_dsl>
 <condition_postfix>
 job.state "WY" streq
 </condition_postfix>
@@ -9214,7 +9214,7 @@ job.state "WY" streq
 <condition_details>
 <condition_number>52</condition_number>
 <condition_comment>State has no income tax</condition_comment>
-<condition_description>State in no_income_tax_states array</condition_description>
+<condition_dsl>State in no_income_tax_states array</condition_dsl>
 <condition_postfix>
 result.no_income_tax_states job.state contains
 </condition_postfix>
@@ -9225,7 +9225,7 @@ result.no_income_tax_states job.state contains
 <condition_details>
 <condition_number>53</condition_number>
 <condition_comment>State tax not yet implemented</condition_comment>
-<condition_description>Otherwise (unimplemented state)</condition_description>
+<condition_dsl>Otherwise (unimplemented state)</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -9785,7 +9785,7 @@ job.state " has no state income tax - state_tax_liability set to $0" strconcat j
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize GBC calculation</action_description>
+<action_dsl>Initialize GBC calculation</action_dsl>
 <action_postfix>
 0.0 /result.general_business_credit_total xdef
 0.0 /result.general_business_credit_used xdef
@@ -9798,7 +9798,7 @@ job.state " has no state income tax - state_tax_liability set to $0" strconcat j
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Any business credits present</condition_comment>
-<condition_description>Sum of business credits greater than 0</condition_description>
+<condition_dsl>Sum of business credits greater than 0</condition_dsl>
 <condition_postfix>
 result.work_opportunity_credit result.research_credit f+ result.low_income_housing_credit f+
 result.disabled_access_credit f+ result.small_employer_pension_credit f+
@@ -9812,7 +9812,7 @@ result.small_employer_health_credit f+ result.employer_credit_paid_family_leave 
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate total GBC (Part I)</action_comment>
-<action_description>Sum all component business credits</action_description>
+<action_dsl>Sum all component business credits</action_dsl>
 <action_postfix>
 result.work_opportunity_credit result.research_credit f+ result.low_income_housing_credit f+
 result.disabled_access_credit f+ result.small_employer_pension_credit f+
@@ -9831,7 +9831,7 @@ result.employer_credit_paid_family_leave 0 &gt; { "    Employer Paid Family Leav
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate GBC limitation (Part II)</action_comment>
-<action_description>Apply tax liability limitation</action_description>
+<action_dsl>Apply tax liability limitation</action_dsl>
 <action_postfix>
 /tax_before_credits result.total_tax_before_credits def
 /threshold constants.gbc_threshold def
@@ -9850,7 +9850,7 @@ result.general_business_credit_carryforward 0 &gt; { "  GBC carryforward: $" res
 <action_details>
 <action_number>3</action_number>
 <action_comment>No business credits</action_comment>
-<action_description>Log no GBC applicable</action_description>
+<action_dsl>Log no GBC applicable</action_dsl>
 <action_postfix>
 "No general business credits (Form 3800 not applicable)" job.audit_trail swap addto
 </action_postfix>
@@ -9872,7 +9872,7 @@ result.general_business_credit_carryforward 0 &gt; { "  GBC carryforward: $" res
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Log kiddie tax calculation start</action_description>
+<action_dsl>Log kiddie tax calculation start</action_dsl>
 <action_postfix>
 "KIDDIE TAX CALCULATION (Form 8615)" job.audit_trail swap addto
 </action_postfix>
@@ -9882,7 +9882,7 @@ result.general_business_credit_carryforward 0 &gt; { "  GBC carryforward: $" res
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always process kiddie tax for all dependents</condition_comment>
-<condition_description>always</condition_description>
+<condition_dsl>always</condition_dsl>
 <condition_postfix>
 always
 </condition_postfix>
@@ -9893,7 +9893,7 @@ always
 <action_details>
 <action_number>1</action_number>
 <action_comment>Process kiddie tax for each dependent</action_comment>
-<action_description>Calculate_Kiddie_Tax_For_Dependent for each dependent</action_description>
+<action_dsl>Calculate_Kiddie_Tax_For_Dependent for each dependent</action_dsl>
 <action_postfix>
 { /Calculate_Kiddie_Tax_For_Dependent executetable } job.dependents forall
 </action_postfix>
@@ -9918,7 +9918,7 @@ always
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Dependent is under 19 with unearned income over threshold</condition_comment>
-<condition_description>dependent.age lt 19 and dependent.unearned_income gt kiddie_tax_threshold</condition_description>
+<condition_dsl>dependent.age lt 19 and dependent.unearned_income gt kiddie_tax_threshold</condition_dsl>
 <condition_postfix>
 dependent.age 19 &lt;
 dependent.unearned_income kiddie_tax_threshold &gt;
@@ -9929,7 +9929,7 @@ and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Dependent is 19-23 full-time student with unearned income over threshold</condition_comment>
-<condition_description>dependent.age between 19 and 23 and is_student and unearned_income gt threshold</condition_description>
+<condition_dsl>dependent.age between 19 and 23 and is_student and unearned_income gt threshold</condition_dsl>
 <condition_postfix>
 dependent.age 19 &gt;=
 dependent.age 24 &lt;
@@ -9944,7 +9944,7 @@ and
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Kiddie tax does not apply</condition_comment>
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>
 otherwise
 </condition_postfix>
@@ -9955,7 +9955,7 @@ otherwise
 <action_details>
 <action_number>1</action_number>
 <action_comment>Mark dependent subject to kiddie tax</action_comment>
-<action_description>Set kiddie tax flag to true</action_description>
+<action_dsl>Set kiddie tax flag to true</action_dsl>
 <action_postfix>
 true /dependent.subject_to_kiddie_tax xdef
 </action_postfix>
@@ -9965,7 +9965,7 @@ true /dependent.subject_to_kiddie_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate net unearned income subject to parent's tax rate</action_comment>
-<action_description>Net unearned income = unearned_income - kiddie_tax_threshold</action_description>
+<action_dsl>Net unearned income = unearned_income - kiddie_tax_threshold</action_dsl>
 <action_postfix>
 dependent.unearned_income kiddie_tax_threshold f- 0 fmax /net_unearned_income local
 "  Dependent: " dependent.name strconcat job.audit_trail swap addto
@@ -9980,7 +9980,7 @@ dependent.unearned_income kiddie_tax_threshold f- 0 fmax /net_unearned_income lo
 <action_details>
 <action_number>3</action_number>
 <action_comment>Determine parent's marginal tax rate based on filing status</action_comment>
-<action_description>Calculate parent's marginal rate for MFJ filing status</action_description>
+<action_dsl>Calculate parent's marginal rate for MFJ filing status</action_dsl>
 <action_postfix>
 0.10 /parent_marginal_rate local
 result.agi bracket_1_mfj &lt;={
@@ -10014,7 +10014,7 @@ net_unearned_income parent_marginal_rate f* /dependent.kiddie_tax_amount xdef
 <action_details>
 <action_number>4</action_number>
 <action_comment>Add kiddie tax to total tax before credits</action_comment>
-<action_description>Add kiddie tax to total tax</action_description>
+<action_dsl>Add kiddie tax to total tax</action_dsl>
 <action_postfix>
 result.total_tax_before_credits dependent.kiddie_tax_amount f+ /result.total_tax_before_credits xdef
 "    Total tax before credits increased to: $" result.total_tax_before_credits cvs strconcat job.audit_trail swap addto
@@ -10025,7 +10025,7 @@ result.total_tax_before_credits dependent.kiddie_tax_amount f+ /result.total_tax
 <action_details>
 <action_number>5</action_number>
 <action_comment>Kiddie tax does not apply - initialize to zero</action_comment>
-<action_description>No kiddie tax applicable</action_description>
+<action_dsl>No kiddie tax applicable</action_dsl>
 <action_postfix>
 false /dependent.subject_to_kiddie_tax xdef
 0.0 /dependent.kiddie_tax_amount xdef
@@ -10048,7 +10048,7 @@ false /dependent.subject_to_kiddie_tax xdef
 <contexts></contexts>
 <initial_actions>
 <initial_action>
-<action_description>Initialize Schedule H calculation</action_description>
+<action_dsl>Initialize Schedule H calculation</action_dsl>
 <action_postfix>
 "SCHEDULE H - Household Employment Taxes" job.audit_trail swap addto
 0.0 /result.schedule_h_social_security_tax xdef
@@ -10062,7 +10062,7 @@ false /dependent.subject_to_kiddie_tax xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Has household employees</condition_comment>
-<condition_description>job.household_employees length greater than 0</condition_description>
+<condition_dsl>job.household_employees length greater than 0</condition_dsl>
 <condition_postfix>
 job.household_employees length 0 &gt;
 </condition_postfix>
@@ -10074,7 +10074,7 @@ job.household_employees length 0 &gt;
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate employer FICA and FUTA for each employee</action_comment>
-<action_description>Process each household employee</action_description>
+<action_dsl>Process each household employee</action_dsl>
 <action_postfix>
 {
   /employee xdef
@@ -10112,7 +10112,7 @@ result.schedule_h_social_security_tax result.schedule_h_medicare_tax f+ result.s
 <action_details>
 <action_number>2</action_number>
 <action_comment>No household employees</action_comment>
-<action_description>Skip Schedule H</action_description>
+<action_dsl>Skip Schedule H</action_dsl>
 <action_postfix>
 "  No household employees - Schedule H not applicable" job.audit_trail swap addto
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/AL_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/AL_dt.xml
@@ -37,7 +37,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married filing jointly</condition_comment>
-<condition_description>Married filing jointly</condition_description>
+<condition_dsl>Married filing jointly</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MFJ&quot;
 </condition_postfix>
@@ -45,7 +45,7 @@ filing_status == &quot;MFJ&quot;
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of household</condition_comment>
-<condition_description>Head of household</condition_description>
+<condition_dsl>Head of household</condition_dsl>
 <condition_postfix>
 filing_status == &quot;HOH&quot;
 </condition_postfix>
@@ -53,7 +53,7 @@ filing_status == &quot;HOH&quot;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Married filing separately</condition_comment>
-<condition_description>Married filing separately</condition_description>
+<condition_dsl>Married filing separately</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MFS&quot;
 </condition_postfix>
@@ -63,7 +63,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate Alabama tax - Married filing jointly (progressive brackets)</action_comment>
-<action_description>Calculate Alabama tax - Married filing jointly (progressive brackets)</action_description>
+<action_dsl>Calculate Alabama tax - Married filing jointly (progressive brackets)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -71,7 +71,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Alabama tax - Head of household (progressive brackets, uses joint exemption)</action_comment>
-<action_description>Calculate Alabama tax - Head of household (progressive brackets, uses joint exemption)</action_description>
+<action_dsl>Calculate Alabama tax - Head of household (progressive brackets, uses joint exemption)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -79,7 +79,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate Alabama tax - Married filing separately (progressive brackets)</action_comment>
-<action_description>Calculate Alabama tax - Married filing separately (progressive brackets)</action_description>
+<action_dsl>Calculate Alabama tax - Married filing separately (progressive brackets)</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/AR_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/AR_dt.xml
@@ -37,7 +37,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married filing jointly</condition_comment>
-<condition_description>Married filing jointly</condition_description>
+<condition_dsl>Married filing jointly</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MFJ&quot;
 </condition_postfix>
@@ -45,7 +45,7 @@ filing_status == &quot;MFJ&quot;
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of household</condition_comment>
-<condition_description>Head of household</condition_description>
+<condition_dsl>Head of household</condition_dsl>
 <condition_postfix>
 filing_status == &quot;HOH&quot;
 </condition_postfix>
@@ -53,7 +53,7 @@ filing_status == &quot;HOH&quot;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Married filing separately</condition_comment>
-<condition_description>Married filing separately</condition_description>
+<condition_dsl>Married filing separately</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MFS&quot;
 </condition_postfix>
@@ -63,7 +63,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate Arkansas tax - Married filing jointly (progressive brackets)</action_comment>
-<action_description>Calculate Arkansas tax - Married filing jointly (progressive brackets)</action_description>
+<action_dsl>Calculate Arkansas tax - Married filing jointly (progressive brackets)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -71,7 +71,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Arkansas tax - Head of household (progressive brackets)</action_comment>
-<action_description>Calculate Arkansas tax - Head of household (progressive brackets)</action_description>
+<action_dsl>Calculate Arkansas tax - Head of household (progressive brackets)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -79,7 +79,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate Arkansas tax - Married filing separately (progressive brackets)</action_comment>
-<action_description>Calculate Arkansas tax - Married filing separately (progressive brackets)</action_description>
+<action_dsl>Calculate Arkansas tax - Married filing separately (progressive brackets)</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/AS_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/AS_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has only AS-source income</condition_comment>
-<condition_description>Has only AS-source income</condition_description>
+<condition_dsl>Has only AS-source income</condition_dsl>
 <condition_postfix>
 All income from American Samoa sources
 </condition_postfix>
@@ -28,7 +28,7 @@ All income from American Samoa sources
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Has self-employment income &gt;= $400</condition_comment>
-<condition_description>Has self-employment income &gt;= $400</condition_description>
+<condition_dsl>Has self-employment income &gt;= $400</condition_dsl>
 <condition_postfix>
 Subject to US self-employment tax
 </condition_postfix>
@@ -41,7 +41,7 @@ Subject to US self-employment tax
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bona fide resident with only AS income, no SE tax</action_comment>
-<action_description>Bona fide resident with only AS income, no SE tax</action_description>
+<action_dsl>Bona fide resident with only AS income, no SE tax</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -49,7 +49,7 @@ Subject to US self-employment tax
 <action_details>
 <action_number>3</action_number>
 <action_comment>Not bona fide resident or has US income - files with IRS</action_comment>
-<action_description>Not bona fide resident or has US income - files with IRS</action_description>
+<action_dsl>Not bona fide resident or has US income - files with IRS</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/AZ_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/AZ_dt.xml
@@ -37,7 +37,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly</condition_comment>
-<condition_description>Filing status is Married Filing Jointly</condition_description>
+<condition_dsl>Filing status is Married Filing Jointly</condition_dsl>
 <condition_postfix>
 Filing status is MFJ
 </condition_postfix>
@@ -45,7 +45,7 @@ Filing status is MFJ
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Filing status is Head of Household</condition_comment>
-<condition_description>Filing status is Head of Household</condition_description>
+<condition_dsl>Filing status is Head of Household</condition_dsl>
 <condition_postfix>
 Filing status is HOH
 </condition_postfix>
@@ -55,7 +55,7 @@ Filing status is HOH
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate AZ tax for MFJ</action_comment>
-<action_description>Calculate AZ tax for MFJ</action_description>
+<action_dsl>Calculate AZ tax for MFJ</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -63,7 +63,7 @@ Filing status is HOH
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate AZ tax for Head of Household</action_comment>
-<action_description>Calculate AZ tax for Head of Household</action_description>
+<action_dsl>Calculate AZ tax for Head of Household</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/CA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/CA_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single filer, AGI ≤ $125k; Single AND AGI ≤ $125,000</condition_comment>
-<condition_description>Single filer, AGI ≤ $125k; Single AND AGI ≤ $125,000</condition_description>
+<condition_dsl>Single filer, AGI ≤ $125k; Single AND AGI ≤ $125,000</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -26,7 +26,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Joint filer, AGI ≤ $250k; Married Filing Jointly AND AGI ≤ $250,000</condition_comment>
-<condition_description>Joint filer, AGI ≤ $250k; Married Filing Jointly AND AGI ≤ $250,000</condition_description>
+<condition_dsl>Joint filer, AGI ≤ $250k; Married Filing Jointly AND AGI ≤ $250,000</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -37,7 +37,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Apply CA $20,000 military retirement exemption (Joint, AGI ≤ $250k)</action_comment>
-<action_description>Apply CA $20,000 military retirement exemption (Joint, AGI ≤ $250k)</action_description>
+<action_dsl>Apply CA $20,000 military retirement exemption (Joint, AGI ≤ $250k)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>No CA military retirement exemption (AGI exceeds limit)</action_comment>
-<action_description>No CA military retirement exemption (AGI exceeds limit)</action_description>
+<action_dsl>No CA military retirement exemption (AGI exceeds limit)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -53,7 +53,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>No military retirement pay</action_comment>
-<action_description>No military retirement pay</action_description>
+<action_dsl>No military retirement pay</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -79,7 +79,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single filer within AGI limit</condition_comment>
-<condition_description>Single filer within AGI limit</condition_description>
+<condition_dsl>Single filer within AGI limit</condition_dsl>
 <condition_postfix>
 Single AND AGI &lt;= $50,746
 </condition_postfix>
@@ -89,7 +89,7 @@ Single AND AGI &lt;= $50,746
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Joint/HOH filer within AGI limit</condition_comment>
-<condition_description>Joint/HOH filer within AGI limit</condition_description>
+<condition_dsl>Joint/HOH filer within AGI limit</condition_dsl>
 <condition_postfix>
 Joint/HOH AND AGI &lt;= $101,492
 </condition_postfix>
@@ -101,7 +101,7 @@ Joint/HOH AND AGI &lt;= $101,492
 <action_details>
 <action_number>2</action_number>
 <action_comment>Apply CA $120 renter's credit (Joint/HOH filer)</action_comment>
-<action_description>Apply CA $120 renter's credit (Joint/HOH filer)</action_description>
+<action_dsl>Apply CA $120 renter's credit (Joint/HOH filer)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -109,7 +109,7 @@ Joint/HOH AND AGI &lt;= $101,492
 <action_details>
 <action_number>3</action_number>
 <action_comment>Not eligible for CA renter's credit</action_comment>
-<action_description>Not eligible for CA renter's credit</action_description>
+<action_dsl>Not eligible for CA renter's credit</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -135,7 +135,7 @@ Joint/HOH AND AGI &lt;= $101,492
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly or Head of Household; Filing Status is MFJ or HOH</condition_comment>
-<condition_description>Filing status is Married Filing Jointly or Head of Household; Filing Status is MFJ or HOH</condition_description>
+<condition_dsl>Filing status is Married Filing Jointly or Head of Household; Filing Status is MFJ or HOH</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -145,7 +145,7 @@ Joint/HOH AND AGI &lt;= $101,492
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate CA tax for Married Filing Jointly/HOH using progressive brackets (10 brackets: 1% to 13.3%)</action_comment>
-<action_description>Calculate CA tax for Married Filing Jointly/HOH using progressive brackets (10 brackets: 1% to 13.3%)</action_description>
+<action_dsl>Calculate CA tax for Married Filing Jointly/HOH using progressive brackets (10 brackets: 1% to 13.3%)</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/CO_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/CO_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No federal EITC - no Colorado EITC</action_comment>
-<action_description>No federal EITC - no Colorado EITC</action_description>
+<action_dsl>No federal EITC - no Colorado EITC</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Age less than 55</condition_comment>
-<condition_description>Age less than 55</condition_description>
+<condition_dsl>Age less than 55</condition_dsl>
 <condition_postfix>
 age &lt; 55
 </condition_postfix>
@@ -54,7 +54,7 @@ age &lt; 55
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Age 55 to 64</condition_comment>
-<condition_description>Age 55 to 64</condition_description>
+<condition_dsl>Age 55 to 64</condition_dsl>
 <condition_postfix>
 age &gt;= 55 AND age &lt; 65
 </condition_postfix>
@@ -63,7 +63,7 @@ age &gt;= 55 AND age &lt; 65
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Age 65 or older</condition_comment>
-<condition_description>Age 65 or older</condition_description>
+<condition_dsl>Age 65 or older</condition_dsl>
 <condition_postfix>
 age &gt;= 65
 </condition_postfix>
@@ -74,7 +74,7 @@ age &gt;= 65
 <action_details>
 <action_number>2</action_number>
 <action_comment>Apply CO $20,000 military retirement exemption (age 55-64)</action_comment>
-<action_description>Apply CO $20,000 military retirement exemption (age 55-64)</action_description>
+<action_dsl>Apply CO $20,000 military retirement exemption (age 55-64)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -82,7 +82,7 @@ age &gt;= 65
 <action_details>
 <action_number>3</action_number>
 <action_comment>Apply CO $24,000 military retirement exemption (age 65+)</action_comment>
-<action_description>Apply CO $24,000 military retirement exemption (age 65+)</action_description>
+<action_dsl>Apply CO $24,000 military retirement exemption (age 65+)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -90,7 +90,7 @@ age &gt;= 65
 <action_details>
 <action_number>4</action_number>
 <action_comment>No military retirement pay</action_comment>
-<action_description>No military retirement pay</action_description>
+<action_dsl>No military retirement pay</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -116,7 +116,7 @@ age &gt;= 65
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Age 55 to 64</condition_comment>
-<condition_description>Age 55 to 64</condition_description>
+<condition_dsl>Age 55 to 64</condition_dsl>
 <condition_postfix>
 age &gt;= 55 AND age &lt; 65
 </condition_postfix>
@@ -125,7 +125,7 @@ age &gt;= 55 AND age &lt; 65
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Age 65 or older</condition_comment>
-<condition_description>Age 65 or older</condition_description>
+<condition_dsl>Age 65 or older</condition_dsl>
 <condition_postfix>
 age &gt;= 65
 </condition_postfix>
@@ -136,7 +136,7 @@ age &gt;= 65
 <action_details>
 <action_number>2</action_number>
 <action_comment>Apply CO $24,000 pension/annuity subtraction (age 65+)</action_comment>
-<action_description>Apply CO $24,000 pension/annuity subtraction (age 65+)</action_description>
+<action_dsl>Apply CO $24,000 pension/annuity subtraction (age 65+)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -144,7 +144,7 @@ age &gt;= 65
 <action_details>
 <action_number>3</action_number>
 <action_comment>No pension/annuity subtraction applicable</action_comment>
-<action_description>No pension/annuity subtraction applicable</action_description>
+<action_dsl>No pension/annuity subtraction applicable</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/CT_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/CT_dt.xml
@@ -37,7 +37,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly</condition_comment>
-<condition_description>Filing status is Married Filing Jointly</condition_description>
+<condition_dsl>Filing status is Married Filing Jointly</condition_dsl>
 <condition_postfix>
 Filing Status is MFJ
 </condition_postfix>
@@ -47,7 +47,7 @@ Filing Status is MFJ
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate CT tax for Married Filing Jointly using progressive brackets</action_comment>
-<action_description>Calculate CT tax for Married Filing Jointly using progressive brackets</action_description>
+<action_dsl>Calculate CT tax for Married Filing Jointly using progressive brackets</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/DC_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/DC_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Age 62 or older</condition_comment>
-<condition_description>Age 62 or older</condition_description>
+<condition_dsl>Age 62 or older</condition_dsl>
 <condition_postfix>
 age &gt;= 62
 </condition_postfix>
@@ -28,7 +28,7 @@ age &gt;= 62
 <action_details>
 <action_number>2</action_number>
 <action_comment>No DC military retirement exemption (age &lt; 62)</action_comment>
-<action_description>No DC military retirement exemption (age &lt; 62)</action_description>
+<action_dsl>No DC military retirement exemption (age &lt; 62)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -36,7 +36,7 @@ age &gt;= 62
 <action_details>
 <action_number>3</action_number>
 <action_comment>No military retirement pay</action_comment>
-<action_description>No military retirement pay</action_description>
+<action_dsl>No military retirement pay</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -62,7 +62,7 @@ age &gt;= 62
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly</condition_comment>
-<condition_description>Filing status is Married Filing Jointly</condition_description>
+<condition_dsl>Filing status is Married Filing Jointly</condition_dsl>
 <condition_postfix>
 Filing Status is MFJ
 </condition_postfix>
@@ -70,7 +70,7 @@ Filing Status is MFJ
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Filing status is Head of Household</condition_comment>
-<condition_description>Filing status is Head of Household</condition_description>
+<condition_dsl>Filing status is Head of Household</condition_dsl>
 <condition_postfix>
 Filing Status is HOH
 </condition_postfix>
@@ -80,7 +80,7 @@ Filing Status is HOH
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate DC tax for Married Filing Jointly using progressive brackets</action_comment>
-<action_description>Calculate DC tax for Married Filing Jointly using progressive brackets</action_description>
+<action_dsl>Calculate DC tax for Married Filing Jointly using progressive brackets</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -88,7 +88,7 @@ Filing Status is HOH
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate DC tax for Head of Household using progressive brackets</action_comment>
-<action_description>Calculate DC tax for Head of Household using progressive brackets</action_description>
+<action_dsl>Calculate DC tax for Head of Household using progressive brackets</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/DE_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/DE_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay</action_comment>
-<action_description>No military retirement pay</action_description>
+<action_dsl>No military retirement pay</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly</condition_comment>
-<condition_description>Filing status is Married Filing Jointly</condition_description>
+<condition_dsl>Filing status is Married Filing Jointly</condition_dsl>
 <condition_postfix>
 Filing Status is MFJ
 </condition_postfix>
@@ -53,7 +53,7 @@ Filing Status is MFJ
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Filing status is Head of Household</condition_comment>
-<condition_description>Filing status is Head of Household</condition_description>
+<condition_dsl>Filing status is Head of Household</condition_dsl>
 <condition_postfix>
 Filing Status is HOH
 </condition_postfix>
@@ -63,7 +63,7 @@ Filing Status is HOH
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate DE tax for Married Filing Jointly using progressive brackets</action_comment>
-<action_description>Calculate DE tax for Married Filing Jointly using progressive brackets</action_description>
+<action_dsl>Calculate DE tax for Married Filing Jointly using progressive brackets</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -71,7 +71,7 @@ Filing Status is HOH
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate DE tax for Head of Household using progressive brackets</action_comment>
-<action_description>Calculate DE tax for Head of Household using progressive brackets</action_description>
+<action_dsl>Calculate DE tax for Head of Household using progressive brackets</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/GA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/GA_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Age less than 62</condition_comment>
-<condition_description>Age less than 62</condition_description>
+<condition_dsl>Age less than 62</condition_dsl>
 <condition_postfix>
 age &lt; 62
 </condition_postfix>
@@ -27,7 +27,7 @@ age &lt; 62
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Earned income &gt;= $17,500</condition_comment>
-<condition_description>Earned income &gt;= $17,500</condition_description>
+<condition_dsl>Earned income &gt;= $17,500</condition_dsl>
 <condition_postfix>
 earned_income &gt;= $17,500
 </condition_postfix>
@@ -36,7 +36,7 @@ earned_income &gt;= $17,500
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Age 62 to 64</condition_comment>
-<condition_description>Age 62 to 64</condition_description>
+<condition_dsl>Age 62 to 64</condition_dsl>
 <condition_postfix>
 age &gt;= 62 AND age &lt; 65
 </condition_postfix>
@@ -45,7 +45,7 @@ age &gt;= 62 AND age &lt; 65
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>Age 65 or older</condition_comment>
-<condition_description>Age 65 or older</condition_description>
+<condition_dsl>Age 65 or older</condition_dsl>
 <condition_postfix>
 age &gt;= 65
 </condition_postfix>
@@ -56,7 +56,7 @@ age &gt;= 65
 <action_details>
 <action_number>2</action_number>
 <action_comment>Apply GA $17,500 military retirement exemption (age &lt; 62, earned &lt; $17.5k)</action_comment>
-<action_description>Apply GA $17,500 military retirement exemption (age &lt; 62, earned &lt; $17.5k)</action_description>
+<action_dsl>Apply GA $17,500 military retirement exemption (age &lt; 62, earned &lt; $17.5k)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -64,7 +64,7 @@ age &gt;= 65
 <action_details>
 <action_number>3</action_number>
 <action_comment>Apply GA $35,000 military retirement exemption (age 62-64)</action_comment>
-<action_description>Apply GA $35,000 military retirement exemption (age 62-64)</action_description>
+<action_dsl>Apply GA $35,000 military retirement exemption (age 62-64)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -72,7 +72,7 @@ age &gt;= 65
 <action_details>
 <action_number>4</action_number>
 <action_comment>Apply GA $65,000 military retirement exemption (age 65+)</action_comment>
-<action_description>Apply GA $65,000 military retirement exemption (age 65+)</action_description>
+<action_dsl>Apply GA $65,000 military retirement exemption (age 65+)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -80,7 +80,7 @@ age &gt;= 65
 <action_details>
 <action_number>5</action_number>
 <action_comment>No military retirement pay</action_comment>
-<action_description>No military retirement pay</action_description>
+<action_dsl>No military retirement pay</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/GU_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/GU_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Non-resident - requires Form 5074 for allocation</action_comment>
-<action_description>Non-resident - requires Form 5074 for allocation</action_description>
+<action_dsl>Non-resident - requires Form 5074 for allocation</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/HI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/HI_dt.xml
@@ -37,7 +37,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly</condition_comment>
-<condition_description>Filing status is Married Filing Jointly</condition_description>
+<condition_dsl>Filing status is Married Filing Jointly</condition_dsl>
 <condition_postfix>
 Filing Status is MFJ
 </condition_postfix>
@@ -47,7 +47,7 @@ Filing Status is MFJ
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate HI tax for Married Filing Jointly using progressive brackets</action_comment>
-<action_description>Calculate HI tax for Married Filing Jointly using progressive brackets</action_description>
+<action_dsl>Calculate HI tax for Married Filing Jointly using progressive brackets</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/ID_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/ID_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Disabled veteran OR age 62+; is_disabled OR age &gt;= 62</condition_comment>
-<condition_description>Disabled veteran OR age 62+; is_disabled OR age &gt;= 62</condition_description>
+<condition_dsl>Disabled veteran OR age 62+; is_disabled OR age &gt;= 62</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -28,7 +28,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No ID military retirement exemption (not disabled, age &lt; 62)</action_comment>
-<action_description>No ID military retirement exemption (not disabled, age &lt; 62)</action_description>
+<action_dsl>No ID military retirement exemption (not disabled, age &lt; 62)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -36,7 +36,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>No military retirement pay</action_comment>
-<action_description>No military retirement pay</action_description>
+<action_dsl>No military retirement pay</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/KY_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/KY_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay</action_comment>
-<action_description>No military retirement pay</action_description>
+<action_dsl>No military retirement pay</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/LA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/LA_dt.xml
@@ -37,7 +37,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly or Head of Household; filing_status == &quot;married_filing_jointly&quot; OR filing_status == &quot;head_of_household&quot;</condition_comment>
-<condition_description>Filing status is Married Filing Jointly or Head of Household; filing_status == &quot;married_filing_jointly&quot; OR filing_status == &quot;head_of_household&quot;</condition_description>
+<condition_dsl>Filing status is Married Filing Jointly or Head of Household; filing_status == &quot;married_filing_jointly&quot; OR filing_status == &quot;head_of_household&quot;</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -49,7 +49,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate LA tax with joint/HOH standard deduction</action_comment>
-<action_description>Calculate LA tax with joint/HOH standard deduction</action_description>
+<action_dsl>Calculate LA tax with joint/HOH standard deduction</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/MA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MA_dt.xml
@@ -37,7 +37,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly</condition_comment>
-<condition_description>Filing status is Married Filing Jointly</condition_description>
+<condition_dsl>Filing status is Married Filing Jointly</condition_dsl>
 <condition_postfix>
 filing_status = 'Married Filing Jointly'
 </condition_postfix>
@@ -45,7 +45,7 @@ filing_status = 'Married Filing Jointly'
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Filing status is Head of Household</condition_comment>
-<condition_description>Filing status is Head of Household</condition_description>
+<condition_dsl>Filing status is Head of Household</condition_dsl>
 <condition_postfix>
 filing_status = 'Head of Household'
 </condition_postfix>
@@ -55,7 +55,7 @@ filing_status = 'Head of Household'
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate MA tax for Married Filing Jointly</action_comment>
-<action_description>Calculate MA tax for Married Filing Jointly</action_description>
+<action_dsl>Calculate MA tax for Married Filing Jointly</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -63,7 +63,7 @@ filing_status = 'Head of Household'
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate MA tax for Head of Household</action_comment>
-<action_description>Calculate MA tax for Head of Household</action_description>
+<action_dsl>Calculate MA tax for Head of Household</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/MD_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MD_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Age 55 or older</condition_comment>
-<condition_description>Age 55 or older</condition_description>
+<condition_dsl>Age 55 or older</condition_dsl>
 <condition_postfix>
 age &gt;= 55
 </condition_postfix>
@@ -28,7 +28,7 @@ age &gt;= 55
 <action_details>
 <action_number>2</action_number>
 <action_comment>Apply MD $12,500 military retirement exemption (under age 55)</action_comment>
-<action_description>Apply MD $12,500 military retirement exemption (under age 55)</action_description>
+<action_dsl>Apply MD $12,500 military retirement exemption (under age 55)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -36,7 +36,7 @@ age &gt;= 55
 <action_details>
 <action_number>3</action_number>
 <action_comment>No military retirement pay - no exemption</action_comment>
-<action_description>No military retirement pay - no exemption</action_description>
+<action_dsl>No military retirement pay - no exemption</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/MI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MI_dt.xml
@@ -37,7 +37,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly</condition_comment>
-<condition_description>Filing status is Married Filing Jointly</condition_description>
+<condition_dsl>Filing status is Married Filing Jointly</condition_dsl>
 <condition_postfix>
 result.filing_status &quot;married_filing_jointly&quot; ==
 </condition_postfix>
@@ -49,7 +49,7 @@ result.filing_status &quot;married_filing_jointly&quot; ==
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Filing status is Head of Household</condition_comment>
-<condition_description>Filing status is Head of Household</condition_description>
+<condition_dsl>Filing status is Head of Household</condition_dsl>
 <condition_postfix>
 result.filing_status &quot;head_of_household&quot; ==
 </condition_postfix>
@@ -61,7 +61,7 @@ result.filing_status &quot;head_of_household&quot; ==
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Default case (Married Filing Separately, etc.)</condition_comment>
-<condition_description>Default case (Married Filing Separately, etc.)</condition_description>
+<condition_dsl>Default case (Married Filing Separately, etc.)</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -75,7 +75,7 @@ true
 <action_details>
 <action_number>2</action_number>
 <action_comment>Married Filing Jointly: base exemption (2 x $5,800) + dependent exemptions</action_comment>
-<action_description>Married Filing Jointly: base exemption (2 x $5,800) + dependent exemptions</action_description>
+<action_dsl>Married Filing Jointly: base exemption (2 x $5,800) + dependent exemptions</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -83,7 +83,7 @@ true
 <action_details>
 <action_number>3</action_number>
 <action_comment>Head of Household: base exemption + dependent exemptions</action_comment>
-<action_description>Head of Household: base exemption + dependent exemptions</action_description>
+<action_dsl>Head of Household: base exemption + dependent exemptions</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -91,7 +91,7 @@ true
 <action_details>
 <action_number>4</action_number>
 <action_comment>Other statuses: base exemption + dependent exemptions</action_comment>
-<action_description>Other statuses: base exemption + dependent exemptions</action_description>
+<action_dsl>Other statuses: base exemption + dependent exemptions</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -99,7 +99,7 @@ true
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate MI taxable income (AGI - exemptions, minimum 0)</action_comment>
-<action_description>Calculate MI taxable income (AGI - exemptions, minimum 0)</action_description>
+<action_dsl>Calculate MI taxable income (AGI - exemptions, minimum 0)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -108,7 +108,7 @@ true
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate MI tax: taxable income × 4.25%</action_comment>
-<action_description>Calculate MI tax: taxable income × 4.25%</action_description>
+<action_dsl>Calculate MI tax: taxable income × 4.25%</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/MN_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MN_dt.xml
@@ -37,7 +37,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly</condition_comment>
-<condition_description>Filing status is Married Filing Jointly</condition_description>
+<condition_dsl>Filing status is Married Filing Jointly</condition_dsl>
 <condition_postfix>
 Filing Status is MFJ
 </condition_postfix>
@@ -47,7 +47,7 @@ Filing Status is MFJ
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate MN tax for Married Filing Jointly using progressive brackets</action_comment>
-<action_description>Calculate MN tax for Married Filing Jointly using progressive brackets</action_description>
+<action_dsl>Calculate MN tax for Married Filing Jointly using progressive brackets</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/MO_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MO_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_description>No military retirement pay - no exclusion</action_description>
+<action_dsl>No military retirement pay - no exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/MP_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MP_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Tax amount &lt;= $20,000; Qualifies for tier 1 rebate (90%)</condition_comment>
-<condition_description>Tax amount &lt;= $20,000; Qualifies for tier 1 rebate (90%)</condition_description>
+<condition_dsl>Tax amount &lt;= $20,000; Qualifies for tier 1 rebate (90%)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -27,7 +27,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Tax amount &gt; $20,000 and &lt;= $100,000; Qualifies for tier 2 rebate (70% on excess)</condition_comment>
-<condition_description>Tax amount &gt; $20,000 and &lt;= $100,000; Qualifies for tier 2 rebate (70% on excess)</condition_description>
+<condition_dsl>Tax amount &gt; $20,000 and &lt;= $100,000; Qualifies for tier 2 rebate (70% on excess)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -37,7 +37,7 @@
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Tax amount &gt; $100,000; Qualifies for tier 3 rebate (50% on excess over $100k)</condition_comment>
-<condition_description>Tax amount &gt; $100,000; Qualifies for tier 3 rebate (50% on excess over $100k)</condition_description>
+<condition_dsl>Tax amount &gt; $100,000; Qualifies for tier 3 rebate (50% on excess over $100k)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -49,7 +49,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bona fide resident with tax $20k-$100k - tiered rebate</action_comment>
-<action_description>Bona fide resident with tax $20k-$100k - tiered rebate</action_description>
+<action_dsl>Bona fide resident with tax $20k-$100k - tiered rebate</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -57,7 +57,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Bona fide resident with tax &gt; $100k - three-tier rebate</action_comment>
-<action_description>Bona fide resident with tax &gt; $100k - three-tier rebate</action_description>
+<action_dsl>Bona fide resident with tax &gt; $100k - three-tier rebate</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -65,7 +65,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Non-resident - requires Form 5074 for allocation</action_comment>
-<action_description>Non-resident - requires Form 5074 for allocation</action_description>
+<action_dsl>Non-resident - requires Form 5074 for allocation</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/MS_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MS_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_description>No military retirement pay - no exclusion</action_description>
+<action_dsl>No military retirement pay - no exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married filing jointly</condition_comment>
-<condition_description>Married filing jointly</condition_description>
+<condition_dsl>Married filing jointly</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MFJ&quot;
 </condition_postfix>
@@ -53,7 +53,7 @@ filing_status == &quot;MFJ&quot;
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of household</condition_comment>
-<condition_description>Head of household</condition_description>
+<condition_dsl>Head of household</condition_dsl>
 <condition_postfix>
 filing_status == &quot;HOH&quot;
 </condition_postfix>
@@ -61,7 +61,7 @@ filing_status == &quot;HOH&quot;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Married filing separately</condition_comment>
-<condition_description>Married filing separately</condition_description>
+<condition_dsl>Married filing separately</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MFS&quot;
 </condition_postfix>
@@ -71,7 +71,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate MS tax - MFJ (progressive: 0% up to $10k, 4.4% above)</action_comment>
-<action_description>Calculate MS tax - MFJ (progressive: 0% up to $10k, 4.4% above)</action_description>
+<action_dsl>Calculate MS tax - MFJ (progressive: 0% up to $10k, 4.4% above)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -79,7 +79,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate MS tax - HOH (progressive: 0% up to $10k, 4.4% above)</action_comment>
-<action_description>Calculate MS tax - HOH (progressive: 0% up to $10k, 4.4% above)</action_description>
+<action_dsl>Calculate MS tax - HOH (progressive: 0% up to $10k, 4.4% above)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -87,7 +87,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate MS tax - MFS (progressive: 0% up to $10k, 4.4% above)</action_comment>
-<action_description>Calculate MS tax - MFS (progressive: 0% up to $10k, 4.4% above)</action_description>
+<action_dsl>Calculate MS tax - MFS (progressive: 0% up to $10k, 4.4% above)</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/MT_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MT_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Is Montana National Guard member</condition_comment>
-<condition_description>Is Montana National Guard member</condition_description>
+<condition_dsl>Is Montana National Guard member</condition_dsl>
 <condition_postfix>
 is_mt_national_guard == true
 </condition_postfix>
@@ -27,7 +27,7 @@ is_mt_national_guard == true
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Is new resident within 5 years of separation</condition_comment>
-<condition_description>Is new resident within 5 years of separation</condition_description>
+<condition_dsl>Is new resident within 5 years of separation</condition_dsl>
 <condition_postfix>
 is_mt_new_resident == true AND years_since_separation &lt;= 5
 </condition_postfix>
@@ -38,7 +38,7 @@ is_mt_new_resident == true AND years_since_separation &lt;= 5
 <action_details>
 <action_number>2</action_number>
 <action_comment>Apply MT new resident 50% deduction (5-year limit)</action_comment>
-<action_description>Apply MT new resident 50% deduction (5-year limit)</action_description>
+<action_dsl>Apply MT new resident 50% deduction (5-year limit)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -46,7 +46,7 @@ is_mt_new_resident == true AND years_since_separation &lt;= 5
 <action_details>
 <action_number>3</action_number>
 <action_comment>No MT military retirement deduction - fully taxable</action_comment>
-<action_description>No MT military retirement deduction - fully taxable</action_description>
+<action_dsl>No MT military retirement deduction - fully taxable</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/NC_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NC_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_description>No military retirement pay - no exclusion</action_description>
+<action_dsl>No military retirement pay - no exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly</condition_comment>
-<condition_description>Filing status is Married Filing Jointly</condition_description>
+<condition_dsl>Filing status is Married Filing Jointly</condition_dsl>
 <condition_postfix>
 result.filing_status &quot;married_filing_jointly&quot; ==
 </condition_postfix>
@@ -57,7 +57,7 @@ result.filing_status &quot;married_filing_jointly&quot; ==
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Filing status is Head of Household</condition_comment>
-<condition_description>Filing status is Head of Household</condition_description>
+<condition_dsl>Filing status is Head of Household</condition_dsl>
 <condition_postfix>
 result.filing_status &quot;head_of_household&quot; ==
 </condition_postfix>
@@ -69,7 +69,7 @@ result.filing_status &quot;head_of_household&quot; ==
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Default case (Married Filing Separately, etc.)</condition_comment>
-<condition_description>Default case (Married Filing Separately, etc.)</condition_description>
+<condition_dsl>Default case (Married Filing Separately, etc.)</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>
@@ -83,7 +83,7 @@ true
 <action_details>
 <action_number>2</action_number>
 <action_comment>Married Filing Jointly: Apply standard deduction $25,500</action_comment>
-<action_description>Married Filing Jointly: Apply standard deduction $25,500</action_description>
+<action_dsl>Married Filing Jointly: Apply standard deduction $25,500</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -91,7 +91,7 @@ true
 <action_details>
 <action_number>3</action_number>
 <action_comment>Head of Household: Apply standard deduction $22,500</action_comment>
-<action_description>Head of Household: Apply standard deduction $22,500</action_description>
+<action_dsl>Head of Household: Apply standard deduction $22,500</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -99,7 +99,7 @@ true
 <action_details>
 <action_number>4</action_number>
 <action_comment>Other statuses: Apply single standard deduction $12,750</action_comment>
-<action_description>Other statuses: Apply single standard deduction $12,750</action_description>
+<action_dsl>Other statuses: Apply single standard deduction $12,750</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -107,7 +107,7 @@ true
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate NC AGI (Federal AGI minus subtractions)</action_comment>
-<action_description>Calculate NC AGI (Federal AGI minus subtractions)</action_description>
+<action_dsl>Calculate NC AGI (Federal AGI minus subtractions)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -116,7 +116,7 @@ true
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate NC taxable income (NC AGI - standard deduction, minimum 0)</action_comment>
-<action_description>Calculate NC taxable income (NC AGI - standard deduction, minimum 0)</action_description>
+<action_dsl>Calculate NC taxable income (NC AGI - standard deduction, minimum 0)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -125,7 +125,7 @@ true
 <action_details>
 <action_number>7</action_number>
 <action_comment>Calculate NC tax: taxable income × 4.25%</action_comment>
-<action_description>Calculate NC tax: taxable income × 4.25%</action_description>
+<action_dsl>Calculate NC tax: taxable income × 4.25%</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/ND_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/ND_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_description>No military retirement pay - no exclusion</action_description>
+<action_dsl>No military retirement pay - no exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married filing jointly</condition_comment>
-<condition_description>Married filing jointly</condition_description>
+<condition_dsl>Married filing jointly</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MarriedFilingJointly&quot;
 </condition_postfix>
@@ -55,7 +55,7 @@ filing_status == &quot;MarriedFilingJointly&quot;
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate North Dakota tax - Married filing jointly (progressive brackets)</action_comment>
-<action_description>Calculate North Dakota tax - Married filing jointly (progressive brackets)</action_description>
+<action_dsl>Calculate North Dakota tax - Married filing jointly (progressive brackets)</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/NE_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NE_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_description>No military retirement pay - no exclusion</action_description>
+<action_dsl>No military retirement pay - no exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly</condition_comment>
-<condition_description>Filing status is Married Filing Jointly</condition_description>
+<condition_dsl>Filing status is Married Filing Jointly</condition_dsl>
 <condition_postfix>
 Filing Status is MFJ
 </condition_postfix>
@@ -55,7 +55,7 @@ Filing Status is MFJ
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate NE tax for Married Filing Jointly using progressive brackets</action_comment>
-<action_description>Calculate NE tax for Married Filing Jointly using progressive brackets</action_description>
+<action_dsl>Calculate NE tax for Married Filing Jointly using progressive brackets</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/NJ_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NJ_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_description>No military retirement pay - no exclusion</action_description>
+<action_dsl>No military retirement pay - no exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -47,7 +47,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate NJ tax - Progressive 8 brackets (MFJ)</action_comment>
-<action_description>Calculate NJ tax - Progressive 8 brackets (MFJ)</action_description>
+<action_dsl>Calculate NJ tax - Progressive 8 brackets (MFJ)</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/NM_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NM_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_description>No military retirement pay - no exclusion</action_description>
+<action_dsl>No military retirement pay - no exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married filing jointly</condition_comment>
-<condition_description>Married filing jointly</condition_description>
+<condition_dsl>Married filing jointly</condition_dsl>
 <condition_postfix>
 filing_status == &quot;married_filing_jointly&quot;
 </condition_postfix>
@@ -56,7 +56,7 @@ filing_status == &quot;married_filing_jointly&quot;
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of household</condition_comment>
-<condition_description>Head of household</condition_description>
+<condition_dsl>Head of household</condition_dsl>
 <condition_postfix>
 filing_status == &quot;head_of_household&quot;
 </condition_postfix>
@@ -69,7 +69,7 @@ filing_status == &quot;head_of_household&quot;
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate New Mexico tax - Married filing jointly (6 progressive brackets + LICTR)</action_comment>
-<action_description>Calculate New Mexico tax - Married filing jointly (6 progressive brackets + LICTR)</action_description>
+<action_dsl>Calculate New Mexico tax - Married filing jointly (6 progressive brackets + LICTR)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -77,7 +77,7 @@ filing_status == &quot;head_of_household&quot;
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate New Mexico tax - Head of Household (6 progressive brackets + LICTR)</action_comment>
-<action_description>Calculate New Mexico tax - Head of Household (6 progressive brackets + LICTR)</action_description>
+<action_dsl>Calculate New Mexico tax - Head of Household (6 progressive brackets + LICTR)</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/NY_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NY_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_description>No military retirement pay - no exclusion</action_description>
+<action_dsl>No military retirement pay - no exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/OH_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/OH_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_description>No military retirement pay - no exclusion</action_description>
+<action_dsl>No military retirement pay - no exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/OK_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/OK_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_description>No military retirement pay - no exclusion</action_description>
+<action_dsl>No military retirement pay - no exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married filing jointly</condition_comment>
-<condition_description>Married filing jointly</condition_description>
+<condition_dsl>Married filing jointly</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MFJ&quot;
 </condition_postfix>
@@ -53,7 +53,7 @@ filing_status == &quot;MFJ&quot;
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of household</condition_comment>
-<condition_description>Head of household</condition_description>
+<condition_dsl>Head of household</condition_dsl>
 <condition_postfix>
 filing_status == &quot;HOH&quot;
 </condition_postfix>
@@ -61,7 +61,7 @@ filing_status == &quot;HOH&quot;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Married filing separately</condition_comment>
-<condition_description>Married filing separately</condition_description>
+<condition_dsl>Married filing separately</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MFS&quot;
 </condition_postfix>
@@ -71,7 +71,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate Oklahoma tax - Married filing jointly (progressive brackets with personal exemption credit)</action_comment>
-<action_description>Calculate Oklahoma tax - Married filing jointly (progressive brackets with personal exemption credit)</action_description>
+<action_dsl>Calculate Oklahoma tax - Married filing jointly (progressive brackets with personal exemption credit)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -79,7 +79,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Oklahoma tax - Head of household (progressive brackets with personal exemption credit)</action_comment>
-<action_description>Calculate Oklahoma tax - Head of household (progressive brackets with personal exemption credit)</action_description>
+<action_dsl>Calculate Oklahoma tax - Head of household (progressive brackets with personal exemption credit)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -87,7 +87,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate Oklahoma tax - Married filing separately (progressive brackets with personal exemption credit)</action_comment>
-<action_description>Calculate Oklahoma tax - Married filing separately (progressive brackets with personal exemption credit)</action_description>
+<action_dsl>Calculate Oklahoma tax - Married filing separately (progressive brackets with personal exemption credit)</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/OR_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/OR_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>All service before Oct 1, 1991</condition_comment>
-<condition_description>All service before Oct 1, 1991</condition_description>
+<condition_dsl>All service before Oct 1, 1991</condition_dsl>
 <condition_postfix>
 service_all_before_1991_10_01 == true
 </condition_postfix>
@@ -28,7 +28,7 @@ service_all_before_1991_10_01 == true
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Mixed service before and after Oct 1, 1991</condition_comment>
-<condition_description>Mixed service before and after Oct 1, 1991</condition_description>
+<condition_dsl>Mixed service before and after Oct 1, 1991</condition_dsl>
 <condition_postfix>
 has_service_before_1991 == true AND has_service_after_1991 == true
 </condition_postfix>
@@ -40,7 +40,7 @@ has_service_before_1991 == true AND has_service_after_1991 == true
 <action_details>
 <action_number>2</action_number>
 <action_comment>Mixed service - prorated exemption</action_comment>
-<action_description>Mixed service - prorated exemption</action_description>
+<action_dsl>Mixed service - prorated exemption</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -48,7 +48,7 @@ has_service_before_1991 == true AND has_service_after_1991 == true
 <action_details>
 <action_number>3</action_number>
 <action_comment>All service after Oct 1, 1991 - fully taxable</action_comment>
-<action_description>All service after Oct 1, 1991 - fully taxable</action_description>
+<action_dsl>All service after Oct 1, 1991 - fully taxable</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -56,7 +56,7 @@ has_service_before_1991 == true AND has_service_after_1991 == true
 <action_details>
 <action_number>4</action_number>
 <action_comment>No military retirement pay</action_comment>
-<action_description>No military retirement pay</action_description>
+<action_dsl>No military retirement pay</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -82,7 +82,7 @@ has_service_before_1991 == true AND has_service_after_1991 == true
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married filing jointly</condition_comment>
-<condition_description>Married filing jointly</condition_description>
+<condition_dsl>Married filing jointly</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MFJ&quot;
 </condition_postfix>
@@ -94,7 +94,7 @@ filing_status == &quot;MFJ&quot;
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate Oregon progressive tax - Joint</action_comment>
-<action_description>Calculate Oregon progressive tax - Joint</action_description>
+<action_dsl>Calculate Oregon progressive tax - Joint</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/PA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/PA_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate PA Class 2: Interest Income</action_comment>
-<action_description>Calculate PA Class 2: Interest Income</action_description>
+<action_dsl>Calculate PA Class 2: Interest Income</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -28,7 +28,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate PA Class 3: Dividends</action_comment>
-<action_description>Calculate PA Class 3: Dividends</action_description>
+<action_dsl>Calculate PA Class 3: Dividends</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -37,7 +37,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate PA Class 4: Net Profits from Business (Schedule C)</action_comment>
-<action_description>Calculate PA Class 4: Net Profits from Business (Schedule C)</action_description>
+<action_dsl>Calculate PA Class 4: Net Profits from Business (Schedule C)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -46,7 +46,7 @@
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate PA Class 5: Net Gains (Schedule D Capital Gains)</action_comment>
-<action_description>Calculate PA Class 5: Net Gains (Schedule D Capital Gains)</action_description>
+<action_dsl>Calculate PA Class 5: Net Gains (Schedule D Capital Gains)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -55,7 +55,7 @@
 <action_details>
 <action_number>6</action_number>
 <action_comment>Calculate PA Class 6: Rents and Royalties (Schedule E)</action_comment>
-<action_description>Calculate PA Class 6: Rents and Royalties (Schedule E)</action_description>
+<action_dsl>Calculate PA Class 6: Rents and Royalties (Schedule E)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -64,7 +64,7 @@
 <action_details>
 <action_number>7</action_number>
 <action_comment>Calculate PA Class 7: Estate or Trust Income (K-1)</action_comment>
-<action_description>Calculate PA Class 7: Estate or Trust Income (K-1)</action_description>
+<action_dsl>Calculate PA Class 7: Estate or Trust Income (K-1)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -73,7 +73,7 @@
 <action_details>
 <action_number>8</action_number>
 <action_comment>Calculate PA Class 8: Gambling and Lottery Winnings</action_comment>
-<action_description>Calculate PA Class 8: Gambling and Lottery Winnings</action_description>
+<action_dsl>Calculate PA Class 8: Gambling and Lottery Winnings</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -82,7 +82,7 @@
 <action_details>
 <action_number>9</action_number>
 <action_comment>Exclude ALL retirement income (Social Security, pensions, IRA)</action_comment>
-<action_description>Exclude ALL retirement income (Social Security, pensions, IRA)</action_description>
+<action_dsl>Exclude ALL retirement income (Social Security, pensions, IRA)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -91,7 +91,7 @@
 <action_details>
 <action_number>10</action_number>
 <action_comment>Sum all 8 PA income classes to get PA total income</action_comment>
-<action_description>Sum all 8 PA income classes to get PA total income</action_description>
+<action_dsl>Sum all 8 PA income classes to get PA total income</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -100,7 +100,7 @@
 <action_details>
 <action_number>11</action_number>
 <action_comment>Apply PA flat tax rate of 3.07% (NO deductions, NO exemptions)</action_comment>
-<action_description>Apply PA flat tax rate of 3.07% (NO deductions, NO exemptions)</action_description>
+<action_dsl>Apply PA flat tax rate of 3.07% (NO deductions, NO exemptions)</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/PR_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/PR_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Qualifies for Act 60 investor benefits; Act 60 investor (0% capital gains)</condition_comment>
-<condition_description>Qualifies for Act 60 investor benefits; Act 60 investor (0% capital gains)</condition_description>
+<condition_dsl>Qualifies for Act 60 investor benefits; Act 60 investor (0% capital gains)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -27,7 +27,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Qualifies for Act 60 business benefits; Act 60 business (4% rate)</condition_comment>
-<condition_description>Qualifies for Act 60 business benefits; Act 60 business (4% rate)</condition_description>
+<condition_dsl>Qualifies for Act 60 business benefits; Act 60 business (4% rate)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -39,7 +39,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Not bona fide resident - subject to US tax</action_comment>
-<action_description>Not bona fide resident - subject to US tax</action_description>
+<action_dsl>Not bona fide resident - subject to US tax</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/RI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/RI_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_description>No military retirement pay - no exclusion</action_description>
+<action_dsl>No military retirement pay - no exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly</condition_comment>
-<condition_description>Filing status is Married Filing Jointly</condition_description>
+<condition_dsl>Filing status is Married Filing Jointly</condition_dsl>
 <condition_postfix>
 Filing Status is MFJ
 </condition_postfix>
@@ -53,7 +53,7 @@ Filing Status is MFJ
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Filing status is Head of Household</condition_comment>
-<condition_description>Filing status is Head of Household</condition_description>
+<condition_dsl>Filing status is Head of Household</condition_dsl>
 <condition_postfix>
 Filing Status is HOH
 </condition_postfix>
@@ -63,7 +63,7 @@ Filing Status is HOH
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate RI tax for Married Filing Jointly using progressive brackets</action_comment>
-<action_description>Calculate RI tax for Married Filing Jointly using progressive brackets</action_description>
+<action_dsl>Calculate RI tax for Married Filing Jointly using progressive brackets</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -71,7 +71,7 @@ Filing Status is HOH
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate RI tax for Head of Household using progressive brackets</action_comment>
-<action_description>Calculate RI tax for Head of Household using progressive brackets</action_description>
+<action_dsl>Calculate RI tax for Head of Household using progressive brackets</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/SC_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/SC_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_description>No military retirement pay - no exclusion</action_description>
+<action_dsl>No military retirement pay - no exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Taxable income in bracket 2; SC taxable income over $3,560 and under or equal to $17,830</condition_comment>
-<condition_description>Taxable income in bracket 2; SC taxable income over $3,560 and under or equal to $17,830</condition_description>
+<condition_dsl>Taxable income in bracket 2; SC taxable income over $3,560 and under or equal to $17,830</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -53,7 +53,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Taxable income in bracket 3</condition_comment>
-<condition_description>Taxable income in bracket 3</condition_description>
+<condition_dsl>Taxable income in bracket 3</condition_dsl>
 <condition_postfix>
 SC taxable income over $17,830
 </condition_postfix>
@@ -63,7 +63,7 @@ SC taxable income over $17,830
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bracket 2 tax (3%)</action_comment>
-<action_description>Bracket 2 tax (3%)</action_description>
+<action_dsl>Bracket 2 tax (3%)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -71,7 +71,7 @@ SC taxable income over $17,830
 <action_details>
 <action_number>3</action_number>
 <action_comment>Bracket 3 tax (6%)</action_comment>
-<action_description>Bracket 3 tax (6%)</action_description>
+<action_dsl>Bracket 3 tax (6%)</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/TEMPLATE_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/TEMPLATE_dt.xml
@@ -33,7 +33,7 @@
 
 <initial_actions>
 <initial_action>
-<action_description>Initialize [STATE] tax calculation</action_description>
+<action_dsl>Initialize [STATE] tax calculation</action_dsl>
 <action_postfix>
 "[STATE NAME] Tax Calculation Started" job.audit_trail swap addto
 </action_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Always execute</condition_comment>
-<condition_description>true</condition_description>
+<condition_dsl>true</condition_dsl>
 <condition_postfix>
 true
 </condition_postfix>

--- a/sampleprojects/TaxReturn/xml/states/UT_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/UT_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single filer within AGI cap</condition_comment>
-<condition_description>Single filer within AGI cap</condition_description>
+<condition_dsl>Single filer within AGI cap</condition_dsl>
 <condition_postfix>
 filing_status == &quot;Single&quot; AND agi &lt;= $50,000
 </condition_postfix>
@@ -27,7 +27,7 @@ filing_status == &quot;Single&quot; AND agi &lt;= $50,000
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Joint filer within AGI cap</condition_comment>
-<condition_description>Joint filer within AGI cap</condition_description>
+<condition_dsl>Joint filer within AGI cap</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MFJ&quot; AND agi &lt;= $65,000
 </condition_postfix>
@@ -39,7 +39,7 @@ filing_status == &quot;MFJ&quot; AND agi &lt;= $65,000
 <action_details>
 <action_number>2</action_number>
 <action_comment>No exemption - exceeds AGI cap</action_comment>
-<action_description>No exemption - exceeds AGI cap</action_description>
+<action_dsl>No exemption - exceeds AGI cap</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -47,7 +47,7 @@ filing_status == &quot;MFJ&quot; AND agi &lt;= $65,000
 <action_details>
 <action_number>3</action_number>
 <action_comment>No military retirement pay - no exemption</action_comment>
-<action_description>No military retirement pay - no exemption</action_description>
+<action_dsl>No military retirement pay - no exemption</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -73,7 +73,7 @@ filing_status == &quot;MFJ&quot; AND agi &lt;= $65,000
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married filing jointly</condition_comment>
-<condition_description>Married filing jointly</condition_description>
+<condition_dsl>Married filing jointly</condition_dsl>
 <condition_postfix>
 Filing status is Married Filing Jointly
 </condition_postfix>
@@ -84,7 +84,7 @@ Filing status is Married Filing Jointly
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of household</condition_comment>
-<condition_description>Head of household</condition_description>
+<condition_dsl>Head of household</condition_dsl>
 <condition_postfix>
 Filing status is Head of Household
 </condition_postfix>
@@ -97,7 +97,7 @@ Filing status is Head of Household
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate UT tax for joint filer</action_comment>
-<action_description>Calculate UT tax for joint filer</action_description>
+<action_dsl>Calculate UT tax for joint filer</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -105,7 +105,7 @@ Filing status is Head of Household
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate UT tax for head of household</action_comment>
-<action_description>Calculate UT tax for head of household</action_description>
+<action_dsl>Calculate UT tax for head of household</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/VA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/VA_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exemption</action_comment>
-<action_description>No military retirement pay - no exemption</action_description>
+<action_dsl>No military retirement pay - no exemption</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single</condition_comment>
-<condition_description>Single</condition_description>
+<condition_dsl>Single</condition_dsl>
 <condition_postfix>
 filing_status == &quot;Single&quot;
 </condition_postfix>
@@ -53,7 +53,7 @@ filing_status == &quot;Single&quot;
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_description>Head of Household</condition_description>
+<condition_dsl>Head of Household</condition_dsl>
 <condition_postfix>
 filing_status == &quot;HOH&quot;
 </condition_postfix>
@@ -61,7 +61,7 @@ filing_status == &quot;HOH&quot;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Married Filing Separately</condition_comment>
-<condition_description>Married Filing Separately</condition_description>
+<condition_dsl>Married Filing Separately</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MFS&quot;
 </condition_postfix>
@@ -71,7 +71,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate Virginia progressive tax - Single</action_comment>
-<action_description>Calculate Virginia progressive tax - Single</action_description>
+<action_dsl>Calculate Virginia progressive tax - Single</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -79,7 +79,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Virginia progressive tax - HOH</action_comment>
-<action_description>Calculate Virginia progressive tax - HOH</action_description>
+<action_dsl>Calculate Virginia progressive tax - HOH</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -87,7 +87,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate Virginia progressive tax - MFS</action_comment>
-<action_description>Calculate Virginia progressive tax - MFS</action_description>
+<action_dsl>Calculate Virginia progressive tax - MFS</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/VI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/VI_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Qualifies for EDC benefits; Has Economic Development Commission benefits (up to 90% reduction)</condition_comment>
-<condition_description>Qualifies for EDC benefits; Has Economic Development Commission benefits (up to 90% reduction)</condition_description>
+<condition_dsl>Qualifies for EDC benefits; Has Economic Development Commission benefits (up to 90% reduction)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -29,7 +29,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Non-resident - requires Form 8689 for allocation</action_comment>
-<action_description>Non-resident - requires Form 8689 for allocation</action_description>
+<action_dsl>Non-resident - requires Form 8689 for allocation</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/VT_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/VT_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>AGI ≤ $125,000; AGI ≤ $125,000 (full exemption)</condition_comment>
-<condition_description>AGI ≤ $125,000; AGI ≤ $125,000 (full exemption)</condition_description>
+<condition_dsl>AGI ≤ $125,000; AGI ≤ $125,000 (full exemption)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -26,7 +26,7 @@
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>AGI in phase-out range; $125,000 &lt; AGI &lt; $175,000 (partial exemption)</condition_comment>
-<condition_description>AGI in phase-out range; $125,000 &lt; AGI &lt; $175,000 (partial exemption)</condition_description>
+<condition_dsl>AGI in phase-out range; $125,000 &lt; AGI &lt; $175,000 (partial exemption)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -35,7 +35,7 @@
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>AGI ≥ $175,000; AGI ≥ $175,000 (no exemption)</condition_comment>
-<condition_description>AGI ≥ $175,000; AGI ≥ $175,000 (no exemption)</condition_description>
+<condition_dsl>AGI ≥ $175,000; AGI ≥ $175,000 (no exemption)</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -46,7 +46,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Apply VT partial military retirement exemption (AGI phase-out)</action_comment>
-<action_description>Apply VT partial military retirement exemption (AGI phase-out)</action_description>
+<action_dsl>Apply VT partial military retirement exemption (AGI phase-out)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -54,7 +54,7 @@
 <action_details>
 <action_number>3</action_number>
 <action_comment>No VT military retirement exemption (AGI ≥ $175,000)</action_comment>
-<action_description>No VT military retirement exemption (AGI ≥ $175,000)</action_description>
+<action_dsl>No VT military retirement exemption (AGI ≥ $175,000)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -62,7 +62,7 @@
 <action_details>
 <action_number>4</action_number>
 <action_comment>No military retirement pay - no exemption</action_comment>
-<action_description>No military retirement pay - no exemption</action_description>
+<action_dsl>No military retirement pay - no exemption</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -88,7 +88,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Filing status is Married Filing Jointly or Head of Household; Filing Status is MFJ or HOH</condition_comment>
-<condition_description>Filing status is Married Filing Jointly or Head of Household; Filing Status is MFJ or HOH</condition_description>
+<condition_dsl>Filing status is Married Filing Jointly or Head of Household; Filing Status is MFJ or HOH</condition_dsl>
 <condition_postfix>
 
 </condition_postfix>
@@ -98,7 +98,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate VT tax for Married Filing Jointly/HOH using progressive brackets</action_comment>
-<action_description>Calculate VT tax for Married Filing Jointly/HOH using progressive brackets</action_description>
+<action_dsl>Calculate VT tax for Married Filing Jointly/HOH using progressive brackets</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/WI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/WI_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_description>No military retirement pay - no exclusion</action_description>
+<action_dsl>No military retirement pay - no exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Married filing jointly</condition_comment>
-<condition_description>Married filing jointly</condition_description>
+<condition_dsl>Married filing jointly</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MFJ&quot;
 </condition_postfix>
@@ -53,7 +53,7 @@ filing_status == &quot;MFJ&quot;
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of household</condition_comment>
-<condition_description>Head of household</condition_description>
+<condition_dsl>Head of household</condition_dsl>
 <condition_postfix>
 filing_status == &quot;HOH&quot;
 </condition_postfix>
@@ -61,7 +61,7 @@ filing_status == &quot;HOH&quot;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Married filing separately</condition_comment>
-<condition_description>Married filing separately</condition_description>
+<condition_dsl>Married filing separately</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MFS&quot;
 </condition_postfix>
@@ -71,7 +71,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate Wisconsin tax - Married filing jointly (progressive brackets)</action_comment>
-<action_description>Calculate Wisconsin tax - Married filing jointly (progressive brackets)</action_description>
+<action_dsl>Calculate Wisconsin tax - Married filing jointly (progressive brackets)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -79,7 +79,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Wisconsin tax - Head of household (progressive brackets, uses single brackets)</action_comment>
-<action_description>Calculate Wisconsin tax - Head of household (progressive brackets, uses single brackets)</action_description>
+<action_dsl>Calculate Wisconsin tax - Head of household (progressive brackets, uses single brackets)</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -87,7 +87,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate Wisconsin tax - Married filing separately (progressive brackets, uses single brackets)</action_comment>
-<action_description>Calculate Wisconsin tax - Married filing separately (progressive brackets, uses single brackets)</action_description>
+<action_dsl>Calculate Wisconsin tax - Married filing separately (progressive brackets, uses single brackets)</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/WV_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/WV_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_description>No military retirement pay - no exclusion</action_description>
+<action_dsl>No military retirement pay - no exclusion</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TestProject/repository/xml/Test_dt.xml
+++ b/sampleprojects/TestProject/repository/xml/Test_dt.xml
@@ -9,7 +9,7 @@
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_description>for all things</context_description>
+<context_dsl>for all things</context_dsl>
 <context_postfix>
 dup things forall pop 
 </context_postfix></context_details></contexts>
@@ -19,7 +19,7 @@ dup things forall pop
 <condition_number>1</condition_number>
 <condition_comment></condition_comment>
 <condition_requirement></condition_requirement>
-<condition_description>thing.value == 1</condition_description>
+<condition_dsl>thing.value == 1</condition_dsl>
 <condition_postfix>
 thing.value 1 == 
 </condition_postfix>
@@ -28,7 +28,7 @@ thing.value 1 ==
 <condition_number>2</condition_number>
 <condition_comment></condition_comment>
 <condition_requirement></condition_requirement>
-<condition_description>thing.value == 2</condition_description>
+<condition_dsl>thing.value == 2</condition_dsl>
 <condition_postfix>
 thing.value 2 == 
 </condition_postfix>
@@ -37,7 +37,7 @@ thing.value 2 ==
 <condition_number>3</condition_number>
 <condition_comment></condition_comment>
 <condition_requirement></condition_requirement>
-<condition_description>thing.value == 3</condition_description>
+<condition_dsl>thing.value == 3</condition_dsl>
 <condition_postfix>
 thing.value 3 == 
 </condition_postfix>
@@ -46,7 +46,7 @@ thing.value 3 ==
 <condition_number>4</condition_number>
 <condition_comment></condition_comment>
 <condition_requirement></condition_requirement>
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>
 otherwise 
 </condition_postfix>
@@ -56,7 +56,7 @@ otherwise
 <action_number>1</action_number>
 <action_comment></action_comment>
 <initial_action_requirement></initial_action_requirement>
-<action_description>add the policy statements to the job.notes</action_description>
+<action_dsl>add the policy statements to the job.notes</action_dsl>
 <action_postfix>
 policystatements job.notes true  addarray 
 </action_postfix>

--- a/sampleprojects/TestProject/xml/Test_dt.xml
+++ b/sampleprojects/TestProject/xml/Test_dt.xml
@@ -10,7 +10,7 @@
 <context_details>
 <context_number>1</context_number>
 <context_comment></context_comment>
-<context_description>for all things</context_description>
+<context_dsl>for all things</context_dsl>
 <context_postfix>
 dup things forall pop 
 </context_postfix></context_details></contexts>
@@ -20,7 +20,7 @@ dup things forall pop
 <condition_number>1</condition_number>
 <condition_comment></condition_comment>
 <condition_requirement></condition_requirement>
-<condition_description>thing.value == 1</condition_description>
+<condition_dsl>thing.value == 1</condition_dsl>
 <condition_postfix>
 thing.value 1 == 
 </condition_postfix>
@@ -29,7 +29,7 @@ thing.value 1 ==
 <condition_number>2</condition_number>
 <condition_comment></condition_comment>
 <condition_requirement></condition_requirement>
-<condition_description>thing.value == 2</condition_description>
+<condition_dsl>thing.value == 2</condition_dsl>
 <condition_postfix>
 thing.value 2 == 
 </condition_postfix>
@@ -38,7 +38,7 @@ thing.value 2 ==
 <condition_number>3</condition_number>
 <condition_comment></condition_comment>
 <condition_requirement></condition_requirement>
-<condition_description>thing.value == 3</condition_description>
+<condition_dsl>thing.value == 3</condition_dsl>
 <condition_postfix>
 thing.value 3 == 
 </condition_postfix>
@@ -47,7 +47,7 @@ thing.value 3 ==
 <condition_number>4</condition_number>
 <condition_comment></condition_comment>
 <condition_requirement></condition_requirement>
-<condition_description>otherwise</condition_description>
+<condition_dsl>otherwise</condition_dsl>
 <condition_postfix>
 otherwise 
 </condition_postfix>
@@ -57,7 +57,7 @@ otherwise
 <action_number>1</action_number>
 <action_comment></action_comment>
 <action_requirement></action_requirement>
-<action_description>add the policy statements to the job.notes</action_description>
+<action_dsl>add the policy statements to the job.notes</action_dsl>
 <action_postfix>
 policystatements job.notes true  addarray 
 </action_postfix>


### PR DESCRIPTION
## Summary

Rename DSL expression tags to avoid confusion between DSL code and human-readable comments:

| Old Tag | New Tag |
|---------|---------|
| `condition_description` | `condition_dsl` |
| `action_description` | `action_dsl` |
| `context_description` | `context_dsl` |
| `initial_action_description` | `initial_action_dsl` |

**Note:** `policy_description` remains unchanged (it's a label, not compiled DSL).

## Changes

- **pkg/dtrules/loader/dt.go** - Added DSL fields with backward-compatible GetDSL() methods
- **pkg/dtrules/excel/dt_importer.go** - Renamed fields to DSL, exports new tag names
- **pkg/dtrules/sync/validation.go** - Added DSL fields for validation compatibility
- **cmd/dtrules/docs.go** - Updated embedded documentation
- **sampleprojects/** - Migrated 225 XML files to new tag names

## Backward Compatibility

The loader reads both old `*_description` and new `*_dsl` tags, preferring the new format when both exist.

Resolves #410, #411, #412, #413, #414, #415

## Test plan

- [x] Build passes
- [x] loader, excel, sync package tests pass
- [x] Existing XML files load correctly with new tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)