### PR TITLE
fix(authoring): LoadTestData processes mapping initialization section

### DIFF
--- a/pkg/dtrules/authoring/execute.go
+++ b/pkg/dtrules/authoring/execute.go
@@ -582,3 +582,22 @@ func goValueToDTRules(v any) (dtrules.Object, error) {
 		return nil, fmt.Errorf("unsupported value type %T", v)
 	}
 }
+
+// EntityStackNames returns the entity names currently on the entity stack,
+// ordered from top (index 0) to bottom.
+func (p *Project) EntityStackNames() []string {
+	if p.execSt == nil {
+		return nil
+	}
+	state := p.execSt.state
+	depth := state.EntityDepth()
+	names := make([]string, 0, depth)
+	for i := 0; i < depth; i++ {
+		ent, err := state.EntityFetch(i)
+		if err != nil {
+			continue
+		}
+		names = append(names, ent.GetName().StringValue())
+	}
+	return names
+}

--- a/pkg/dtrules/authoring/loadtestdata_test.go
+++ b/pkg/dtrules/authoring/loadtestdata_test.go
@@ -1,0 +1,149 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+func loadTestdataDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+	return filepath.Join(filepath.Dir(file), "testdata", "loadtestdata")
+}
+
+func openLoadTestDataProject(t *testing.T) *authoring.Project {
+	t.Helper()
+	p, err := authoring.OpenProject(loadTestdataDir(t))
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+	return p
+}
+
+// jobData is minimal XML data for a job entity.
+const jobData = `<?xml version="1.0" encoding="UTF-8"?>
+<test><job><id>1</id><age>30</age></job></test>`
+
+// TestLoadTestData_PushesInitEntities verifies that <initialentity epush='true'>
+// for an entity NOT in <entities> still pushes it onto the entity stack (created fresh).
+func TestLoadTestData_PushesInitEntities(t *testing.T) {
+	p := openLoadTestDataProject(t)
+
+	// 'params' is in the EDD but NOT in <entities> cardinality section — only epush drives the push.
+	mapXML := `<mapping><XMLtoEDD>
+		<map>
+			<createentity entity='job' tag='job' id='id'></createentity>
+		</map>
+		<initialization>
+			<initialentity entity='params' epush='true'></initialentity>
+		</initialization>
+	</XMLtoEDD></mapping>`
+
+	err := p.LoadTestDataReader(strings.NewReader(mapXML), strings.NewReader(jobData))
+	if err != nil {
+		t.Fatalf("LoadTestDataReader: %v", err)
+	}
+
+	names := p.EntityStackNames()
+	if !slices.Contains(names, "params") {
+		t.Errorf("expected 'params' on entity stack after epush=true, got %v", names)
+	}
+}
+
+// TestLoadTestData_EpushFalseNotPushed verifies that epush='false' leaves the
+// entity off the entity stack.
+func TestLoadTestData_EpushFalseNotPushed(t *testing.T) {
+	p := openLoadTestDataProject(t)
+
+	// 'params' is in the EDD but NOT in <entities> — epush=false means it stays off stack.
+	mapXML := `<mapping><XMLtoEDD>
+		<map>
+			<createentity entity='job' tag='job' id='id'></createentity>
+		</map>
+		<initialization>
+			<initialentity entity='params' epush='false'></initialentity>
+		</initialization>
+	</XMLtoEDD></mapping>`
+
+	err := p.LoadTestDataReader(strings.NewReader(mapXML), strings.NewReader(jobData))
+	if err != nil {
+		t.Fatalf("LoadTestDataReader: %v", err)
+	}
+
+	names := p.EntityStackNames()
+	if slices.Contains(names, "params") {
+		t.Errorf("expected 'params' NOT on entity stack (epush=false), got %v", names)
+	}
+}
+
+// TestLoadTestData_NoInitializationSection verifies that a mapping without any
+// <initialization> section loads without error and does not push params.
+func TestLoadTestData_NoInitializationSection(t *testing.T) {
+	p := openLoadTestDataProject(t)
+
+	// No <initialization> section at all; 'params' should not appear on the stack.
+	mapXML := `<mapping><XMLtoEDD>
+		<map>
+			<createentity entity='job' tag='job' id='id'></createentity>
+		</map>
+	</XMLtoEDD></mapping>`
+
+	err := p.LoadTestDataReader(strings.NewReader(mapXML), strings.NewReader(jobData))
+	if err != nil {
+		t.Fatalf("LoadTestDataReader: %v", err)
+	}
+
+	names := p.EntityStackNames()
+	if slices.Contains(names, "params") {
+		t.Errorf("expected 'params' absent from entity stack (no <initialization>), got %v", names)
+	}
+}
+
+// TestLoadTestData_IntegrationWithExecuteEntry verifies that after LoadTestData
+// pushes 'job' via epush='true', ExecuteEntry can resolve job.age in conditions.
+func TestLoadTestData_IntegrationWithExecuteEntry(t *testing.T) {
+	p := openLoadTestDataProject(t)
+
+	dataPath := filepath.Join(loadTestdataDir(t), "inputs", "job_senior.xml")
+	if err := p.LoadTestData(dataPath); err != nil {
+		t.Fatalf("LoadTestData: %v", err)
+	}
+
+	// job_senior.xml sets age=45; Check_Job_Age column 1 fires when age >= 40.
+	trace, err := p.ExecuteEntry("Check_Job_Age")
+	if err != nil {
+		t.Fatalf("ExecuteEntry: %v", err)
+	}
+
+	found := false
+	for _, inv := range trace.Invocations {
+		if inv.TableName == "Check_Job_Age" && inv.Column == 1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected Check_Job_Age column 1 to fire for age=45, got invocations: %v", trace.Invocations)
+	}
+}

