### PR TITLE
feat(excel): ExtractExcel — rebuild xlsx tree from embedded XML (#543)

### DIFF
--- a/cmd/dtrules/doc_embedding.go
+++ b/cmd/dtrules/doc_embedding.go
@@ -229,6 +229,29 @@ For a large production rule set (dozens of states, hundreds of tables), expect
 budgets for server applications.
 
 
+Dumping embedded rules back to xlsx
+------------------------------------
+When debugging a deployed binary or handing rules back to an author without
+the dev repo, use excel.ExtractExcel to reconstruct the xlsx tree from the
+embedded XML.  This is useful for field debugging, compliance audits, and
+letting rule authors inspect exactly what shipped in a given binary.
+
+    // Minimal app that can dump its own embedded rules:
+    func main() {
+        if len(os.Args) > 2 && os.Args[1] == "--dump-rules" {
+            if err := excel.ExtractExcel(rulesFS, os.Args[2]); err != nil {
+                log.Fatal(err)
+            }
+            return
+        }
+        // ... normal app startup ...
+    }
+
+ExtractExcel walks the embedded fs.FS and writes one xlsx file for every
+*_dt.xml, *_edd.xml, and *_map.xml it finds, preserving the subdirectory
+layout.  The output directory is created if it does not exist.
+
+
 See Also
 --------
   dtrules docs workflow        Build and sync pipeline

--- a/cmd/dtrules/docs_test.go
+++ b/cmd/dtrules/docs_test.go
@@ -84,3 +84,13 @@ func TestDocumentation_EmbeddingTopic(t *testing.T) {
 		}
 	}
 }
+
+func TestDocumentation_EmbeddingContainsExtractExcel(t *testing.T) {
+	doc, ok := docTopics["embedding"]
+	if !ok {
+		t.Fatal("embedding topic not registered in docTopics")
+	}
+	if !strings.Contains(doc, "ExtractExcel") {
+		t.Error("embedding doc should document ExtractExcel for dumping embedded rules")
+	}
+}

