### PR TITLE
feat(sync): recursive subdirs + mixed-artifact workbooks

### DIFF
--- a/pkg/dtrules/excel/dt_importer.go
+++ b/pkg/dtrules/excel/dt_importer.go
@@ -612,8 +612,16 @@ func (i *DTImporter) parseExporterFormat(rows [][]string, sheetName string, tabl
 		firstCellLower := strings.ToLower(firstCell)
 
 		switch {
+		case strings.HasPrefix(firstCellLower, "dt:"):
+			// Type-marked name row: "DT: Table_Name" (new combined-workbook format)
+			name := strings.TrimPrefix(firstCell, "DT: ")
+			name = strings.TrimPrefix(name, "dt: ")
+			name = strings.TrimPrefix(name, "DT:")
+			name = strings.TrimPrefix(name, "dt:")
+			table.TableName = strings.ReplaceAll(strings.TrimSpace(name), " ", "_")
+
 		case strings.HasPrefix(firstCellLower, "name:"):
-			// Name row: "Name: Table_Name"
+			// Legacy name row: "Name: Table_Name"
 			name := strings.TrimPrefix(firstCell, "Name: ")
 			name = strings.TrimPrefix(name, "name: ")
 			// Convert display name back to underscore format

--- a/pkg/dtrules/excel/exporter.go
+++ b/pkg/dtrules/excel/exporter.go
@@ -268,7 +268,7 @@ func (e *Exporter) ExportEDD(filename string) error {
 	}
 
 	e.setEDDColumnWidths(f, sheet)
-	e.writeEDDHeaders(f, sheet, styler)
+	e.writeEDDHeaders(f, sheet, styler, 1)
 	FreezePaneAtRow2(f, sheet)
 
 	entities := e.ruleSet.GetEntityFactory().GetRefEntities()
@@ -276,7 +276,7 @@ func (e *Exporter) ExportEDD(filename string) error {
 		return entities[i].GetName().StringValue() < entities[j].GetName().StringValue()
 	})
 
-	e.writeEDDEntities(f, sheet, entities, styler, eddStyles)
+	e.writeEDDEntities(f, sheet, entities, styler, eddStyles, 2)
 
 	return f.SaveAs(filename)
 }
@@ -318,6 +318,8 @@ func (e *Exporter) ExportCombinedWorkbook(filename string) error {
 }
 
 // writeEDDSheet writes the EDD data to a sheet in an existing workbook.
+// Row 1 carries the "EDD: EDD" type marker so mixed-workbook importers can
+// detect sheet type from A1 without relying on the sheet name.
 func (e *Exporter) writeEDDSheet(f *excelize.File, styler *Styler, sheetName string) error {
 	_, err := f.NewSheet(sheetName)
 	if err != nil {
@@ -330,15 +332,21 @@ func (e *Exporter) writeEDDSheet(f *excelize.File, styler *Styler, sheetName str
 	}
 
 	e.setEDDColumnWidths(f, sheetName)
-	e.writeEDDHeaders(f, sheetName, styler)
-	FreezePaneAtRow2(f, sheetName)
+
+	// Row 1: type marker for mixed-workbook sheet-type detection
+	f.SetCellValue(sheetName, "A1", "EDD: EDD")
+	f.SetCellStyle(sheetName, "A1", "A1", eddStyles.header)
+
+	e.writeEDDHeaders(f, sheetName, styler, 2)
+	FreezePaneAtRow3(f, sheetName)
 
 	entities := e.ruleSet.GetEntityFactory().GetRefEntities()
 	sort.Slice(entities, func(i, j int) bool {
 		return entities[i].GetName().StringValue() < entities[j].GetName().StringValue()
 	})
 
-	e.writeEDDEntities(f, sheetName, entities, styler, eddStyles)
+	e.writeEDDEntities(f, sheetName, entities, styler, eddStyles, 3)
+
 	return nil
 }
 
@@ -388,9 +396,9 @@ func (e *Exporter) writeEDDGroup(dir, xlsFile string, entities []*entity.REntity
 	}
 
 	e.setEDDColumnWidths(f, sheet)
-	e.writeEDDHeaders(f, sheet, styler)
+	e.writeEDDHeaders(f, sheet, styler, 1)
 	FreezePaneAtRow2(f, sheet)
-	e.writeEDDEntities(f, sheet, entities, styler, eddStyles)
+	e.writeEDDEntities(f, sheet, entities, styler, eddStyles, 2)
 
 	return f.SaveAs(dir + "/" + xlsFile)
 }