--- a/pkg/dtrules/authoring/testdata/loadtestdata/inputs/job_senior.xml
+++ b/pkg/dtrules/authoring/testdata/loadtestdata/inputs/job_senior.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test>
+  <job>
+    <id>1</id>
+    <age>45</age>
+  </job>
+</test>

--- a/pkg/dtrules/authoring/testdata/loadtestdata/xml/loadtestdata_dt.xml
+++ b/pkg/dtrules/authoring/testdata/loadtestdata/xml/loadtestdata_dt.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+
+<!-- TABLE 1: Check_Job_Age -->
+<decision_table el_compiled="true">
+<table_name>Check_Job_Age</table_name>
+<xls_file>loadtestdata_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>1</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions>
+</initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>Senior worker</condition_comment>
+<condition_dsl>job.age &gt;= 40</condition_dsl>
+<condition_postfix>
+job.age 40 &gt;=
+</condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Set senior result</action_comment>
+<action_dsl>set job.result = "senior"</action_dsl>
+<action_postfix>
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+<action_details>
+<action_number>2</action_number>
+<action_comment>Set junior result</action_comment>
+<action_dsl>set job.result = "junior"</action_dsl>
+<action_postfix>
+</action_postfix>
+<action_column column_number="2" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+</policy_statements>
+</decision_table>
+
+</decision_tables>

--- a/pkg/dtrules/authoring/testdata/loadtestdata/xml/loadtestdata_edd.xml
+++ b/pkg/dtrules/authoring/testdata/loadtestdata/xml/loadtestdata_edd.xml
@@ -1,0 +1,11 @@
+<entity_data_dictionary version='2' xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+	<entity name='job' access='rw' comment=''>
+		<field name='job' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='age' type='integer' subtype='' access='rw' input='main' default_value='0' comment='Job holder age'></field>
+		<field name='result' type='string' subtype='' access='rw' input='' default_value='' comment='Decision result'></field>
+	</entity>
+	<entity name='params' access='rw' comment=''>
+		<field name='params' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='rate' type='double' subtype='' access='rw' input='' default_value='0' comment='Rate parameter'></field>
+	</entity>
+</entity_data_dictionary>

