### PR TITLE
feat(release): version command, Makefile release target, GH Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Set version info
+        id: version
+        run: |
+          echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Build release binaries
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          COMMIT:  ${{ steps.version.outputs.commit }}
+          DATE:    ${{ steps.version.outputs.date }}
+        run: make release
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/dtrules-linux-amd64
+            dist/dtrules-linux-arm64
+            dist/dtrules-darwin-amd64
+            dist/dtrules-darwin-arm64
+            dist/dtrules-windows-amd64.exe
+            dist/checksums.txt
+          generate_release_notes: true

--- a/Makefile
+++ b/Makefile
@@ -7,34 +7,28 @@
 #   make install
 
 # Version info
-# Uses git describe to get version from tags (e.g., "v1.0.0" or "v1.0.0-5-gabcdef")
+VERSION  ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT   ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+DATE     ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
-BUILD_DATE ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
-
-# Check if working directory is clean (empty = clean, non-empty = dirty)
-GIT_DIRTY := $(shell git status --porcelain 2>/dev/null)
-
-# If dirty, omit commit hash (code doesn't match any commit)
-ifdef GIT_DIRTY
-  GIT_COMMIT ?= uncommitted
-  VERSION ?= $(GIT_BRANCH)-dev
-else
-  GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-  VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo "dev")
-endif
 
 # Build flags
 PKG := github.com/DTRules/DTRules/pkg/dtrules/version
-LDFLAGS := -X $(PKG).Version=$(VERSION)
-LDFLAGS += -X $(PKG).GitCommit=$(GIT_COMMIT)
-LDFLAGS += -X $(PKG).GitBranch=$(GIT_BRANCH)
-LDFLAGS += -X $(PKG).BuildDate=$(BUILD_DATE)
+LDFLAGS := -s -w \
+           -X $(PKG).Version=$(VERSION) \
+           -X $(PKG).Commit=$(COMMIT) \
+           -X $(PKG).Date=$(DATE) \
+           -X $(PKG).GitCommit=$(COMMIT) \
+           -X $(PKG).GitBranch=$(GIT_BRANCH) \
+           -X $(PKG).BuildDate=$(DATE)
 
 # Output
-BINARY := dtrules
+BINARY   := dtrules
 BUILD_DIR := build
+DIST_DIR  := dist
 
-.PHONY: all build install clean test version
+.PHONY: all build install clean test version release
 
 all: build
 
@@ -49,7 +43,7 @@ install:
 
 clean:
 	@echo "Cleaning..."
-	rm -rf $(BUILD_DIR)
+	rm -rf $(BUILD_DIR) $(DIST_DIR)
 	go clean
 
 test:
@@ -58,11 +52,24 @@ test:
 
 version:
 	@echo "Version: $(VERSION)"
-	@echo "Commit:  $(GIT_COMMIT)"
+	@echo "Commit:  $(COMMIT)"
 	@echo "Branch:  $(GIT_BRANCH)"
-	@echo "Date:    $(BUILD_DATE)"
+	@echo "Date:    $(DATE)"
 
-# Cross-compilation targets
+# Release: cross-compile for all platforms and produce checksums in dist/
+release:
+	@echo "Building release $(VERSION)..."
+	@mkdir -p $(DIST_DIR)
+	GOOS=linux   GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $(DIST_DIR)/$(BINARY)-linux-amd64       ./cmd/dtrules/
+	GOOS=linux   GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o $(DIST_DIR)/$(BINARY)-linux-arm64       ./cmd/dtrules/
+	GOOS=darwin  GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $(DIST_DIR)/$(BINARY)-darwin-amd64      ./cmd/dtrules/
+	GOOS=darwin  GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o $(DIST_DIR)/$(BINARY)-darwin-arm64      ./cmd/dtrules/
+	GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $(DIST_DIR)/$(BINARY)-windows-amd64.exe ./cmd/dtrules/
+	cd $(DIST_DIR) && sha256sum * > checksums.txt
+	@echo "Release artifacts in $(DIST_DIR)/"
+	@ls -lh $(DIST_DIR)/
+
+# Cross-compilation targets (individual platforms, output to build/)
 .PHONY: build-linux build-darwin build-windows build-all
 
 build-linux:

--- a/README.md
+++ b/README.md
@@ -22,13 +22,27 @@ DTRules has been used in production systems including:
 - Insurance eligibility determination systems
 - Commercial business logic applications
 
-## Quick Start
+## Install
 
-### Install
+**Option 1 — go install (requires Go 1.21+):**
 
 ```bash
 go install github.com/DTRules/DTRules/cmd/dtrules@latest
 ```
