### PR TITLE
feat(authoring): RunTrace assertion helpers

### DIFF
--- a/pkg/dtrules/authoring/debug_session.go
+++ b/pkg/dtrules/authoring/debug_session.go
@@ -32,6 +32,7 @@ type TableInvocation struct {
 	Index      int               // Position in the flat pre-order list
 	TableName  string            // Name of the invoked table
 	Depth      int               // Call depth (0 = entry table, 1 = called by entry, etc.)
+	Column     int               // Column that triggered this invocation (0 = entry or unknown)
 	StartState map[string]string // Entity attribute snapshot before execution
 	EndState   map[string]string // Entity attribute snapshot after execution
 }

--- a/pkg/dtrules/authoring/trace_asserts.go
+++ b/pkg/dtrules/authoring/trace_asserts.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import "fmt"
+
+// AssertVisited returns an error if no invocation of table was found in the trace.
+// If column > 0, the invocation must have been triggered from that specific column.
+// If column == 0, any column matches.
+func (t *RunTrace) AssertVisited(table string, column int) error {
+	for _, inv := range t.Invocations {
+		if inv.TableName != table {
+			continue
+		}
+		if column == 0 || inv.Column == column {
+			return nil
+		}
+	}
+	if column == 0 {
+		return fmt.Errorf("AssertVisited: table %q was not visited", table)
+	}
+	return fmt.Errorf("AssertVisited: table %q was not visited at column %d", table, column)
+}
+
+// AssertNotVisited returns an error if table was invoked at all in the trace.
+func (t *RunTrace) AssertNotVisited(table string) error {
+	for _, inv := range t.Invocations {
+		if inv.TableName == table {
+			return fmt.Errorf("AssertNotVisited: table %q was visited (index %d)", table, inv.Index)
+		}
+	}
+	return nil
+}
+
+// AssertSequence returns an error if the tables do not appear in the given order
+// within the trace. The tables may be non-contiguous but must appear in order.
+func (t *RunTrace) AssertSequence(tables []string) error {
+	if len(tables) == 0 {
+		return nil
+	}
+
+	pos := 0 // current scan position in t.Invocations
+	for i, want := range tables {
+		found := false
+		for pos < len(t.Invocations) {
+			if t.Invocations[pos].TableName == want {
+				pos++
+				found = true
+				break
+			}
+			pos++
+		}
+		if !found {
+			if i == 0 {
+				return fmt.Errorf("AssertSequence: table %q not found in trace", want)
+			}
+			prev := tables[i-1]
+			return fmt.Errorf("AssertSequence: table %q not found after %q", want, prev)
+		}
+	}
+	return nil
+}