--- a/pkg/dtrules/authoring/testdata/loadtestdata/xml/loadtestdata_map.xml
+++ b/pkg/dtrules/authoring/testdata/loadtestdata/xml/loadtestdata_map.xml
@@ -1,0 +1,14 @@
+<mapping>
+	<XMLtoEDD>
+		<map>
+			<setattribute tag='age' RAttribute='age' enclosure='job' type='integer'></setattribute>
+			<createentity entity='job' tag='job' id='id'></createentity>
+		</map>
+		<entities>
+			<entity name='job' number='1'></entity>
+		</entities>
+		<initialization>
+			<initialentity entity='job' epush='true'></initialentity>
+		</initialization>
+	</XMLtoEDD>
+</mapping>

--- a/pkg/dtrules/mapping/map_loader.go
+++ b/pkg/dtrules/mapping/map_loader.go
@@ -161,12 +161,16 @@ func (l *mapLoader) handleEntity(attrs map[string]string) error {
 }
 
 // handleInitialEntity processes an <initialentity> element.
+// epush='false' opts the entity out of being pushed; absent or 'true' includes it.
 func (l *mapLoader) handleInitialEntity(attrs map[string]string) error {
 	entity := attrs["entity"]
 	if entity == "" {
 		return fmt.Errorf("initialentity requires entity attribute")
 	}
 
+	if epushVal, ok := attrs["epush"]; ok && strings.ToLower(epushVal) == "false" {
+		return nil
+	}
 	l.mapping.AddInitialEntity(entity)
 	return nil
 }

--- a/pkg/dtrules/mapping/mapping.go
+++ b/pkg/dtrules/mapping/mapping.go
@@ -263,16 +263,43 @@ func (m *Mapping) SingletonEntityNames() []string {
 	return names
 }
 
-// LoadDataAndPushSingletons loads XML data and pushes all cardinality-1 entities
-// onto the entity stack so they are available for rule evaluation.
+// LoadDataAndPushSingletons loads XML data and pushes entities onto the entity
+// stack. Two push mechanisms are applied:
+//  1. Each entity named in <initialentity epush='true'> (entitystack) is pushed
+//     in order; if the entity exists in the loaded data that instance is used,
+//     otherwise a fresh entity is created. This handles singleton params that may
+//     not appear in the data XML.
+//  2. Remaining cardinality-1 entities found in the data that were not already
+//     pushed via entitystack are also pushed.
 func (m *Mapping) LoadDataAndPushSingletons(r io.Reader) error {
 	loader := newDataLoader(m)
 	if err := loader.Load(r); err != nil {
 		return err
 	}
-	// Push singleton entities in deterministic order
+
+	pushed := make(map[string]bool)
+
+	// Push entities from the initialization stack in declared order.
+	for _, name := range m.entitystack {
+		if entity, ok := loader.entities[name]; ok {
+			m.state.EntityPush(entity)
+		} else {
+			rname := dtrules.GetRName(name)
+			if rname == nil {
+				return fmt.Errorf("invalid entity name in initialization: %s", name)
+			}
+			entity, err := m.session.CreateEntity(rname)
+			if err != nil {
+				return fmt.Errorf("create initialization entity %s: %w", name, err)
+			}
+			m.state.EntityPush(entity)
+		}
+		pushed[name] = true
+	}
+
+	// Push remaining cardinality-1 entities found in the loaded data.
 	for name, card := range m.entities {
-		if card != "1" {
+		if card != "1" || pushed[name] {
 			continue
 		}
 		entity, ok := loader.entities[name]


### PR DESCRIPTION
## Summary

- `LoadDataAndPushSingletons` now processes the `<initialization>` entity stack first (in declared order), creating fresh entities when not found in data, before pushing remaining cardinality-1 data entities
- `handleInitialEntity` in the map loader now respects `epush='false'` by skipping `AddInitialEntity`
- Added `EntityStackNames()` helper to `Project` for test introspection

Closes #625