--- a/pkg/dtrules/excel/extract.go
+++ b/pkg/dtrules/excel/extract.go
@@ -1,0 +1,145 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// ExtractExcel walks src and writes every *_dt.xml, *_edd.xml, and *_map.xml
+// back to an equivalent xlsx under dst, preserving subdirectory layout.
+// src is typically an embed.FS; dst is a filesystem directory path.
+// Extracted trees can be re-authored and round-tripped back through
+// `dtrules build`.
+//
+// Limitation: the loader currently requires a session/entity context to compile
+// postfix expressions, so each _edd.xml and _dt.xml is loaded into an isolated
+// RuleSet. Tables that reference entities defined in other files may produce
+// loader warnings but will still be extracted. See issue #541 for the fs.FS
+// loader follow-up that will remove this limitation.
+func ExtractExcel(src fs.FS, dst string) error {
+	return fs.WalkDir(src, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		name := d.Name()
+		switch {
+		case strings.HasSuffix(name, "_map.xml"):
+			return extractMap(src, path, dst)
+		case strings.HasSuffix(name, "_edd.xml"):
+			return extractEDD(src, path, dst)
+		case strings.HasSuffix(name, "_dt.xml"):
+			return extractDT(src, path, dst)
+		}
+		return nil
+	})
+}
+
+// xlsxPath converts a source relative path (foo/bar_dt.xml) to the
+// destination xlsx path under dst (dst/foo/bar_dt.xlsx).
+func xlsxPath(dst, relPath string) string {
+	noExt := strings.TrimSuffix(relPath, ".xml")
+	return filepath.Join(dst, filepath.FromSlash(noExt+".xlsx"))
+}
+
+func extractMap(src fs.FS, relPath, dst string) error {
+	data, err := fs.ReadFile(src, relPath)
+	if err != nil {
+		return fmt.Errorf("extract %s: %w", relPath, err)
+	}
+
+	m, err := loadMapXMLFromReader(bytes.NewReader(data), relPath)
+	if err != nil {
+		return fmt.Errorf("extract %s: %w", relPath, err)
+	}
+
+	out := xlsxPath(dst, relPath)
+	if err := os.MkdirAll(filepath.Dir(out), 0755); err != nil {
+		return fmt.Errorf("extract %s: %w", relPath, err)
+	}
+
+	exp := NewMapExporter()
+	if err := exp.ExportToFile(m, out); err != nil {
+		return fmt.Errorf("extract %s: %w", relPath, err)
+	}
+	return nil
+}
+
+func extractEDD(src fs.FS, relPath, dst string) error {
+	data, err := fs.ReadFile(src, relPath)
+	if err != nil {
+		return fmt.Errorf("extract %s: %w", relPath, err)
+	}
+
+	rs := session.NewRuleSet("extract")
+	if rs == nil {
+		return fmt.Errorf("extract %s: failed to create rule set", relPath)
+	}
+
+	if err := rs.LoadEDD(bytes.NewReader(data)); err != nil {
+		return fmt.Errorf("extract %s: %w", relPath, err)
+	}
+
+	out := xlsxPath(dst, relPath)
+	if err := os.MkdirAll(filepath.Dir(out), 0755); err != nil {
+		return fmt.Errorf("extract %s: %w", relPath, err)
+	}
+
+	exp := NewExporter(rs)
+	if err := exp.ExportEDD(out); err != nil {
+		return fmt.Errorf("extract %s: %w", relPath, err)
+	}
+	return nil
+}
+
+func extractDT(src fs.FS, relPath, dst string) error {
+	data, err := fs.ReadFile(src, relPath)
+	if err != nil {
+		return fmt.Errorf("extract %s: %w", relPath, err)
+	}
+
+	rs := session.NewRuleSet("extract")
+	if rs == nil {
+		return fmt.Errorf("extract %s: failed to create rule set", relPath)
+	}
+
+	// The DT loader compiles EL expressions; warnings may appear for tables
+	// referencing entities not in this isolated RuleSet (issue #541).
+	if err := rs.LoadDecisionTables(bytes.NewReader(data)); err != nil {
+		return fmt.Errorf("extract %s: %w", relPath, err)
+	}
+
+	out := xlsxPath(dst, relPath)
+	if err := os.MkdirAll(filepath.Dir(out), 0755); err != nil {
+		return fmt.Errorf("extract %s: %w", relPath, err)
+	}
+
+	exp := NewExporter(rs)
+	if err := exp.ExportDecisionTables(out); err != nil {
+		return fmt.Errorf("extract %s: %w", relPath, err)
+	}
+	return nil
+}

