### PR TITLE
feat(cli): --xml-dir and --excel-dir flags for verify/validate/build

### DIFF
--- a/cmd/dtrules/build.go
+++ b/cmd/dtrules/build.go
@@ -31,6 +31,8 @@ type buildOptions struct {
 	fromExcel bool
 	dryRun    bool
 	verbose   bool
+	xmlDir    string
+	excelDir  string
 }
 
 // runBuild handles the `dtrules build [path]` command.
@@ -49,6 +51,16 @@ func (c *CLI) runBuild(args []string) int {
 			opts.dryRun = true
 		case "-v", "--verbose":
 			opts.verbose = true
+		case "--xml-dir":
+			if i+1 < len(args) {
+				opts.xmlDir = args[i+1]
+				i++
+			}
+		case "--excel-dir":
+			if i+1 < len(args) {
+				opts.excelDir = args[i+1]
+				i++
+			}
 		default:
 			if !strings.HasPrefix(args[i], "-") {
 				opts.path = args[i]
@@ -71,13 +83,25 @@ func (c *CLI) runBuild(args []string) int {
 		return 1
 	}
 
-	xmlDir := filepath.Join(absPath, "xml")
-	excelDir := filepath.Join(absPath, "excel")
+	xmlDir, excelDir, err := resolveDirs(absPath, opts.xmlDir, opts.excelDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		return 1
+	}
 
 	// Validate directories exist
 	if !dirExists(xmlDir) && !dirExists(excelDir) {
-		fmt.Fprintf(os.Stderr, "Error: no xml/ or excel/ directory found in %s\n", absPath)
-		fmt.Fprintln(os.Stderr, "Run 'dtrules init' to create a new project.")
+		if opts.xmlDir != "" || opts.excelDir != "" {
+			if !dirExists(xmlDir) {
+				fmt.Fprintf(os.Stderr, "ERROR: could not find xml directory\n  Tried: %s\n  Use --xml-dir <path> or declare <xml_dir> in DTRules.xml.\n", xmlDir)
+			}
+			if !dirExists(excelDir) {
+				fmt.Fprintf(os.Stderr, "ERROR: could not find excel directory\n  Tried: %s\n  Use --excel-dir <path> or declare <excel_dir> in DTRules.xml.\n", excelDir)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: no xml/ or excel/ directory found in %s\n", absPath)
+			fmt.Fprintln(os.Stderr, "Run 'dtrules init' to create a new project.")
+		}
 		return 1
 	}
 
@@ -404,17 +428,25 @@ files are newer and runs the appropriate path. Both paths end with canonical
 Excel files and compiled execution XML on disk.
 
 Arguments:
-  path         Project directory to build (default: .)
+  path                Project directory to build (default: .)
 
 Options:
-  --from-excel  Force Excel-authored path (Excel → XML)
-  --from-xml    Force XML-authored path (XML → Excel → XML)
-  --dry-run     Report what would change without writing files
-  -v, --verbose Verbose output
+  --xml-dir <path>    Override XML directory (relative to project root or absolute)
+  --excel-dir <path>  Override Excel directory (relative to project root or absolute)
+  --from-excel        Force Excel-authored path (Excel → XML)
+  --from-xml          Force XML-authored path (XML → Excel → XML)
+  --dry-run           Report what would change without writing files
+  -v, --verbose       Verbose output
+
+Directory resolution (highest to lowest priority):
+  1. --xml-dir / --excel-dir flags
+  2. <xml_dir> / <excel_dir> elements in DTRules.xml
+  3. Default: xml/ and excel/ relative to the project root
 
 Examples:
   dtrules build
   dtrules build ./sampleprojects/TaxReturn
   dtrules build --from-xml
-  dtrules build --dry-run`)
+  dtrules build --dry-run
+  dtrules build --xml-dir pkg/dtrules/rules --excel-dir pkg/dtrules/excel /path/to/project`)
 }

--- a/cmd/dtrules/cli.go
+++ b/cmd/dtrules/cli.go
@@ -569,18 +569,19 @@ func (c *CLI) runValidate(args []string) int {
 	var strict bool
 	var allowLegacy bool
 	var projectDir string
+	var flagXMLDir, flagExcelDir string
 
 	// Parse flags
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--xml-dir":
 			if i+1 < len(args) {
-				c.xmlDir = args[i+1]
+				flagXMLDir = args[i+1]
 				i++
 			}
 		case "--excel-dir":
 			if i+1 < len(args) {
-				c.excelDir = args[i+1]
+				flagExcelDir = args[i+1]
 				i++
 			}
 		case "--project", "-p":
@@ -594,6 +595,10 @@ func (c *CLI) runValidate(args []string) int {
 			strict = true
 		case "--allow-legacy":
 			allowLegacy = true
+		default:
+			if !strings.HasPrefix(args[i], "-") && projectDir == "" {
+				projectDir = args[i]
+			}
 		}
 	}
 
@@ -601,12 +606,20 @@ func (c *CLI) runValidate(args []string) int {
 	if projectDir == "" {
 		projectDir = "."
 	}
-	if c.xmlDir == "" {
-		c.xmlDir = filepath.Join(projectDir, "xml")
+
+	absProjectDir, err := filepath.Abs(projectDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error resolving path: %v\n", err)
+		return 1
 	}
-	if c.excelDir == "" {
-		c.excelDir = filepath.Join(projectDir, "excel")
+
+	resolvedXML, resolvedExcel, err := resolveDirs(absProjectDir, flagXMLDir, flagExcelDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		return 1
 	}
+	c.xmlDir = resolvedXML
+	c.excelDir = resolvedExcel
 
 	fmt.Printf("Validating DTRules project in %s\n", projectDir)
 	fmt.Println()
@@ -615,7 +628,7 @@ func (c *CLI) runValidate(args []string) int {
 
 	// 1. Validate project structure
 	fmt.Println("Checking project structure...")
-	structResult, err := sync.ValidateProjectStructure(projectDir)
+	structResult, err := sync.ValidateProjectStructure(absProjectDir, flagXMLDir, flagExcelDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error validating structure: %v\n", err)
 		return 1

--- a/cmd/dtrules/doc_project_layout.go
+++ b/cmd/dtrules/doc_project_layout.go
@@ -88,6 +88,41 @@ Multiple <Entities> and <Decisiontables> elements are allowed — the engine
 loads them in the order listed.
 
 
+Custom Directory Overrides in DTRules.xml
+------------------------------------------
+Projects that store rules in non-standard directories can declare overrides
+directly in DTRules.xml. This removes the need to pass flags on every command:
+
+    <dtrules>
+      <xml_dir>pkg/dtrules/rules</xml_dir>
+      <excel_dir>pkg/dtrules/excel</excel_dir>
+      ...
+    </dtrules>
+
+Both elements are optional. Paths may be relative (resolved against the project
+root) or absolute.
+
+When these elements are present, verify, validate, and build all use them
+automatically. CLI flags still take the highest priority if supplied:
+
+    dtrules verify --xml-dir override/path          # flag wins
+    dtrules verify                                   # DTRules.xml wins
+    dtrules verify /project/without/dtrules-xml     # defaults (xml/, excel/)
+
+Directory resolution order (highest to lowest priority):
+  1. --xml-dir / --excel-dir CLI flags
+  2. <xml_dir> / <excel_dir> in DTRules.xml
+  3. Default: xml/ and excel/ relative to the project root
+
+Better error messages:
+  When a custom directory cannot be found, the error message names the
+  flag you can use to correct it:
+
+      ERROR: could not find xml directory
+        Tried: /home/user/project/nonexistent
+        Use --xml-dir <path> or declare <xml_dir> in DTRules.xml.
+
+
 File Naming Convention (v1.5.0+)
 ----------------------------------
 Since v1.5.0, each file's suffix signals what artifact type it contains.

--- a/cmd/dtrules/path_flags_test.go
+++ b/cmd/dtrules/path_flags_test.go
@@ -1,0 +1,198 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fixtureDir returns the path to the custom_layout test fixture.
+func fixtureDir() string {
+	return filepath.Join("testdata", "custom_layout")
+}
+
+// TestVerifyCustomLayoutViaFlags verifies that --xml-dir and --excel-dir flags
+// allow verify to find non-standard directories.
+func TestVerifyCustomLayoutViaFlags(t *testing.T) {
+	fixture := fixtureDir()
+	if _, err := os.Stat(fixture); err != nil {
+		t.Skipf("fixture not found: %v", err)
+	}
+
+	absFixture, err := filepath.Abs(fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli := NewCLI()
+	code := cli.runVerify([]string{
+		"--xml-dir", "rules",
+		"--excel-dir", "workbooks",
+		absFixture,
+	})
+	// verify should exit 0: rules/ exists, workbooks/ is absent but that's
+	// acceptable (only fails when both are missing). All checks either pass
+	// or are skipped due to missing excel dir.
+	if code != 0 {
+		t.Errorf("expected exit 0, got %d", code)
+	}
+}
+
+// TestVerifyCustomLayoutViaDTRulesXML verifies that DTRules.xml declaring
+// <xml_dir> and <excel_dir> is respected without any CLI flags.
+func TestVerifyCustomLayoutViaDTRulesXML(t *testing.T) {
+	fixture := fixtureDir()
+	if _, err := os.Stat(fixture); err != nil {
+		t.Skipf("fixture not found: %v", err)
+	}
+
+	absFixture, err := filepath.Abs(fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No --xml-dir / --excel-dir flags; resolution should come from DTRules.xml.
+	cli := NewCLI()
+	code := cli.runVerify([]string{absFixture})
+	if code != 0 {
+		t.Errorf("expected exit 0 when DTRules.xml declares dirs, got %d", code)
+	}
+}
+
+// TestVerifyLegacyLayoutStillWorks ensures that a project with the standard
+// xml/ and excel/ directories continues to work with no flags (regression).
+func TestVerifyLegacyLayoutStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "xml"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "excel"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cli := NewCLI()
+	code := cli.runVerify([]string{dir})
+	// An empty project with xml/ and excel/ should pass (nothing to check).
+	if code != 0 {
+		t.Errorf("expected exit 0 for empty project with standard dirs, got %d", code)
+	}
+}
+
+// TestVerifyBadPathErrorMessage verifies that a missing --xml-dir produces a
+// non-zero exit and mentions the flag name in the error output.
+func TestVerifyBadPathErrorMessage(t *testing.T) {
+	dir := t.TempDir()
+
+	cli := NewCLI()
+	code := cli.runVerify([]string{
+		"--xml-dir", "nonexistent",
+		dir,
+	})
+	if code == 0 {
+		t.Error("expected non-zero exit for nonexistent --xml-dir")
+	}
+}
+
+// TestBuildCustomLayoutViaFlags verifies that --xml-dir / --excel-dir are
+// accepted by the build command and resolve correctly.
+func TestBuildCustomLayoutViaFlags(t *testing.T) {
+	dir := t.TempDir()
+	rulesDir := filepath.Join(dir, "rules")
+	if err := os.MkdirAll(rulesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cli := NewCLI()
+	// --dry-run so we don't actually write files.
+	code := cli.runBuild([]string{
+		"--xml-dir", "rules",
+		"--excel-dir", "workbooks",
+		"--dry-run",
+		dir,
+	})
+	// rules/ exists, workbooks/ does not — both absent check fails only if both missing.
+	// Since rules/ exists, build should proceed (no-op dry-run).
+	if code != 0 {
+		t.Errorf("expected exit 0 for build with --xml-dir flag, got %d", code)
+	}
+}
+
+// TestResolveDirsFromDTRulesXML unit-tests the resolveDirs helper reading a
+// DTRules.xml file that declares custom directories.
+func TestResolveDirsFromDTRulesXML(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a DTRules.xml with custom dir declarations.
+	xmlContent := `<dtrules><xml_dir>myrules</xml_dir><excel_dir>mybooks</excel_dir></dtrules>`
+	if err := os.WriteFile(filepath.Join(dir, "DTRules.xml"), []byte(xmlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	xmlDir, excelDir, err := resolveDirs(dir, "", "")
+	if err != nil {
+		t.Fatalf("resolveDirs: %v", err)
+	}
+
+	wantXML := filepath.Join(dir, "myrules")
+	wantExcel := filepath.Join(dir, "mybooks")
+
+	if xmlDir != wantXML {
+		t.Errorf("xmlDir: got %s, want %s", xmlDir, wantXML)
+	}
+	if excelDir != wantExcel {
+		t.Errorf("excelDir: got %s, want %s", excelDir, wantExcel)
+	}
+}
+
+// TestResolveDirsFlagOverridesDTRulesXML verifies that a CLI flag takes
+// precedence over what DTRules.xml declares.
+func TestResolveDirsFlagOverridesDTRulesXML(t *testing.T) {
+	dir := t.TempDir()
+
+	xmlContent := `<dtrules><xml_dir>fromconfig</xml_dir><excel_dir>fromconfig</excel_dir></dtrules>`
+	if err := os.WriteFile(filepath.Join(dir, "DTRules.xml"), []byte(xmlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	xmlDir, _, err := resolveDirs(dir, "fromflag", "")
+	if err != nil {
+		t.Fatalf("resolveDirs: %v", err)
+	}
+
+	wantXML := filepath.Join(dir, "fromflag")
+	if xmlDir != wantXML {
+		t.Errorf("flag should override config: got %s, want %s", xmlDir, wantXML)
+	}
+}
+
+// TestResolveDirsDefaultsWhenNoDTRulesXML verifies that defaults (xml/ and
+// excel/) apply when there is no DTRules.xml and no flags.
+func TestResolveDirsDefaultsWhenNoDTRulesXML(t *testing.T) {
+	dir := t.TempDir()
+
+	xmlDir, excelDir, err := resolveDirs(dir, "", "")
+	if err != nil {
+		t.Fatalf("resolveDirs: %v", err)
+	}
+
+	if xmlDir != filepath.Join(dir, "xml") {
+		t.Errorf("xmlDir: got %s, want %s", xmlDir, filepath.Join(dir, "xml"))
+	}
+	if excelDir != filepath.Join(dir, "excel") {
+		t.Errorf("excelDir: got %s, want %s", excelDir, filepath.Join(dir, "excel"))
+	}
+}

--- a/cmd/dtrules/project_config.go
+++ b/cmd/dtrules/project_config.go
@@ -1,0 +1,99 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// projectConfig holds optional directory overrides declared in DTRules.xml.
+type projectConfig struct {
+	XMLDir   string `xml:"xml_dir"`
+	ExcelDir string `xml:"excel_dir"`
+}
+
+// loadProjectConfig reads DTRules.xml from projectRoot and returns any
+// declared directory overrides. Returns an empty config (not an error) if
+// the file does not exist or contains no override elements.
+func loadProjectConfig(projectRoot string) (*projectConfig, error) {
+	configPath := filepath.Join(projectRoot, "DTRules.xml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &projectConfig{}, nil
+		}
+		return nil, fmt.Errorf("reading DTRules.xml: %w", err)
+	}
+
+	var cfg projectConfig
+	if err := xml.Unmarshal(data, &cfg); err != nil {
+		// Malformed DTRules.xml — ignore overrides, don't fail.
+		return &projectConfig{}, nil
+	}
+	return &cfg, nil
+}
+
+// resolveDirs determines the xml and excel directories for a project using
+// the three-level precedence:
+//  1. CLI flags (flagXMLDir / flagExcelDir) — non-empty string wins
+//  2. DTRules.xml declarations in projectRoot
+//  3. Default: "xml" and "excel" relative to projectRoot
+//
+// Returned paths are absolute.
+func resolveDirs(projectRoot, flagXMLDir, flagExcelDir string) (xmlDir, excelDir string, err error) {
+	cfg, err := loadProjectConfig(projectRoot)
+	if err != nil {
+		return "", "", err
+	}
+
+	resolveOne := func(flag, fromCfg, defaultName string) (string, error) {
+		rel := flag
+		if rel == "" {
+			rel = fromCfg
+		}
+		if rel == "" {
+			rel = defaultName
+		}
+		if filepath.IsAbs(rel) {
+			return rel, nil
+		}
+		return filepath.Abs(filepath.Join(projectRoot, rel))
+	}
+
+	xmlDir, err = resolveOne(flagXMLDir, cfg.XMLDir, "xml")
+	if err != nil {
+		return "", "", err
+	}
+	excelDir, err = resolveOne(flagExcelDir, cfg.ExcelDir, "excel")
+	if err != nil {
+		return "", "", err
+	}
+	return xmlDir, excelDir, nil
+}
+
+// checkDirWithHint returns a non-nil error with a helpful message if the
+// directory does not exist, telling the user which flag to use.
+func checkDirWithHint(dir, flagName string) error {
+	if dirExists(dir) {
+		return nil
+	}
+	return fmt.Errorf(
+		"could not find directory\n  Tried: %s\n  Use %s <path> or declare the element in DTRules.xml.",
+		dir, flagName,
+	)
+}

--- a/cmd/dtrules/testdata/custom_layout/DTRules.xml
+++ b/cmd/dtrules/testdata/custom_layout/DTRules.xml
@@ -1,0 +1,9 @@
+<dtrules>
+  <xml_dir>rules</xml_dir>
+  <excel_dir>workbooks</excel_dir>
+  <RuleSet name="simple" source="file">
+    <RuleSetFilePath>/rules</RuleSetFilePath>
+    <Entities       name="Simple_edd.xml" />
+    <Decisiontables name="Simple_dt.xml"  />
+  </RuleSet>
+</dtrules>

--- a/cmd/dtrules/testdata/custom_layout/rules/Simple_dt.xml
+++ b/cmd/dtrules/testdata/custom_layout/rules/Simple_dt.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+<decision_table>
+<table_name>SimpleRule</table_name>
+<xls_file>Simple.xlsx</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS>A simple test rule</COMMENTS>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
+<conditions></conditions>
+<actions></actions>
+</decision_table>
+</decision_tables>

--- a/cmd/dtrules/testdata/custom_layout/rules/Simple_edd.xml
+++ b/cmd/dtrules/testdata/custom_layout/rules/Simple_edd.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity_data_dictionary version='2' xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+  <entity name="test" xls_file="Simple.xlsx" access="rw" comment="Test entity">
+    <field name="value" type="number" subtype="" access="rw" input="" default_value="" comment="A test value" />
+  </entity>
+</entity_data_dictionary>

--- a/cmd/dtrules/verify.go
+++ b/cmd/dtrules/verify.go
@@ -34,9 +34,11 @@ import (
 
 // verifyOptions holds parsed options for the verify command.
 type verifyOptions struct {
-	path   string
-	diff   bool
-	strict bool
+	path     string
+	diff     bool
+	strict   bool
+	xmlDir   string
+	excelDir string
 }
 
 // verifyFailure records one failing check.
@@ -50,17 +52,27 @@ type verifyFailure struct {
 func (c *CLI) runVerify(args []string) int {
 	opts := &verifyOptions{path: "."}
 
-	for _, arg := range args {
-		switch arg {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
 		case "--diff":
 			opts.diff = true
 		case "--strict":
 			opts.strict = true
+		case "--xml-dir":
+			if i+1 < len(args) {
+				opts.xmlDir = args[i+1]
+				i++
+			}
+		case "--excel-dir":
+			if i+1 < len(args) {
+				opts.excelDir = args[i+1]
+				i++
+			}
 		default:
-			if !strings.HasPrefix(arg, "-") {
-				opts.path = arg
+			if !strings.HasPrefix(args[i], "-") {
+				opts.path = args[i]
 			} else {
-				fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", arg)
+				fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", args[i])
 				c.printVerifyUsage()
 				return 1
 			}
@@ -73,11 +85,23 @@ func (c *CLI) runVerify(args []string) int {
 		return 1
 	}
 
-	xmlDir := filepath.Join(absPath, "xml")
-	excelDir := filepath.Join(absPath, "excel")
+	xmlDir, excelDir, err := resolveDirs(absPath, opts.xmlDir, opts.excelDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		return 1
+	}
 
 	if !dirExists(xmlDir) && !dirExists(excelDir) {
-		fmt.Fprintf(os.Stderr, "Error: no xml/ or excel/ directory found in %s\n", absPath)
+		if opts.xmlDir != "" || opts.excelDir != "" {
+			if !dirExists(xmlDir) {
+				fmt.Fprintf(os.Stderr, "ERROR: could not find xml directory\n  Tried: %s\n  Use --xml-dir <path> or declare <xml_dir> in DTRules.xml.\n", xmlDir)
+			}
+			if !dirExists(excelDir) {
+				fmt.Fprintf(os.Stderr, "ERROR: could not find excel directory\n  Tried: %s\n  Use --excel-dir <path> or declare <excel_dir> in DTRules.xml.\n", excelDir)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "ERROR: no xml/ or excel/ directory found in %s\n", absPath)
+		}
 		return 1
 	}
 
@@ -772,11 +796,18 @@ Gates CI/pre-commit by checking that committed XML matches what dtrules build
 from the committed Excel would produce.
 
 Arguments:
-  path         Project directory to verify (default: .)
+  path              Project directory to verify (default: .)
 
 Options:
-  --diff       On failure, show diff between committed and build output
-  --strict     Also fail on warnings (e.g. missing <source> header)
+  --xml-dir <path>    Override XML directory (relative to project root or absolute)
+  --excel-dir <path>  Override Excel directory (relative to project root or absolute)
+  --diff              On failure, show diff between committed and build output
+  --strict            Also fail on warnings (e.g. missing <source> header)
+
+Directory resolution (highest to lowest priority):
+  1. --xml-dir / --excel-dir flags
+  2. <xml_dir> / <excel_dir> elements in DTRules.xml
+  3. Default: xml/ and excel/ relative to the project root
 
 Exit codes:
   0  All checks passed
@@ -790,5 +821,6 @@ Checks performed:
 Examples:
   dtrules verify
   dtrules verify ./sampleprojects/TaxReturn
-  dtrules verify --diff --strict`)
+  dtrules verify --diff --strict
+  dtrules verify --xml-dir pkg/dtrules/rules --excel-dir pkg/dtrules/excel /path/to/project`)
 }

--- a/pkg/dtrules/sync/nested_mixed_test.go
+++ b/pkg/dtrules/sync/nested_mixed_test.go
@@ -343,7 +343,7 @@ func TestNestedMixedSubdirStructureMirror(t *testing.T) {
 		os.WriteFile(f, []byte("<decision_tables/>"), 0644)
 	}
 
-	result, err := ValidateProjectStructure(tmpDir)
+	result, err := ValidateProjectStructure(tmpDir, "", "")
 	if err != nil {
 		t.Fatalf("ValidateProjectStructure: %v", err)
 	}

--- a/pkg/dtrules/sync/structure.go
+++ b/pkg/dtrules/sync/structure.go
@@ -90,7 +90,10 @@ func (r *StructureValidationResult) IsValid() bool {
 // - xml/ directory exists
 // - For each Excel file, corresponding XML files exist (or warns if not)
 // - No orphaned XML files without Excel source (warns)
-func ValidateProjectStructure(projectRoot string) (*StructureValidationResult, error) {
+//
+// xmlDirOverride and excelDirOverride, when non-empty, replace the default
+// xml/ and excel/ subdirectory paths respectively.
+func ValidateProjectStructure(projectRoot string, xmlDirOverride, excelDirOverride string) (*StructureValidationResult, error) {
 	result := &StructureValidationResult{
 		Structure: &ProjectStructure{
 			ProjectRoot: projectRoot,
@@ -104,9 +107,18 @@ func ValidateProjectStructure(projectRoot string) (*StructureValidationResult, e
 	}
 	result.Structure.ProjectRoot = absRoot
 
-	// Set standard paths
-	result.Structure.ExcelDir = filepath.Join(absRoot, "excel")
-	result.Structure.XMLDir = filepath.Join(absRoot, "xml")
+	// Set paths, respecting overrides.
+	resolveDir := func(override, defaultName string) string {
+		if override != "" {
+			if filepath.IsAbs(override) {
+				return override
+			}
+			return filepath.Join(absRoot, override)
+		}
+		return filepath.Join(absRoot, defaultName)
+	}
+	result.Structure.ExcelDir = resolveDir(excelDirOverride, "excel")
+	result.Structure.XMLDir = resolveDir(xmlDirOverride, "xml")
 	result.Structure.TestDir = filepath.Join(absRoot, "testfiles")
 	result.Structure.ManifestPath = filepath.Join(result.Structure.ExcelDir, DefaultManifestName)
 

--- a/pkg/dtrules/sync/structure_test.go
+++ b/pkg/dtrules/sync/structure_test.go
@@ -27,7 +27,7 @@ func TestValidateProjectStructure_Valid(t *testing.T) {
 	os.MkdirAll(filepath.Join(tmpDir, "xml"), 0755)
 	os.MkdirAll(filepath.Join(tmpDir, "testfiles"), 0755)
 
-	result, err := ValidateProjectStructure(tmpDir)
+	result, err := ValidateProjectStructure(tmpDir, "", "")
 	if err != nil {
 		t.Fatalf("ValidateProjectStructure failed: %v", err)
 	}
@@ -53,7 +53,7 @@ func TestValidateProjectStructure_MissingExcel(t *testing.T) {
 	os.MkdirAll(filepath.Join(tmpDir, "xml"), 0755)
 	// Missing excel/ directory
 
-	result, err := ValidateProjectStructure(tmpDir)
+	result, err := ValidateProjectStructure(tmpDir, "", "")
 	if err != nil {
 		t.Fatalf("ValidateProjectStructure failed: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestValidateProjectStructure_MissingXML(t *testing.T) {
 	os.MkdirAll(filepath.Join(tmpDir, "excel"), 0755)
 	// Missing xml/ directory
 
-	result, err := ValidateProjectStructure(tmpDir)
+	result, err := ValidateProjectStructure(tmpDir, "", "")
 	if err != nil {
 		t.Fatalf("ValidateProjectStructure failed: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestValidateProjectStructure_OrphanedXML(t *testing.T) {
 	// Create XML file without Excel source
 	os.WriteFile(filepath.Join(tmpDir, "xml", "orphan_dt.xml"), []byte("<decision_tables/>"), 0644)
 
-	result, err := ValidateProjectStructure(tmpDir)
+	result, err := ValidateProjectStructure(tmpDir, "", "")
 	if err != nil {
 		t.Fatalf("ValidateProjectStructure failed: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Adds `--xml-dir` and `--excel-dir` flags to `dtrules verify`, `dtrules validate`, and `dtrules build`
- Reads optional `<xml_dir>` / `<excel_dir>` elements from `DTRules.xml` as a middle precedence level (flag > DTRules.xml > default)
- Improves error messages when directories are not found: names the flag the user should use
- Adds `cmd/dtrules/project_config.go` with `resolveDirs` helper centralizing the three-level precedence
- Updates `ValidateProjectStructure` to accept optional dir overrides (backwards-compatible: pass `""` for defaults)
- Documents the new flags and DTRules.xml elements in `dtrules docs project-layout`

## Test plan

- [ ] `TestVerifyCustomLayoutViaFlags` — verify exits 0 with `--xml-dir rules --excel-dir workbooks` on non-standard fixture
- [ ] `TestVerifyCustomLayoutViaDTRulesXML` — verify exits 0 reading dirs from DTRules.xml (no flags)
- [ ] `TestVerifyLegacyLayoutStillWorks` — standard `xml/` + `excel/` project still exits 0 (regression)
- [ ] `TestVerifyBadPathErrorMessage` — nonexistent `--xml-dir` exits non-zero
- [ ] `TestBuildCustomLayoutViaFlags` — build accepts `--xml-dir`/`--excel-dir`
- [ ] `TestResolveDirsFromDTRulesXML` / `TestResolveDirsFlagOverridesDTRulesXML` / `TestResolveDirsDefaultsWhenNoDTRulesXML` — unit tests for precedence logic

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)