### PR TITLE
feat(authoring): CheckCondition/CheckAction/CheckContext EL validators

### DIFF
--- a/pkg/dtrules/authoring/el_check.go
+++ b/pkg/dtrules/authoring/el_check.go
@@ -1,0 +1,64 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package authoring provides a typed Go SDK for editing DTRules projects —
+// decision tables, EDD, and mapping — without touching XML directly.
+//
+// Every mutation is validated before it is committed; authored EL is
+// compiled to postfix at the API boundary so invalid expressions surface
+// as named errors before they ever reach a file on disk.
+//
+// This is the primary authoring interface. Consumers should not edit the
+// underlying XML files directly; doing so goes against the #504 policy and
+// round-trip semantics enforced by `dtrules build`.
+package authoring
+
+import (
+	"strings"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+)
+
+// CheckCondition compiles an EL condition expression to postfix using the
+// given symbol table. Returns the postfix on success or a position-annotated
+// error on failure. symbols may be nil; the parser works loosely without them.
+func CheckCondition(elStr string, symbols map[string]string) (postfix string, err error) {
+	elStr = strings.TrimSpace(elStr)
+	if elStr == "" {
+		return "", nil
+	}
+	c := el.NewCompiler()
+	if symbols != nil {
+		c.SetSymbols(symbols)
+	}
+	return c.CompileCondition(elStr)
+}
+
+// CheckAction compiles an EL action statement to postfix. See CheckCondition.
+func CheckAction(elStr string, symbols map[string]string) (postfix string, err error) {
+	c := el.NewCompiler()
+	if symbols != nil {
+		c.SetSymbols(symbols)
+	}
+	return c.CompileAction(strings.TrimSpace(elStr))
+}
+
+// CheckContext compiles an EL context statement to postfix. See CheckCondition.
+func CheckContext(elStr string, symbols map[string]string) (postfix string, err error) {
+	c := el.NewCompiler()
+	if symbols != nil {
+		c.SetSymbols(symbols)
+	}
+	return c.CompileContext(strings.TrimSpace(elStr))
+}

--- a/pkg/dtrules/authoring/el_check_test.go
+++ b/pkg/dtrules/authoring/el_check_test.go
@@ -1,0 +1,132 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring_test
+
+import (
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+func TestCheckCondition_WithSymbols(t *testing.T) {
+	symbols := map[string]string{"age": "long"}
+	postfix, err := authoring.CheckCondition("age is greater than 18", symbols)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if postfix == "" {
+		t.Fatal("expected non-empty postfix")
+	}
+}
+
+func TestCheckCondition_NilSymbols(t *testing.T) {
+	postfix, err := authoring.CheckCondition("x is equal to 5", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if postfix == "" {
+		t.Fatal("expected non-empty postfix")
+	}
+}
+
+func TestCheckCondition_InvalidExpression(t *testing.T) {
+	_, err := authoring.CheckCondition("age ~ 18", nil)
+	if err == nil {
+		t.Fatal("expected error for invalid expression")
+	}
+	// Error should contain position info (line N:M)
+	if !strings.Contains(err.Error(), "line") {
+		t.Errorf("expected position info in error, got: %v", err)
+	}
+}
+
+func TestCheckAction_Valid(t *testing.T) {
+	postfix, err := authoring.CheckAction("set x = 5;", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if postfix == "" {
+		t.Fatal("expected non-empty postfix")
+	}
+}
+
+func TestCheckAction_Invalid(t *testing.T) {
+	_, err := authoring.CheckAction("set = = =;", nil)
+	if err == nil {
+		t.Fatal("expected error for invalid action")
+	}
+}
+
+func TestCheckContext_Valid(t *testing.T) {
+	postfix, err := authoring.CheckContext("local bigint x = (bigint) 10;", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if postfix == "" {
+		t.Fatal("expected non-empty postfix")
+	}
+}
+
+func TestCheckCondition_EmptyString(t *testing.T) {
+	postfix, err := authoring.CheckCondition("", nil)
+	if err != nil {
+		t.Fatalf("unexpected error for empty input: %v", err)
+	}
+	if postfix != "" {
+		t.Errorf("expected empty postfix for empty input, got: %q", postfix)
+	}
+}
+
+func TestCheckAction_EmptyString(t *testing.T) {
+	postfix, err := authoring.CheckAction("", nil)
+	if err != nil {
+		t.Fatalf("unexpected error for empty input: %v", err)
+	}
+	if postfix != "" {
+		t.Errorf("expected empty postfix for empty input, got: %q", postfix)
+	}
+}
+
+func TestCheckContext_EmptyString(t *testing.T) {
+	postfix, err := authoring.CheckContext("", nil)
+	if err != nil {
+		t.Fatalf("unexpected error for empty input: %v", err)
+	}
+	if postfix != "" {
+		t.Errorf("expected empty postfix for empty input, got: %q", postfix)
+	}
+}
+
+// TestAuthoringHasNoCmdImports ensures the authoring package has no cmd/ dependencies.
+func TestAuthoringHasNoCmdImports(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", nil, parser.ImportsOnly)
+	if err != nil {
+		t.Fatalf("failed to parse authoring package: %v", err)
+	}
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, imp := range file.Imports {
+				path := strings.Trim(imp.Path.Value, `"`)
+				if strings.Contains(path, "cmd/") {
+					t.Errorf("authoring package must not import cmd/ packages, found: %s", path)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds new `pkg/dtrules/authoring` package with three public functions: `CheckCondition`, `CheckAction`, `CheckContext`
- Each function creates a fresh `el.Compiler`, optionally sets symbols, trims input, and delegates to the matching compile method
- Built directly on `el.Compiler` (not `eltest`) for a clean public API with simple `(postfix, error)` returns

## Test plan

- [x] Valid condition with symbol table returns non-empty postfix
- [x] Valid condition with nil symbols returns non-empty postfix
- [x] Invalid condition (`age ~ 18`) returns position-annotated error
- [x] Valid action (`set x = 5;`) returns postfix
- [x] Invalid action returns error
- [x] Valid context (`local bigint x = (bigint) 10;`) returns postfix
- [x] Empty string inputs return empty postfix with nil error for all three functions
- [x] `TestAuthoringHasNoCmdImports` verifies no `cmd/` imports in the package
- [x] `make check` passes

Closes #591, part of #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)