--- a/pkg/dtrules/excel/extract_test.go
+++ b/pkg/dtrules/excel/extract_test.go
@@ -1,0 +1,223 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/xuri/excelize/v2"
+)
+
+const minimalEDD = `<?xml version="1.0" encoding="UTF-8"?>
+<entity_data_dictionary version="2">
+	<entity name="result" xls_file="test.xlsx" access="rw">
+		<field name="tax_amount" type="double" subtype="" access="rw" input="" default_value="0" comment="Computed tax"></field>
+	</entity>
+</entity_data_dictionary>`
+
+const minimalDT = `<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+<decision_table>
+<table_name>Calculate_Tax</table_name>
+<xls_file>test.xlsx</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS>Simple tax calculation</COMMENTS>
+<TABLE_NUMBER>1</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
+<conditions></conditions>
+<actions></actions>
+<policy_statements></policy_statements>
+</decision_table>
+</decision_tables>`
+
+const minimalMap = `<mapping>
+	<XMLtoEDD>
+		<map>
+			<!-- Job mappings -->
+			<setattribute tag='id' RAttribute='id' enclosure='job' type='integer'></setattribute>
+		</map>
+	</XMLtoEDD>
+</mapping>`
+
+func TestExtractExcel_SimpleTree(t *testing.T) {
+	src := fstest.MapFS{
+		"test_dt.xml":  &fstest.MapFile{Data: []byte(minimalDT)},
+		"test_edd.xml": &fstest.MapFile{Data: []byte(minimalEDD)},
+		"test_map.xml": &fstest.MapFile{Data: []byte(minimalMap)},
+	}
+
+	dst := t.TempDir()
+	if err := ExtractExcel(src, dst); err != nil {
+		t.Fatalf("ExtractExcel: %v", err)
+	}
+
+	expected := []string{
+		filepath.Join(dst, "test_dt.xlsx"),
+		filepath.Join(dst, "test_edd.xlsx"),
+		filepath.Join(dst, "test_map.xlsx"),
+	}
+
+	for _, p := range expected {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Errorf("expected file %s: %v", p, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("file %s is empty", p)
+			continue
+		}
+		// Verify the xlsx opens without error
+		f, err := excelize.OpenFile(p)
+		if err != nil {
+			t.Errorf("open %s: %v", p, err)
+			continue
+		}
+		f.Close()
+	}
+}
+
+func TestExtractExcel_PreservesSubdirs(t *testing.T) {
+	src := fstest.MapFS{
+		"states/CO_dt.xml":  &fstest.MapFile{Data: []byte(minimalDT)},
+		"states/CO_edd.xml": &fstest.MapFile{Data: []byte(minimalEDD)},
+	}
+
+	dst := t.TempDir()
+	if err := ExtractExcel(src, dst); err != nil {
+		t.Fatalf("ExtractExcel: %v", err)
+	}
+
+	expected := []string{
+		filepath.Join(dst, "states", "CO_dt.xlsx"),
+		filepath.Join(dst, "states", "CO_edd.xlsx"),
+	}
+
+	for _, p := range expected {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("expected file %s: %v", p, err)
+		}
+	}
+}
+
+func TestExtractExcel_FromFixture(t *testing.T) {
+	// Use a small subset of the TaxReturn sample project.
+	// We build an fstest.MapFS from a few known state files so the test
+	// is fast and does not depend on large merged files.
+	akEDD, err := os.ReadFile("../../../sampleprojects/TaxReturn/xml/states/AK_edd.xml")
+	if err != nil {
+		t.Skipf("fixture not found: %v", err)
+	}
+	akDT, err := os.ReadFile("../../../sampleprojects/TaxReturn/xml/states/AK_dt.xml")
+	if err != nil {
+		t.Skipf("fixture not found: %v", err)
+	}
+	mapXML, err := os.ReadFile("../../../sampleprojects/TaxReturn/xml/TaxReturn_map.xml")
+	if err != nil {
+		t.Skipf("fixture not found: %v", err)
+	}
+
+	src := fstest.MapFS{
+		"states/AK_edd.xml":   &fstest.MapFile{Data: akEDD},
+		"states/AK_dt.xml":    &fstest.MapFile{Data: akDT},
+		"TaxReturn_map.xml":   &fstest.MapFile{Data: mapXML},
+	}
+
+	dst := t.TempDir()
+	if err := ExtractExcel(src, dst); err != nil {
+		t.Fatalf("ExtractExcel: %v", err)
+	}
+
+	outputs := []string{
+		filepath.Join(dst, "states", "AK_edd.xlsx"),
+		filepath.Join(dst, "states", "AK_dt.xlsx"),
+		filepath.Join(dst, "TaxReturn_map.xlsx"),
+	}
+
+	for _, p := range outputs {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Errorf("expected output %s: %v", p, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("output %s is empty", p)
+		}
+	}
+}
+
+func TestExtractExcel_BadXMLReturnsError(t *testing.T) {
+	src := fstest.MapFS{
+		"broken_edd.xml": &fstest.MapFile{Data: []byte(`<entity_data_dictionary UNCLOSED`)},
+	}
+
+	dst := t.TempDir()
+	err := ExtractExcel(src, dst)
+	if err == nil {
+		t.Fatal("expected error for malformed XML, got nil")
+	}
+	if !strings.Contains(err.Error(), "broken_edd.xml") {
+		t.Errorf("error message should include offending filename, got: %s", err.Error())
+	}
+}
+
+// TestExtractExcel_RoundTrip verifies that extracted xlsx files exist and have
+// the expected root xlsx structure. Full XML re-import round-trip is skipped
+// here because the export produces a different XML dialect than the source
+// (the importer path is Excel→XML, not XML→XML), making byte-level comparison
+// meaningless. Semantic equivalence is covered by the existing roundtrip tests.
+func TestExtractExcel_RoundTrip(t *testing.T) {
+	akEDD, err := os.ReadFile("../../../sampleprojects/TaxReturn/xml/states/AK_edd.xml")
+	if err != nil {
+		t.Skipf("fixture not found: %v", err)
+	}
+	akDT, err := os.ReadFile("../../../sampleprojects/TaxReturn/xml/states/AK_dt.xml")
+	if err != nil {
+		t.Skipf("fixture not found: %v", err)
+	}
+
+	src := fstest.MapFS{
+		"states/AK_edd.xml": &fstest.MapFile{Data: akEDD},
+		"states/AK_dt.xml":  &fstest.MapFile{Data: akDT},
+	}
+
+	dst := t.TempDir()
+	if err := ExtractExcel(src, dst); err != nil {
+		t.Fatalf("ExtractExcel: %v", err)
+	}
+
+	// Verify each xlsx has at least one sheet with recognizable content
+	for _, rel := range []string{"states/AK_edd.xlsx", "states/AK_dt.xlsx"} {
+		p := filepath.Join(dst, rel)
+		f, err := excelize.OpenFile(p)
+		if err != nil {
+			t.Errorf("open %s: %v", rel, err)
+			continue
+		}
+		sheets := f.GetSheetList()
+		if len(sheets) == 0 {
+			t.Errorf("%s has no sheets", rel)
+		}
+		f.Close()
+	}
+}
+


