### PR TITLE
fix(excel): unbreak main after #514 rebase

### DIFF
--- a/pkg/dtrules/excel/exporter.go
+++ b/pkg/dtrules/excel/exporter.go
@@ -335,7 +335,7 @@ func (e *Exporter) writeEDDSheet(f *excelize.File, styler *Styler, sheetName str
 
 	// Row 1: type marker for mixed-workbook sheet-type detection
 	f.SetCellValue(sheetName, "A1", "EDD: EDD")
-	f.SetCellStyle(sheetName, "A1", "A1", eddStyles.header)
+	f.SetCellStyle(sheetName, "A1", "A1", styler.HeaderStyle)
 
 	e.writeEDDHeaders(f, sheetName, styler, 2)
 	FreezePaneAtRow3(f, sheetName)


### PR DESCRIPTION
Hotfix: #514's rebase onto main left a dangling reference to `eddStyles.header`, which was removed in #512's Styler refactor. Fixes the build.