### PR TITLE
feat(authoring): execute and step through tables with loaded EDD data

### DIFF
--- a/pkg/dtrules/authoring/execute.go
+++ b/pkg/dtrules/authoring/execute.go
@@ -1,0 +1,581 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/entity"
+	"github.com/DTRules/DTRules/pkg/dtrules/excel"
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+	"github.com/DTRules/DTRules/pkg/dtrules/mapping"
+	"github.com/DTRules/DTRules/pkg/dtrules/operators"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// AttributeChange records a single attribute mutation caused by an action.
+type AttributeChange struct {
+	Entity    string
+	Attribute string
+	OldValue  string
+	NewValue  string
+}
+
+// StepKind describes what a Step represents.
+type StepKind string
+
+const (
+	StepCondition StepKind = "condition"
+	StepAction    StepKind = "action"
+)
+
+// Step is one unit of execution during a table walk.
+type Step struct {
+	Kind      StepKind
+	Condition string // EL text when Kind==StepCondition
+	Result    bool   // evaluation result when Kind==StepCondition
+	Column    int    // rule column this step belongs to
+	Action    string // EL text when Kind==StepAction
+	StateDiff []AttributeChange
+	Error     error
+}
+
+// ExecutionTrace holds the complete record of a table execution.
+type ExecutionTrace struct {
+	Steps      []Step
+	FinalState map[string]string // "Entity.Attribute" -> value
+	Errors     []error
+}
+
+// execState holds the lazily-created rule session used for execution.
+type execState struct {
+	ruleSet *session.RuleSet
+	sess    *session.RSession
+	state   *interpreter.DTState
+}
+
+// ensureExecState builds the execState on Project if it doesn't exist yet.
+func (p *Project) ensureExecState() error {
+	if p.execSt != nil {
+		return nil
+	}
+
+	rs := session.NewRuleSet("authoring")
+	if rs == nil {
+		return fmt.Errorf("failed to create rule set")
+	}
+
+	// Load EDD files
+	eddFiles, _ := filepath.Glob(filepath.Join(p.xmlDir, "*_edd.xml"))
+	for _, path := range eddFiles {
+		if err := rs.LoadEDDFile(path); err != nil {
+			return fmt.Errorf("LoadEDD %s: %w", path, err)
+		}
+	}
+
+	// Write in-memory DT model to temp file and load it.
+	// This ensures unsaved mutations are reflected in the session.
+	for _, entry := range p.dtFiles {
+		tmp, err := os.CreateTemp("", "authoring-dt-*.xml")
+		if err != nil {
+			return fmt.Errorf("create temp dt: %w", err)
+		}
+		tmpPath := tmp.Name()
+		tmp.Close()
+
+		imp := excel.NewDTImporter()
+		if err := imp.WriteXML(entry.tables, tmpPath); err != nil {
+			os.Remove(tmpPath)
+			return fmt.Errorf("write temp dt: %w", err)
+		}
+		if err := rs.LoadDecisionTablesFile(tmpPath); err != nil {
+			os.Remove(tmpPath)
+			return fmt.Errorf("load temp dt %s: %w", tmpPath, err)
+		}
+		os.Remove(tmpPath)
+	}
+
+	rawSess, err := session.NewSession(rs)
+	if err != nil {
+		return fmt.Errorf("new session: %w", err)
+	}
+
+	dtState, ok := rawSess.GetState().(*interpreter.DTState)
+	if !ok {
+		return fmt.Errorf("unexpected state type %T", rawSess.GetState())
+	}
+
+	// Wire the global operator table so bytecode can call operators like xdef, cvb, etc.
+	dtState.SetOperatorTable(operators.GetOperatorTable())
+
+	p.execSt = &execState{
+		ruleSet: rs,
+		sess:    rawSess,
+		state:   dtState,
+	}
+	return nil
+}
+
+// LoadTestData populates entity state from an XML test-data file using the
+// project's _map.xml file. Accumulates across successive calls.
+func (p *Project) LoadTestData(path string) error {
+	if err := p.ensureExecState(); err != nil {
+		return err
+	}
+
+	mapPath, err := p.findMapFile()
+	if err != nil {
+		return err
+	}
+
+	mapF, err := os.Open(mapPath)
+	if err != nil {
+		return fmt.Errorf("open map file: %w", err)
+	}
+	defer mapF.Close()
+
+	dataF, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open test data: %w", err)
+	}
+	defer dataF.Close()
+
+	return p.loadTestDataFromReaders(mapF, dataF)
+}
+
+// LoadTestDataReader populates entity state from readers for map+data XML.
+func (p *Project) LoadTestDataReader(mapReader, dataReader io.Reader) error {
+	if err := p.ensureExecState(); err != nil {
+		return err
+	}
+	return p.loadTestDataFromReaders(mapReader, dataReader)
+}
+
+func (p *Project) loadTestDataFromReaders(mapReader, dataReader io.Reader) error {
+	m := mapping.NewMapping(p.execSt.sess)
+	if err := m.LoadMapping(mapReader); err != nil {
+		return fmt.Errorf("load mapping: %w", err)
+	}
+	// LoadDataAndPushSingletons creates entities from XML and pushes singletons
+	// onto the entity stack so conditions/actions can resolve attributes.
+	if err := m.LoadDataAndPushSingletons(dataReader); err != nil {
+		return fmt.Errorf("load data: %w", err)
+	}
+	return nil
+}
+
+// SetAttribute sets an entity attribute programmatically.
+// entityName is the entity type name (e.g. "applicant"), attribute is the
+// field name (e.g. "age"), value is a Go primitive or string.
+func (p *Project) SetAttribute(entityName, attribute string, value any) error {
+	if err := p.ensureExecState(); err != nil {
+		return err
+	}
+
+	eName := dtrules.GetRName(entityName)
+	if eName == nil {
+		return fmt.Errorf("invalid entity name: %s", entityName)
+	}
+	aName := dtrules.GetRName(attribute)
+	if aName == nil {
+		return fmt.Errorf("invalid attribute name: %s", attribute)
+	}
+
+	ent, err := p.findEntityOnStack(eName)
+	if err != nil {
+		return err
+	}
+	if ent == nil {
+		// Entity not on stack — create one and push it
+		newEnt, err := p.execSt.sess.CreateEntity(eName)
+		if err != nil {
+			return fmt.Errorf("create entity %s: %w", entityName, err)
+		}
+		if err := p.execSt.state.EntityPush(newEnt); err != nil {
+			return fmt.Errorf("push entity %s: %w", entityName, err)
+		}
+		ent = newEnt
+	}
+
+	obj, err := goValueToDTRules(value)
+	if err != nil {
+		return fmt.Errorf("convert value: %w", err)
+	}
+	return ent.Put(aName, obj)
+}
+
+// ResetState drops the loaded entity state; the rule set is preserved so
+// EDD/DT do not need to be reloaded from disk.
+func (p *Project) ResetState() {
+	if p.execSt == nil {
+		return
+	}
+	rawSess, err := session.NewSession(p.execSt.ruleSet)
+	if err != nil {
+		p.execSt = nil
+		return
+	}
+	dtState, ok := rawSess.GetState().(*interpreter.DTState)
+	if !ok {
+		p.execSt = nil
+		return
+	}
+	dtState.SetOperatorTable(operators.GetOperatorTable())
+	p.execSt.sess = rawSess
+	p.execSt.state = dtState
+}
+
+// EvalCondition compiles an EL condition and evaluates it against current state.
+// Uses the Object-based execution path so operators (cvb, xdef, etc.) work correctly.
+func (p *Project) EvalCondition(el string) (bool, error) {
+	if err := p.ensureExecState(); err != nil {
+		return false, err
+	}
+	postfix, err := CheckCondition(el, p.symbols)
+	if err != nil {
+		return false, fmt.Errorf("compile condition: %w", err)
+	}
+	code, err := p.execSt.sess.Compile(postfix)
+	if err != nil {
+		return false, fmt.Errorf("compile postfix: %w", err)
+	}
+	state := p.execSt.state
+	initialDepth := state.DataStackDepth()
+	if err := code.Execute(state); err != nil {
+		return false, err
+	}
+	if state.DataStackDepth() <= initialDepth {
+		return false, fmt.Errorf("condition produced no result on stack")
+	}
+	result, err := state.DataPop()
+	if err != nil {
+		return false, err
+	}
+	// Clean up any extra values
+	for state.DataStackDepth() > initialDepth {
+		state.DataPop()
+	}
+	boolResult, err := result.BooleanValue()
+	if err != nil {
+		return false, fmt.Errorf("condition result is not boolean: %w", err)
+	}
+	return boolResult, nil
+}
+
+// EvalAction compiles an EL action, executes it, and returns attribute changes.
+// Uses the Object-based execution path so operators (xdef, cvb, etc.) work correctly.
+func (p *Project) EvalAction(el string) ([]AttributeChange, error) {
+	if err := p.ensureExecState(); err != nil {
+		return nil, err
+	}
+	postfix, err := CheckAction(el, p.symbols)
+	if err != nil {
+		return nil, fmt.Errorf("compile action: %w", err)
+	}
+	code, err := p.execSt.sess.Compile(postfix)
+	if err != nil {
+		return nil, fmt.Errorf("compile postfix: %w", err)
+	}
+
+	state := p.execSt.state
+	before := p.snapshotState()
+	if err := code.Execute(state); err != nil {
+		return nil, err
+	}
+	return p.diffState(before), nil
+}
+
+// Execute runs the full decision table and returns an execution trace.
+func (t *Table) Execute(p *Project) (*ExecutionTrace, error) {
+	if err := p.ensureExecState(); err != nil {
+		return nil, err
+	}
+
+	trace := &ExecutionTrace{}
+	stepper := t.NewStepper(p)
+
+	for stepper.Next() {
+		step := stepper.Current()
+		trace.Steps = append(trace.Steps, step)
+		if step.Error != nil {
+			trace.Errors = append(trace.Errors, step.Error)
+		}
+	}
+
+	trace.FinalState = p.snapshotState()
+	return trace, nil
+}
+
+// Stepper walks a decision table one step at a time.
+type Stepper struct {
+	table   *Table
+	project *Project
+
+	// condCache caches condition evaluations: conditionNumber -> bool result
+	condCache map[int]bool
+
+	// pending is a FIFO of steps yet to be returned from Next()
+	pending []Step
+
+	done    bool
+	current Step
+
+	// col is the next column to process (1-based)
+	col int
+}
+
+// NewStepper creates a new Stepper for step-by-step execution.
+func (t *Table) NewStepper(p *Project) *Stepper {
+	return &Stepper{
+		table:     t,
+		project:   p,
+		condCache: make(map[int]bool),
+		col:       1,
+	}
+}
+
+// Next advances to the next step. Returns false when exhausted.
+func (s *Stepper) Next() bool {
+	// Drain any pending steps before checking done — this ensures action steps
+	// for the last matched column (e.g. under FIRST policy) are still yielded.
+	if len(s.pending) > 0 {
+		s.current = s.pending[0]
+		s.pending = s.pending[1:]
+		if s.current.Error != nil {
+			s.done = true
+		}
+		return true
+	}
+
+	if s.done {
+		return false
+	}
+
+	if err := s.project.ensureExecState(); err != nil {
+		s.current = Step{Kind: StepCondition, Error: err}
+		s.done = true
+		return true
+	}
+
+	numCols := s.table.Columns()
+	for s.col <= numCols {
+		steps, matched, err := s.processColumn(s.col)
+		if err != nil {
+			s.current = Step{Kind: StepCondition, Column: s.col, Error: err}
+			s.done = true
+			return true
+		}
+
+		if len(steps) > 0 {
+			s.pending = append(s.pending, steps[1:]...)
+			s.current = steps[0]
+			if matched && strings.ToUpper(s.table.Policy) == "FIRST" {
+				s.done = true // stop after this column's actions drain
+			}
+			s.col++
+			return true
+		}
+
+		// No steps for this column (no conditions matched, no actions)
+		if matched && strings.ToUpper(s.table.Policy) == "FIRST" {
+			s.done = true
+			s.col++
+			return false
+		}
+		s.col++
+	}
+
+	s.done = true
+	return false
+}
+
+// processColumn evaluates conditions and, if matched, collects action steps
+// for the given column. Returns (steps, columnMatched, error).
+func (s *Stepper) processColumn(col int) ([]Step, bool, error) {
+	var steps []Step
+
+	// Evaluate conditions (cached), yield a step per relevant condition
+	matched := true
+	for _, cond := range s.table.Conditions {
+		colVal, hasVal := cond.Columns[col]
+		if !hasVal || colVal == "-" {
+			continue
+		}
+
+		result, cached := s.condCache[cond.Number]
+		if !cached {
+			var evalErr error
+			result, evalErr = s.project.EvalCondition(cond.DSL)
+			if evalErr != nil {
+				return nil, false, evalErr
+			}
+			s.condCache[cond.Number] = result
+		}
+
+		steps = append(steps, Step{
+			Kind:      StepCondition,
+			Condition: cond.DSL,
+			Result:    result,
+			Column:    col,
+		})
+
+		wantTrue := (colVal == "Y")
+		if result != wantTrue {
+			matched = false
+		}
+	}
+
+	if !matched {
+		return steps, false, nil
+	}
+
+	// Column matched — collect action steps
+	for _, act := range s.table.Actions {
+		if !act.Columns[col] || act.DSL == "" {
+			continue
+		}
+		before := s.project.snapshotState()
+		_, evalErr := s.project.EvalAction(act.DSL)
+		var diff []AttributeChange
+		if evalErr == nil {
+			diff = s.project.diffState(before)
+		}
+		steps = append(steps, Step{
+			Kind:      StepAction,
+			Action:    act.DSL,
+			Column:    col,
+			StateDiff: diff,
+			Error:     evalErr,
+		})
+		if evalErr != nil {
+			return steps, true, nil
+		}
+	}
+
+	return steps, true, nil
+}
+
+// Current returns the most recently yielded step.
+func (s *Stepper) Current() Step {
+	return s.current
+}
+
+// snapshotState captures the current string value of all entity attributes
+// on the entity stack.
+func (p *Project) snapshotState() map[string]string {
+	snap := make(map[string]string)
+	if p.execSt == nil {
+		return snap
+	}
+	state := p.execSt.state
+	depth := state.EntityDepth()
+	for i := 0; i < depth; i++ {
+		ent, err := state.EntityFetch(i)
+		if err != nil {
+			continue
+		}
+		re, ok := ent.(*entity.REntity)
+		if !ok {
+			continue
+		}
+		entName := re.GetName().StringValue()
+		for _, attrName := range re.GetAttributeNames() {
+			val, err := re.Get(attrName)
+			if err != nil || val == nil {
+				continue
+			}
+			key := entName + "." + attrName.StringValue()
+			snap[key] = val.StringValue()
+		}
+	}
+	return snap
+}
+
+// diffState compares before snapshot with current state and returns changes.
+func (p *Project) diffState(before map[string]string) []AttributeChange {
+	after := p.snapshotState()
+	var changes []AttributeChange
+	for key, newVal := range after {
+		oldVal := before[key]
+		if oldVal != newVal {
+			parts := strings.SplitN(key, ".", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			changes = append(changes, AttributeChange{
+				Entity:    parts[0],
+				Attribute: parts[1],
+				OldValue:  oldVal,
+				NewValue:  newVal,
+			})
+		}
+	}
+	return changes
+}
+
+// findEntityOnStack searches the entity stack for an entity with the given name.
+func (p *Project) findEntityOnStack(name *dtrules.RName) (dtrules.Entity, error) {
+	state := p.execSt.state
+	depth := state.EntityDepth()
+	for i := 0; i < depth; i++ {
+		ent, err := state.EntityFetch(i)
+		if err != nil {
+			continue
+		}
+		if ent.GetName() == name {
+			return ent, nil
+		}
+	}
+	return nil, nil
+}
+
+// findMapFile looks for a *_map.xml file in the project xml dir.
+func (p *Project) findMapFile() (string, error) {
+	maps, err := filepath.Glob(filepath.Join(p.xmlDir, "*_map.xml"))
+	if err != nil {
+		return "", err
+	}
+	if len(maps) == 0 {
+		return "", fmt.Errorf("no *_map.xml file found in %s", p.xmlDir)
+	}
+	return maps[0], nil
+}
+
+// goValueToDTRules converts a Go primitive to a dtrules.Object.
+func goValueToDTRules(v any) (dtrules.Object, error) {
+	switch val := v.(type) {
+	case bool:
+		return dtrules.GetRBoolean(val), nil
+	case int:
+		return dtrules.GetRIntegerValue(int64(val)), nil
+	case int64:
+		return dtrules.GetRIntegerValue(val), nil
+	case float64:
+		return dtrules.GetRDoubleValue(val), nil
+	case float32:
+		return dtrules.GetRDoubleValue(float64(val)), nil
+	case string:
+		return dtrules.NewRString(val), nil
+	case dtrules.Object:
+		return val, nil
+	default:
+		return nil, fmt.Errorf("unsupported value type %T", v)
+	}
+}

--- a/pkg/dtrules/authoring/execute_test.go
+++ b/pkg/dtrules/authoring/execute_test.go
@@ -1,0 +1,285 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+func executeTestdataDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+	return filepath.Join(filepath.Dir(file), "testdata", "execute")
+}
+
+func openExecuteProject(t *testing.T) *authoring.Project {
+	t.Helper()
+	p, err := authoring.OpenProject(executeTestdataDir(t))
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+	return p
+}
+
+// TestEvalCondition_True checks EvalCondition returns true when condition holds.
+func TestEvalCondition_True(t *testing.T) {
+	p := openExecuteProject(t)
+	if err := p.SetAttribute("applicant", "age", 25); err != nil {
+		t.Fatalf("SetAttribute: %v", err)
+	}
+	result, err := p.EvalCondition("applicant.age >= 18")
+	if err != nil {
+		t.Fatalf("EvalCondition: %v", err)
+	}
+	if !result {
+		t.Error("expected true for age=25 >= 18")
+	}
+}
+
+// TestEvalCondition_False checks EvalCondition returns false when condition fails.
+func TestEvalCondition_False(t *testing.T) {
+	p := openExecuteProject(t)
+	if err := p.SetAttribute("applicant", "age", 15); err != nil {
+		t.Fatalf("SetAttribute: %v", err)
+	}
+	result, err := p.EvalCondition("applicant.age >= 18")
+	if err != nil {
+		t.Fatalf("EvalCondition: %v", err)
+	}
+	if result {
+		t.Error("expected false for age=15 >= 18")
+	}
+}
+
+// TestEvalAction_MutatesState verifies EvalAction changes entity state and
+// returns an AttributeChange record.
+func TestEvalAction_MutatesState(t *testing.T) {
+	p := openExecuteProject(t)
+	if err := p.SetAttribute("applicant", "age", 25); err != nil {
+		t.Fatalf("SetAttribute: %v", err)
+	}
+
+	changes, err := p.EvalAction(`set applicant.eligible = true`)
+	if err != nil {
+		t.Fatalf("EvalAction: %v", err)
+	}
+
+	found := false
+	for _, ch := range changes {
+		if ch.Entity == "applicant" && ch.Attribute == "eligible" && ch.NewValue == "true" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected applicant.eligible=true change, got %v", changes)
+	}
+
+	// Confirm state persisted
+	after, err := p.EvalCondition("applicant.eligible = true")
+	if err != nil {
+		t.Fatalf("verify condition: %v", err)
+	}
+	if !after {
+		t.Error("expected eligible to be true after EvalAction")
+	}
+}
+
+// TestExecute_SingleColumnMatch ensures the trace contains the right actions
+// when only one column fires (FIRST policy, adult applicant).
+func TestExecute_SingleColumnMatch(t *testing.T) {
+	p := openExecuteProject(t)
+	if err := p.SetAttribute("applicant", "age", 25); err != nil {
+		t.Fatalf("SetAttribute: %v", err)
+	}
+
+	tbl := p.Table("Check_Eligibility")
+	if tbl == nil {
+		t.Fatal("Check_Eligibility table not found")
+	}
+
+	trace, err := tbl.Execute(p)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(trace.Errors) > 0 {
+		t.Fatalf("trace errors: %v", trace.Errors)
+	}
+
+	// Find action steps — column 1 should have fired, not column 2
+	var actionSteps []authoring.Step
+	for _, s := range trace.Steps {
+		if s.Kind == authoring.StepAction {
+			actionSteps = append(actionSteps, s)
+		}
+	}
+	if len(actionSteps) == 0 {
+		t.Fatal("expected at least one action step")
+	}
+	for _, s := range actionSteps {
+		if s.Column != 1 {
+			t.Errorf("expected actions only from column 1 (FIRST policy), got column %d", s.Column)
+		}
+	}
+
+	// eligible should be true
+	if v, ok := trace.FinalState["applicant.eligible"]; !ok || v != "true" {
+		t.Errorf("expected applicant.eligible=true in final state, got %q", v)
+	}
+}
+
+// TestExecute_MultiColumnAllPolicy checks that ALL policy fires actions in
+// every matching column for Score_Tiers (low score → column 2 only).
+func TestExecute_MultiColumnAllPolicy(t *testing.T) {
+	p := openExecuteProject(t)
+	if err := p.SetAttribute("applicant", "score", 50); err != nil {
+		t.Fatalf("SetAttribute: %v", err)
+	}
+
+	tbl := p.Table("Score_Tiers")
+	if tbl == nil {
+		t.Fatal("Score_Tiers table not found")
+	}
+
+	trace, err := tbl.Execute(p)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(trace.Errors) > 0 {
+		t.Fatalf("trace errors: %v", trace.Errors)
+	}
+
+	// tier should be "B"
+	if v, ok := trace.FinalState["applicant.tier"]; !ok || v != "B" {
+		t.Errorf("expected applicant.tier=B, got %q", v)
+	}
+}
+
+// TestStepper_YieldsExpectedSequence checks that Next() yields condition then
+// action steps in order for the adult applicant (column 1 matches, FIRST).
+func TestStepper_YieldsExpectedSequence(t *testing.T) {
+	p := openExecuteProject(t)
+	if err := p.SetAttribute("applicant", "age", 25); err != nil {
+		t.Fatalf("SetAttribute: %v", err)
+	}
+
+	tbl := p.Table("Check_Eligibility")
+	if tbl == nil {
+		t.Fatal("Check_Eligibility table not found")
+	}
+
+	stepper := tbl.NewStepper(p)
+	var kinds []authoring.StepKind
+	for stepper.Next() {
+		s := stepper.Current()
+		if s.Error != nil {
+			t.Fatalf("stepper error: %v", s.Error)
+		}
+		kinds = append(kinds, s.Kind)
+	}
+
+	// Expect: condition(col1), action(col1) — FIRST policy stops after col1
+	if len(kinds) == 0 {
+		t.Fatal("no steps yielded")
+	}
+	if kinds[0] != authoring.StepCondition {
+		t.Errorf("expected first step to be condition, got %s", kinds[0])
+	}
+	hasAction := false
+	for _, k := range kinds {
+		if k == authoring.StepAction {
+			hasAction = true
+		}
+	}
+	if !hasAction {
+		t.Error("expected at least one action step")
+	}
+}
+
+// TestStepper_StopsOnFirstForFirstPolicy verifies that FIRST policy stops
+// processing after the first matching column.
+func TestStepper_StopsOnFirstForFirstPolicy(t *testing.T) {
+	p := openExecuteProject(t)
+	if err := p.SetAttribute("applicant", "age", 25); err != nil {
+		t.Fatalf("SetAttribute: %v", err)
+	}
+
+	tbl := p.Table("Check_Eligibility")
+	if tbl == nil {
+		t.Fatal("Check_Eligibility table not found")
+	}
+
+	stepper := tbl.NewStepper(p)
+	cols := map[int]bool{}
+	for stepper.Next() {
+		s := stepper.Current()
+		if s.Error != nil {
+			t.Fatalf("stepper error: %v", s.Error)
+		}
+		if s.Kind == authoring.StepAction {
+			cols[s.Column] = true
+		}
+	}
+
+	// Only column 1 should have fired actions
+	if cols[2] {
+		t.Error("column 2 actions should not fire under FIRST policy when col 1 matched")
+	}
+	if !cols[1] {
+		t.Error("column 1 actions should have fired")
+	}
+}
+
+// TestLoadTestData_AccumulatesAcrossCalls loads test data twice (different
+// files) and verifies the last load wins for single-cardinality entities.
+func TestLoadTestData_AccumulatesAcrossCalls(t *testing.T) {
+	p := openExecuteProject(t)
+
+	testDir := filepath.Join(executeTestdataDir(t), "inputs")
+
+	if err := p.LoadTestData(filepath.Join(testDir, "adult_high.xml")); err != nil {
+		t.Fatalf("LoadTestData adult_high: %v", err)
+	}
+
+	// Verify the loaded state
+	result1, err := p.EvalCondition("applicant.age >= 18")
+	if err != nil {
+		t.Fatalf("EvalCondition: %v", err)
+	}
+	if !result1 {
+		t.Error("expected adult after loading adult_high.xml")
+	}
+
+	// Load a second file; since it's a '1' cardinality entity, the same
+	// entity should be reused and attributes overwritten.
+	p.ResetState()
+	if err := p.LoadTestData(filepath.Join(testDir, "minor.xml")); err != nil {
+		t.Fatalf("LoadTestData minor: %v", err)
+	}
+
+	result2, err := p.EvalCondition("applicant.age >= 18")
+	if err != nil {
+		t.Fatalf("EvalCondition: %v", err)
+	}
+	if result2 {
+		t.Error("expected minor (age=15) after loading minor.xml")
+	}
+}

