### PR TITLE
feat(authoring): Table view with per-artifact and atomic-column mutations

### DIFF
--- a/pkg/dtrules/authoring/project.go
+++ b/pkg/dtrules/authoring/project.go
@@ -1,0 +1,224 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/excel"
+)
+
+// Project holds all loaded decision tables for a DTRules project. It provides
+// a typed Go API for reading and mutating tables without touching XML directly.
+type Project struct {
+	xmlDir    string
+	dtFiles   []dtFileEntry // one entry per loaded _dt.xml file
+	symbols   map[string]string
+}
+
+// dtFileEntry tracks a single decision-table XML file and its in-memory model.
+type dtFileEntry struct {
+	path   string
+	tables *excel.DecisionTablesXML
+}
+
+// OpenProject loads a DTRules project from path. It looks for an xml/ subdirectory
+// by convention and reads all *_dt.xml files from it.
+func OpenProject(path string) (*Project, error) {
+	xmlDir := filepath.Join(path, "xml")
+	if _, err := os.Stat(xmlDir); err != nil {
+		return nil, fmt.Errorf("no xml/ directory found in %s", path)
+	}
+
+	p := &Project{
+		xmlDir:  xmlDir,
+		symbols: make(map[string]string),
+	}
+
+	if err := p.loadEDD(xmlDir); err != nil {
+		// non-fatal: continue without symbol table
+		_ = err
+	}
+
+	if err := p.loadDTFiles(xmlDir); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// loadEDD parses *_edd.xml files and extracts field names+types for validation.
+func (p *Project) loadEDD(xmlDir string) error {
+	entries, err := filepath.Glob(filepath.Join(xmlDir, "*_edd.xml"))
+	if err != nil {
+		return err
+	}
+
+	type eddField struct {
+		Name string `xml:"name,attr"`
+		Type string `xml:"type,attr"`
+	}
+	type eddEntity struct {
+		Name   string     `xml:"name,attr"`
+		Fields []eddField `xml:"field"`
+	}
+	type eddFile struct {
+		Entities []eddEntity `xml:"entity"`
+	}
+
+	for _, path := range entries {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var f eddFile
+		if err := xml.Unmarshal(data, &f); err != nil {
+			continue
+		}
+		for _, ent := range f.Entities {
+			for _, field := range ent.Fields {
+				key := ent.Name + "." + field.Name
+				p.symbols[key] = field.Type
+			}
+		}
+	}
+	return nil
+}
+
+// loadDTFiles reads all *_dt.xml files from xmlDir.
+func (p *Project) loadDTFiles(xmlDir string) error {
+	entries, err := filepath.Glob(filepath.Join(xmlDir, "*_dt.xml"))
+	if err != nil {
+		return fmt.Errorf("failed to list dt files: %w", err)
+	}
+
+	for _, path := range entries {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %w", path, err)
+		}
+		var tables excel.DecisionTablesXML
+		if err := xml.Unmarshal(data, &tables); err != nil {
+			return fmt.Errorf("failed to parse %s: %w", path, err)
+		}
+		p.dtFiles = append(p.dtFiles, dtFileEntry{path: path, tables: &tables})
+	}
+
+	// If no _dt.xml files found, try any _dt.xml suffix-less XML files
+	if len(p.dtFiles) == 0 {
+		all, _ := filepath.Glob(filepath.Join(xmlDir, "*.xml"))
+		for _, path := range all {
+			if strings.HasSuffix(path, "_edd.xml") || strings.HasSuffix(path, "_map.xml") {
+				continue
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+			if !strings.Contains(string(data), "<decision_tables") {
+				continue
+			}
+			var tables excel.DecisionTablesXML
+			if err := xml.Unmarshal(data, &tables); err != nil {
+				continue
+			}
+			p.dtFiles = append(p.dtFiles, dtFileEntry{path: path, tables: &tables})
+		}
+	}
+
+	return nil
+}
+
+// Save writes all pending mutations back to disk as canonical XML files.
+// The output uses the same format as the DTImporter.WriteXML pipeline.
+func (p *Project) Save() error {
+	imp := excel.NewDTImporter()
+	for _, entry := range p.dtFiles {
+		if err := imp.WriteXML(entry.tables, entry.path); err != nil {
+			return fmt.Errorf("failed to write %s: %w", entry.path, err)
+		}
+	}
+	return nil
+}
+
+// Tables lists the names of every decision table in the project.
+func (p *Project) Tables() []string {
+	var names []string
+	for _, entry := range p.dtFiles {
+		for _, t := range entry.tables.Tables {
+			names = append(names, t.TableName)
+		}
+	}
+	return names
+}
+
+// Table returns a typed view of the named decision table, or nil if not found.
+func (p *Project) Table(name string) *Table {
+	for fi := range p.dtFiles {
+		for ti := range p.dtFiles[fi].tables.Tables {
+			if p.dtFiles[fi].tables.Tables[ti].TableName == name {
+				return newTable(&p.dtFiles[fi].tables.Tables[ti], p.symbols)
+			}
+		}
+	}
+	return nil
+}
+
+// AddTable creates a new decision table with the given name.
+func (p *Project) AddTable(name string) (*Table, error) {
+	for _, entry := range p.dtFiles {
+		for _, t := range entry.tables.Tables {
+			if t.TableName == name {
+				return nil, fmt.Errorf("table %q already exists", name)
+			}
+		}
+	}
+	xmlTable := excel.DecisionTableXML{
+		TableName: name,
+		AttributeFields: excel.AttributeFieldsXML{
+			Type: "FIRST",
+		},
+	}
+	if len(p.dtFiles) == 0 {
+		// Create a new file entry using conventional naming
+		path := filepath.Join(p.xmlDir, strings.ToLower(name)+"_dt.xml")
+		p.dtFiles = append(p.dtFiles, dtFileEntry{
+			path:   path,
+			tables: &excel.DecisionTablesXML{},
+		})
+	}
+	// Append to the first file
+	p.dtFiles[0].tables.Tables = append(p.dtFiles[0].tables.Tables, xmlTable)
+	last := &p.dtFiles[0].tables.Tables[len(p.dtFiles[0].tables.Tables)-1]
+	return newTable(last, p.symbols), nil
+}
+
+// DeleteTable removes the named table.
+func (p *Project) DeleteTable(name string) error {
+	for fi := range p.dtFiles {
+		tables := p.dtFiles[fi].tables.Tables
+		for ti, t := range tables {
+			if t.TableName == name {
+				p.dtFiles[fi].tables.Tables = append(tables[:ti], tables[ti+1:]...)
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("table %q not found", name)
+}

--- a/pkg/dtrules/authoring/table.go
+++ b/pkg/dtrules/authoring/table.go
@@ -1,0 +1,503 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/excel"
+)
+
+// Table is a typed view of a single decision table. All mutations validate EL
+// before committing, so invalid expressions are rejected at the API boundary.
+type Table struct {
+	Name           string
+	Policy         string
+	Contexts       []Context
+	InitialActions []InitialAction
+	Conditions     []Condition
+	Actions        []Action
+
+	xml     *excel.DecisionTableXML
+	symbols map[string]string
+}
+
+// Context holds a context entity reference for a decision table.
+type Context struct {
+	DSL string
+}
+
+// InitialAction holds an action that runs before the decision table columns.
+type InitialAction struct {
+	DSL string
+}
+
+// Condition holds one condition row of a decision table.
+type Condition struct {
+	Number  int
+	Comment string
+	DSL     string
+	Columns map[int]string // col -> "Y" / "N" / "-"
+}
+
+// Action holds one action row of a decision table.
+type Action struct {
+	Number  int
+	Comment string
+	DSL     string
+	Columns map[int]bool // col -> executes on that column?
+}
+
+// newTable builds a Table view from an underlying XML struct.
+func newTable(x *excel.DecisionTableXML, symbols map[string]string) *Table {
+	t := &Table{
+		Name:    x.TableName,
+		Policy:  x.AttributeFields.Type,
+		xml:     x,
+		symbols: symbols,
+	}
+	t.syncFromXML()
+	return t
+}
+
+// syncFromXML refreshes the typed view from the underlying XML model.
+func (t *Table) syncFromXML() {
+	t.Name = t.xml.TableName
+	t.Policy = t.xml.AttributeFields.Type
+
+	t.Contexts = nil
+	if t.xml.Contexts != "" {
+		t.Contexts = []Context{{DSL: t.xml.Contexts}}
+	}
+
+	t.InitialActions = nil
+	for _, ia := range t.xml.InitialActions {
+		t.InitialActions = append(t.InitialActions, InitialAction{DSL: ia.DSL})
+	}
+
+	t.Conditions = nil
+	for _, c := range t.xml.Conditions {
+		num, _ := strconv.Atoi(c.Number)
+		cols := make(map[int]string)
+		for _, cv := range c.Columns {
+			cols[cv.Number] = cv.Value
+		}
+		t.Conditions = append(t.Conditions, Condition{
+			Number:  num,
+			Comment: c.Comment,
+			DSL:     c.DSL,
+			Columns: cols,
+		})
+	}
+
+	t.Actions = nil
+	for _, a := range t.xml.Actions {
+		num, _ := strconv.Atoi(a.Number)
+		cols := make(map[int]bool)
+		for _, cv := range a.Columns {
+			cols[cv.Number] = cv.Value != ""
+		}
+		t.Actions = append(t.Actions, Action{
+			Number:  num,
+			Comment: a.Comment,
+			DSL:     a.DSL,
+			Columns: cols,
+		})
+	}
+}
+
+// syncToXML writes the typed view back into the underlying XML model.
+func (t *Table) syncToXML() {
+	t.xml.TableName = t.Name
+	t.xml.AttributeFields.Type = t.Policy
+
+	if len(t.Contexts) > 0 {
+		t.xml.Contexts = t.Contexts[0].DSL
+	} else {
+		t.xml.Contexts = ""
+	}
+
+	t.xml.InitialActions = nil
+	for _, ia := range t.InitialActions {
+		t.xml.InitialActions = append(t.xml.InitialActions, excel.InitialActionXML{DSL: ia.DSL})
+	}
+
+	t.xml.Conditions = nil
+	for _, c := range t.Conditions {
+		var cols []excel.ColumnValueXML
+		for n, v := range c.Columns {
+			if v != "" && v != "-" {
+				cols = append(cols, excel.ColumnValueXML{Number: n, Value: v})
+			}
+		}
+		t.xml.Conditions = append(t.xml.Conditions, excel.ConditionXML{
+			Number:  strconv.Itoa(c.Number),
+			Comment: c.Comment,
+			DSL:     c.DSL,
+			Columns: cols,
+		})
+	}
+
+	t.xml.Actions = nil
+	for _, a := range t.Actions {
+		var cols []excel.ColumnValueXML
+		for n, ok := range a.Columns {
+			if ok {
+				cols = append(cols, excel.ColumnValueXML{Number: n, Value: "X"})
+			}
+		}
+		t.xml.Actions = append(t.xml.Actions, excel.ActionXML{
+			Number:  strconv.Itoa(a.Number),
+			Comment: a.Comment,
+			DSL:     a.DSL,
+			Columns: cols,
+		})
+	}
+}
+
+// Columns returns the number of rule columns in this table.
+func (t *Table) Columns() int {
+	max := 0
+	for _, c := range t.Conditions {
+		for n := range c.Columns {
+			if n > max {
+				max = n
+			}
+		}
+	}
+	for _, a := range t.Actions {
+		for n := range a.Columns {
+			if n > max {
+				max = n
+			}
+		}
+	}
+	return max
+}
+
+// nextConditionNumber returns 1 + the current max condition number.
+func (t *Table) nextConditionNumber() int {
+	max := 0
+	for _, c := range t.Conditions {
+		if c.Number > max {
+			max = c.Number
+		}
+	}
+	return max + 1
+}
+
+// nextActionNumber returns 1 + the current max action number.
+func (t *Table) nextActionNumber() int {
+	max := 0
+	for _, a := range t.Actions {
+		if a.Number > max {
+			max = a.Number
+		}
+	}
+	return max + 1
+}
+
+// --- Condition mutations ---
+
+// AddCondition validates and appends a condition. If c.Number == 0, it is auto-assigned.
+func (t *Table) AddCondition(c Condition) error {
+	if _, err := CheckCondition(c.DSL, t.symbols); err != nil {
+		return err
+	}
+	if c.Number == 0 {
+		c.Number = t.nextConditionNumber()
+	}
+	if c.Columns == nil {
+		c.Columns = make(map[int]string)
+	}
+	t.Conditions = append(t.Conditions, c)
+	t.syncToXML()
+	return nil
+}
+
+// UpdateCondition replaces the condition with the given number.
+func (t *Table) UpdateCondition(num int, c Condition) error {
+	if _, err := CheckCondition(c.DSL, t.symbols); err != nil {
+		return err
+	}
+	for i, existing := range t.Conditions {
+		if existing.Number == num {
+			c.Number = num
+			if c.Columns == nil {
+				c.Columns = existing.Columns
+			}
+			t.Conditions[i] = c
+			t.syncToXML()
+			return nil
+		}
+	}
+	return fmt.Errorf("condition number %d not found", num)
+}
+
+// DeleteCondition removes the condition with the given number.
+func (t *Table) DeleteCondition(num int) error {
+	for i, c := range t.Conditions {
+		if c.Number == num {
+			t.Conditions = append(t.Conditions[:i], t.Conditions[i+1:]...)
+			t.syncToXML()
+			return nil
+		}
+	}
+	return fmt.Errorf("condition number %d not found", num)
+}
+
+// --- Action mutations ---
+
+// AddAction validates and appends an action. If a.Number == 0, it is auto-assigned.
+func (t *Table) AddAction(a Action) error {
+	if _, err := CheckAction(a.DSL, t.symbols); err != nil {
+		return err
+	}
+	if a.Number == 0 {
+		a.Number = t.nextActionNumber()
+	}
+	if a.Columns == nil {
+		a.Columns = make(map[int]bool)
+	}
+	t.Actions = append(t.Actions, a)
+	t.syncToXML()
+	return nil
+}
+
+// UpdateAction replaces the action with the given number.
+func (t *Table) UpdateAction(num int, a Action) error {
+	if _, err := CheckAction(a.DSL, t.symbols); err != nil {
+		return err
+	}
+	for i, existing := range t.Actions {
+		if existing.Number == num {
+			a.Number = num
+			if a.Columns == nil {
+				a.Columns = existing.Columns
+			}
+			t.Actions[i] = a
+			t.syncToXML()
+			return nil
+		}
+	}
+	return fmt.Errorf("action number %d not found", num)
+}
+
+// DeleteAction removes the action with the given number.
+func (t *Table) DeleteAction(num int) error {
+	for i, a := range t.Actions {
+		if a.Number == num {
+			t.Actions = append(t.Actions[:i], t.Actions[i+1:]...)
+			t.syncToXML()
+			return nil
+		}
+	}
+	return fmt.Errorf("action number %d not found", num)
+}
+
+// --- InitialAction mutations ---
+
+// AddInitialAction validates and appends an initial action.
+func (t *Table) AddInitialAction(a InitialAction) error {
+	if _, err := CheckAction(a.DSL, t.symbols); err != nil {
+		return err
+	}
+	t.InitialActions = append(t.InitialActions, a)
+	t.syncToXML()
+	return nil
+}
+
+// UpdateInitialAction replaces the initial action at idx.
+func (t *Table) UpdateInitialAction(idx int, a InitialAction) error {
+	if idx < 0 || idx >= len(t.InitialActions) {
+		return fmt.Errorf("initial action index %d out of range (len %d)", idx, len(t.InitialActions))
+	}
+	if _, err := CheckAction(a.DSL, t.symbols); err != nil {
+		return err
+	}
+	t.InitialActions[idx] = a
+	t.syncToXML()
+	return nil
+}
+
+// DeleteInitialAction removes the initial action at idx.
+func (t *Table) DeleteInitialAction(idx int) error {
+	if idx < 0 || idx >= len(t.InitialActions) {
+		return fmt.Errorf("initial action index %d out of range (len %d)", idx, len(t.InitialActions))
+	}
+	t.InitialActions = append(t.InitialActions[:idx], t.InitialActions[idx+1:]...)
+	t.syncToXML()
+	return nil
+}
+
+// --- Context mutations ---
+
+// AddContext validates and appends a context.
+func (t *Table) AddContext(c Context) error {
+	if _, err := CheckContext(c.DSL, t.symbols); err != nil {
+		return err
+	}
+	t.Contexts = append(t.Contexts, c)
+	t.syncToXML()
+	return nil
+}
+
+// UpdateContext replaces the context at idx.
+func (t *Table) UpdateContext(idx int, c Context) error {
+	if idx < 0 || idx >= len(t.Contexts) {
+		return fmt.Errorf("context index %d out of range (len %d)", idx, len(t.Contexts))
+	}
+	if _, err := CheckContext(c.DSL, t.symbols); err != nil {
+		return err
+	}
+	t.Contexts[idx] = c
+	t.syncToXML()
+	return nil
+}
+
+// DeleteContext removes the context at idx.
+func (t *Table) DeleteContext(idx int) error {
+	if idx < 0 || idx >= len(t.Contexts) {
+		return fmt.Errorf("context index %d out of range (len %d)", idx, len(t.Contexts))
+	}
+	t.Contexts = append(t.Contexts[:idx], t.Contexts[idx+1:]...)
+	t.syncToXML()
+	return nil
+}
+
+// --- Column operations ---
+
+// validColumnValue checks that a condition column value is one of the legal tokens.
+func validColumnValue(v string) bool {
+	return v == "Y" || v == "N" || v == "-"
+}
+
+// AddColumn adds a new rule column. conditions maps condition Number -> "Y"/"N"/"-".
+// actions is the list of action Numbers that execute on this column.
+func (t *Table) AddColumn(conditions map[int]string, actions []int) error {
+	if err := t.validateColumnArgs(conditions, actions); err != nil {
+		return err
+	}
+	col := t.Columns() + 1
+	t.applyColumn(col, conditions, actions)
+	t.syncToXML()
+	return nil
+}
+
+// UpdateColumn replaces an existing column.
+func (t *Table) UpdateColumn(col int, conditions map[int]string, actions []int) error {
+	if col < 1 || col > t.Columns() {
+		return fmt.Errorf("column %d out of range (table has %d columns)", col, t.Columns())
+	}
+	if err := t.validateColumnArgs(conditions, actions); err != nil {
+		return err
+	}
+	// Remove col from all conditions and actions, then re-apply.
+	for i := range t.Conditions {
+		delete(t.Conditions[i].Columns, col)
+	}
+	for i := range t.Actions {
+		delete(t.Actions[i].Columns, col)
+	}
+	t.applyColumn(col, conditions, actions)
+	t.syncToXML()
+	return nil
+}
+
+// DeleteColumn removes column col. Columns after it are renumbered downward by 1.
+func (t *Table) DeleteColumn(col int) error {
+	numCols := t.Columns()
+	if col < 1 || col > numCols {
+		return fmt.Errorf("column %d out of range (table has %d columns)", col, numCols)
+	}
+	for i := range t.Conditions {
+		delete(t.Conditions[i].Columns, col)
+		// Renumber columns > col
+		newCols := make(map[int]string)
+		for n, v := range t.Conditions[i].Columns {
+			if n > col {
+				newCols[n-1] = v
+			} else {
+				newCols[n] = v
+			}
+		}
+		t.Conditions[i].Columns = newCols
+	}
+	for i := range t.Actions {
+		delete(t.Actions[i].Columns, col)
+		newCols := make(map[int]bool)
+		for n, v := range t.Actions[i].Columns {
+			if n > col {
+				newCols[n-1] = v
+			} else {
+				newCols[n] = v
+			}
+		}
+		t.Actions[i].Columns = newCols
+	}
+	t.syncToXML()
+	return nil
+}
+
+// validateColumnArgs checks that all referenced condition/action numbers exist and
+// that condition values are legal.
+func (t *Table) validateColumnArgs(conditions map[int]string, actions []int) error {
+	condIdx := make(map[int]bool, len(t.Conditions))
+	for _, c := range t.Conditions {
+		condIdx[c.Number] = true
+	}
+	actionIdx := make(map[int]bool, len(t.Actions))
+	for _, a := range t.Actions {
+		actionIdx[a.Number] = true
+	}
+
+	for num, val := range conditions {
+		if !condIdx[num] {
+			return fmt.Errorf("condition number %d does not exist in table", num)
+		}
+		if !validColumnValue(val) {
+			return fmt.Errorf("invalid column value %q for condition %d: must be Y, N, or -", val, num)
+		}
+	}
+	for _, num := range actions {
+		if !actionIdx[num] {
+			return fmt.Errorf("action number %d does not exist in table", num)
+		}
+	}
+	return nil
+}
+
+// applyColumn writes col into every affected condition and action.
+func (t *Table) applyColumn(col int, conditions map[int]string, actions []int) {
+	for i, c := range t.Conditions {
+		if val, ok := conditions[c.Number]; ok {
+			if t.Conditions[i].Columns == nil {
+				t.Conditions[i].Columns = make(map[int]string)
+			}
+			t.Conditions[i].Columns[col] = val
+		}
+	}
+	actionSet := make(map[int]bool, len(actions))
+	for _, num := range actions {
+		actionSet[num] = true
+	}
+	for i, a := range t.Actions {
+		if t.Actions[i].Columns == nil {
+			t.Actions[i].Columns = make(map[int]bool)
+		}
+		t.Actions[i].Columns[col] = actionSet[a.Number]
+	}
+}

--- a/pkg/dtrules/authoring/table_test.go
+++ b/pkg/dtrules/authoring/table_test.go
@@ -1,0 +1,266 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+const testdataMinimal = "testdata/minimal"
+
+func TestOpenSaveProject(t *testing.T) {
+	p, err := authoring.OpenProject(testdataMinimal)
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+	tables := p.Tables()
+	if len(tables) == 0 {
+		t.Fatal("expected at least one table")
+	}
+
+	// Save to a temp dir to verify no panic on write.
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "xml"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Copy the fixture xml directory to tmp so Save has real paths.
+	p2, err := authoring.OpenProject(testdataMinimal)
+	if err != nil {
+		t.Fatalf("second OpenProject: %v", err)
+	}
+	_ = p2 // Save would write back to testdata; skip to avoid modifying fixtures.
+}
+
+func TestAddCondition_ValidatesEL(t *testing.T) {
+	p, err := authoring.OpenProject(testdataMinimal)
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+	tbl := p.Table("Check_Eligibility")
+	if tbl == nil {
+		t.Fatal("table Check_Eligibility not found")
+	}
+	before := len(tbl.Conditions)
+
+	// Add condition with invalid EL — should fail.
+	err = tbl.AddCondition(authoring.Condition{DSL: "!!!invalid EL$$$"})
+	if err == nil {
+		t.Fatal("expected error for invalid EL, got nil")
+	}
+	// Error should mention parse position.
+	if len(tbl.Conditions) != before {
+		t.Errorf("conditions mutated on invalid EL: was %d, now %d", before, len(tbl.Conditions))
+	}
+}
+
+func TestAddAction_ValidatesEL(t *testing.T) {
+	p, err := authoring.OpenProject(testdataMinimal)
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+	tbl := p.Table("Check_Eligibility")
+	if tbl == nil {
+		t.Fatal("table Check_Eligibility not found")
+	}
+	before := len(tbl.Actions)
+
+	err = tbl.AddAction(authoring.Action{DSL: "!!!bad action$$$"})
+	if err == nil {
+		t.Fatal("expected error for invalid action EL, got nil")
+	}
+	if len(tbl.Actions) != before {
+		t.Errorf("actions mutated on invalid EL: was %d, now %d", before, len(tbl.Actions))
+	}
+}
+
+func TestAddColumn_NumbersMustExist(t *testing.T) {
+	p, err := authoring.OpenProject(testdataMinimal)
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+	tbl := p.Table("Check_Eligibility")
+	if tbl == nil {
+		t.Fatal("table Check_Eligibility not found")
+	}
+
+	// Reference a non-existent condition number (99).
+	err = tbl.AddColumn(map[int]string{99: "Y"}, nil)
+	if err == nil {
+		t.Fatal("expected error for non-existent condition number")
+	}
+	t.Logf("got expected error: %v", err)
+}
+
+func TestAddColumn_ValidValues(t *testing.T) {
+	p, err := authoring.OpenProject(testdataMinimal)
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+	tbl := p.Table("Check_Eligibility")
+	if tbl == nil {
+		t.Fatal("table Check_Eligibility not found")
+	}
+
+	beforeCols := tbl.Columns()
+
+	// Condition 1 exists (loaded from fixture). Actions 1 and 2 exist.
+	err = tbl.AddColumn(map[int]string{1: "Y"}, []int{1})
+	if err != nil {
+		t.Fatalf("AddColumn: %v", err)
+	}
+
+	afterCols := tbl.Columns()
+	if afterCols != beforeCols+1 {
+		t.Errorf("expected %d columns after AddColumn, got %d", beforeCols+1, afterCols)
+	}
+
+	// Condition 1 should have the new column value.
+	newCol := afterCols
+	for _, c := range tbl.Conditions {
+		if c.Number == 1 {
+			val, ok := c.Columns[newCol]
+			if !ok {
+				t.Errorf("condition 1 missing column %d", newCol)
+			} else if val != "Y" {
+				t.Errorf("condition 1 col %d: want Y, got %s", newCol, val)
+			}
+		}
+	}
+	// Action 1 should execute; Action 2 should not.
+	for _, a := range tbl.Actions {
+		switch a.Number {
+		case 1:
+			if !a.Columns[newCol] {
+				t.Errorf("action 1 should execute on col %d", newCol)
+			}
+		case 2:
+			if a.Columns[newCol] {
+				t.Errorf("action 2 should NOT execute on col %d", newCol)
+			}
+		}
+	}
+}
+
+func TestDeleteColumn_RemovesFromAllArtifacts(t *testing.T) {
+	p, err := authoring.OpenProject(testdataMinimal)
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+	tbl := p.Table("Check_Eligibility")
+	if tbl == nil {
+		t.Fatal("table Check_Eligibility not found")
+	}
+
+	beforeCols := tbl.Columns()
+	if beforeCols < 1 {
+		t.Fatal("fixture table has no columns")
+	}
+
+	// Delete column 1.
+	if err := tbl.DeleteColumn(1); err != nil {
+		t.Fatalf("DeleteColumn: %v", err)
+	}
+
+	afterCols := tbl.Columns()
+	if afterCols != beforeCols-1 {
+		t.Errorf("expected %d columns after delete, got %d", beforeCols-1, afterCols)
+	}
+
+	// After deleting column 1, there should be no column key >= beforeCols in any
+	// condition or action (i.e., the old last column was renumbered down).
+	maxAllowed := beforeCols - 1
+	for _, c := range tbl.Conditions {
+		for n := range c.Columns {
+			if n > maxAllowed {
+				t.Errorf("condition %d has column %d > max allowed %d after delete", c.Number, n, maxAllowed)
+			}
+		}
+	}
+	for _, a := range tbl.Actions {
+		for n := range a.Columns {
+			if n > maxAllowed {
+				t.Errorf("action %d has column %d > max allowed %d after delete", a.Number, n, maxAllowed)
+			}
+		}
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	// Copy the fixture to a temp dir so we can save without affecting the repo.
+	src := testdataMinimal
+	tmp := t.TempDir()
+	xmlDir := filepath.Join(tmp, "xml")
+	if err := os.MkdirAll(xmlDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy all files from testdata/minimal/xml into tmp/xml.
+	entries, err := os.ReadDir(filepath.Join(src, "xml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		data, err := os.ReadFile(filepath.Join(src, "xml", e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(xmlDir, e.Name()), data, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Open, add an action, save, re-open, verify.
+	p, err := authoring.OpenProject(tmp)
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+	tbl := p.Table("Check_Eligibility")
+	if tbl == nil {
+		t.Fatal("Check_Eligibility not found")
+	}
+
+	newDSL := "set applicant.eligible = true"
+	if err := tbl.AddAction(authoring.Action{DSL: newDSL, Comment: "Round-trip action"}); err != nil {
+		t.Fatalf("AddAction: %v", err)
+	}
+
+	if err := p.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Re-open and verify the action persisted.
+	p2, err := authoring.OpenProject(tmp)
+	if err != nil {
+		t.Fatalf("re-OpenProject: %v", err)
+	}
+	tbl2 := p2.Table("Check_Eligibility")
+	if tbl2 == nil {
+		t.Fatal("re-open: Check_Eligibility not found")
+	}
+	found := false
+	for _, a := range tbl2.Actions {
+		if a.DSL == newDSL && a.Comment == "Round-trip action" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("action with DSL %q not found after round-trip; actions: %+v", newDSL, tbl2.Actions)
+	}
+}

--- a/pkg/dtrules/authoring/testdata/minimal/xml/minimal_dt.xml
+++ b/pkg/dtrules/authoring/testdata/minimal/xml/minimal_dt.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+
+<!-- TABLE 1: Check_Eligibility -->
+<decision_table el_compiled="true">
+<table_name>Check_Eligibility</table_name>
+<xls_file>minimal_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>1</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions>
+</initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Adult applicant</condition_comment>
+<condition_dsl>applicant.age &gt;= 18</condition_dsl>
+<condition_postfix>
+applicant.age 18 &gt;=
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Grant eligibility</action_comment>
+<action_dsl>set applicant.eligible = true</action_dsl>
+<action_postfix>
+true applicant.eligible =
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Deny eligibility</action_comment>
+<action_dsl>set applicant.eligible = false</action_dsl>
+<action_postfix>
+false applicant.eligible =
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+</policy_statements>
+</decision_table>
+</decision_tables>

--- a/pkg/dtrules/authoring/testdata/minimal/xml/minimal_edd.xml
+++ b/pkg/dtrules/authoring/testdata/minimal/xml/minimal_edd.xml
@@ -1,0 +1,7 @@
+<entity_data_dictionary version='2' xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+	<entity name='applicant' access='rw' comment=''>
+		<field name='applicant' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='age' type='integer' subtype='' access='rw' input='main' default_value='0' comment='Age of applicant'></field>
+		<field name='eligible' type='boolean' subtype='' access='rw' input='' default_value='false' comment='Eligibility result'></field>
+	</entity>
+</entity_data_dictionary>


### PR DESCRIPTION
## Summary

- Adds `Project` (OpenProject, Save, Tables, Table, AddTable, DeleteTable) and `Table` types to `pkg/dtrules/authoring`
- Every condition/action/context/initialAction mutation validates EL via `CheckCondition`/`CheckAction`/`CheckContext` before committing
- Atomic column operations (`AddColumn`, `UpdateColumn`, `DeleteColumn`) touch all conditions and actions in one pass; deleted columns renumber remaining columns downward
- Minimal fixture project under `pkg/dtrules/authoring/testdata/minimal/` with 1 table, 1 condition, 2 actions, 2 columns

## Test plan

- [x] `TestOpenSaveProject` — opens fixture, no panic
- [x] `TestAddCondition_ValidatesEL` — invalid EL rejected; state unchanged
- [x] `TestAddAction_ValidatesEL` — invalid action EL rejected; state unchanged
- [x] `TestAddColumn_NumbersMustExist` — non-existent condition number → named error
- [x] `TestAddColumn_ValidValues` — column added; Conditions and Actions reflect it
- [x] `TestDeleteColumn_RemovesFromAllArtifacts` — column removed; remaining renumbered
- [x] `TestRoundTrip` — open, add action, save, re-open, action persists
- [x] `make check` passes cleanly

Closes #592, part of #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)