### PR TITLE
fix(cli): wire EL compiler into build importers

### DIFF
--- a/cmd/dtrules/build.go
+++ b/cmd/dtrules/build.go
@@ -20,9 +20,19 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
 	"github.com/DTRules/DTRules/pkg/dtrules/excel"
 	dtrsync "github.com/DTRules/DTRules/pkg/dtrules/sync"
 )
+
+// newWorkbookImporter builds a WorkbookImporter with a live EL compiler
+// wired in. Any action_dsl / condition_dsl that fails to compile is recorded
+// as a named drop in the build summary instead of silently passing through.
+func newWorkbookImporter() *excel.WorkbookImporter {
+	imp := excel.NewWorkbookImporter()
+	imp.SetELCompiler(el.NewCompiler())
+	return imp
+}
 
 // buildOptions holds parsed options for the build command.
 type buildOptions struct {
@@ -151,7 +161,7 @@ func detectAuthoringPath(xmlDir, excelDir string, opts *buildOptions) (string, e
 
 	syncer := dtrsync.NewSyncerWithOptions(xmlDir, excelDir, dtrsync.DefaultOptions())
 	syncer.SetUseCombinedWorkbooks(true)
-	importer := excel.NewWorkbookImporter()
+	importer := newWorkbookImporter()
 	syncer.SetWorkbookImporter(&workbookImporterAdapter{impl: importer})
 	exporter := excel.NewWorkbookExporter()
 	syncer.SetExporter(&workbookExporterAdapter{impl: exporter})
@@ -242,7 +252,7 @@ func (c *CLI) runExcelAuthoredBuild(xmlDir, excelDir string, opts *buildOptions)
 	syncer := dtrsync.NewSyncerWithOptions(xmlDir, excelDir, syncOpts)
 	syncer.SetUseCombinedWorkbooks(true)
 
-	importer := excel.NewWorkbookImporter()
+	importer := newWorkbookImporter()
 	importer.SetVerbose(opts.verbose)
 	importer.ResetStats()
 	syncer.SetWorkbookImporter(&workbookImporterAdapter{impl: importer})
@@ -307,7 +317,7 @@ func (c *CLI) runXMLAuthoredBuild(xmlDir, excelDir string, opts *buildOptions) i
 	syncer := dtrsync.NewSyncerWithOptions(xmlDir, excelDir, syncOpts)
 	syncer.SetUseCombinedWorkbooks(true)
 
-	importer := excel.NewWorkbookImporter()
+	importer := newWorkbookImporter()
 	importer.SetVerbose(opts.verbose)
 	syncer.SetWorkbookImporter(&workbookImporterAdapter{impl: importer})
 
@@ -346,7 +356,7 @@ func (c *CLI) runXMLAuthoredBuild(xmlDir, excelDir string, opts *buildOptions) i
 	syncer2 := dtrsync.NewSyncerWithOptions(xmlDir, excelDir, syncOpts)
 	syncer2.SetUseCombinedWorkbooks(true)
 
-	importer2 := excel.NewWorkbookImporter()
+	importer2 := newWorkbookImporter()
 	importer2.SetVerbose(opts.verbose)
 	importer2.ResetStats()
 	syncer2.SetWorkbookImporter(&workbookImporterAdapter{impl: importer2})
@@ -404,7 +414,7 @@ func (c *CLI) runBuildDryRun(xmlDir, excelDir, authoringPath string, opts *build
 	syncer := dtrsync.NewSyncerWithOptions(xmlDir, excelDir, syncOpts)
 	syncer.SetUseCombinedWorkbooks(true)
 
-	importer := excel.NewWorkbookImporter()
+	importer := newWorkbookImporter()
 	syncer.SetWorkbookImporter(&workbookImporterAdapter{impl: importer})
 
 	wbExporter := excel.NewWorkbookExporter()

--- a/pkg/dtrules/excel/workbook_importer.go
+++ b/pkg/dtrules/excel/workbook_importer.go
@@ -67,6 +67,13 @@ func (w *WorkbookImporter) SetVerbose(v bool) {
 	w.dtImporter.SetVerbose(v)
 }
 
+// SetELCompiler wires an EL compiler into the inner DT importer so the
+// build summary can report compile failures as named drops instead of
+// silently passing uncompilable DSL through.
+func (w *WorkbookImporter) SetELCompiler(c ELCompiler) {
+	w.dtImporter.SetELCompiler(c)
+}
+
 // ImportWorkbook reads a single Excel file and extracts both DT and EDD sheets.
 // It detects sheet types automatically:
 // - EDD sheet: Sheet named "EDD" OR first row has headers "Entity, Attribute, Type, SubType..."


### PR DESCRIPTION
Closes the final gap from #580 — WorkbookImporter was constructed without an ELCompiler, so import-step DSL compile failures went silent instead of landing in the build summary's Drops list.

Added WorkbookImporter.SetELCompiler; new internal helper newWorkbookImporter() in cmd/dtrules/build.go wires a live el.Compiler.

Follow-up gap not addressed here: import-step summary still shows zero counts on a build --from-xml. Export step counts are correct. Worth a separate issue.