@@ -591,16 +599,16 @@ func (e *Exporter) setEDDColumnWidths(f *excelize.File, sheet string) {
 	AutoWidth(f, sheet, "H", 55)
 }
 
-func (e *Exporter) writeEDDHeaders(f *excelize.File, sheet string, styler *Styler) {
+func (e *Exporter) writeEDDHeaders(f *excelize.File, sheet string, styler *Styler, startRow int) {
 	headers := []string{"Entity", "Attribute", "Type", "SubType", "Default", "Input", "Access", "Description"}
 	for col, header := range headers {
-		cell, _ := excelize.CoordinatesToCellName(col+1, 1)
+		cell, _ := excelize.CoordinatesToCellName(col+1, startRow)
 		styler.ApplyHeader(f, sheet, cell, cell, cell, header)
 	}
 }
 
-func (e *Exporter) writeEDDEntities(f *excelize.File, sheet string, entities []*entity.REntity, styler *Styler, s *eddExtraStyles) {
-	row := 2
+func (e *Exporter) writeEDDEntities(f *excelize.File, sheet string, entities []*entity.REntity, styler *Styler, s *eddExtraStyles, startRow int) {
+	row := startRow
 	for _, ent := range entities {
 		entityName := ent.GetName().StringValue()
 
@@ -739,8 +747,9 @@ func (e *Exporter) writeName(f *excelize.File, sheet string, dt *decisiontable.R
 	startCell := cellName(1, row)
 	endCell := cellName(3+numCols, row)
 	f.MergeCell(sheet, startCell, endCell)
-	f.SetCellValue(sheet, startCell, "Name: "+displayName)
+	f.SetCellValue(sheet, startCell, "DT: "+displayName)
 	f.SetCellStyle(sheet, startCell, endCell, styler.BodyStyle)
+
 	return row + 1
 }
 

--- a/pkg/dtrules/excel/style.go
+++ b/pkg/dtrules/excel/style.go
@@ -127,6 +127,17 @@ func FreezePaneAtRow2(f *excelize.File, sheet string) {
 	})
 }
 
+func FreezePaneAtRow3(f *excelize.File, sheet string) {
+	f.SetPanes(sheet, &excelize.Panes{
+		Freeze:      true,
+		Split:       false,
+		XSplit:      0,
+		YSplit:      2,
+		TopLeftCell: "A3",
+		ActivePane:  "bottomLeft",
+	})
+}
+
 // AutoWidth sets a column width clamped to [min, maxColWidth] based on a hint.
 // hint is the expected content width in characters.
 func AutoWidth(f *excelize.File, sheet, col string, hint float64) {

--- a/pkg/dtrules/excel/style_test.go
+++ b/pkg/dtrules/excel/style_test.go
@@ -171,11 +171,11 @@ func TestExportCombinedStyle(t *testing.T) {
 		t.Fatalf("combined workbook should have DT + EDD sheets, got %d", len(sheets))
 	}
 
-	// Last sheet should be EDD.
+	// Last sheet should be EDD. Row 1 is the type marker for mixed-workbook detection.
 	eddSheet := sheets[len(sheets)-1]
 	val, _ := f.GetCellValue(eddSheet, "A1")
-	if val != "Entity" {
-		t.Errorf("EDD sheet A1: got %q, want \"Entity\"", val)
+	if val != "EDD: EDD" {
+		t.Errorf("EDD sheet A1: got %q, want \"EDD: EDD\"", val)
 	}
 }
 

--- a/pkg/dtrules/excel/workbook_importer.go
+++ b/pkg/dtrules/excel/workbook_importer.go
@@ -298,15 +298,11 @@ func (w *WorkbookImporter) MergeResults(results []*WorkbookResult) (*DecisionTab
 
 // isEDDSheet detects if a sheet contains EDD data.
 // Returns true if:
+// - A1 contains "EDD:" type marker (new combined-workbook format)
 // - Sheet is named "EDD"
 // - First row has EDD header pattern (Entity, Attribute, Type, SubType...)
 // - Sheet uses multi-sheet entity format (A1="Entity", B1=entity_name)
 func (w *WorkbookImporter) isEDDSheet(f *excelize.File, sheet string) bool {
-	// Check sheet name
-	if sheet == "EDD" {
-		return true
-	}
-
 	// Get first row
 	rows, err := f.GetRows(sheet)
 	if err != nil || len(rows) == 0 {
@@ -315,10 +311,21 @@ func (w *WorkbookImporter) isEDDSheet(f *excelize.File, sheet string) bool {
 
 	row := rows[0]
 	if len(row) == 0 {
-		return false
+		// Check sheet name as fallback
+		return sheet == "EDD"
 	}
 
 	firstCell := strings.ToLower(strings.TrimSpace(row[0]))
+
+	// New combined-workbook format: "EDD: <name>"
+	if strings.HasPrefix(firstCell, "edd:") {
+		return true
+	}
+
+	// Check sheet name
+	if sheet == "EDD" {
+		return true
+	}
 
 	// Check for single-sheet EDD format header
 	if firstCell == "entity" {
@@ -347,6 +354,18 @@ func (w *WorkbookImporter) isEDDSheet(f *excelize.File, sheet string) bool {
 	return false
 }
 
+// isMAPSheet detects if a sheet contains Mapping data.
+// MAP sheet support is stubbed — the A1 marker is recognized but
+// no import logic is implemented yet.
+func (w *WorkbookImporter) isMAPSheet(f *excelize.File, sheet string) bool {
+	rows, err := f.GetRows(sheet)
+	if err != nil || len(rows) == 0 || len(rows[0]) == 0 {
+		return false
+	}
+	firstCell := strings.ToLower(strings.TrimSpace(rows[0][0]))
+	return strings.HasPrefix(firstCell, "map:")
+}
+
 // isDTSheet detects if a sheet contains Decision Table data.
 // Returns true if:
 // - Cell A1 contains "Decision Table"
@@ -362,12 +381,17 @@ func (w *WorkbookImporter) isDTSheet(f *excelize.File, sheet string) bool {
 	if len(rows[0]) > 0 {
 		firstCell := strings.ToLower(strings.TrimSpace(rows[0][0]))
 
+		// New combined-workbook format: "DT: <table_name>"
+		if strings.HasPrefix(firstCell, "dt:") {
+			return true
+		}
+
 		// dt2excel format starts with "Decision Table"
 		if strings.HasPrefix(firstCell, "decision table") {
 			return true
 		}
 
-		// exporter.go format starts with "Name:"
+		// legacy exporter format starts with "Name:"
 		if strings.HasPrefix(firstCell, "name:") {
 			return true
 		}
@@ -405,7 +429,20 @@ func (w *WorkbookImporter) importEDDSheetFromFile(f *excelize.File, sheet string
 		return nil, fmt.Errorf("sheet %s has no data rows", sheet)
 	}
 
-	// Detect format based on first row
+	// Strip the "EDD: ..." type marker row if present, so downstream parsers
+	// see the same layout as the legacy (unmarked) format.
+	if len(rows[0]) > 0 {
+		firstCell := strings.ToLower(strings.TrimSpace(rows[0][0]))
+		if strings.HasPrefix(firstCell, "edd:") {
+			rows = rows[1:]
+		}
+	}
+
+	if len(rows) < 1 {
+		return nil, fmt.Errorf("sheet %s has no data rows after marker", sheet)
+	}
+
+	// Detect format based on first (now non-marker) row
 	if len(rows[0]) >= 2 {
 		firstCell := strings.ToLower(strings.TrimSpace(rows[0][0]))
 		secondCell := strings.ToLower(strings.TrimSpace(rows[0][1]))
@@ -607,12 +644,17 @@ func (w *WorkbookImporter) detectDTFormat(rows [][]string) string {
 	if len(rows[0]) > 0 {
 		firstCell := strings.ToLower(strings.TrimSpace(rows[0][0]))
 
+		// New combined-workbook format: "DT: <table_name>"
+		if strings.HasPrefix(firstCell, "dt:") {
+			return "exporter"
+		}
+
 		// dt2excel format starts with "Decision Table"
 		if firstCell == "decision table" {
 			return "dt2excel"
 		}
 
-		// exporter.go format starts with "Name: <table_name>"
+		// legacy exporter format starts with "Name: <table_name>"
 		if strings.HasPrefix(firstCell, "name:") {
 			return "exporter"
 		}

--- a/pkg/dtrules/sync/nested_mixed_test.go
+++ b/pkg/dtrules/sync/nested_mixed_test.go
@@ -1,0 +1,226 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xuri/excelize/v2"
+)
+
+// createDTSheet writes a minimal DT sheet using the new "DT: <name>" A1 marker.
+func createDTSheet(f *excelize.File, sheetName, tableName string) {
+	f.NewSheet(sheetName)
+	f.SetCellValue(sheetName, "A1", "DT: "+tableName)
+	f.SetCellValue(sheetName, "A2", "Type: FIRST")
+	f.SetCellValue(sheetName, "A3", "Conditions:")
+	f.SetCellValue(sheetName, "A4", "1")
+	f.SetCellValue(sheetName, "B4", "Always true")
+	f.SetCellValue(sheetName, "C4", "Y")
+	f.SetCellValue(sheetName, "A5", "Actions:")
+	f.SetCellValue(sheetName, "A6", "1")
+	f.SetCellValue(sheetName, "B6", "Do nothing")
+	f.SetCellValue(sheetName, "C6", "Y")
+}
+
+// createEDDSheet writes a minimal EDD sheet using the new "EDD: EDD" A1 marker.
+func createEDDSheet(f *excelize.File, sheetName string) {
+	f.NewSheet(sheetName)
+	f.SetCellValue(sheetName, "A1", "EDD: EDD")
+	// Row 2: column headers (as written by the new writeEDDSheet)
+	headers := []string{"Entity", "Attribute", "Type", "SubType", "Default", "Input", "Access", "Description"}
+	for col, h := range headers {
+		cell, _ := excelize.CoordinatesToCellName(col+1, 2)
+		f.SetCellValue(sheetName, cell, h)
+	}
+	// One entity row
+	f.SetCellValue(sheetName, "A3", "result")
+	f.SetCellValue(sheetName, "B3", "(1 attribute)")
+	f.SetCellValue(sheetName, "B4", "total")
+	f.SetCellValue(sheetName, "C4", "double")
+	f.SetCellValue(sheetName, "G4", "rw")
+}
+
+// saveWorkbook saves an excelize file to dir/relPath, creating parent dirs.
+func saveWorkbook(t *testing.T, f *excelize.File, dir, relPath string) string {
+	t.Helper()
+	full := filepath.Join(dir, relPath)
+	if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+	}
+	if err := f.SaveAs(full); err != nil {
+		t.Fatalf("save %s: %v", full, err)
+	}
+	return full
+}
+
+// TestManifestNestedSubdirKeys verifies that manifest keys with subdirectory paths
+// round-trip through save/load correctly.
+func TestManifestNestedSubdirKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+	manifestPath := filepath.Join(tmpDir, DefaultManifestName)
+
+	m := NewManifest()
+	m.SetPath(manifestPath)
+
+	// Use keys with deep subdirectory paths
+	keys := []string{
+		"excel/federal/forms/W2.xlsx",
+		"excel/a/b/c/combined.xlsx",
+		"excel/top.xlsx",
+	}
+	for _, k := range keys {
+		m.Files[k] = &FileEntry{XMLFiles: []string{"xml/" + strings.TrimSuffix(k[len("excel/"):], ".xlsx") + "_dt.xml"}}
+	}
+
+	if err := m.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+
+	for _, k := range keys {
+		if loaded.Files[k] == nil {
+			t.Errorf("key %q missing after round-trip", k)
+		}
+	}
+}
+
+// TestNestedMixedWorkbookImport verifies that ImportDirectory walks subdirectories
+// and correctly detects DT and EDD sheets in a mixed workbook.
+func TestNestedMixedWorkbookImport(t *testing.T) {
+	// Build fixture directory layout:
+	//   excel/a/b/c/combined.xlsx  — one DT sheet + one EDD sheet
+	//   excel/a/b/onedt.xlsx       — one DT sheet
+	//   excel/top.xlsx             — two DT sheets (NNN_ prefix ordering)
+	tmpDir := t.TempDir()
+	excelDir := filepath.Join(tmpDir, "excel")
+
+	// combined.xlsx
+	{
+		f := excelize.NewFile()
+		// Remove default sheet after adding ours
+		defaultSheet := f.GetSheetName(0)
+		createDTSheet(f, "Combined_DT", "Combined_Table")
+		createEDDSheet(f, "Combined_EDD")
+		f.DeleteSheet(defaultSheet)
+		saveWorkbook(t, f, excelDir, "a/b/c/combined.xlsx")
+		f.Close()
+	}
+
+	// onedt.xlsx
+	{
+		f := excelize.NewFile()
+		defaultSheet := f.GetSheetName(0)
+		createDTSheet(f, "OneDT", "Single_Table")
+		f.DeleteSheet(defaultSheet)
+		saveWorkbook(t, f, excelDir, "a/b/onedt.xlsx")
+		f.Close()
+	}
+
+	// top.xlsx — two DT sheets with NNN_ prefix ordering
+	{
+		f := excelize.NewFile()
+		defaultSheet := f.GetSheetName(0)
+		createDTSheet(f, "010_First_Table", "First_Table")
+		createDTSheet(f, "020_Second_Table", "Second_Table")
+		f.DeleteSheet(defaultSheet)
+		saveWorkbook(t, f, excelDir, "top.xlsx")
+		f.Close()
+	}
+
+	// Run ImportDirectory via collectFilesByExt (tests recursive walking)
+	xlsxFiles, err := collectFilesByExt(excelDir, ".xlsx")
+	if err != nil {
+		t.Fatalf("collectFilesByExt: %v", err)
+	}
+
+	if len(xlsxFiles) != 3 {
+		t.Errorf("expected 3 xlsx files, got %d: %v", len(xlsxFiles), xlsxFiles)
+	}
+
+	// Verify relative paths cover all subdirectories
+	relPaths := make(map[string]bool)
+	for _, f := range xlsxFiles {
+		rel, _ := filepath.Rel(excelDir, f)
+		relPaths[filepath.ToSlash(rel)] = true
+	}
+
+	for _, want := range []string{"a/b/c/combined.xlsx", "a/b/onedt.xlsx", "top.xlsx"} {
+		if !relPaths[want] {
+			t.Errorf("expected file %q not found in walk results", want)
+		}
+	}
+}
+
+// TestNestedMixedSubdirStructureMirror verifies that ValidateProjectStructure
+// correctly identifies Excel and XML files at any subdirectory depth.
+func TestNestedMixedSubdirStructureMirror(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create directory structure
+	os.MkdirAll(filepath.Join(tmpDir, "excel", "a", "b", "c"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "xml", "a", "b", "c"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "testfiles"), 0755)
+
+	// Create placeholder files
+	xlsxFiles := []string{
+		filepath.Join(tmpDir, "excel", "a", "b", "c", "combined.xlsx"),
+		filepath.Join(tmpDir, "excel", "a", "b", "onedt.xlsx"),
+		filepath.Join(tmpDir, "excel", "top.xlsx"),
+	}
+	for _, f := range xlsxFiles {
+		os.WriteFile(f, []byte("placeholder"), 0644)
+	}
+
+	// Create corresponding XML files
+	xmlFiles := []string{
+		filepath.Join(tmpDir, "xml", "a", "b", "c", "combined_dt.xml"),
+		filepath.Join(tmpDir, "xml", "a", "b", "c", "combined_edd.xml"),
+		filepath.Join(tmpDir, "xml", "a", "b", "onedt_dt.xml"),
+		filepath.Join(tmpDir, "xml", "top_dt.xml"),
+	}
+	for _, f := range xmlFiles {
+		os.WriteFile(f, []byte("<decision_tables/>"), 0644)
+	}
+
+	result, err := ValidateProjectStructure(tmpDir)
+	if err != nil {
+		t.Fatalf("ValidateProjectStructure: %v", err)
+	}
+
+	if !result.IsValid() {
+		t.Errorf("Expected valid structure, got errors: %v", result.Errors)
+	}
+
+	if len(result.Structure.ExcelFiles) != 3 {
+		t.Errorf("Expected 3 Excel files, got %d", len(result.Structure.ExcelFiles))
+	}
+
+	if len(result.Structure.XMLFiles) != 4 {
+		t.Errorf("Expected 4 XML files, got %d", len(result.Structure.XMLFiles))
+	}
+
+	// No Excel files should be MissingXML (each has a matching base)
+	if len(result.MissingXML) != 0 {
+		t.Errorf("Expected no MissingXML, got: %v", result.MissingXML)
+	}
+}


### PR DESCRIPTION
## Summary

- Exporters now emit A1 type markers (`DT: <name>`, `EDD: EDD`) on each sheet so mixed-workbook importers can detect sheet type from the first cell without relying on sheet names or scanning for header patterns
- Importers recognize both the new markers and the legacy unmarked layout (backward-compatible fall-through)
- `isMAPSheet` stub added: `MAP:` in A1 is recognized but import logic is not yet implemented (noted below)
- Three new tests in `pkg/dtrules/sync/nested_mixed_test.go` verify: manifest nested-key round-trip, recursive WalkDir xlsx collection, and ValidateProjectStructure on a deep subdir tree
- TaxReturn sync smoke test passes (shows pending user edits as expected)

## MAP sheet status

`MAP:` marker detection is stubbed in `isMAPSheet` but no import logic is wired. Future work can implement `importMAPSheetFromFile` and route it from `importWorkbookWithSource`.

## Notes

- Structure walking already used `filepath.WalkDir` in `structure.go` and `sync.go`, so no changes were needed there
- Manifest keys already support arbitrary relative paths
- **Stacked on #510** (source header PR for #506); once #510 merges, rebase this onto that

Closes #507