### PR TITLE
feat(runtime): RDate accepts timestamps

### DIFF
--- a/cmd/dtrules/docs.go
+++ b/cmd/dtrules/docs.go
@@ -454,10 +454,20 @@ Sources:
     taxpayer's birthDate           possessive
 
 Cast to date:
-    (date) "2024-01-15"            parse string to date
+    (date) "2024-01-15"            parse string to date (pure date, midnight UTC)
+    (date) "2026-04-17T21:05:30Z"  parse RFC 3339 timestamp
+    (date) "2026-04-17 21:05:30"   parse space-separated datetime
     (date) accounts[i]             array element as date
     (date) someTable("key")        table lookup returning date
     using myEntity(myDate)         delegate to entity's table
+
+Accepted string formats (most-specific tried first):
+    RFC 3339 with nanoseconds: "2026-04-17T21:05:30.123456789Z"
+    RFC 3339:                  "2026-04-17T21:05:30Z"
+    Space-separated datetime:  "2026-04-17 21:05:30"
+    Pure date (midnight UTC):  "2026-04-17"
+
+Pure dates serialize as "YYYY-MM-DD"; timestamps serialize as RFC 3339.
 
 Date arithmetic (returns dexpr):
     (5 days)                       duration literal (integer days)

--- a/docs/EL-REFERENCE.md
+++ b/docs/EL-REFERENCE.md
@@ -438,8 +438,20 @@ Natural language forms (`is greater than`, `at or above`, etc.) compile identica
 
 **Syntax**: `(date) strexpr` or `date(strexpr)`
 **Semantics**: Parse a string into a date value. Postfix: `cvd`.
+
+The parser accepts both pure dates and full timestamps. Formats tried in order:
+- RFC 3339 with nanoseconds: `2026-04-17T21:05:30.123456789Z`
+- RFC 3339: `2026-04-17T21:05:30Z`
+- Space-separated datetime: `2026-04-17 21:05:30`
+- Pure date (midnight UTC): `2026-04-17`
+
+Pure dates (midnight UTC) serialize back as `YYYY-MM-DD`; timestamps serialize as RFC 3339.
+
 **Example (EL)**: `(date)"2024-01-01" is before current date`
 **Compiled postfix**: `"2024-01-01" cvd currentdate d<`
+
+**Example (EL with timestamp)**: `(date)"2026-04-17T21:05:30Z" is before current date`
+**Compiled postfix**: `"2026-04-17T21:05:30Z" cvd currentdate d<`
 
 #### Date arithmetic (date plus/minus days/months/years)
 

--- a/pkg/dtrules/date.go
+++ b/pkg/dtrules/date.go
@@ -104,8 +104,14 @@ func (r *RDate) Compare(o Object) (int, error) {
 }
 
 // StringValue returns the string representation of this date.
+// Pure dates (midnight UTC) are serialized as YYYY-MM-DD to preserve existing
+// XML/Excel output. Timestamps with a non-zero time component use RFC3339Nano.
 func (r *RDate) StringValue() string {
-	return r.time.Format(DateFormat)
+	t := r.time.UTC()
+	if t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0 && t.Nanosecond() == 0 {
+		return t.Format("2006-01-02")
+	}
+	return t.Format(time.RFC3339Nano)
 }
 
 // PostFix returns the postfix representation.

