### PR TITLE
feat(session): LoadRulesFromFS for direct embed.FS loading

### DIFF
--- a/cmd/dtrules/doc_embedding.go
+++ b/cmd/dtrules/doc_embedding.go
@@ -55,36 +55,18 @@ A typical layout inside your Go module:
     └── go.mod
 
 
-Current limitation: loader requires a filesystem path
-------------------------------------------------------
-The session loader (session.LoadFromDirectory) currently accepts an
-os-filesystem directory path, not an fs.FS.  Until the API is updated
-(see follow-up issue #536), copy the embedded files to a temp directory
-at startup, then load by path.
-
-A follow-up issue has been filed:
-  https://github.com/DTRules/DTRules/issues/536
-  "Loader should accept fs.FS directly (no tempdir round-trip)"
-
-The minimal end-to-end example below uses the tempdir workaround.
-When issue #536 is resolved the tempdir block can be replaced with a
-direct fs.FS call.
-
-
 Minimal end-to-end example
 ---------------------------
-The following self-contained program embeds a compiled rules tree, loads it,
-sets one input field, calls a decision table, and reads a result.
+The following self-contained program embeds a compiled rules tree, loads it
+directly from the embed.FS (no temp-directory round-trip), sets one input
+field, calls a decision table, and reads a result.
 
     package main
 
     import (
         "embed"
         "fmt"
-        "io/fs"
         "log"
-        "os"
-        "path/filepath"
 
         "github.com/DTRules/DTRules/pkg/dtrules"
         "github.com/DTRules/DTRules/pkg/dtrules/session"
@@ -94,25 +76,13 @@ sets one input field, calls a decision table, and reads a result.
     var rulesFS embed.FS
 
     func main() {
-        // --- step 1: copy embedded xml to a temp directory ---
-        // (workaround until loader accepts fs.FS; see issue #536)
-        tmpDir, err := os.MkdirTemp("", "dtrules-*")
-        if err != nil {
-            log.Fatal(err)
-        }
-        defer os.RemoveAll(tmpDir)
-
-        if err := copyEmbedToDir(rulesFS, "rules/xml", tmpDir); err != nil {
-            log.Fatal(err)
-        }
-
-        // --- step 2: load the rule set ---
-        rs, err := session.LoadRulesFromDirectory("TaxReturn", tmpDir)
+        // --- step 1: load the rule set directly from the embedded FS ---
+        rs, err := session.LoadRulesFromFS("TaxReturn", rulesFS, "rules/xml")
         if err != nil {
             log.Fatal(err)
         }
 
-        // --- step 3: create a session and build input entities ---
+        // --- step 2: create a session and build input entities ---
         sess, err := rs.NewSession()
         if err != nil {
             log.Fatal(err)
@@ -128,12 +98,12 @@ sets one input field, calls a decision table, and reads a result.
         state := sess.GetState()
         state.EntityPush(taxpayer)
 
-        // --- step 4: execute the entry-point decision table ---
+        // --- step 3: execute the entry-point decision table ---
         if err := sess.Execute("Compute_Tax_Return"); err != nil {
             log.Fatal(err)
         }
 
-        // --- step 5: read a result field ---
+        // --- step 4: read a result field ---
         result, err := sess.CreateEntity(dtrules.GetRName("result"))
         if err != nil {
             log.Fatal(err)
@@ -143,25 +113,6 @@ sets one input field, calls a decision table, and reads a result.
             log.Fatal(err)
         }
         fmt.Printf("federal_tax = %s\n", val.StringValue())
-    }
-
-    // copyEmbedToDir copies all files from an embed.FS subtree to a real directory.
-    func copyEmbedToDir(fsys embed.FS, src, dst string) error {
-        return fs.WalkDir(fsys, src, func(path string, d fs.DirEntry, err error) error {
-            if err != nil {
-                return err
-            }
-            rel, _ := filepath.Rel(src, path)
-            target := filepath.Join(dst, rel)
-            if d.IsDir() {
-                return os.MkdirAll(target, 0755)
-            }
-            data, err := fsys.ReadFile(path)
-            if err != nil {
-                return err
-            }
-            return os.WriteFile(target, data, 0644)
-        })
     }
 
 To use this in your own project:

--- a/cmd/dtrules/docs_test.go
+++ b/cmd/dtrules/docs_test.go
@@ -94,3 +94,16 @@ func TestDocumentation_EmbeddingContainsExtractExcel(t *testing.T) {
 		t.Error("embedding doc should document ExtractExcel for dumping embedded rules")
 	}
 }
+
+func TestDocumentation_EmbeddingUsesLoadRulesFromFS(t *testing.T) {
+	doc, ok := docTopics["embedding"]
+	if !ok {
+		t.Fatal("embedding topic not registered in docTopics")
+	}
+	if !strings.Contains(doc, "LoadRulesFromFS") {
+		t.Error("embedding doc should show LoadRulesFromFS (not tempdir workaround)")
+	}
+	if strings.Contains(doc, "MkdirTemp") || strings.Contains(doc, "copyEmbedToDir") {
+		t.Error("embedding doc should not reference the old tempdir workaround")
+	}
+}

--- a/pkg/dtrules/loader/directory.go
+++ b/pkg/dtrules/loader/directory.go
@@ -83,6 +83,159 @@ func CollectXMLFiles(dirPath string) ([]string, error) {
 	return files, err
 }
 
+// collectXMLFilesFS scans an fs.FS recursively for *.xml files under root.
+func collectXMLFilesFS(fsys fs.FS, root string) ([]string, error) {
+	var files []string
+	err := fs.WalkDir(fsys, root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(strings.ToLower(path), ".xml") {
+			if !shouldSkipFile(path) {
+				files = append(files, path)
+			}
+		}
+		return nil
+	})
+	return files, err
+}
+
+// parseFileMetadataFS extracts metadata from an XML file within an fs.FS.
+func parseFileMetadataFS(fsys fs.FS, filePath string) (*xmlFileInfo, error) {
+	f, err := fsys.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open %s: %w", filePath, err)
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", filePath, err)
+	}
+
+	// Quick validation
+	dataStr := string(data)
+	hasDecisionTables := strings.Contains(dataStr, "<decision_tables")
+	hasEntityDict := strings.Contains(dataStr, "<entity_data_dictionary") ||
+		strings.Contains(dataStr, "<entity_dictionary")
+
+	if !hasDecisionTables && !hasEntityDict {
+		return nil, fmt.Errorf("file %s does not appear to be a DTRules XML file", filePath)
+	}
+
+	// Reuse path-based metadata parsing by writing to a temp file
+	// is wasteful; instead duplicate the parse logic with the data we already have.
+	info := &xmlFileInfo{
+		Path: filePath,
+	}
+
+	if hasDecisionTables {
+		var dtFile DTFile
+		if err := xml.Unmarshal(data, &dtFile); err == nil && len(dtFile.Tables) > 0 {
+			info.IsDecisionTable = true
+
+			if dtFile.Tables[0].AttributeFields.TableNumber != "" {
+				tableNumStr := strings.TrimSpace(dtFile.Tables[0].AttributeFields.TableNumber)
+				if strings.Contains(tableNumStr, "X") || strings.Contains(tableNumStr, "?") {
+					return nil, fmt.Errorf("template file with placeholder TABLE_NUMBER: %s", tableNumStr)
+				}
+				num, err := strconv.Atoi(tableNumStr)
+				if err != nil {
+					return nil, fmt.Errorf("invalid TABLE_NUMBER in %s: %w", filePath, err)
+				}
+				info.Number = num
+			}
+
+			if info.Number == 0 {
+				base := filepath.Base(filePath)
+				numStr := ""
+				for _, ch := range base {
+					if ch >= '0' && ch <= '9' {
+						numStr += string(ch)
+					} else {
+						break
+					}
+				}
+				if numStr != "" {
+					if num, err := strconv.Atoi(numStr); err == nil {
+						info.Number = num
+					}
+				}
+			}
+
+			filePathStr := strings.TrimSpace(dtFile.Tables[0].AttributeFields.FilePath)
+			info.FilePath = filePathStr
+
+			if filePathStr == "" {
+				base := filepath.Base(filePath)
+				base = strings.TrimSuffix(base, filepath.Ext(base))
+				base = strings.TrimSuffix(base, "_dt")
+				info.FilePath = base
+				if info.Number == 0 {
+					info.Number = 99999
+				}
+			}
+
+			return info, nil
+		}
+	}
+
+	if hasEntityDict {
+		var entityCount int
+		var filePathStr string
+
+		var eddFile EDDFile
+		if err := xml.Unmarshal(data, &eddFile); err == nil && len(eddFile.Entities) > 0 {
+			entityCount = len(eddFile.Entities)
+			filePathStr = strings.TrimSpace(eddFile.FileMetadata.FilePath)
+		} else {
+			var legacyFile EDDFileLegacy
+			if err := xml.Unmarshal(data, &legacyFile); err == nil && len(legacyFile.Entities) > 0 {
+				entityCount = len(legacyFile.Entities)
+			}
+		}
+
+		if entityCount > 0 {
+			info.IsDecisionTable = false
+			info.FilePath = filePathStr
+
+			if filePathStr == "" {
+				base := filepath.Base(filePath)
+				base = strings.TrimSuffix(base, filepath.Ext(base))
+				if entityCount > 10 {
+					return nil, fmt.Errorf("EDD file missing file_path (likely a merged/generated file)")
+				}
+				filePathStr = base
+				info.FilePath = filePathStr
+			}
+
+			parts := strings.Split(filePathStr, "/")
+			if len(parts) > 0 {
+				lastPart := parts[len(parts)-1]
+				numStr := ""
+				for _, ch := range lastPart {
+					if ch >= '0' && ch <= '9' {
+						numStr += string(ch)
+					} else {
+						break
+					}
+				}
+				if numStr != "" {
+					num, err := strconv.Atoi(numStr)
+					if err != nil {
+						return nil, fmt.Errorf("invalid file_path number in %s: %w", filePathStr, err)
+					}
+					info.Number = num
+				}
+			}
+
+			return info, nil
+		}
+	}
+
+	return nil, fmt.Errorf("file %s is neither a valid decision table nor EDD file", filePath)
+}
+
 // ParseFileMetadata extracts metadata from an XML file.
 func ParseFileMetadata(filePath string) (*xmlFileInfo, error) {
 	f, err := os.Open(filePath)
@@ -247,25 +400,25 @@ func ParseFileMetadata(filePath string) (*xmlFileInfo, error) {
 	return nil, fmt.Errorf("file %s is neither a valid decision table nor EDD file", filePath)
 }
 
-// LoadRulesFromDirectory loads all XML files from a directory.
+// LoadRulesFromFS loads all XML files from an fs.FS under the given root path.
 // EDDs are loaded first (in order), then decision tables (in order).
-func LoadRulesFromDirectory(rs dtrules.RuleSet, dirPath string) error {
+// Use "." as root to load from the FS root.
+func LoadRulesFromFS(rs dtrules.RuleSet, fsys fs.FS, root string) error {
 	// 1. Collect all XML files
-	files, err := CollectXMLFiles(dirPath)
+	files, err := collectXMLFilesFS(fsys, root)
 	if err != nil {
-		return fmt.Errorf("failed to collect XML files from %s: %w", dirPath, err)
+		return fmt.Errorf("failed to collect XML files from FS root %q: %w", root, err)
 	}
 
 	if len(files) == 0 {
-		return fmt.Errorf("no XML files found in directory: %s", dirPath)
+		return fmt.Errorf("no XML files found in FS root: %s", root)
 	}
 
 	// 2. Parse metadata for each file
 	var fileInfos []*xmlFileInfo
 	for _, file := range files {
-		info, err := ParseFileMetadata(file)
+		info, err := parseFileMetadataFS(fsys, file)
 		if err != nil {
-			// Log warning but continue
 			fmt.Printf("Warning: skipping file %s: %v\n", file, err)
 			continue
 		}
@@ -273,7 +426,7 @@ func LoadRulesFromDirectory(rs dtrules.RuleSet, dirPath string) error {
 	}
 
 	if len(fileInfos) == 0 {
-		return fmt.Errorf("no valid XML files found in directory: %s", dirPath)
+		return fmt.Errorf("no valid XML files found in FS root: %s", root)
 	}
 
 	// 3. Sort by number
@@ -293,24 +446,24 @@ func LoadRulesFromDirectory(rs dtrules.RuleSet, dirPath string) error {
 	}
 
 	// Get session and factory
-	session, err := rs.NewSession()
+	sess, err := rs.NewSession()
 	if err != nil {
 		return fmt.Errorf("failed to create session: %w", err)
 	}
-	factory := session.GetEntityFactory().(*entity.Factory)
+	factory := sess.GetEntityFactory().(*entity.Factory)
 
 	var errs []error
 
 	// 5. Load EDDs in order
 	for _, info := range edds {
-		if err := loadEDDFile(session, factory, info.Path); err != nil {
+		if err := loadEDDFromFS(fsys, sess, factory, info.Path); err != nil {
 			errs = append(errs, fmt.Errorf("failed to load EDD %s: %w", info.Path, err))
 		}
 	}
 
 	// 6. Load DTs in order
 	for _, info := range dts {
-		if err := loadDTFile(session, factory, info.Path); err != nil {
+		if err := loadDTFromFS(fsys, sess, factory, info.Path); err != nil {
 			errs = append(errs, fmt.Errorf("failed to load DT %s: %w", info.Path, err))
 		}
 	}
@@ -328,26 +481,32 @@ func LoadRulesFromDirectory(rs dtrules.RuleSet, dirPath string) error {
 	return nil
 }
 
-// loadEDDFile loads a single EDD file.
-func loadEDDFile(session dtrules.Session, factory *entity.Factory, filePath string) error {
-	f, err := os.Open(filePath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	loader := NewEDDLoader(session, factory)
-	return loader.Load(f)
+// LoadRulesFromDirectory loads all XML files from a directory.
+// EDDs are loaded first (in order), then decision tables (in order).
+func LoadRulesFromDirectory(rs dtrules.RuleSet, dirPath string) error {
+	return LoadRulesFromFS(rs, os.DirFS(dirPath), ".")
 }
 
-// loadDTFile loads a single decision table file.
-func loadDTFile(session dtrules.Session, factory *entity.Factory, filePath string) error {
-	f, err := os.Open(filePath)
+// loadEDDFromFS loads a single EDD file from an fs.FS.
+func loadEDDFromFS(fsys fs.FS, sess dtrules.Session, factory *entity.Factory, filePath string) error {
+	f, err := fsys.Open(filePath)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
-	loader := NewDTLoader(session, factory)
-	return loader.Load(f)
+	l := NewEDDLoader(sess, factory)
+	return l.Load(f)
+}
+
+// loadDTFromFS loads a single decision table file from an fs.FS.
+func loadDTFromFS(fsys fs.FS, sess dtrules.Session, factory *entity.Factory, filePath string) error {
+	f, err := fsys.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	l := NewDTLoader(sess, factory)
+	return l.Load(f)
 }

--- a/pkg/dtrules/session/fs_test.go
+++ b/pkg/dtrules/session/fs_test.go
@@ -1,0 +1,158 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session_test
+
+import (
+	"os"
+	"testing"
+	"testing/fstest"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+const minimalEDD = `<?xml version="1.0" encoding="UTF-8"?>
+<entity_data_dictionary version="1.0">
+  <file_metadata>
+    <file_path>test/10000_constants</file_path>
+  </file_metadata>
+  <entity name="result">
+    <field name="test_value" type="double" default_value="42.0"/>
+  </entity>
+</entity_data_dictionary>`
+
+const minimalDT = `<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+  <decision_table>
+    <table_name>Test_Table</table_name>
+    <xls_file>test.xls</xls_file>
+    <attribute_fields>
+      <TABLE_NUMBER>10001</TABLE_NUMBER>
+      <FILE_PATH>test/10001_Test_Table</FILE_PATH>
+      <Type>FIRST</Type>
+    </attribute_fields>
+    <contexts></contexts>
+    <initial_actions></initial_actions>
+    <conditions>
+      <condition_details>
+        <condition_number>1</condition_number>
+        <condition_dsl>true</condition_dsl>
+        <condition_postfix>true</condition_postfix>
+        <condition_column column_number="1" column_value="X"/>
+      </condition_details>
+    </conditions>
+    <actions>
+      <action_details>
+        <action_number>1</action_number>
+        <action_dsl>Set result.test_value = 100</action_dsl>
+        <action_postfix>100.0 result test_value !</action_postfix>
+        <action_column column_number="1" column_value="X"/>
+      </action_details>
+    </actions>
+    <policy_statements>
+      <policy_statement column="1">
+        <policy_description>Test case</policy_description>
+        <policy_statement_postfix></policy_statement_postfix>
+      </policy_statement>
+    </policy_statements>
+  </decision_table>
+</decision_tables>`
+
+// TestLoadRulesFromFS_WithEmbed simulates loading from an embed.FS using fstest.MapFS.
+func TestLoadRulesFromFS_WithEmbed(t *testing.T) {
+	mapFS := fstest.MapFS{
+		"test_edd.xml": {Data: []byte(minimalEDD)},
+		"test_dt.xml":  {Data: []byte(minimalDT)},
+	}
+
+	rs, err := session.LoadRulesFromFS("TestFS", mapFS, ".")
+	if err != nil {
+		t.Fatalf("LoadRulesFromFS failed: %v", err)
+	}
+
+	factory := rs.GetEntityFactory()
+	dtName := dtrules.GetRName("Test_Table")
+	dt := factory.FindDecisionTable(dtName)
+	if dt == nil {
+		t.Error("expected decision table 'Test_Table' to be loaded")
+	}
+
+	entityNames := rs.GetEntityNames()
+	found := false
+	for _, n := range entityNames {
+		if n.GetName() == "result" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected entity 'result' to be loaded")
+	}
+}
+
+// TestLoadRulesFromFS_NestedRoot verifies that root can be a subdirectory inside the FS.
+func TestLoadRulesFromFS_NestedRoot(t *testing.T) {
+	mapFS := fstest.MapFS{
+		"rules/test_edd.xml": {Data: []byte(minimalEDD)},
+		"rules/test_dt.xml":  {Data: []byte(minimalDT)},
+		// file outside the root should be ignored
+		"other/ignored.xml": {Data: []byte("<root/>")},
+	}
+
+	rs, err := session.LoadRulesFromFS("TestFSNested", mapFS, "rules")
+	if err != nil {
+		t.Fatalf("LoadRulesFromFS (nested root) failed: %v", err)
+	}
+
+	factory := rs.GetEntityFactory()
+	dtName := dtrules.GetRName("Test_Table")
+	if factory.FindDecisionTable(dtName) == nil {
+		t.Error("expected decision table 'Test_Table' to be loaded from nested root")
+	}
+}
+
+// TestLoadRulesFromDirectory_StillWorks is a regression test ensuring the path-based API is unchanged.
+func TestLoadRulesFromDirectory_StillWorks(t *testing.T) {
+	dirPath := t.TempDir()
+
+	if err := os.WriteFile(dirPath+"/test_edd.xml", []byte(minimalEDD), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dirPath+"/test_dt.xml", []byte(minimalDT), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rs, err := session.LoadRulesFromDirectory("TestDir", dirPath)
+	if err != nil {
+		t.Fatalf("LoadRulesFromDirectory failed: %v", err)
+	}
+
+	factory := rs.GetEntityFactory()
+	if factory.FindDecisionTable(dtrules.GetRName("Test_Table")) == nil {
+		t.Error("expected decision table to be loaded via directory path")
+	}
+}
+
+// TestLoadRulesFromFS_MissingFile verifies a useful error when the FS root contains no XML.
+func TestLoadRulesFromFS_MissingFile(t *testing.T) {
+	mapFS := fstest.MapFS{
+		"readme.txt": {Data: []byte("no xml here")},
+	}
+
+	_, err := session.LoadRulesFromFS("TestMissing", mapFS, ".")
+	if err == nil {
+		t.Fatal("expected error when no XML files present, got nil")
+	}
+}

--- a/pkg/dtrules/session/ruleset.go
+++ b/pkg/dtrules/session/ruleset.go
@@ -18,6 +18,7 @@ package session
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 
 	"github.com/DTRules/DTRules/pkg/dtrules"
@@ -108,10 +109,25 @@ func (rs *RuleSet) LoadDecisionTables(r io.Reader) error {
 // in the correct order based on TABLE_NUMBER (for DTs) and file_path numbering (for EDDs).
 //
 // Example:
-//   rs := session.NewRuleSet("TaxReturn")
-//   err := rs.LoadFromDirectory("./sampleprojects/TaxReturn/xml")
+//
+//	rs := session.NewRuleSet("TaxReturn")
+//	err := rs.LoadFromDirectory("./sampleprojects/TaxReturn/xml")
 func (rs *RuleSet) LoadFromDirectory(dirPath string) error {
 	return loader.LoadRulesFromDirectory(rs, dirPath)
+}
+
+// LoadFromFS loads all XML files from an fs.FS under the given root path.
+// Use "." as root to load from the FS root, or a subdirectory like "rules/xml".
+//
+// Example:
+//
+//	//go:embed rules/xml
+//	var rulesFS embed.FS
+//
+//	rs := session.NewRuleSet("TaxReturn")
+//	err := rs.LoadFromFS(rulesFS, "rules/xml")
+func (rs *RuleSet) LoadFromFS(fsys fs.FS, root string) error {
+	return loader.LoadRulesFromFS(rs, fsys, root)
 }
 
 // LoadEDDFile loads an EDD from a file path.
@@ -176,11 +192,32 @@ func (rs *RuleSet) LoadFromPath(path, eddPath, dtPath string) error {
 	return fmt.Errorf("must specify either path or both eddPath and dtPath")
 }
 
+// LoadRulesFromFS loads rules from an fs.FS into a new RuleSet.
+// root is the subdirectory inside fsys that contains the XML tree (use "." for the FS root).
+//
+// Example:
+//
+//	//go:embed rules/xml
+//	var rulesFS embed.FS
+//
+//	rs, err := session.LoadRulesFromFS("TaxReturn", rulesFS, "rules/xml")
+func LoadRulesFromFS(name string, fsys fs.FS, root string) (*RuleSet, error) {
+	rs := NewRuleSet(name)
+	if rs == nil {
+		return nil, fmt.Errorf("invalid rule set name: %s", name)
+	}
+	if err := rs.LoadFromFS(fsys, root); err != nil {
+		return nil, err
+	}
+	return rs, nil
+}
+
 // LoadRulesFromDirectory is a package-level convenience function for loading
 // rules from a directory into a new RuleSet.
 //
 // Example:
-//   rs, err := session.LoadRulesFromDirectory("TaxReturn", "./sampleprojects/TaxReturn/xml")
+//
+//	rs, err := session.LoadRulesFromDirectory("TaxReturn", "./sampleprojects/TaxReturn/xml")
 func LoadRulesFromDirectory(name, dirPath string) (*RuleSet, error) {
 	rs := NewRuleSet(name)
 	if rs == nil {


### PR DESCRIPTION
## Summary

- Add `session.LoadRulesFromFS(name string, fsys fs.FS, root string) (*RuleSet, error)` — consumers with `//go:embed` can now load rules with zero tempdir overhead
- Refactor `loader.LoadRulesFromDirectory` to delegate to the new FS-based primitive via `os.DirFS` — fully backwards-compatible
- Also expose `RuleSet.LoadFromFS(fsys fs.FS, root string)` as a method-level variant
- Update `dtrules docs embedding` to show the new direct-FS recipe; remove the old `copyEmbedToDir` / `MkdirTemp` workaround
- Add `pkg/dtrules/session/fs_test.go` with four tests: `TestLoadRulesFromFS_WithEmbed`, `TestLoadRulesFromFS_NestedRoot`, `TestLoadRulesFromDirectory_StillWorks`, `TestLoadRulesFromFS_MissingFile`

## Loader refactor depth

The refactor was **shallow**: the existing EDD/DT loaders already accept `io.Reader`, so the only change was in `loader/directory.go` — the file-collection and metadata-parsing logic was duplicated into FS-aware variants (`collectXMLFilesFS`, `parseFileMetadataFS`) that use `fs.WalkDir` / `fsys.Open` instead of `filepath.WalkDir` / `os.Open`. The core XML parsing logic is unchanged.

## Test plan

- [ ] `go test ./pkg/dtrules/session/...` — all four new FS tests pass
- [ ] `go test ./pkg/dtrules/loader/...` — all existing loader tests still pass
- [ ] `go test ./cmd/dtrules/...` — new doc test `TestDocumentation_EmbeddingUsesLoadRulesFromFS` passes
- [ ] Full `go test ./...` — only pre-existing SC tax failures; no regressions

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)