+
+**Option 2 — Prebuilt binaries:**
+
+Download from [GitHub Releases](https://github.com/DTRules/DTRules/releases) for linux-amd64, linux-arm64, darwin-amd64, darwin-arm64, and windows-amd64.
+
+**Verify install:**
+
+```bash
+dtrules version && dtrules docs
+```
+
+<!-- TODO: Homebrew tap -->
+
+## Quick Start
 
 ### Build from Source
 

--- a/pkg/dtrules/version/version.go
+++ b/pkg/dtrules/version/version.go
@@ -23,18 +23,26 @@ import (
 
 // These variables are set at build time using ldflags:
 //
-//	go build -ldflags "-X github.com/DTRules/DTRules/pkg/dtrules/version.Version=1.0.0"
+//	go build -ldflags "-X github.com/DTRules/DTRules/pkg/dtrules/version.Version=1.0.0 \
+//	                   -X github.com/DTRules/DTRules/pkg/dtrules/version.Commit=abc1234 \
+//	                   -X github.com/DTRules/DTRules/pkg/dtrules/version.Date=2024-01-01T00:00:00Z"
 var (
-	// Version is the semantic version (e.g., "5.0.0", "5.0.0-SNAPSHOT")
+	// Version is the semantic version (e.g., "v1.0.0")
 	Version = "dev"
 
-	// GitCommit is the git commit hash
+	// Commit is the short git commit SHA injected at build time.
+	Commit = ""
+
+	// Date is the RFC3339 build timestamp injected at build time.
+	Date = ""
+
+	// GitCommit is an alias for Commit kept for backward compatibility.
 	GitCommit = ""
 
 	// GitBranch is the git branch name
 	GitBranch = ""
 
-	// BuildDate is the build timestamp
+	// BuildDate is an alias for Date kept for backward compatibility.
 	BuildDate = ""
 )
 
@@ -58,14 +66,22 @@ func Info() string {
 func Full() string {
 	info := Info()
 
-	if GitCommit != "" {
-		info += fmt.Sprintf("\nCommit: %s", GitCommit)
+	commit := Commit
+	if commit == "" {
+		commit = GitCommit
+	}
+	if commit != "" {
+		info += fmt.Sprintf("\nCommit: %s", commit)
 	}
 	if GitBranch != "" {
 		info += fmt.Sprintf("\nBranch: %s", GitBranch)
 	}
-	if BuildDate != "" {
-		info += fmt.Sprintf("\nBuilt:  %s", BuildDate)
+	date := Date
+	if date == "" {
+		date = BuildDate
+	}
+	if date != "" {
+		info += fmt.Sprintf("\nBuilt:  %s", date)
 	}
 
 	return info

--- a/pkg/dtrules/version/version_test.go
+++ b/pkg/dtrules/version/version_test.go
@@ -1,0 +1,73 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultValues(t *testing.T) {
+	if Version != "dev" {
+		t.Errorf("Version default = %q, want %q", Version, "dev")
+	}
+	if Commit != "" {
+		t.Errorf("Commit default = %q, want empty string", Commit)
+	}
+	if Date != "" {
+		t.Errorf("Date default = %q, want empty string", Date)
+	}
+}
+
+func TestInfo(t *testing.T) {
+	info := Info()
+	if !strings.Contains(info, "DTRules") {
+		t.Errorf("Info() = %q, want it to contain 'DTRules'", info)
+	}
+}
+
+func TestFull(t *testing.T) {
+	full := Full()
+	if !strings.Contains(full, "DTRules") {
+		t.Errorf("Full() = %q, want it to contain 'DTRules'", full)
+	}
+}
+
+func TestShort(t *testing.T) {
+	short := Short()
+	if short == "" {
+		t.Error("Short() returned empty string, want at least 'dev'")
+	}
+}
+
+func TestFullWithInjectedValues(t *testing.T) {
+	orig := Commit
+	origDate := Date
+	defer func() {
+		Commit = orig
+		Date = origDate
+	}()
+
+	Commit = "abc1234"
+	Date = "2024-01-01T00:00:00Z"
+
+	full := Full()
+	if !strings.Contains(full, "abc1234") {
+		t.Errorf("Full() = %q, want it to contain commit 'abc1234'", full)
+	}
+	if !strings.Contains(full, "2024-01-01T00:00:00Z") {
+		t.Errorf("Full() = %q, want it to contain date '2024-01-01T00:00:00Z'", full)
+	}
+}


### PR DESCRIPTION
Closes #513

## Summary

- `dtrules version` command now prints semver + commit SHA + build date injected via `-ldflags` at build time
- Makefile updated: canonical `VERSION`/`COMMIT`/`DATE` vars, `-s -w` in `LDFLAGS`, and new `release` target producing cross-platform binaries in `dist/` with SHA256 checksums
- GitHub Actions `release.yml` triggers on `v*` tags, builds all 5 platforms, uploads binaries + checksums via `softprops/action-gh-release`
- README Install section updated with `go install` path, prebuilt binaries link, and `dtrules version && dtrules docs` verification
- `pkg/dtrules/version/version_test.go` asserts default values (`"dev"`, `""`, `""`) and injected values work correctly

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/dtrules/version/...` passes
- [x] `make build` succeeds and injects version/commit/date
- [x] `./build/dtrules version` prints semver, commit SHA, and build date
- [x] Pre-existing test failures in `pkg/dtrules` confirmed unrelated to this PR (fail on main too)
- [ ] CI release workflow will exercise cross-compile on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)