### PR TITLE
feat(authoring): Table.Dependencies and Callers

### DIFF
--- a/pkg/dtrules/authoring/dependencies.go
+++ b/pkg/dtrules/authoring/dependencies.go
@@ -1,0 +1,86 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"regexp"
+	"sort"
+)
+
+// performRe matches "perform <identifier>" in DSL text.
+// Limitation: does not distinguish perform inside a quoted string, which is
+// uncommon in practice. Callers that need precise analysis should use the EL compiler.
+var performRe = regexp.MustCompile(`\bperform\s+([A-Za-z_][A-Za-z0-9_]*)`)
+
+// dslTexts returns all action and initial-action DSL strings for this table.
+func (t *Table) dslTexts() []string {
+	texts := make([]string, 0, len(t.InitialActions)+len(t.Actions))
+	for _, ia := range t.InitialActions {
+		texts = append(texts, ia.DSL)
+	}
+	for _, a := range t.Actions {
+		texts = append(texts, a.DSL)
+	}
+	return texts
+}
+
+// Dependencies returns the sorted, deduplicated list of table names that this
+// table calls via "perform <name>" in its action or initial-action DSL.
+func (t *Table) Dependencies() []string {
+	seen := make(map[string]bool)
+	for _, dsl := range t.dslTexts() {
+		for _, m := range performRe.FindAllStringSubmatch(dsl, -1) {
+			seen[m[1]] = true
+		}
+	}
+	result := make([]string, 0, len(seen))
+	for name := range seen {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// Callers returns the sorted, deduplicated list of table names in the project
+// that call this table via "perform <name>". Returns nil if the table has no
+// project context (constructed outside of a Project).
+func (t *Table) Callers() []string {
+	if t.project == nil {
+		return nil
+	}
+	seen := make(map[string]bool)
+	for _, entry := range t.project.dtFiles {
+		for i := range entry.tables.Tables {
+			x := &entry.tables.Tables[i]
+			if x.TableName == t.Name {
+				continue
+			}
+			other := newTable(x, t.project.symbols)
+			for _, dsl := range other.dslTexts() {
+				for _, m := range performRe.FindAllStringSubmatch(dsl, -1) {
+					if m[1] == t.Name {
+						seen[x.TableName] = true
+					}
+				}
+			}
+		}
+	}
+	result := make([]string, 0, len(seen))
+	for name := range seen {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/pkg/dtrules/authoring/dependencies_test.go
+++ b/pkg/dtrules/authoring/dependencies_test.go
@@ -1,0 +1,123 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+func newTestProject(t *testing.T) *authoring.Project {
+	t.Helper()
+	p, err := authoring.NewInMemoryProject(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewInMemoryProject: %v", err)
+	}
+	return p
+}
+
+func TestDependencies_DirectPerforms(t *testing.T) {
+	p := newTestProject(t)
+	tbl, err := p.AddTable("Root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tbl.AddAction(authoring.Action{DSL: "perform TableA"})
+	_ = tbl.AddAction(authoring.Action{DSL: "perform TableB"})
+
+	got := p.Table("Root").Dependencies()
+	want := []string{"TableA", "TableB"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Dependencies() = %v, want %v", got, want)
+	}
+}
+
+func TestDependencies_Deduplicated(t *testing.T) {
+	p := newTestProject(t)
+	tbl, err := p.AddTable("Root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tbl.AddAction(authoring.Action{DSL: "perform TableA"})
+	_ = tbl.AddAction(authoring.Action{DSL: "perform TableA"})
+
+	got := p.Table("Root").Dependencies()
+	want := []string{"TableA"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Dependencies() = %v, want %v", got, want)
+	}
+}
+
+func TestDependencies_NoPerforms(t *testing.T) {
+	p := newTestProject(t)
+	tbl, err := p.AddTable("Root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tbl.AddAction(authoring.Action{DSL: "set applicant.eligible = true"})
+
+	got := p.Table("Root").Dependencies()
+	if len(got) != 0 {
+		t.Errorf("Dependencies() = %v, want empty", got)
+	}
+}
+
+func TestCallers_CrossTableSearch(t *testing.T) {
+	// TableA -> TableB -> TableC
+	p := newTestProject(t)
+
+	tblA, err := p.AddTable("TableA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tblA.AddAction(authoring.Action{DSL: "perform TableB"})
+
+	tblB, err := p.AddTable("TableB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tblB.AddAction(authoring.Action{DSL: "perform TableC"})
+
+	_, err = p.AddTable("TableC")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := p.Table("TableB").Callers()
+	want := []string{"TableA"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Callers() = %v, want %v", got, want)
+	}
+}
+
+func TestCallers_None(t *testing.T) {
+	p := newTestProject(t)
+	_, err := p.AddTable("TableA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tblB, err := p.AddTable("TableB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tblB.AddAction(authoring.Action{DSL: "set applicant.eligible = true"})
+
+	got := p.Table("TableA").Callers()
+	if len(got) != 0 {
+		t.Errorf("Callers() = %v, want empty", got)
+	}
+}

--- a/pkg/dtrules/authoring/project.go
+++ b/pkg/dtrules/authoring/project.go
@@ -65,6 +65,26 @@ func OpenProject(path string) (*Project, error) {
 	return p, nil
 }
 
+// NewInMemoryProject creates an empty project rooted at dir. An xml/ subdirectory
+// is created automatically. No files are read from disk.
+func NewInMemoryProject(dir string) (*Project, error) {
+	xmlDir := filepath.Join(dir, "xml")
+	if err := os.MkdirAll(xmlDir, 0755); err != nil {
+		return nil, fmt.Errorf("mkdir xml: %w", err)
+	}
+	p := &Project{
+		xmlDir:  xmlDir,
+		symbols: make(map[string]string),
+		dtFiles: []dtFileEntry{
+			{
+				path:   filepath.Join(xmlDir, "tables_dt.xml"),
+				tables: &excel.DecisionTablesXML{},
+			},
+		},
+	}
+	return p, nil
+}
+
 // loadEDD parses *_edd.xml files and extracts field names+types for validation.
 func (p *Project) loadEDD(xmlDir string) error {
 	entries, err := filepath.Glob(filepath.Join(xmlDir, "*_edd.xml"))
@@ -175,7 +195,7 @@ func (p *Project) Table(name string) *Table {
 	for fi := range p.dtFiles {
 		for ti := range p.dtFiles[fi].tables.Tables {
 			if p.dtFiles[fi].tables.Tables[ti].TableName == name {
-				return newTable(&p.dtFiles[fi].tables.Tables[ti], p.symbols)
+				return newTableWithProject(&p.dtFiles[fi].tables.Tables[ti], p.symbols, p)
 			}
 		}
 	}
@@ -208,7 +228,7 @@ func (p *Project) AddTable(name string) (*Table, error) {
 	// Append to the first file
 	p.dtFiles[0].tables.Tables = append(p.dtFiles[0].tables.Tables, xmlTable)
 	last := &p.dtFiles[0].tables.Tables[len(p.dtFiles[0].tables.Tables)-1]
-	return newTable(last, p.symbols), nil
+	return newTableWithProject(last, p.symbols, p), nil
 }
 
 // DeleteEntity removes the named entity from the EDD, checking that no loaded

--- a/pkg/dtrules/authoring/table.go
+++ b/pkg/dtrules/authoring/table.go
@@ -33,6 +33,7 @@ type Table struct {
 
 	xml     *excel.DecisionTableXML
 	symbols map[string]string
+	project *Project // nil when constructed outside a project context
 }
 
 // Context holds a context entity reference for a decision table.
@@ -70,6 +71,13 @@ func newTable(x *excel.DecisionTableXML, symbols map[string]string) *Table {
 		symbols: symbols,
 	}
 	t.syncFromXML()
+	return t
+}
+
+// newTableWithProject builds a Table view linked to its owning project (enables Callers).
+func newTableWithProject(x *excel.DecisionTableXML, symbols map[string]string, p *Project) *Table {
+	t := newTable(x, symbols)
+	t.project = p
 	return t
 }
 


### PR DESCRIPTION
## Summary

- Adds `Table.Dependencies()`: returns sorted, deduplicated table names called via `perform <name>` in action and initial-action DSL
- Adds `Table.Callers()`: walks all tables in the project to find which ones call this table via `perform`
- Adds `NewInMemoryProject()` constructor for testing without disk fixtures
- Detection is regex-based (`\bperform\s+([A-Za-z_][A-Za-z0-9_]*)`); does not invoke the EL compiler (limitation: does not distinguish `perform` inside a quoted string, which is uncommon in practice)

## Test plan

- `TestDependencies_DirectPerforms` — table with two `perform` actions returns both names sorted
- `TestDependencies_Deduplicated` — duplicate `perform TableA` returns `[TableA]`
- `TestDependencies_NoPerforms` — action without perform returns empty
- `TestCallers_CrossTableSearch` — chain A→B→C; `TableB.Callers()` returns `[TableA]`
- `TestCallers_None` — entry table with no callers returns empty

Closes #610, part of #605

🤖 Generated with [Claude Code](https://claude.ai/claude-code)