--- a/pkg/dtrules/date_timestamp_test.go
+++ b/pkg/dtrules/date_timestamp_test.go
@@ -1,0 +1,196 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtrules
+
+import (
+	"testing"
+	"time"
+)
+
+// stubDateParser is a minimal DateParser that uses Go's time.Parse with RFC3339 formats.
+// It mirrors the production NewDateParser() order so tests remain independent of session/.
+type stubDateParser struct{}
+
+func (s *stubDateParser) GetDate(str string) (time.Time, error) {
+	formats := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05",
+		"2006-01-02",
+	}
+	for _, f := range formats {
+		if t, err := time.Parse(f, str); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, NewRulesError("DateParser", "GetDate", "Could not parse date: "+str)
+}
+
+func (s *stubDateParser) Parse(str string) (time.Time, error) {
+	return s.GetDate(str)
+}
+
+// stubSession wraps the stub date parser for GetRDate usage.
+type stubSession struct{}
+
+func (s *stubSession) GetDateParser() DateParser { return &stubDateParser{} }
+
+func getTestDate(str string) (*RDate, error) {
+	parser := &stubDateParser{}
+	t, err := parser.GetDate(str)
+	if err != nil {
+		return nil, err
+	}
+	return GetRTime(t), nil
+}
+
+func TestRDateParseRFC3339(t *testing.T) {
+	d, err := getTestDate("2026-04-17T21:05:30Z")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	tt := d.Time().UTC()
+	if tt.Year() != 2026 || tt.Month() != 4 || tt.Day() != 17 {
+		t.Errorf("wrong date: %v", tt)
+	}
+	if tt.Hour() != 21 || tt.Minute() != 5 || tt.Second() != 30 {
+		t.Errorf("wrong time: %v", tt)
+	}
+}
+
+func TestRDateParseSpaceSeparated(t *testing.T) {
+	d, err := getTestDate("2026-04-17 21:05:30")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	tt := d.Time().UTC()
+	if tt.Hour() != 21 || tt.Minute() != 5 || tt.Second() != 30 {
+		t.Errorf("wrong time: %v", tt)
+	}
+}
+
+func TestRDateParseNanoseconds(t *testing.T) {
+	d, err := getTestDate("2026-04-17T21:05:30.123456789Z")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	tt := d.Time().UTC()
+	if tt.Nanosecond() != 123456789 {
+		t.Errorf("wrong nanoseconds: got %d, want 123456789", tt.Nanosecond())
+	}
+}
+
+func TestRDateParsePureDate(t *testing.T) {
+	d, err := getTestDate("2026-04-17")
+	if err != nil {
+		t.Fatalf("parse failed (regression): %v", err)
+	}
+	tt := d.Time().UTC()
+	if tt.Hour() != 0 || tt.Minute() != 0 || tt.Second() != 0 || tt.Nanosecond() != 0 {
+		t.Errorf("pure date should have zero time component: %v", tt)
+	}
+}
+
+func TestRDateParseInvalid(t *testing.T) {
+	_, err := getTestDate("not-a-date")
+	if err == nil {
+		t.Error("expected error for invalid date")
+	}
+}
+
+func TestRDateStringValuePureDate(t *testing.T) {
+	d := GetRTime(time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC))
+	got := d.StringValue()
+	if got != "2026-04-17" {
+		t.Errorf("pure date StringValue = %q, want 2026-04-17", got)
+	}
+}
+
+func TestRDateStringValueTimestamp(t *testing.T) {
+	d := GetRTime(time.Date(2026, 4, 17, 21, 5, 30, 0, time.UTC))
+	got := d.StringValue()
+	if got != "2026-04-17T21:05:30Z" {
+		t.Errorf("timestamp StringValue = %q, want 2026-04-17T21:05:30Z", got)
+	}
+}
+
+func TestRDateComparisonTimestamps(t *testing.T) {
+	earlier, _ := getTestDate("2026-04-17T12:00:00Z")
+	later, _ := getTestDate("2026-04-17T18:00:00Z")
+
+	cmp, err := earlier.Compare(later)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmp >= 0 {
+		t.Errorf("expected earlier < later, got Compare=%d", cmp)
+	}
+}
+
+func TestRDatePureDateEqualsTimestampMidnight(t *testing.T) {
+	pure, _ := getTestDate("2026-04-17")
+	midnight, _ := getTestDate("2026-04-17T00:00:00Z")
+
+	eq, err := pure.Equals(midnight)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !eq {
+		t.Error("pure date 2026-04-17 should equal 2026-04-17T00:00:00Z")
+	}
+}
+
+func TestRDatePureDateBeforeOneSecondLater(t *testing.T) {
+	pure, _ := getTestDate("2026-04-17")
+	oneSecLater, _ := getTestDate("2026-04-17T00:00:01Z")
+
+	cmp, err := pure.Compare(oneSecLater)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmp >= 0 {
+		t.Errorf("2026-04-17 should be before 2026-04-17T00:00:01Z, Compare=%d", cmp)
+	}
+}
+
+func TestRDateRoundTrip(t *testing.T) {
+	orig, _ := getTestDate("2026-04-17T21:05:30Z")
+	serialized := orig.StringValue()
+
+	roundTripped, err := getTestDate(serialized)
+	if err != nil {
+		t.Fatalf("round-trip parse failed for %q: %v", serialized, err)
+	}
+
+	origTime := orig.Time().UTC().Truncate(time.Second)
+	rtTime := roundTripped.Time().UTC().Truncate(time.Second)
+	if !origTime.Equal(rtTime) {
+		t.Errorf("round-trip mismatch: orig=%v, got=%v", origTime, rtTime)
+	}
+}
+
+func TestRDateRoundTripNanoseconds(t *testing.T) {
+	orig, _ := getTestDate("2026-04-17T21:05:30.123456789Z")
+	serialized := orig.StringValue()
+
+	roundTripped, err := getTestDate(serialized)
+	if err != nil {
+		t.Fatalf("round-trip parse failed for %q: %v", serialized, err)
+	}
+
+	if !orig.Time().Equal(roundTripped.Time()) {
+		t.Errorf("nanosecond round-trip mismatch: orig=%v, got=%v", orig.Time(), roundTripped.Time())
+	}
+}

