### PR TITLE
fix(cmd): custom_layout test fixture

### DIFF
--- a/cmd/dtrules/testdata/custom_layout/rules/Simple_dt.xml
+++ b/cmd/dtrules/testdata/custom_layout/rules/Simple_dt.xml
@@ -2,7 +2,6 @@
 <decision_tables>
 <decision_table>
 <table_name>SimpleRule</table_name>
-<xls_file>Simple.xlsx</xls_file>
 <attribute_fields>
 <Type>FIRST</Type>
 <COMMENTS>A simple test rule</COMMENTS>

--- a/cmd/dtrules/testdata/custom_layout/rules/Simple_edd.xml
+++ b/cmd/dtrules/testdata/custom_layout/rules/Simple_edd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <entity_data_dictionary version='2' xmlns:xs='http://www.w3.org/2001/XMLSchema'>
-  <entity name="test" xls_file="Simple.xlsx" access="rw" comment="Test entity">
+  <entity name="test" access="rw" comment="Test entity">
     <field name="value" type="number" subtype="" access="rw" input="" default_value="" comment="A test value" />
   </entity>
 </entity_data_dictionary>


### PR DESCRIPTION
#576 landed with 2 failing tests I merged anyway. This hotfix strips the dangling xls_file references from the test fixture so the tests exercise only the path-flag behavior they were designed for.