### PR TITLE
feat(authoring): regression diff across projects (#612)

### DIFF
--- a/pkg/dtrules/authoring/batch.go
+++ b/pkg/dtrules/authoring/batch.go
@@ -1,0 +1,126 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ScenarioFile is the JSON schema for a scenario file on disk.
+type ScenarioFile struct {
+	Name       string         `json:"name"`
+	EntryTable string         `json:"entryTable"`
+	Inputs     map[string]any `json:"inputs"`
+	Expected   map[string]any `json:"expected"`
+}
+
+// BatchResult holds the aggregate outcome of RunAllScenarios.
+type BatchResult struct {
+	Results []ScenarioResult
+	Passed  int
+	Failed  int
+	Skipped int
+}
+
+// AllPassed returns true only when there are no failures and no skipped scenarios.
+func (b *BatchResult) AllPassed() bool {
+	return b.Failed == 0 && b.Skipped == 0
+}
+
+// Summary returns a one-line human-readable summary. When there are failures,
+// each failing scenario is listed on its own line.
+func (b *BatchResult) Summary() string {
+	line := fmt.Sprintf("%d passed, %d failed, %d skipped", b.Passed, b.Failed, b.Skipped)
+	if b.Failed == 0 {
+		return line
+	}
+	var sb strings.Builder
+	sb.WriteString(line)
+	for i := range b.Results {
+		r := &b.Results[i]
+		if r.Pass || r.Err != nil {
+			continue
+		}
+		name := ""
+		if r.Scenario != nil {
+			name = r.Scenario.Name
+		}
+		sb.WriteString("\n  FAIL: ")
+		sb.WriteString(name)
+		for _, f := range r.Failures {
+			sb.WriteString(fmt.Sprintf(" [%s: want %v got %v]", f.Attribute, f.Expected, f.Actual))
+		}
+	}
+	return sb.String()
+}
+
+// RunAllScenarios walks dir non-recursively, reads every *.json file as a
+// Scenario, runs it against p, and returns the aggregate BatchResult.
+// Files that cannot be parsed contribute a Skipped entry; all other files
+// still run regardless of parse or execution errors in sibling files.
+func (p *Project) RunAllScenarios(dir string) (*BatchResult, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read dir %s: %w", dir, err)
+	}
+
+	batch := &BatchResult{}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			batch.Results = append(batch.Results, ScenarioResult{Err: fmt.Errorf("read %s: %w", entry.Name(), err)})
+			batch.Skipped++
+			continue
+		}
+
+		var sf ScenarioFile
+		if err := json.Unmarshal(data, &sf); err != nil {
+			batch.Results = append(batch.Results, ScenarioResult{Err: fmt.Errorf("parse %s: %w", entry.Name(), err)})
+			batch.Skipped++
+			continue
+		}
+
+		s := &Scenario{
+			Name:       sf.Name,
+			EntryTable: sf.EntryTable,
+			Inputs:     sf.Inputs,
+			Expected:   sf.Expected,
+		}
+
+		result := s.Run(p)
+		batch.Results = append(batch.Results, *result)
+
+		switch {
+		case result.Err != nil:
+			batch.Skipped++
+		case result.Pass:
+			batch.Passed++
+		default:
+			batch.Failed++
+		}
+	}
+
+	return batch, nil
+}

