### PR TITLE
fix(excel): ExtractExcel pure XML→xlsx transform

### DIFF
--- a/pkg/dtrules/excel/extract.go
+++ b/pkg/dtrules/excel/extract.go
@@ -21,21 +21,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/DTRules/DTRules/pkg/dtrules/session"
 )
 
 // ExtractExcel walks src and writes every *_dt.xml, *_edd.xml, and *_map.xml
-// back to an equivalent xlsx under dst, preserving subdirectory layout.
-// src is typically an embed.FS; dst is a filesystem directory path.
-// Extracted trees can be re-authored and round-tripped back through
-// `dtrules build`.
-//
-// Limitation: the loader currently requires a session/entity context to compile
-// postfix expressions, so each _edd.xml and _dt.xml is loaded into an isolated
-// RuleSet. Tables that reference entities defined in other files may produce
-// loader warnings but will still be extracted. See issue #541 for the fs.FS
-// loader follow-up that will remove this limitation.
+// to an equivalent xlsx under dst, preserving subdirectory layout.
+// This is a pure XML→xlsx representation conversion; no session or RuleSet is required.
 func ExtractExcel(src fs.FS, dst string) error {
 	return fs.WalkDir(src, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -94,12 +84,8 @@ func extractEDD(src fs.FS, relPath, dst string) error {
 		return fmt.Errorf("extract %s: %w", relPath, err)
 	}
 
-	rs := session.NewRuleSet("extract")
-	if rs == nil {
-		return fmt.Errorf("extract %s: failed to create rule set", relPath)
-	}
-
-	if err := rs.LoadEDD(bytes.NewReader(data)); err != nil {
+	edd, err := UnmarshalEDDXML(data)
+	if err != nil {
 		return fmt.Errorf("extract %s: %w", relPath, err)
 	}
 
@@ -108,8 +94,7 @@ func extractEDD(src fs.FS, relPath, dst string) error {
 		return fmt.Errorf("extract %s: %w", relPath, err)
 	}
 
-	exp := NewExporter(rs)
-	if err := exp.ExportEDD(out); err != nil {
+	if err := WriteEDDXMLToExcel(edd, out); err != nil {
 		return fmt.Errorf("extract %s: %w", relPath, err)
 	}
 	return nil
@@ -121,14 +106,8 @@ func extractDT(src fs.FS, relPath, dst string) error {
 		return fmt.Errorf("extract %s: %w", relPath, err)
 	}
 
-	rs := session.NewRuleSet("extract")
-	if rs == nil {
-		return fmt.Errorf("extract %s: failed to create rule set", relPath)
-	}
-
-	// The DT loader compiles EL expressions; warnings may appear for tables
-	// referencing entities not in this isolated RuleSet (issue #541).
-	if err := rs.LoadDecisionTables(bytes.NewReader(data)); err != nil {
+	dt, err := UnmarshalDecisionTablesXML(data)
+	if err != nil {
 		return fmt.Errorf("extract %s: %w", relPath, err)
 	}
 
@@ -137,8 +116,7 @@ func extractDT(src fs.FS, relPath, dst string) error {
 		return fmt.Errorf("extract %s: %w", relPath, err)
 	}
 
-	exp := NewExporter(rs)
-	if err := exp.ExportDecisionTables(out); err != nil {
+	if err := WriteDTXMLToExcel(dt, out); err != nil {
 		return fmt.Errorf("extract %s: %w", relPath, err)
 	}
 	return nil

--- a/pkg/dtrules/excel/extract_test.go
+++ b/pkg/dtrules/excel/extract_test.go
@@ -15,6 +15,8 @@
 package excel
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -177,6 +179,87 @@ func TestExtractExcel_BadXMLReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "broken_edd.xml") {
 		t.Errorf("error message should include offending filename, got: %s", err.Error())
+	}
+}
+
+// TestExtractExcel_NoLoaderWarnings verifies that extracting a DT file that
+// references entities not declared in the same file produces no stderr output.
+// The old RuleSet-per-file implementation would emit loader warnings in this case.
+func TestExtractExcel_NoLoaderWarnings(t *testing.T) {
+	crossRefDT := `<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+<decision_table>
+<table_name>CrossRef_Table</table_name>
+<xls_file>test.xlsx</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS>References entity from a different file</COMMENTS>
+<TABLE_NUMBER>1</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>uses external entity</condition_comment>
+<condition_dsl>result.tax_amount &gt; 0</condition_dsl>
+<condition_postfix>result.tax_amount 0 &gt;</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+</condition_details>
+</conditions>
+<actions></actions>
+<policy_statements></policy_statements>
+</decision_table>
+</decision_tables>`
+
+	src := fstest.MapFS{
+		"CO_dt.xml": &fstest.MapFile{Data: []byte(crossRefDT)},
+		"TaxReturn_edd.xml": &fstest.MapFile{Data: []byte(minimalEDD)},
+	}
+
+	// Capture stderr by redirecting os.Stderr temporarily.
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+
+	dst := t.TempDir()
+	extractErr := ExtractExcel(src, dst)
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	r.Close()
+
+	if extractErr != nil {
+		t.Fatalf("ExtractExcel: %v", extractErr)
+	}
+	if buf.Len() > 0 {
+		t.Errorf("unexpected stderr output (loader warnings should not appear): %s", buf.String())
+	}
+}
+
+// TestExtractExcel_NoSessionImport asserts that the excel package's extract.go
+// does not import session or loader packages. We verify this by checking that
+// the compiled package works without those imports (build-time guarantee via the
+// rewrite), and confirm the source file contains no such import paths.
+func TestExtractExcel_NoSessionImport(t *testing.T) {
+	extractSrc, err := os.ReadFile("extract.go")
+	if err != nil {
+		t.Fatalf("read extract.go: %v", err)
+	}
+	forbidden := []string{
+		"pkg/dtrules/session",
+		"pkg/dtrules/loader",
+	}
+	for _, pkg := range forbidden {
+		if strings.Contains(string(extractSrc), pkg) {
+			t.Errorf("extract.go must not import %q", pkg)
+		}
 	}
 }
 

--- a/pkg/dtrules/excel/xml_exporter.go
+++ b/pkg/dtrules/excel/xml_exporter.go
@@ -1,0 +1,469 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import (
+	"encoding/xml"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/xuri/excelize/v2"
+)
+
+// UnmarshalDecisionTablesXML parses raw XML bytes into a DecisionTablesXML model.
+func UnmarshalDecisionTablesXML(data []byte) (*DecisionTablesXML, error) {
+	var dt DecisionTablesXML
+	if err := xml.Unmarshal(data, &dt); err != nil {
+		return nil, err
+	}
+	return &dt, nil
+}
+
+// UnmarshalEDDXML parses raw XML bytes into an EDDXML model.
+func UnmarshalEDDXML(data []byte) (*EDDXML, error) {
+	var edd EDDXML
+	if err := xml.Unmarshal(data, &edd); err != nil {
+		return nil, err
+	}
+	return &edd, nil
+}
+
+// WriteDTXMLToExcel writes a DecisionTablesXML model to an xlsx file.
+// It is a pure XML→xlsx conversion; no RuleSet or session is required.
+func WriteDTXMLToExcel(dt *DecisionTablesXML, filename string) error {
+	f := excelize.NewFile()
+	defer f.Close()
+
+	defaultSheet := f.GetSheetName(0)
+
+	styler, err := NewStyler(f)
+	if err != nil {
+		return fmt.Errorf("failed to create styles: %w", err)
+	}
+
+	tables := make([]DecisionTableXML, len(dt.Tables))
+	copy(tables, dt.Tables)
+	sortDecisionTableXMLByNumber(tables)
+
+	for i := range tables {
+		if err := writeDTXMLSheet(f, &tables[i], styler); err != nil {
+			return fmt.Errorf("failed to write table %s: %w", tables[i].TableName, err)
+		}
+	}
+
+	sheetList := f.GetSheetList()
+	if len(sheetList) > 1 {
+		f.DeleteSheet(defaultSheet)
+	}
+
+	return f.SaveAs(filename)
+}
+
+func sortDecisionTableXMLByNumber(tables []DecisionTableXML) {
+	sort.SliceStable(tables, func(i, j int) bool {
+		ni, erri := strconv.Atoi(tables[i].AttributeFields.TableNumber)
+		nj, errj := strconv.Atoi(tables[j].AttributeFields.TableNumber)
+		if erri == nil && errj == nil {
+			return ni < nj
+		}
+		if erri == nil {
+			return true
+		}
+		if errj == nil {
+			return false
+		}
+		return tables[i].TableName < tables[j].TableName
+	})
+}
+
+func writeDTXMLSheet(f *excelize.File, dt *DecisionTableXML, styler *Styler) error {
+	name := dt.TableName
+	sheetName := sanitizeSheetName(name)
+	for i := 1; ; i++ {
+		idx, _ := f.GetSheetIndex(sheetName)
+		if idx == -1 {
+			break
+		}
+		sheetName = fmt.Sprintf("%s_%d", sanitizeSheetName(name)[:min(28, len(name))], i)
+	}
+
+	if _, err := f.NewSheet(sheetName); err != nil {
+		return err
+	}
+
+	AutoWidth(f, sheetName, "A", 20)
+	AutoWidth(f, sheetName, "B", wideColWidth)
+	AutoWidth(f, sheetName, "C", wideColWidth)
+
+	numCols := maxColFromDTXML(dt)
+	if numCols < maxCol {
+		numCols = maxCol
+	}
+	for i := 0; i < numCols; i++ {
+		col, _ := excelize.ColumnNumberToName(4 + i)
+		f.SetColWidth(sheetName, col, col, narrowColWidth)
+	}
+
+	row := 1
+	row = writeDTXMLName(f, sheetName, dt, row, numCols, styler)
+	row = writeDTXMLType(f, sheetName, dt, row, numCols, styler)
+	row = writeDTXMLFields(f, sheetName, dt, row, numCols, styler)
+	row++
+	row = writeDTXMLContexts(f, sheetName, dt, row, numCols, styler)
+	row = writeDTXMLInitialActions(f, sheetName, dt, row, numCols, styler)
+	row = writeDTXMLConditions(f, sheetName, dt, row, numCols, styler)
+	row = writeDTXMLActions(f, sheetName, dt, row, numCols, styler)
+	writeDTXMLPolicyStatements(f, sheetName, dt, row, numCols, styler)
+	return nil
+}
+
+func maxColFromDTXML(dt *DecisionTableXML) int {
+	n := 0
+	for _, c := range dt.Conditions {
+		for _, col := range c.Columns {
+			if col.Number > n {
+				n = col.Number
+			}
+		}
+	}
+	for _, a := range dt.Actions {
+		for _, col := range a.Columns {
+			if col.Number > n {
+				n = col.Number
+			}
+		}
+	}
+	return n
+}
+
+func writeDTXMLName(f *excelize.File, sheet string, dt *DecisionTableXML, row, numCols int, styler *Styler) int {
+	displayName := strings.ReplaceAll(dt.TableName, "_", " ")
+	startCell := cellName(1, row)
+	endCell := cellName(3+numCols, row)
+	f.MergeCell(sheet, startCell, endCell)
+	f.SetCellValue(sheet, startCell, "DT: "+displayName)
+	f.SetCellStyle(sheet, startCell, endCell, styler.BodyStyle)
+	return row + 1
+}
+
+func writeDTXMLType(f *excelize.File, sheet string, dt *DecisionTableXML, row, numCols int, styler *Styler) int {
+	startCell := cellName(1, row)
+	endCell := cellName(3+numCols, row)
+	f.MergeCell(sheet, startCell, endCell)
+	f.SetCellValue(sheet, startCell, "Type: "+dt.AttributeFields.Type)
+	f.SetCellStyle(sheet, startCell, endCell, styler.DSLStyle)
+	return row + 1
+}
+
+func writeDTXMLFields(f *excelize.File, sheet string, dt *DecisionTableXML, row, numCols int, styler *Styler) int {
+	type kv struct{ k, v string }
+	var fields []kv
+	if dt.AttributeFields.Comments != "" {
+		fields = append(fields, kv{"COMMENTS", dt.AttributeFields.Comments})
+	}
+	if dt.AttributeFields.TableNumber != "" {
+		fields = append(fields, kv{"TABLE_NUMBER", dt.AttributeFields.TableNumber})
+	}
+	if dt.AttributeFields.FilePath != "" {
+		fields = append(fields, kv{"FILE_PATH", dt.AttributeFields.FilePath})
+	}
+	sort.Slice(fields, func(i, j int) bool { return fields[i].k < fields[j].k })
+
+	for _, f2 := range fields {
+		startCell := cellName(1, row)
+		endCell := cellName(3+numCols, row)
+		f.MergeCell(sheet, startCell, endCell)
+		f.SetCellValue(sheet, startCell, f2.k+": "+f2.v)
+		f.SetCellStyle(sheet, startCell, endCell, styler.BodyStyle)
+		row++
+	}
+	return row
+}
+
+func writeDTXMLContexts(f *excelize.File, sheet string, dt *DecisionTableXML, row, numCols int, styler *Styler) int {
+	f.MergeCell(sheet, cellName(1, row), cellName(2, row))
+	styler.ApplyHeader(f, sheet, cellName(1, row), cellName(1, row), cellName(2, row), "CONTEXTS: COMMENTS")
+	f.MergeCell(sheet, cellName(3, row), cellName(3+numCols, row))
+	styler.ApplyHeader(f, sheet, cellName(3, row), cellName(3, row), cellName(3+numCols, row), "DSL: CONTEXTS")
+	row++
+
+	if dt.Contexts != "" {
+		contexts := strings.Split(dt.Contexts, ",")
+		for i, ctx := range contexts {
+			ctx = strings.TrimSpace(ctx)
+			f.SetCellValue(sheet, cellName(1, row), i+1)
+			f.SetCellStyle(sheet, cellName(1, row), cellName(1, row), styler.NumberStyle)
+			styler.ApplyBody(f, sheet, cellName(2, row), "")
+			startCell := cellName(3, row)
+			endCell := cellName(3+numCols, row)
+			f.MergeCell(sheet, startCell, endCell)
+			styler.ApplyDSL(f, sheet, startCell, ctx)
+			f.SetCellStyle(sheet, startCell, endCell, styler.DSLStyle)
+			row++
+		}
+	}
+
+	row++
+	return row
+}
+
+func writeDTXMLInitialActions(f *excelize.File, sheet string, dt *DecisionTableXML, row, numCols int, styler *Styler) int {
+	f.MergeCell(sheet, cellName(1, row), cellName(2, row))
+	styler.ApplyHeader(f, sheet, cellName(1, row), cellName(1, row), cellName(2, row), "INITIAL ACTIONS: COMMENTS")
+	f.MergeCell(sheet, cellName(3, row), cellName(3+numCols, row))
+	styler.ApplyHeader(f, sheet, cellName(3, row), cellName(3, row), cellName(3+numCols, row), "DSL: INITIAL ACTIONS")
+	row++
+
+	for i, action := range dt.InitialActions {
+		f.SetCellValue(sheet, cellName(1, row), i+1)
+		f.SetCellStyle(sheet, cellName(1, row), cellName(1, row), styler.NumberStyle)
+		styler.ApplyBody(f, sheet, cellName(2, row), "")
+		startCell := cellName(3, row)
+		endCell := cellName(3+numCols, row)
+		f.MergeCell(sheet, startCell, endCell)
+		styler.ApplyDSL(f, sheet, startCell, action.DSL)
+		f.SetCellStyle(sheet, startCell, endCell, styler.DSLStyle)
+		row++
+	}
+
+	row++
+	return row
+}
+
+func writeDTXMLConditions(f *excelize.File, sheet string, dt *DecisionTableXML, row, numCols int, styler *Styler) int {
+	f.MergeCell(sheet, cellName(1, row), cellName(2, row))
+	styler.ApplyHeader(f, sheet, cellName(1, row), cellName(1, row), cellName(2, row), "CONDITIONS: COMMENTS")
+	styler.ApplyHeader(f, sheet, cellName(3, row), cellName(3, row), cellName(3, row), "DSL: CONDITIONS")
+	for i := 0; i < numCols; i++ {
+		cell := cellName(4+i, row)
+		f.SetCellValue(sheet, cell, i+1)
+		f.SetCellStyle(sheet, cell, cell, styler.HeaderStyle)
+	}
+	row++
+
+	for i, cond := range dt.Conditions {
+		f.SetCellValue(sheet, cellName(1, row), i+1)
+		f.SetCellStyle(sheet, cellName(1, row), cellName(1, row), styler.NumberStyle)
+		styler.ApplyBody(f, sheet, cellName(2, row), cond.Comment)
+		styler.ApplyDSL(f, sheet, cellName(3, row), cond.DSL)
+
+		colVals := make(map[int]string, len(cond.Columns))
+		for _, cv := range cond.Columns {
+			colVals[cv.Number] = cv.Value
+		}
+		for j := 0; j < numCols; j++ {
+			val := colVals[j+1]
+			cell := cellName(4+j, row)
+			f.SetCellValue(sheet, cell, val)
+			f.SetCellStyle(sheet, cell, cell, styler.BodyStyle)
+		}
+		row++
+	}
+
+	row++
+	return row
+}
+
+func writeDTXMLActions(f *excelize.File, sheet string, dt *DecisionTableXML, row, numCols int, styler *Styler) int {
+	f.MergeCell(sheet, cellName(1, row), cellName(2, row))
+	styler.ApplyHeader(f, sheet, cellName(1, row), cellName(1, row), cellName(2, row), "ACTIONS: COMMENTS")
+	styler.ApplyHeader(f, sheet, cellName(3, row), cellName(3, row), cellName(3, row), "DSL: ACTIONS")
+	for i := 0; i < numCols; i++ {
+		cell := cellName(4+i, row)
+		f.SetCellValue(sheet, cell, i+1)
+		f.SetCellStyle(sheet, cell, cell, styler.SeparatorStyle)
+	}
+	row++
+
+	for i, action := range dt.Actions {
+		f.SetCellValue(sheet, cellName(1, row), i+1)
+		f.SetCellStyle(sheet, cellName(1, row), cellName(1, row), styler.NumberStyle)
+		styler.ApplyBody(f, sheet, cellName(2, row), action.Comment)
+		styler.ApplyDSL(f, sheet, cellName(3, row), action.DSL)
+
+		colVals := make(map[int]string, len(action.Columns))
+		for _, cv := range action.Columns {
+			colVals[cv.Number] = cv.Value
+		}
+		for j := 0; j < numCols; j++ {
+			val := colVals[j+1]
+			cell := cellName(4+j, row)
+			f.SetCellValue(sheet, cell, val)
+			f.SetCellStyle(sheet, cell, cell, styler.BodyStyle)
+		}
+		row++
+	}
+
+	row++
+	return row
+}
+
+func writeDTXMLPolicyStatements(f *excelize.File, sheet string, dt *DecisionTableXML, row, numCols int, styler *Styler) int {
+	if len(dt.PolicyStatements) == 0 {
+		return row
+	}
+
+	f.MergeCell(sheet, cellName(1, row), cellName(2, row))
+	styler.ApplyHeader(f, sheet, cellName(1, row), cellName(1, row), cellName(2, row), "Policy:")
+	styler.ApplyHeader(f, sheet, cellName(3, row), cellName(3, row), cellName(3, row), "Policy Statements")
+	for i := 0; i < numCols; i++ {
+		cell := cellName(4+i, row)
+		f.SetCellValue(sheet, cell, i+1)
+		f.SetCellStyle(sheet, cell, cell, styler.HeaderStyle)
+	}
+	row++
+
+	for _, ps := range dt.PolicyStatements {
+		colNum, _ := strconv.Atoi(ps.Column)
+		f.SetCellValue(sheet, cellName(1, row), colNum)
+		f.SetCellStyle(sheet, cellName(1, row), cellName(1, row), styler.NumberStyle)
+		styler.ApplyBody(f, sheet, cellName(2, row), ps.Description)
+		styler.ApplyDSL(f, sheet, cellName(3, row), "")
+		for j := 0; j < numCols; j++ {
+			cell := cellName(4+j, row)
+			f.SetCellValue(sheet, cell, "")
+			f.SetCellStyle(sheet, cell, cell, styler.BodyStyle)
+		}
+		row++
+	}
+	return row
+}
+
+// WriteEDDXMLToExcel writes an EDDXML model to an xlsx file.
+// It is a pure XML→xlsx conversion; no RuleSet or session is required.
+func WriteEDDXMLToExcel(edd *EDDXML, filename string) error {
+	f := excelize.NewFile()
+	defer f.Close()
+
+	sheet := "EDD"
+	f.SetSheetName("Sheet1", sheet)
+
+	styler, err := NewStyler(f)
+	if err != nil {
+		return err
+	}
+	eddStyles, err := newEDDStylesForFile(f)
+	if err != nil {
+		return err
+	}
+
+	setEDDColumnWidthsForFile(f, sheet)
+	writeEDDHeadersForFile(f, sheet, styler, 1)
+	FreezePaneAtRow2(f, sheet)
+	writeEDDXMLEntities(f, sheet, edd.Entities, styler, eddStyles, 2)
+
+	return f.SaveAs(filename)
+}
+
+func newEDDStylesForFile(f *excelize.File) (*eddExtraStyles, error) {
+	// Delegate to the Exporter method via a throw-away Exporter (no ruleSet needed).
+	e := &Exporter{}
+	return e.newEDDStyles(f)
+}
+
+func setEDDColumnWidthsForFile(f *excelize.File, sheet string) {
+	AutoWidth(f, sheet, "A", 18)
+	AutoWidth(f, sheet, "B", 25)
+	AutoWidth(f, sheet, "C", 10)
+	AutoWidth(f, sheet, "D", 12)
+	AutoWidth(f, sheet, "E", 18)
+	AutoWidth(f, sheet, "F", 8)
+	AutoWidth(f, sheet, "G", 8)
+	AutoWidth(f, sheet, "H", 55)
+}
+
+func writeEDDHeadersForFile(f *excelize.File, sheet string, styler *Styler, startRow int) {
+	headers := []string{"Entity", "Attribute", "Type", "SubType", "Default", "Input", "Access", "Description"}
+	for col, header := range headers {
+		cell, _ := excelize.CoordinatesToCellName(col+1, startRow)
+		styler.ApplyHeader(f, sheet, cell, cell, cell, header)
+	}
+}
+
+func writeEDDXMLEntities(f *excelize.File, sheet string, entities []*EDDXMLEntity, styler *Styler, s *eddExtraStyles, startRow int) {
+	row := startRow
+	for _, ent := range entities {
+		attrCount := len(ent.Fields)
+		if attrCount == 0 {
+			continue
+		}
+
+		f.SetCellValue(sheet, cellName(1, row), ent.Name)
+		f.SetCellValue(sheet, cellName(2, row), fmt.Sprintf("(%d attributes)", attrCount))
+		for col := 1; col <= 8; col++ {
+			f.SetCellStyle(sheet, cellName(col, row), cellName(col, row), s.entityHeader)
+		}
+		row++
+
+		for attrRow, field := range ent.Fields {
+			rowStyle := s.rowEven
+			if attrRow%2 == 1 {
+				rowStyle = s.rowOdd
+			}
+
+			f.SetCellValue(sheet, cellName(1, row), "")
+			f.SetCellStyle(sheet, cellName(1, row), cellName(1, row), rowStyle)
+
+			f.SetCellValue(sheet, cellName(2, row), field.Name)
+			f.SetCellStyle(sheet, cellName(2, row), cellName(2, row), s.attribute)
+
+			typeStyle := getEDDTypeStyle(s, field.Type)
+			f.SetCellValue(sheet, cellName(3, row), field.Type)
+			f.SetCellStyle(sheet, cellName(3, row), cellName(3, row), typeStyle)
+
+			f.SetCellValue(sheet, cellName(4, row), field.SubType)
+			f.SetCellStyle(sheet, cellName(4, row), cellName(4, row), rowStyle)
+
+			f.SetCellValue(sheet, cellName(5, row), field.DefaultValue)
+			f.SetCellStyle(sheet, cellName(5, row), cellName(5, row), rowStyle)
+
+			inputStyle := rowStyle
+			if field.Input != "" {
+				inputStyle = s.input
+			}
+			f.SetCellValue(sheet, cellName(6, row), field.Input)
+			f.SetCellStyle(sheet, cellName(6, row), cellName(6, row), inputStyle)
+
+			f.SetCellValue(sheet, cellName(7, row), field.Access)
+			f.SetCellStyle(sheet, cellName(7, row), cellName(7, row), rowStyle)
+
+			f.SetCellValue(sheet, cellName(8, row), field.Comment)
+			f.SetCellStyle(sheet, cellName(8, row), cellName(8, row), s.comment)
+
+			row++
+		}
+	}
+}
+
+func getEDDTypeStyle(s *eddExtraStyles, typeName string) int {
+	switch strings.ToLower(typeName) {
+	case "string":
+		return s.typeString
+	case "double":
+		return s.typeDouble
+	case "integer":
+		return s.typeInteger
+	case "boolean":
+		return s.typeBoolean
+	case "date":
+		return s.typeDate
+	case "array":
+		return s.typeArray
+	default:
+		return s.typeDefault
+	}
+}


### PR DESCRIPTION
## Summary

- Rewrites `ExtractExcel` in `pkg/dtrules/excel/extract.go` as a pure XML→xlsx conversion — no `session`, no `loader`, no `RuleSet`
- Adds `pkg/dtrules/excel/xml_exporter.go` with `UnmarshalDecisionTablesXML`, `UnmarshalEDDXML`, `WriteDTXMLToExcel`, and `WriteEDDXMLToExcel` — all operating directly on the existing `DecisionTablesXML` / `EDDXML` model structs
- Each `_dt.xml` / `_edd.xml` is now unmarshalled via `encoding/xml` and written to xlsx without loading into a `RuleSet`; the EDD and DT model structs were already available in `edd_importer.go` / `dt_importer.go`

## Test plan

- [ ] `TestExtractExcel_SimpleTree` — still passes
- [ ] `TestExtractExcel_PreservesSubdirs` — still passes
- [ ] `TestExtractExcel_FromFixture` — still passes
- [ ] `TestExtractExcel_BadXMLReturnsError` — still passes
- [ ] `TestExtractExcel_RoundTrip` — still passes
- [ ] `TestExtractExcel_NoLoaderWarnings` (new) — asserts zero stderr when DT file references entities from a different file
- [ ] `TestExtractExcel_NoSessionImport` (new) — asserts `extract.go` source contains no session/loader import paths

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)