--- a/pkg/dtrules/authoring/project.go
+++ b/pkg/dtrules/authoring/project.go
@@ -27,10 +27,11 @@ import (
 // Project holds all loaded decision tables for a DTRules project. It provides
 // a typed Go API for reading and mutating tables without touching XML directly.
 type Project struct {
-	xmlDir    string
-	dtFiles   []dtFileEntry // one entry per loaded _dt.xml file
-	symbols   map[string]string
-	edd       *EDD // lazily loaded
+	xmlDir  string
+	dtFiles []dtFileEntry // one entry per loaded _dt.xml file
+	symbols map[string]string
+	edd     *EDD       // lazily loaded
+	execSt  *execState // lazily-created execution state; nil until first use
 }
 
 // dtFileEntry tracks a single decision-table XML file and its in-memory model.

--- a/pkg/dtrules/authoring/testdata/execute/inputs/adult_high.xml
+++ b/pkg/dtrules/authoring/testdata/execute/inputs/adult_high.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test>
+  <applicant>
+    <id>1</id>
+    <age>25</age>
+    <score>90</score>
+  </applicant>
+</test>

--- a/pkg/dtrules/authoring/testdata/execute/inputs/minor.xml
+++ b/pkg/dtrules/authoring/testdata/execute/inputs/minor.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test>
+  <applicant>
+    <id>2</id>
+    <age>15</age>
+    <score>90</score>
+  </applicant>
+</test>

--- a/pkg/dtrules/authoring/testdata/execute/xml/execute_dt.xml
+++ b/pkg/dtrules/authoring/testdata/execute/xml/execute_dt.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+
+<!-- TABLE 1: Check_Eligibility - FIRST policy, one condition, two columns -->
+<decision_table el_compiled="true">
+<table_name>Check_Eligibility</table_name>
+<xls_file>execute_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>1</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions>
+</initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Adult applicant</condition_comment>
+<condition_dsl>applicant.age &gt;= 18</condition_dsl>
+<condition_postfix>
+applicant.age 18 &gt;=
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Grant eligibility</action_comment>
+<action_dsl>set applicant.eligible = true</action_dsl>
+<action_postfix>
+true applicant.eligible =
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Deny eligibility</action_comment>
+<action_dsl>set applicant.eligible = false</action_dsl>
+<action_postfix>
+false applicant.eligible =
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+</policy_statements>
+</decision_table>
+
+<!-- TABLE 2: Score_Tiers - ALL policy, two conditions -->
+<decision_table el_compiled="true">
+<table_name>Score_Tiers</table_name>
+<xls_file>execute_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>2</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions>
+</initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>High score</condition_comment>
+<condition_dsl>applicant.score &gt;= 80</condition_dsl>
+<condition_postfix>
+applicant.score 80 &gt;=
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Set tier A</action_comment>
+<action_dsl>set applicant.tier = "A"</action_dsl>
+<action_postfix>
+"A" applicant.tier =
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Set tier B</action_comment>
+<action_dsl>set applicant.tier = "B"</action_dsl>
+<action_postfix>
+"B" applicant.tier =
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+</policy_statements>
+</decision_table>
+
+</decision_tables>

--- a/pkg/dtrules/authoring/testdata/execute/xml/execute_edd.xml
+++ b/pkg/dtrules/authoring/testdata/execute/xml/execute_edd.xml
@@ -1,0 +1,9 @@
+<entity_data_dictionary version='2' xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+	<entity name='applicant' access='rw' comment=''>
+		<field name='applicant' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='age' type='integer' subtype='' access='rw' input='main' default_value='0' comment='Age of applicant'></field>
+		<field name='score' type='integer' subtype='' access='rw' input='main' default_value='0' comment='Score'></field>
+		<field name='eligible' type='boolean' subtype='' access='rw' input='' default_value='false' comment='Eligibility result'></field>
+		<field name='tier' type='string' subtype='' access='rw' input='' default_value='' comment='Applicant tier'></field>
+	</entity>
+</entity_data_dictionary>

--- a/pkg/dtrules/authoring/testdata/execute/xml/execute_map.xml
+++ b/pkg/dtrules/authoring/testdata/execute/xml/execute_map.xml
@@ -1,0 +1,15 @@
+<mapping>
+	<XMLtoEDD>
+		<map>
+			<setattribute tag='age' RAttribute='age' enclosure='applicant' type='integer'></setattribute>
+			<setattribute tag='score' RAttribute='score' enclosure='applicant' type='integer'></setattribute>
+			<createentity entity='applicant' tag='applicant' id='id'></createentity>
+		</map>
+		<entities>
+			<entity name='applicant' number='1'></entity>
+		</entities>
+		<initialization>
+			<initialentity entity='applicant' epush='true'></initialentity>
+		</initialization>
+	</XMLtoEDD>
+</mapping>

--- a/pkg/dtrules/mapping/mapping.go
+++ b/pkg/dtrules/mapping/mapping.go
@@ -251,3 +251,35 @@ func (a *AttributeInfo) Lookup(enclosure string) *Attrib {
 	// Fall back to default (empty enclosure)
 	return a.Attribs[""]
 }
+
+// SingletonEntityNames returns the names of entities with cardinality "1".
+func (m *Mapping) SingletonEntityNames() []string {
+	var names []string
+	for name, card := range m.entities {
+		if card == "1" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// LoadDataAndPushSingletons loads XML data and pushes all cardinality-1 entities
+// onto the entity stack so they are available for rule evaluation.
+func (m *Mapping) LoadDataAndPushSingletons(r io.Reader) error {
+	loader := newDataLoader(m)
+	if err := loader.Load(r); err != nil {
+		return err
+	}
+	// Push singleton entities in deterministic order
+	for name, card := range m.entities {
+		if card != "1" {
+			continue
+		}
+		entity, ok := loader.entities[name]
+		if !ok {
+			continue
+		}
+		m.state.EntityPush(entity)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds `LoadTestData`, `SetAttribute`, `ResetState`, `EvalCondition`, `EvalAction` to `Project` for loading entity state and evaluating EL expressions against live rule sessions
- Adds `Execute(*Project) (*ExecutionTrace, error)` and `NewStepper(*Project) *Stepper` to `Table` for running and stepping through decision tables with full condition/action tracing
- Adds `LoadDataAndPushSingletons` to the `mapping` package so XML test data entities are pushed onto the entity stack after loading
- Uses the Object-based execution path (not bytecode) so all operators (xdef, cvb, entitypush, etc.) resolve correctly

## Test plan

- [x] `TestEvalCondition_True` / `TestEvalCondition_False` — condition evaluation with entity state
- [x] `TestEvalAction_MutatesState` — action mutates entity attribute and returns AttributeChange
- [x] `TestExecute_SingleColumnMatch` — FIRST policy trace contains correct column/actions
- [x] `TestExecute_MultiColumnAllPolicy` — ALL policy fires all matching columns
- [x] `TestStepper_YieldsExpectedSequence` — Next() yields condition then action steps
- [x] `TestStepper_StopsOnFirstForFirstPolicy` — FIRST policy stops after first match
- [x] `TestLoadTestData_AccumulatesAcrossCalls` — LoadTestData + ResetState cycle works
- [x] `make check` passes

Closes #596, part of #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)