--- a/pkg/dtrules/authoring/trace_asserts_test.go
+++ b/pkg/dtrules/authoring/trace_asserts_test.go
@@ -1,0 +1,156 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+// makeTrace builds a RunTrace with the given invocations for use in assertion tests.
+func makeTrace(invs ...*authoring.TableInvocation) *authoring.RunTrace {
+	return &authoring.RunTrace{
+		EntryTable:  "Entry",
+		Invocations: invs,
+		InputState:  map[string]string{},
+		FinalState:  map[string]string{},
+	}
+}
+
+func inv(index int, name string, depth int, column int) *authoring.TableInvocation {
+	return &authoring.TableInvocation{
+		Index:      index,
+		TableName:  name,
+		Depth:      depth,
+		Column:     column,
+		StartState: map[string]string{},
+		EndState:   map[string]string{},
+	}
+}
+
+// --- AssertVisited ---
+
+func TestAssertVisited_Found(t *testing.T) {
+	tr := makeTrace(
+		inv(0, "Entry", 0, 0),
+		inv(1, "Check_Eligibility", 1, 1),
+	)
+	if err := tr.AssertVisited("Check_Eligibility", 1); err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestAssertVisited_NotFound(t *testing.T) {
+	tr := makeTrace(
+		inv(0, "Entry", 0, 0),
+		inv(1, "Score_Tiers", 1, 2),
+	)
+	err := tr.AssertVisited("Check_Eligibility", 1)
+	if err == nil {
+		t.Fatal("expected error for missing table, got nil")
+	}
+	if !strings.Contains(err.Error(), "Check_Eligibility") {
+		t.Errorf("error should name the table, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "1") {
+		t.Errorf("error should name the column, got: %v", err)
+	}
+}
+
+func TestAssertVisited_AnyColumn(t *testing.T) {
+	tr := makeTrace(
+		inv(0, "Entry", 0, 0),
+		inv(1, "Check_Eligibility", 1, 3),
+	)
+	// column == 0 should match regardless of the actual column
+	if err := tr.AssertVisited("Check_Eligibility", 0); err != nil {
+		t.Errorf("column==0 should match any invocation of the table, got: %v", err)
+	}
+}
+
+// --- AssertNotVisited ---
+
+func TestAssertNotVisited_Pass(t *testing.T) {
+	tr := makeTrace(
+		inv(0, "Entry", 0, 0),
+		inv(1, "Score_Tiers", 1, 1),
+	)
+	if err := tr.AssertNotVisited("Check_Eligibility"); err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestAssertNotVisited_Fail(t *testing.T) {
+	tr := makeTrace(
+		inv(0, "Entry", 0, 0),
+		inv(1, "Check_Eligibility", 1, 1),
+	)
+	err := tr.AssertNotVisited("Check_Eligibility")
+	if err == nil {
+		t.Fatal("expected error when table was visited, got nil")
+	}
+	if !strings.Contains(err.Error(), "Check_Eligibility") {
+		t.Errorf("error should name the table, got: %v", err)
+	}
+}
+
+// --- AssertSequence ---
+
+func TestAssertSequence_InOrder(t *testing.T) {
+	tr := makeTrace(
+		inv(0, "Entry", 0, 0),
+		inv(1, "Check_Eligibility", 1, 1),
+		inv(2, "Score_Tiers", 1, 1),
+		inv(3, "Finalize", 1, 1),
+	)
+	if err := tr.AssertSequence([]string{"Check_Eligibility", "Score_Tiers", "Finalize"}); err != nil {
+		t.Errorf("expected no error for in-order sequence, got: %v", err)
+	}
+}
+
+func TestAssertSequence_OutOfOrder(t *testing.T) {
+	tr := makeTrace(
+		inv(0, "Entry", 0, 0),
+		inv(1, "Score_Tiers", 1, 1),
+		inv(2, "Check_Eligibility", 1, 1),
+	)
+	// Requesting Check_Eligibility before Score_Tiers — that's reversed in the trace.
+	err := tr.AssertSequence([]string{"Check_Eligibility", "Score_Tiers"})
+	if err == nil {
+		t.Fatal("expected error for out-of-order sequence, got nil")
+	}
+	if !strings.Contains(err.Error(), "Score_Tiers") {
+		t.Errorf("error should name the out-of-order table, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Check_Eligibility") {
+		t.Errorf("error should name the preceding table, got: %v", err)
+	}
+}
+
+func TestAssertSequence_Missing(t *testing.T) {
+	tr := makeTrace(
+		inv(0, "Entry", 0, 0),
+		inv(1, "Check_Eligibility", 1, 1),
+	)
+	err := tr.AssertSequence([]string{"Check_Eligibility", "Finalize"})
+	if err == nil {
+		t.Fatal("expected error for missing table in sequence, got nil")
+	}
+	if !strings.Contains(err.Error(), "Finalize") {
+		t.Errorf("error should name the missing table, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `AssertVisited(table string, column int) error` to `RunTrace` — finds any invocation of the named table; `column == 0` matches any column
- Add `AssertNotVisited(table string) error` to `RunTrace` — fails with the invocation index if the table was called
- Add `AssertSequence(tables []string) error` to `RunTrace` — verifies tables appear in order (non-contiguous); names the offending pair or missing table in error messages
- Add `Column int` field to `TableInvocation` to record which column triggered the invocation

## Test plan

- [ ] `TestAssertVisited_Found` — table and column match
- [ ] `TestAssertVisited_NotFound` — error names table and column
- [ ] `TestAssertVisited_AnyColumn` — column == 0 matches any invocation
- [ ] `TestAssertNotVisited_Pass` — no visit, no error
- [ ] `TestAssertNotVisited_Fail` — names table + index
- [ ] `TestAssertSequence_InOrder` — passes for correct order
- [ ] `TestAssertSequence_OutOfOrder` — names the reversed pair
- [ ] `TestAssertSequence_Missing` — names the missing table

Closes #607, part of #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)