### PR TITLE
chore(ci): make check target + CI build step + agent guidance (#529)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -163,6 +163,12 @@ git push origin feature/issue-180 > /tmp/git-push.log 2>&1
 ## Build Commands
 
 ```bash
+# BEFORE DECLARING A TASK COMPLETE -- run this:
+make check > /tmp/make-check.log 2>&1 && tail -20 /tmp/make-check.log
+
+# Scoped tests are NOT sufficient. `make check` runs go build ./... (full module)
+# followed by go vet and the scoped test suite. A task is only done when check passes.
+
 # Build CLI (from repo root)
 make build > /tmp/make-build.log 2>&1
 

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
-    - name: Build all packages
+    - name: Build full module (go build ./...)
       run: go build ./...
 
     - name: Run all tests

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ BINARY   := dtrules
 BUILD_DIR := build
 DIST_DIR  := dist
 
-.PHONY: all build install clean test version release
+.PHONY: all build install clean test check version release
 
 all: build
 
@@ -49,6 +49,18 @@ clean:
 test:
 	@echo "Running tests..."
 	go test ./...
+
+# check: full-module verification that agents must run before declaring a task complete.
+# Excludes ./pkg/dtrules/ root (pre-existing tax-content failures tracked in #520).
+# go vet excludes compiler/el (ANTLR-generated), interpreter (ASM), cmd (pre-existing test ref).
+check:
+	@echo "Checking full module build..."
+	go build ./...
+	@echo "Running go vet (pkg packages only)..."
+	go vet ./pkg/dtrules/compiler/ ./pkg/dtrules/decisiontable/... ./pkg/dtrules/encoding/... ./pkg/dtrules/excel/... ./pkg/dtrules/loader/... ./pkg/dtrules/mapping/... ./pkg/dtrules/operators/... ./pkg/dtrules/runtime/... ./pkg/dtrules/session/... ./pkg/dtrules/sync/... ./pkg/dtrules/version/...
+	@echo "Running tests (scoped -- excludes root pkg/dtrules/ known failures)..."
+	go test -count=1 ./cmd/... ./pkg/dtrules/compiler/... ./pkg/dtrules/decisiontable/... ./pkg/dtrules/encoding/... ./pkg/dtrules/excel/... ./pkg/dtrules/interpreter/... ./pkg/dtrules/loader/... ./pkg/dtrules/mapping/... ./pkg/dtrules/operators/... ./pkg/dtrules/runtime/... ./pkg/dtrules/session/... ./pkg/dtrules/sync/... ./pkg/dtrules/version/...
+	@echo "check passed."
 
 version:
 	@echo "Version: $(VERSION)"

--- a/pkg/dtrules/sync/safety_net_test.go
+++ b/pkg/dtrules/sync/safety_net_test.go
@@ -1,0 +1,41 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// findRepoRoot walks up from the test binary's working directory until it finds go.mod.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repo root (no go.mod found)")
+		}
+		dir = parent
+	}
+}
+
+// TestSafetyNet_MakeCheckCoversFullBuild asserts the Makefile 'check' target
+// invokes `go build ./...` (unscoped) so that an unused-but-broken helper in
+// any package fails the build -- the exact class of regression that landed
+// in #515 and #527 when scoped tests passed but the module didn't build.
+func TestSafetyNet_MakeCheckCoversFullBuild(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(findRepoRoot(t), "Makefile"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "go build ./...") {
+		t.Fatal("Makefile does not contain 'go build ./...' -- the check target must exercise the full module")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `make check` target that runs `go build ./...` (full module), `go vet` (scoped to pkg packages), and the scoped test suite — this is the single command agents should run before declaring a task complete
- Renames the CI step to **"Build full module (go build ./...)"** so a broken module build surfaces independently in the CI log, not buried in test output
- Updates `.claude/CLAUDE.md` with a prominent instruction that scoped tests are not sufficient and `make check` must pass
- Adds `pkg/dtrules/sync/safety_net_test.go` that asserts the Makefile contains `go build ./...`, preventing silent removal of the full-module build step

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)