### PR TITLE
feat(authoring): Scenario with Run and AssertState

### DIFF
--- a/pkg/dtrules/authoring/scenario.go
+++ b/pkg/dtrules/authoring/scenario.go
@@ -1,0 +1,136 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Scenario describes a single test case: inputs, an entry table, and expected
+// final state. It is designed to be constructed in code and run against a Project.
+type Scenario struct {
+	Name       string
+	Inputs     map[string]any // "entity.attribute" -> value
+	EntryTable string
+	Expected   map[string]any // "entity.attribute" -> expected value
+}
+
+// ScenarioResult holds the outcome of running a Scenario.
+type ScenarioResult struct {
+	Scenario *Scenario
+	Trace    *ExecutionTrace
+	Pass     bool
+	Failures []AssertionFailure
+	Err      error
+}
+
+// AssertionFailure records a single mismatch between expected and actual state.
+type AssertionFailure struct {
+	Attribute string
+	Expected  any
+	Actual    any
+}
+
+// Run executes the scenario against p and returns the result.
+// It resets state first so each Run is isolated.
+func (s *Scenario) Run(p *Project) *ScenarioResult {
+	result := &ScenarioResult{Scenario: s}
+
+	p.ResetState()
+
+	for key, val := range s.Inputs {
+		entity, attr, err := splitEntityAttr(key)
+		if err != nil {
+			result.Err = fmt.Errorf("input %q: %w", key, err)
+			return result
+		}
+		if err := p.SetAttribute(entity, attr, val); err != nil {
+			result.Err = fmt.Errorf("SetAttribute %q: %w", key, err)
+			return result
+		}
+	}
+
+	tbl := p.Table(s.EntryTable)
+	if tbl == nil {
+		result.Err = fmt.Errorf("table %q not found", s.EntryTable)
+		return result
+	}
+
+	trace, err := tbl.Execute(p)
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	result.Trace = trace
+
+	// Build actual map[string]any from trace.FinalState (string values).
+	actual := make(map[string]any, len(trace.FinalState))
+	for k, v := range trace.FinalState {
+		actual[k] = v
+	}
+
+	result.Failures = AssertState(actual, s.Expected)
+	result.Pass = len(result.Failures) == 0
+	return result
+}
+
+// AssertState compares actual state against expected. actual keys are
+// "entity.attribute" strings with any values; expected keys follow the same
+// convention. Returns one AssertionFailure per mismatch or missing key.
+func AssertState(actual, expected map[string]any) []AssertionFailure {
+	var failures []AssertionFailure
+	for key, want := range expected {
+		got, ok := actual[key]
+		if !ok {
+			failures = append(failures, AssertionFailure{
+				Attribute: key,
+				Expected:  want,
+				Actual:    nil,
+			})
+			continue
+		}
+		if !semanticEqual(got, want) {
+			failures = append(failures, AssertionFailure{
+				Attribute: key,
+				Expected:  want,
+				Actual:    got,
+			})
+		}
+	}
+	return failures
+}
+
+// semanticEqual compares two values for equality, normalising string
+// representations of booleans and numbers so callers can pass typed Go values
+// and compare them against string snapshots from FinalState.
+func semanticEqual(a, b any) bool {
+	if a == b {
+		return true
+	}
+	// Normalise to strings for cross-type comparison (e.g. int 25 vs "25").
+	aStr := fmt.Sprintf("%v", a)
+	bStr := fmt.Sprintf("%v", b)
+	return aStr == bStr
+}
+
+// splitEntityAttr splits "entity.attribute" on the first dot.
+func splitEntityAttr(key string) (entity, attr string, err error) {
+	idx := strings.Index(key, ".")
+	if idx < 0 {
+		return "", "", fmt.Errorf("expected \"entity.attribute\" format")
+	}
+	return key[:idx], key[idx+1:], nil
+}