--- a/pkg/dtrules/authoring/batch_test.go
+++ b/pkg/dtrules/authoring/batch_test.go
@@ -1,0 +1,241 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+// writeScenario writes a scenario JSON file into dir and returns its path.
+func writeScenario(t *testing.T, dir, filename string, sf authoring.ScenarioFile) {
+	t.Helper()
+	data, err := json.Marshal(sf)
+	if err != nil {
+		t.Fatalf("marshal scenario: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, filename), data, 0644); err != nil {
+		t.Fatalf("write scenario file: %v", err)
+	}
+}
+
+// TestRunAllScenarios_MultipleFiles checks that 3 passing scenarios all pass.
+func TestRunAllScenarios_MultipleFiles(t *testing.T) {
+	p := openExecuteProject(t)
+	dir := t.TempDir()
+
+	writeScenario(t, dir, "adult.json", authoring.ScenarioFile{
+		Name:       "adult eligible",
+		EntryTable: "Check_Eligibility",
+		Inputs:     map[string]any{"applicant.age": 25},
+		Expected:   map[string]any{"applicant.eligible": "true"},
+	})
+	writeScenario(t, dir, "minor.json", authoring.ScenarioFile{
+		Name:       "minor not eligible",
+		EntryTable: "Check_Eligibility",
+		Inputs:     map[string]any{"applicant.age": 15},
+		Expected:   map[string]any{"applicant.eligible": "false"},
+	})
+	writeScenario(t, dir, "tier_a.json", authoring.ScenarioFile{
+		Name:       "high score tier A",
+		EntryTable: "Score_Tiers",
+		Inputs:     map[string]any{"applicant.score": 90},
+		Expected:   map[string]any{"applicant.tier": "A"},
+	})
+
+	result, err := p.RunAllScenarios(dir)
+	if err != nil {
+		t.Fatalf("RunAllScenarios: %v", err)
+	}
+	if len(result.Results) != 3 {
+		t.Errorf("expected 3 results, got %d", len(result.Results))
+	}
+	if result.Passed != 3 {
+		t.Errorf("expected 3 passed, got %d", result.Passed)
+	}
+	if result.Failed != 0 {
+		t.Errorf("expected 0 failed, got %d", result.Failed)
+	}
+	if result.Skipped != 0 {
+		t.Errorf("expected 0 skipped, got %d", result.Skipped)
+	}
+	if !result.AllPassed() {
+		t.Error("AllPassed should be true")
+	}
+}
+
+// TestRunAllScenarios_MixedResults checks counts when 2 pass and 1 fails.
+func TestRunAllScenarios_MixedResults(t *testing.T) {
+	p := openExecuteProject(t)
+	dir := t.TempDir()
+
+	writeScenario(t, dir, "pass1.json", authoring.ScenarioFile{
+		Name:       "adult eligible",
+		EntryTable: "Check_Eligibility",
+		Inputs:     map[string]any{"applicant.age": 25},
+		Expected:   map[string]any{"applicant.eligible": "true"},
+	})
+	writeScenario(t, dir, "pass2.json", authoring.ScenarioFile{
+		Name:       "minor not eligible",
+		EntryTable: "Check_Eligibility",
+		Inputs:     map[string]any{"applicant.age": 15},
+		Expected:   map[string]any{"applicant.eligible": "false"},
+	})
+	writeScenario(t, dir, "fail1.json", authoring.ScenarioFile{
+		Name:       "wrong expectation",
+		EntryTable: "Check_Eligibility",
+		Inputs:     map[string]any{"applicant.age": 25},
+		Expected:   map[string]any{"applicant.eligible": "false"}, // wrong
+	})
+
+	result, err := p.RunAllScenarios(dir)
+	if err != nil {
+		t.Fatalf("RunAllScenarios: %v", err)
+	}
+	if len(result.Results) != 3 {
+		t.Errorf("expected 3 results, got %d", len(result.Results))
+	}
+	if result.Passed != 2 {
+		t.Errorf("expected 2 passed, got %d", result.Passed)
+	}
+	if result.Failed != 1 {
+		t.Errorf("expected 1 failed, got %d", result.Failed)
+	}
+	if result.Skipped != 0 {
+		t.Errorf("expected 0 skipped, got %d", result.Skipped)
+	}
+	if result.AllPassed() {
+		t.Error("AllPassed should be false")
+	}
+}
+
+// TestRunAllScenarios_InvalidJSON verifies malformed JSON surfaces as Skipped
+// and does not prevent other scenarios from running.
+func TestRunAllScenarios_InvalidJSON(t *testing.T) {
+	p := openExecuteProject(t)
+	dir := t.TempDir()
+
+	// Valid scenario
+	writeScenario(t, dir, "good.json", authoring.ScenarioFile{
+		Name:       "adult eligible",
+		EntryTable: "Check_Eligibility",
+		Inputs:     map[string]any{"applicant.age": 25},
+		Expected:   map[string]any{"applicant.eligible": "true"},
+	})
+
+	// Malformed JSON
+	if err := os.WriteFile(filepath.Join(dir, "bad.json"), []byte("{not valid json"), 0644); err != nil {
+		t.Fatalf("write bad.json: %v", err)
+	}
+
+	result, err := p.RunAllScenarios(dir)
+	if err != nil {
+		t.Fatalf("RunAllScenarios: %v", err)
+	}
+	if len(result.Results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(result.Results))
+	}
+	if result.Passed != 1 {
+		t.Errorf("expected 1 passed, got %d", result.Passed)
+	}
+	if result.Skipped != 1 {
+		t.Errorf("expected 1 skipped, got %d", result.Skipped)
+	}
+
+	// Find the skipped result and verify it has an error
+	skippedFound := false
+	for _, r := range result.Results {
+		if r.Err != nil {
+			skippedFound = true
+			break
+		}
+	}
+	if !skippedFound {
+		t.Error("expected a result with Err set for invalid JSON")
+	}
+
+	if result.AllPassed() {
+		t.Error("AllPassed should be false when there are skipped scenarios")
+	}
+}
+
+// TestBatchResult_Summary checks the human-readable summary string.
+func TestBatchResult_Summary(t *testing.T) {
+	t.Run("all pass", func(t *testing.T) {
+		b := &authoring.BatchResult{Passed: 3}
+		got := b.Summary()
+		if got != "3 passed, 0 failed, 0 skipped" {
+			t.Errorf("unexpected summary: %q", got)
+		}
+	})
+
+	t.Run("with failures", func(t *testing.T) {
+		s := &authoring.Scenario{Name: "bad scenario"}
+		b := &authoring.BatchResult{
+			Passed: 1,
+			Failed: 1,
+			Results: []authoring.ScenarioResult{
+				{Scenario: s, Pass: false, Failures: []authoring.AssertionFailure{
+					{Attribute: "applicant.eligible", Expected: "true", Actual: "false"},
+				}},
+			},
+		}
+		got := b.Summary()
+		if !strings.HasPrefix(got, "1 passed, 1 failed, 0 skipped") {
+			t.Errorf("unexpected summary prefix: %q", got)
+		}
+		if !strings.Contains(got, "bad scenario") {
+			t.Errorf("expected scenario name in summary: %q", got)
+		}
+		if !strings.Contains(got, "applicant.eligible") {
+			t.Errorf("expected attribute in summary: %q", got)
+		}
+	})
+
+	t.Run("with skipped", func(t *testing.T) {
+		b := &authoring.BatchResult{Passed: 2, Skipped: 1}
+		got := b.Summary()
+		if got != "2 passed, 0 failed, 1 skipped" {
+			t.Errorf("unexpected summary: %q", got)
+		}
+	})
+}
+
+// TestBatchResult_AllPassed checks AllPassed logic.
+func TestBatchResult_AllPassed(t *testing.T) {
+	tests := []struct {
+		name    string
+		batch   authoring.BatchResult
+		want    bool
+	}{
+		{"all pass", authoring.BatchResult{Passed: 3}, true},
+		{"has failure", authoring.BatchResult{Passed: 2, Failed: 1}, false},
+		{"has skip", authoring.BatchResult{Passed: 2, Skipped: 1}, false},
+		{"has both", authoring.BatchResult{Passed: 1, Failed: 1, Skipped: 1}, false},
+		{"empty", authoring.BatchResult{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.batch.AllPassed(); got != tt.want {
+				t.Errorf("AllPassed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/dtrules/authoring/diff.go
+++ b/pkg/dtrules/authoring/diff.go
@@ -1,0 +1,143 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// DiffReport holds the results of a regression diff across two project versions.
+type DiffReport struct {
+	Total    int
+	Matching int
+	Diverged []ScenarioDivergence
+}
+
+// ScenarioDivergence records one scenario that produced different FinalState
+// between the two projects.
+type ScenarioDivergence struct {
+	Scenario *Scenario
+	Diffs    []AttributeDiff
+}
+
+// AttributeDiff records a single attribute whose value differs between the two
+// project versions.
+type AttributeDiff struct {
+	Attribute string
+	ValueIn1  any
+	ValueIn2  any
+}
+
+// Summary returns a human-readable summary of the diff report.
+func (d *DiffReport) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d total, %d matching, %d diverged", d.Total, d.Matching, len(d.Diverged))
+	for _, div := range d.Diverged {
+		fmt.Fprintf(&b, "\n  scenario %q:", div.Scenario.Name)
+		for _, ad := range div.Diffs {
+			fmt.Fprintf(&b, "\n    %s: %v -> %v", ad.Attribute, ad.ValueIn1, ad.ValueIn2)
+		}
+	}
+	return b.String()
+}
+
+// Diff runs each scenario against p1 and p2, compares their FinalState maps,
+// and returns a DiffReport. Scenarios that error in both projects are excluded
+// from both Matching and Diverged counts (shared failure).
+func Diff(p1, p2 *Project, scenarios []*Scenario) *DiffReport {
+	report := &DiffReport{}
+
+	for _, s := range scenarios {
+		r1 := s.Run(p1)
+		r2 := s.Run(p2)
+
+		// Shared failure — skip entirely (not divergence, not match)
+		if r1.Err != nil && r2.Err != nil {
+			continue
+		}
+
+		report.Total++
+
+		diffs := diffFinalState(r1, r2)
+		if len(diffs) == 0 {
+			report.Matching++
+			continue
+		}
+
+		report.Diverged = append(report.Diverged, ScenarioDivergence{
+			Scenario: s,
+			Diffs:    diffs,
+		})
+	}
+
+	return report
+}
+
+// diffFinalState compares the FinalState maps from two ScenarioResults and
+// returns one AttributeDiff per attribute that differs. Attributes present in
+// either result are compared; missing values are treated as empty string.
+func diffFinalState(r1, r2 *ScenarioResult) []AttributeDiff {
+	keys := make(map[string]struct{})
+
+	if r1.Trace != nil {
+		for k := range r1.Trace.FinalState {
+			keys[k] = struct{}{}
+		}
+	}
+	if r2.Trace != nil {
+		for k := range r2.Trace.FinalState {
+			keys[k] = struct{}{}
+		}
+	}
+
+	// If one errored but the other didn't, treat as full divergence with a
+	// synthetic attribute recording the error difference.
+	if r1.Err != nil || r2.Err != nil {
+		var v1, v2 any
+		if r1.Err != nil {
+			v1 = r1.Err.Error()
+		} else {
+			v1 = "<ok>"
+		}
+		if r2.Err != nil {
+			v2 = r2.Err.Error()
+		} else {
+			v2 = "<ok>"
+		}
+		return []AttributeDiff{{Attribute: "<execution>", ValueIn1: v1, ValueIn2: v2}}
+	}
+
+	sorted := make([]string, 0, len(keys))
+	for k := range keys {
+		sorted = append(sorted, k)
+	}
+	sort.Strings(sorted)
+
+	var diffs []AttributeDiff
+	for _, k := range sorted {
+		v1 := r1.Trace.FinalState[k]
+		v2 := r2.Trace.FinalState[k]
+		if !semanticEqual(v1, v2) {
+			diffs = append(diffs, AttributeDiff{
+				Attribute: k,
+				ValueIn1:  v1,
+				ValueIn2:  v2,
+			})
+		}
+	}
+	return diffs
+}

--- a/pkg/dtrules/authoring/diff_test.go
+++ b/pkg/dtrules/authoring/diff_test.go
@@ -1,0 +1,226 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+// TestDiff_IdenticalProjects_NoDivergence opens the same project twice and
+// asserts no divergences.
+func TestDiff_IdenticalProjects_NoDivergence(t *testing.T) {
+	p1 := openExecuteProject(t)
+	p2 := openExecuteProject(t)
+
+	scenarios := []*authoring.Scenario{
+		{
+			Name:       "adult eligible",
+			Inputs:     map[string]any{"applicant.age": 25},
+			EntryTable: "Check_Eligibility",
+			Expected:   map[string]any{"applicant.eligible": "true"},
+		},
+		{
+			Name:       "minor denied",
+			Inputs:     map[string]any{"applicant.age": 15},
+			EntryTable: "Check_Eligibility",
+			Expected:   map[string]any{"applicant.eligible": "false"},
+		},
+	}
+
+	report := authoring.Diff(p1, p2, scenarios)
+
+	if report.Total != 2 {
+		t.Errorf("expected Total=2, got %d", report.Total)
+	}
+	if report.Matching != 2 {
+		t.Errorf("expected Matching=2, got %d", report.Matching)
+	}
+	if len(report.Diverged) != 0 {
+		t.Errorf("expected no divergences, got %d: %v", len(report.Diverged), report.Diverged)
+	}
+}
+
+// TestDiff_ChangedRuleTrigger_NamedDivergence opens two copies of the project,
+// mutates p2 so the adult scenario sets eligible=false instead of true, and
+// asserts the report names that divergence.
+func TestDiff_ChangedRuleTrigger_NamedDivergence(t *testing.T) {
+	p1 := openExecuteProject(t)
+	p2 := openExecuteProject(t)
+
+	// Flip the action in p2: column 1 (adult → eligible=true) becomes eligible=false
+	tbl2 := p2.Table("Check_Eligibility")
+	if tbl2 == nil {
+		t.Fatal("Check_Eligibility not found in p2")
+	}
+
+	err := tbl2.UpdateAction(1, authoring.Action{
+		Number:  1,
+		Comment: "Deny eligibility (mutated)",
+		DSL:     `set applicant.eligible = false`,
+		Columns: map[int]bool{1: true},
+	})
+	if err != nil {
+		t.Fatalf("UpdateAction: %v", err)
+	}
+
+	// Invalidate p2's exec state so it picks up the mutation
+	p2.ResetState()
+
+	adultScenario := &authoring.Scenario{
+		Name:       "adult eligible",
+		Inputs:     map[string]any{"applicant.age": 25},
+		EntryTable: "Check_Eligibility",
+		Expected:   map[string]any{"applicant.eligible": "true"},
+	}
+	minorScenario := &authoring.Scenario{
+		Name:       "minor denied",
+		Inputs:     map[string]any{"applicant.age": 15},
+		EntryTable: "Check_Eligibility",
+		Expected:   map[string]any{"applicant.eligible": "false"},
+	}
+
+	report := authoring.Diff(p1, p2, []*authoring.Scenario{adultScenario, minorScenario})
+
+	if report.Total != 2 {
+		t.Errorf("expected Total=2, got %d", report.Total)
+	}
+	if len(report.Diverged) != 1 {
+		t.Fatalf("expected 1 diverged scenario, got %d", len(report.Diverged))
+	}
+
+	div := report.Diverged[0]
+	if div.Scenario.Name != "adult eligible" {
+		t.Errorf("expected diverged scenario %q, got %q", "adult eligible", div.Scenario.Name)
+	}
+
+	found := false
+	for _, ad := range div.Diffs {
+		if ad.Attribute == "applicant.eligible" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected AttributeDiff for applicant.eligible, got: %v", div.Diffs)
+	}
+}
+
+// TestDiff_ScenarioFailsInBothProjects verifies that a scenario that errors in
+// both projects is excluded from Total, Matching, and Diverged.
+func TestDiff_ScenarioFailsInBothProjects(t *testing.T) {
+	p1 := openExecuteProject(t)
+	p2 := openExecuteProject(t)
+
+	// Reference a non-existent entry table — both projects will error
+	badScenario := &authoring.Scenario{
+		Name:       "bad entry",
+		Inputs:     map[string]any{"applicant.age": 25},
+		EntryTable: "NonExistentTable",
+		Expected:   map[string]any{},
+	}
+	goodScenario := &authoring.Scenario{
+		Name:       "good",
+		Inputs:     map[string]any{"applicant.age": 25},
+		EntryTable: "Check_Eligibility",
+		Expected:   map[string]any{"applicant.eligible": "true"},
+	}
+
+	report := authoring.Diff(p1, p2, []*authoring.Scenario{badScenario, goodScenario})
+
+	// badScenario errored in both → excluded; goodScenario is fine → Total=1
+	if report.Total != 1 {
+		t.Errorf("expected Total=1 (shared-failure excluded), got %d", report.Total)
+	}
+	if report.Matching != 1 {
+		t.Errorf("expected Matching=1, got %d", report.Matching)
+	}
+	if len(report.Diverged) != 0 {
+		t.Errorf("expected no divergences, got %d", len(report.Diverged))
+	}
+}
+
+// TestDiffSummary_Format checks the Summary string format.
+func TestDiffSummary_Format(t *testing.T) {
+	p1 := openExecuteProject(t)
+	p2 := openExecuteProject(t)
+
+	scenarios := []*authoring.Scenario{
+		{
+			Name:       "adult",
+			Inputs:     map[string]any{"applicant.age": 25},
+			EntryTable: "Check_Eligibility",
+			Expected:   map[string]any{"applicant.eligible": "true"},
+		},
+	}
+
+	report := authoring.Diff(p1, p2, scenarios)
+	summary := report.Summary()
+
+	if !strings.Contains(summary, "1 total") {
+		t.Errorf("summary missing '1 total': %q", summary)
+	}
+	if !strings.Contains(summary, "1 matching") {
+		t.Errorf("summary missing '1 matching': %q", summary)
+	}
+	if !strings.Contains(summary, "0 diverged") {
+		t.Errorf("summary missing '0 diverged': %q", summary)
+	}
+}
+
+// TestDiffSummary_DivergenceBlock checks that diverged scenarios appear in the
+// summary with their attribute diffs.
+func TestDiffSummary_DivergenceBlock(t *testing.T) {
+	p1 := openExecuteProject(t)
+	p2 := openExecuteProject(t)
+
+	// Mutate p2 so adult scenario diverges
+	tbl2 := p2.Table("Check_Eligibility")
+	if tbl2 == nil {
+		t.Fatal("Check_Eligibility not found in p2")
+	}
+	if err := tbl2.UpdateAction(1, authoring.Action{
+		Number:  1,
+		Comment: "mutated",
+		DSL:     `set applicant.eligible = false`,
+		Columns: map[int]bool{1: true},
+	}); err != nil {
+		t.Fatalf("UpdateAction: %v", err)
+	}
+	p2.ResetState()
+
+	scenarios := []*authoring.Scenario{
+		{
+			Name:       "adult",
+			Inputs:     map[string]any{"applicant.age": 25},
+			EntryTable: "Check_Eligibility",
+			Expected:   map[string]any{"applicant.eligible": "true"},
+		},
+	}
+
+	report := authoring.Diff(p1, p2, scenarios)
+	summary := report.Summary()
+
+	if !strings.Contains(summary, "1 diverged") {
+		t.Errorf("summary missing '1 diverged': %q", summary)
+	}
+	if !strings.Contains(summary, "adult") {
+		t.Errorf("summary missing scenario name 'adult': %q", summary)
+	}
+	if !strings.Contains(summary, "applicant.eligible") {
+		t.Errorf("summary missing attribute 'applicant.eligible': %q", summary)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `Diff(p1, p2 *Project, scenarios []*Scenario) *DiffReport` to compare two project versions against a shared scenario set
- Shared failures (both projects error on the same scenario) are excluded from Total/Matching/Diverged — only asymmetric outcomes or attribute-value divergences are reported
- `DiffReport.Summary()` renders `"N total, M matching, K diverged"` plus a per-scenario block naming each differing attribute and its two values

## Test plan

- `TestDiff_IdenticalProjects_NoDivergence` — same project opened twice, no divergences
- `TestDiff_ChangedRuleTrigger_NamedDivergence` — p2 action mutated, adult scenario diverges with named `applicant.eligible` AttributeDiff
- `TestDiff_ScenarioFailsInBothProjects` — bad entry table; shared failure excluded from counts
- `TestDiffSummary_Format` — summary contains correct count strings
- `TestDiffSummary_DivergenceBlock` — diverged summary includes scenario name and attribute

Closes #612, part of #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)