--- a/pkg/dtrules/session/date_timestamp_test.go
+++ b/pkg/dtrules/session/date_timestamp_test.go
@@ -1,0 +1,114 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDateParserRFC3339(t *testing.T) {
+	parser := NewDateParser()
+
+	tests := []struct {
+		input   string
+		wantH   int
+		wantM   int
+		wantS   int
+		wantNs  int
+	}{
+		{"2026-04-17T21:05:30Z", 21, 5, 30, 0},
+		{"2026-04-17 21:05:30", 21, 5, 30, 0},
+		{"2026-04-17T21:05:30.123456789Z", 21, 5, 30, 123456789},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := parser.GetDate(tt.input)
+			if err != nil {
+				t.Fatalf("GetDate failed for %q: %v", tt.input, err)
+			}
+			utc := result.UTC()
+			if utc.Hour() != tt.wantH || utc.Minute() != tt.wantM || utc.Second() != tt.wantS {
+				t.Errorf("time: got %02d:%02d:%02d, want %02d:%02d:%02d", utc.Hour(), utc.Minute(), utc.Second(), tt.wantH, tt.wantM, tt.wantS)
+			}
+			if tt.wantNs != 0 && utc.Nanosecond() != tt.wantNs {
+				t.Errorf("nanoseconds: got %d, want %d", utc.Nanosecond(), tt.wantNs)
+			}
+		})
+	}
+}
+
+func TestDateParserPureDateRegressionTimestamp(t *testing.T) {
+	parser := NewDateParser()
+	result, err := parser.GetDate("2026-04-17")
+	if err != nil {
+		t.Fatalf("pure date parse failed: %v", err)
+	}
+	utc := result.UTC()
+	if utc.Hour() != 0 || utc.Minute() != 0 || utc.Second() != 0 {
+		t.Errorf("pure date should have zero time: %v", utc)
+	}
+}
+
+// TestSyncTimeFixture simulates the staking sync_time scenario:
+// a date-typed field receives an ISO-8601 timestamp value via the date parser.
+func TestSyncTimeFixture(t *testing.T) {
+	parser := NewDateParser()
+
+	// The value that would arrive from an input XML like:
+	// <sync_time>2026-04-17T21:05:30.123Z</sync_time>
+	input := "2026-04-17T21:05:30.123Z"
+
+	parsed, err := parser.GetDate(input)
+	if err != nil {
+		t.Fatalf("sync_time parse failed for %q: %v", input, err)
+	}
+
+	utc := parsed.UTC()
+	if utc.Year() != 2026 || utc.Month() != 4 || utc.Day() != 17 {
+		t.Errorf("wrong date: %v", utc)
+	}
+	if utc.Hour() != 21 || utc.Minute() != 5 || utc.Second() != 30 {
+		t.Errorf("wrong time: %v", utc)
+	}
+	// .123Z = 123 milliseconds = 123_000_000 nanoseconds
+	if utc.Nanosecond() != 123_000_000 {
+		t.Errorf("nanoseconds: got %d, want 123000000", utc.Nanosecond())
+	}
+}
+
+// TestDateParserRoundTripTimestamp verifies parse -> serialize -> parse preserves the instant.
+func TestDateParserRoundTripTimestamp(t *testing.T) {
+	parser := NewDateParser()
+
+	input := "2026-04-17T21:05:30Z"
+	parsed, err := parser.GetDate(input)
+	if err != nil {
+		t.Fatalf("initial parse failed: %v", err)
+	}
+
+	// Simulate what RDate.StringValue() produces for a timestamp
+	serialized := parsed.UTC().Format(time.RFC3339Nano)
+
+	roundTripped, err := parser.GetDate(serialized)
+	if err != nil {
+		t.Fatalf("round-trip parse failed for %q: %v", serialized, err)
+	}
+
+	if !parsed.Equal(roundTripped) {
+		t.Errorf("round-trip mismatch: orig=%v, got=%v", parsed, roundTripped)
+	}
+}