### PR DESCRIPTION
## Summary

- Adds `excel.ExtractExcel(src fs.FS, dst string) error` that walks an embedded FS and writes one xlsx per `*_dt.xml`, `*_edd.xml`, and `*_map.xml`, preserving subdirectory layout
- Adds 5 tests: `SimpleTree`, `PreservesSubdirs`, `FromFixture`, `BadXMLReturnsError`, `RoundTrip`
- Extends the `embedding` docs topic with a `--dump-rules` consumer snippet and adds a test that the topic contains `ExtractExcel`

## Limitation

Each `_dt.xml` / `_edd.xml` is loaded into an isolated `RuleSet` (one per file). Tables that reference entities defined in sibling files may produce loader warnings but are still extracted. This is tracked in issue #541 (fs.FS loader follow-up).

The full XML round-trip test (`TestExtractExcel_RoundTrip`) verifies sheet structure rather than byte-level XML equivalence, because the export path produces a different XML dialect than the importer expects. Semantic equivalence for xlsx↔XML round-trips is already covered by the existing roundtrip tests.

## Test plan

- [x] `go build ./...` passes
- [x] `TestExtractExcel_SimpleTree` — three xlsx written, each opens without error
- [x] `TestExtractExcel_PreservesSubdirs` — subdirectory layout preserved
- [x] `TestExtractExcel_FromFixture` — exercises real AK state files + map
- [x] `TestExtractExcel_BadXMLReturnsError` — error includes offending filename
- [x] `TestExtractExcel_RoundTrip` — extracted xlsx has at least one sheet
- [x] `TestDocumentation_EmbeddingContainsExtractExcel` — doc topic updated

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)