--- a/pkg/dtrules/authoring/scenario_test.go
+++ b/pkg/dtrules/authoring/scenario_test.go
@@ -1,0 +1,172 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring_test
+
+import (
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+// TestScenarioRun_Pass verifies a scenario with correct expectations passes.
+func TestScenarioRun_Pass(t *testing.T) {
+	p := openExecuteProject(t)
+
+	s := &authoring.Scenario{
+		Name:       "adult eligible",
+		Inputs:     map[string]any{"applicant.age": 25},
+		EntryTable: "Check_Eligibility",
+		Expected:   map[string]any{"applicant.eligible": "true"},
+	}
+
+	result := s.Run(p)
+	if result.Err != nil {
+		t.Fatalf("Run error: %v", result.Err)
+	}
+	if !result.Pass {
+		t.Errorf("expected Pass=true, failures: %v", result.Failures)
+	}
+}
+
+// TestScenarioRun_Fail verifies a scenario with wrong expected values fails and
+// reports the attribute name.
+func TestScenarioRun_Fail(t *testing.T) {
+	p := openExecuteProject(t)
+
+	s := &authoring.Scenario{
+		Name:       "wrong expectation",
+		Inputs:     map[string]any{"applicant.age": 25},
+		EntryTable: "Check_Eligibility",
+		Expected:   map[string]any{"applicant.eligible": "false"}, // wrong: should be true
+	}
+
+	result := s.Run(p)
+	if result.Err != nil {
+		t.Fatalf("Run error: %v", result.Err)
+	}
+	if result.Pass {
+		t.Error("expected Pass=false for wrong expected value")
+	}
+	found := false
+	for _, f := range result.Failures {
+		if f.Attribute == "applicant.eligible" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected failure for applicant.eligible, got: %v", result.Failures)
+	}
+}
+
+// TestScenarioRun_NumericComparison verifies int inputs compared to string
+// snapshots do not cause spurious failures.
+func TestScenarioRun_NumericComparison(t *testing.T) {
+	p := openExecuteProject(t)
+
+	s := &authoring.Scenario{
+		Name:       "tier check",
+		Inputs:     map[string]any{"applicant.score": 90},
+		EntryTable: "Score_Tiers",
+		Expected:   map[string]any{"applicant.tier": "A"},
+	}
+
+	result := s.Run(p)
+	if result.Err != nil {
+		t.Fatalf("Run error: %v", result.Err)
+	}
+	if !result.Pass {
+		t.Errorf("expected Pass=true, failures: %v", result.Failures)
+	}
+}
+
+// TestScenarioRun_ResetsBetweenRuns ensures state from one Run does not bleed
+// into the next.
+func TestScenarioRun_ResetsBetweenRuns(t *testing.T) {
+	p := openExecuteProject(t)
+
+	adult := &authoring.Scenario{
+		Name:       "adult",
+		Inputs:     map[string]any{"applicant.age": 25},
+		EntryTable: "Check_Eligibility",
+		Expected:   map[string]any{"applicant.eligible": "true"},
+	}
+	minor := &authoring.Scenario{
+		Name:       "minor",
+		Inputs:     map[string]any{"applicant.age": 15},
+		EntryTable: "Check_Eligibility",
+		Expected:   map[string]any{"applicant.eligible": "false"},
+	}
+
+	r1 := adult.Run(p)
+	if r1.Err != nil {
+		t.Fatalf("adult Run error: %v", r1.Err)
+	}
+	if !r1.Pass {
+		t.Errorf("adult: expected Pass=true, failures: %v", r1.Failures)
+	}
+
+	// Run minor immediately after — state must be reset
+	r2 := minor.Run(p)
+	if r2.Err != nil {
+		t.Fatalf("minor Run error: %v", r2.Err)
+	}
+	if !r2.Pass {
+		t.Errorf("minor: expected Pass=true, failures: %v", r2.Failures)
+	}
+}
+
+// TestAssertState_DirectCall exercises AssertState standalone with typed Go values.
+func TestAssertState_DirectCall(t *testing.T) {
+	actual := map[string]any{
+		"applicant.age":      "25",
+		"applicant.eligible": "true",
+		"applicant.tier":     "A",
+	}
+
+	// All match (mixed types — int vs string "25")
+	expected := map[string]any{
+		"applicant.age":      25,
+		"applicant.eligible": "true",
+		"applicant.tier":     "A",
+	}
+	failures := authoring.AssertState(actual, expected)
+	if len(failures) != 0 {
+		t.Errorf("expected no failures, got: %v", failures)
+	}
+
+	// One mismatch
+	expectedBad := map[string]any{
+		"applicant.tier": "B",
+	}
+	failures = authoring.AssertState(actual, expectedBad)
+	if len(failures) != 1 {
+		t.Errorf("expected 1 failure, got %d: %v", len(failures), failures)
+	}
+	if failures[0].Attribute != "applicant.tier" {
+		t.Errorf("expected failure on applicant.tier, got %q", failures[0].Attribute)
+	}
+
+	// Missing key
+	expectedMissing := map[string]any{
+		"applicant.unknown": "x",
+	}
+	failures = authoring.AssertState(actual, expectedMissing)
+	if len(failures) != 1 {
+		t.Errorf("expected 1 failure for missing key, got %d: %v", len(failures), failures)
+	}
+	if failures[0].Actual != nil {
+		t.Errorf("expected Actual=nil for missing key, got %v", failures[0].Actual)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `Scenario` struct with `Name`, `Inputs`, `EntryTable`, and `Expected` fields
- `Run(p *Project)` resets state, sets inputs, executes the entry table, and returns a `ScenarioResult` with `Pass`, `Failures`, and the full `ExecutionTrace`
- `AssertState(actual, expected map[string]any)` performs semantic equality comparison, normalising between typed Go values and string snapshots from `FinalState`

## Test plan

- `TestScenarioRun_Pass` — correct expectations, verifies `Pass=true`
- `TestScenarioRun_Fail` — wrong expected value, verifies failure names the attribute
- `TestScenarioRun_NumericComparison` — int input compared to string snapshot without spurious failure
- `TestScenarioRun_ResetsBetweenRuns` — state from run 1 does not affect run 2
- `TestAssertState_DirectCall` — standalone usage covering match, mismatch, and missing key

Closes #606, part of #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)