--- a/pkg/dtrules/session/session.go
+++ b/pkg/dtrules/session/session.go
@@ -190,14 +190,18 @@ type DateParser struct {
 }
 
 // NewDateParser creates a new date parser with common formats.
+// Most-specific formats are tried first; RFC3339 variants precede date-only formats
+// so that timestamps like "2026-04-17T21:05:30Z" are parsed correctly.
 func NewDateParser() *DateParser {
 	return &DateParser{
 		formats: []string{
+			time.RFC3339Nano,      // 2006-01-02T15:04:05.999999999Z07:00
+			time.RFC3339,          // 2006-01-02T15:04:05Z07:00
+			"2006-01-02 15:04:05", // YYYY-MM-DD HH:MM:SS (space-separated)
+			"2006-01-02",          // YYYY-MM-DD
 			"01/02/2006",          // MM/DD/YYYY
 			"1/2/2006",            // M/D/YYYY
 			"01/02/2006 15:04:05", // MM/DD/YYYY HH:MM:SS
-			"2006-01-02",          // YYYY-MM-DD
-			"2006-01-02 15:04:05", // YYYY-MM-DD HH:MM:SS
 			"Jan 2, 2006",         // Month D, YYYY
 			"January 2, 2006",     // Month D, YYYY
 			dtrules.DateFormat,    // Default format


### PR DESCRIPTION
Closes #568

## What changed

**Accepted formats** (tried most-specific first):
- RFC 3339 with nanoseconds: `2026-04-17T21:05:30.123456789Z`
- RFC 3339: `2026-04-17T21:05:30Z`
- Space-separated datetime: `2026-04-17 21:05:30`
- Pure date (midnight UTC): `2026-04-17` ← existing behavior preserved

**Unix-epoch integers**: not accepted. The EL type system has separate Integer/Double types; accepting integers as dates would be ambiguous. Use `cvd` on a formatted string or the `now`/`today` operators instead.

**Excel / XML serialization**: `RDate.StringValue()` now emits `YYYY-MM-DD` for pure dates (midnight UTC, no change from before) and RFC 3339 for timestamps. The updated parser can read both formats, so round-trips are lossless.

**Date operators**: no changes needed. All operators work via `time.Time` internally and continue to operate correctly on both pure dates and timestamps.

## Files changed

- `pkg/dtrules/session/session.go` — `NewDateParser()` adds RFC3339Nano, RFC3339, and space-separated datetime formats before the existing ones
- `pkg/dtrules/date.go` — `StringValue()` conditionally serializes as `YYYY-MM-DD` or RFC3339Nano
- `pkg/dtrules/date_timestamp_test.go` — unit tests for parse, comparison, round-trip
- `pkg/dtrules/session/date_timestamp_test.go` — session-level tests including `sync_time` fixture
- `docs/EL-REFERENCE.md` + `cmd/dtrules/docs.go` — timestamp acceptance documented

## Test confirmation

No existing tests were modified. All pre-existing failures (9 tax-content tests from #520) are unchanged; no new failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)