### PR TITLE
fix(excel): unbreak main after #526

### DIFF
--- a/cmd/dtrules/build.go
+++ b/cmd/dtrules/build.go
@@ -322,9 +322,6 @@ func (c *CLI) runBuildDryRun(xmlDir, excelDir, authoringPath string, opts *build
 // syncMAPFiles handles _map.xml ↔ _map.xlsx synchronization which the main
 // sync pipeline skips. direction is "xml-to-excel" or "excel-to-xml".
 func (c *CLI) syncMAPFiles(xmlDir, excelDir, direction string, verbose bool) error {
-	wbExporter := excel.NewWorkbookExporter()
-	wbExporter.SetVerbose(verbose)
-	wbImporter := excel.NewWorkbookImporter()
 
 	// Walk XML dir for _map.xml files (xml-to-excel direction)
 	if direction == "xml-to-excel" {
@@ -346,7 +343,11 @@ func (c *CLI) syncMAPFiles(xmlDir, excelDir, direction string, verbose bool) err
 				return nil // xlsx already up to date
 			}
 
-			if err := wbExporter.ExportMap(path, xlsxPath); err != nil {
+			mapXML, err := excel.LoadMapXMLFromFile(path)
+			if err != nil {
+				return fmt.Errorf("load MAP xml %s: %w", rel, err)
+			}
+			if err := excel.NewMapExporter().ExportToFile(mapXML, xlsxPath); err != nil {
 				return fmt.Errorf("export MAP %s: %w", rel, err)
 			}
 			if verbose {
@@ -375,17 +376,17 @@ func (c *CLI) syncMAPFiles(xmlDir, excelDir, direction string, verbose bool) err
 			return nil // xml already up to date
 		}
 
-		result, err := wbImporter.ImportWorkbook(path)
+		mapXML, err := excel.NewMapImporter().ImportFile(path)
 		if err != nil {
 			return fmt.Errorf("import MAP xlsx %s: %w", rel, err)
 		}
-		if result.Map == nil || len(result.Map.Entries) == 0 {
+		if mapXML == nil || len(mapXML.Entries) == 0 {
 			return nil
 		}
 		if err := os.MkdirAll(filepath.Dir(xmlPath), 0755); err != nil {
 			return err
 		}
-		if err := excel.WriteMapXML(result.Map, xmlPath); err != nil {
+		if err := excel.WriteMapXML(mapXML, xmlPath); err != nil {
 			return fmt.Errorf("write MAP XML %s: %w", xmlPath, err)
 		}
 		if verbose {

--- a/pkg/dtrules/excel/artifact_type.go
+++ b/pkg/dtrules/excel/artifact_type.go
@@ -74,32 +74,3 @@ func artifactTypeMismatch(suffix string, hasdt, hasedd, hasmap bool) string {
 	return ""
 }
 
-// suffixForResult returns the appropriate filename suffix for exporting a single-
-// artifact WorkbookResult. Returns "" for mixed-artifact results.
-func suffixForResult(r *WorkbookResult) string {
-	hasDT := r.DTables != nil && len(r.DTables.Tables) > 0
-	hasEDD := r.EDD != nil && len(r.EDD.Entities) > 0
-	hasMAP := r.Map != nil && len(r.Map.Entries) > 0
-	count := 0
-	if hasDT {
-		count++
-	}
-	if hasEDD {
-		count++
-	}
-	if hasMAP {
-		count++
-	}
-	if count != 1 {
-		return "" // mixed — no suffix
-	}
-	switch {
-	case hasDT:
-		return "_dt"
-	case hasEDD:
-		return "_edd"
-	case hasMAP:
-		return "_map"
-	}
-	return ""
-}

--- a/pkg/dtrules/excel/workbook_importer.go
+++ b/pkg/dtrules/excel/workbook_importer.go
@@ -718,6 +718,24 @@ func (w *WorkbookImporter) HasEDDSheet(excelPath string) (bool, error) {
 	return false, nil
 }
 
+// HasMAPSheet checks if the workbook contains a mapping sheet.
+func (w *WorkbookImporter) HasMAPSheet(excelPath string) (bool, error) {
+	f, err := excelize.OpenFile(excelPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to open Excel file: %w", err)
+	}
+	defer f.Close()
+
+	sheets := f.GetSheetList()
+	for _, sheet := range sheets {
+		if w.isMAPSheet(f, sheet) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // ImportWorkbookToDir imports a workbook to separate XML files in the given directory.
 // Returns the paths to the generated XML files (dtPath, eddPath).
 // Either path may be empty if that sheet type doesn't exist in the workbook.


### PR DESCRIPTION
Hotfix for #526 compile errors:

- `suffixForResult` referenced `r.Map` which was never added to `WorkbookResult`. Removed (unused).
- `verify.checkSuffixContentConsistency` called `importer.HasMAPSheet` which was never added. Added the method.
- `build.syncMAPFiles` called `wbExporter.ExportMap` and `result.Map`, neither of which exist. Rewired to use the standalone `MapImporter`/`MapExporter` (which do exist).

Build + all cmd/dtrules + pkg/dtrules/excel + pkg/dtrules/sync tests pass.