### PR TITLE
fix(el): emit postfix for every forall context form

### DIFF
--- a/pkg/dtrules/authoring/forall_test.go
+++ b/pkg/dtrules/authoring/forall_test.go
@@ -23,7 +23,6 @@ func forallTestdataDir(t *testing.T) string {
 	return filepath.Join(filepath.Dir(file), "testdata", "forall")
 }
 
-// forallSetup loads EDD + DT and returns a configured RuleSet.
 func forallSetup(t *testing.T) *session.RuleSet {
 	t.Helper()
 	xmlDir := filepath.Join(forallTestdataDir(t), "xml")
@@ -53,7 +52,6 @@ func forallSetup(t *testing.T) *session.RuleSet {
 	return rs
 }
 
-// forallSession creates a session, wires operators, and loads test data via map.
 func forallSession(t *testing.T, rs *session.RuleSet, inputFile string) (*session.RSession, *interpreter.DTState) {
 	t.Helper()
 	xmlDir := filepath.Join(forallTestdataDir(t), "xml")
@@ -93,7 +91,6 @@ func forallSession(t *testing.T, rs *session.RuleSet, inputFile string) (*sessio
 	return sess, state
 }
 
-// getCount returns calculation_context.processed_count from the entity stack.
 func getCount(t *testing.T, state *interpreter.DTState) int64 {
 	t.Helper()
 	depth := state.EntityDepth()
@@ -121,66 +118,137 @@ func getCount(t *testing.T, state *interpreter.DTState) int64 {
 	return 0
 }
 
-// TestForAll_ArrayElementsOnStack verifies that with 2 authorized and 1
-// unauthorized staking_account, the forall context iterates all three and
-// processed_count ends up at 2.
-func TestForAll_ArrayElementsOnStack(t *testing.T) {
+// runForm executes the named entry table against the named input fixture and
+// returns calculation_context.processed_count. An assertion failure flagging
+// the #626 regression signature ("not defined by any Entity on the Entity
+// Stack") fails the test with a distinct message — every form should have
+// pushed the element entity before running the body.
+func runForm(t *testing.T, table, inputFile string) int64 {
+	t.Helper()
 	rs := forallSetup(t)
-	inputPath := filepath.Join(forallTestdataDir(t), "inputs", "two_auth_one_not.xml")
+	inputPath := filepath.Join(forallTestdataDir(t), "inputs", inputFile)
 	sess, state := forallSession(t, rs, inputPath)
 
-	if err := sess.Execute("Process_Accounts"); err != nil {
-		// Fail only if it's the original "not defined" bug — not a real execution error
+	if err := sess.Execute(table); err != nil {
 		if strings.Contains(err.Error(), "was not defined by any Entity on the Entity Stack") {
-			t.Fatalf("REGRESSION: forall context does not push entity onto stack: %v", err)
+			t.Fatalf("REGRESSION (%s): forall context did not push element onto entity stack: %v", table, err)
 		}
-		t.Fatalf("Execute: %v", err)
+		t.Fatalf("Execute %s: %v", table, err)
 	}
+	return getCount(t, state)
+}
 
-	// 2 authorized × 1 increment + 1 unauthorized × 0 = 2
-	count := getCount(t, state)
-	if count != 2 {
-		t.Errorf("expected processed_count = 2 (two authorized accounts), got %d", count)
+// Each form gets its own subtests. The three input fixtures exercise:
+//   two_auth_one_not: 3 accounts, 2 authorized
+//   empty_accounts  : 0 accounts
+//   three_auth      : 3 accounts, all authorized
+// Simple / InEntity / AllowRemove forms filter inside the body (condition
+// column Y/N), so processed_count == authorized count.
+// Where / InEntityWhere forms filter in the context; their body is
+// unconditional, so processed_count == authorized count as well (the filter
+// predicate is equivalent).
+
+func TestForallSimple(t *testing.T) {
+	cases := map[string]int64{
+		"two_auth_one_not.xml": 2,
+		"empty_accounts.xml":   0,
+		"three_auth.xml":       3,
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := runForm(t, "FA_Simple", input); got != want {
+				t.Errorf("FA_Simple on %s: got %d, want %d", input, got, want)
+			}
+		})
 	}
 }
 
-// TestForAll_EmptyArray verifies that with no staking_accounts, the forall
-// context does not iterate and processed_count stays at 0.
-func TestForAll_EmptyArray(t *testing.T) {
-	rs := forallSetup(t)
-	inputPath := filepath.Join(forallTestdataDir(t), "inputs", "empty_accounts.xml")
-	sess, state := forallSession(t, rs, inputPath)
-
-	if err := sess.Execute("Process_Accounts"); err != nil {
-		if strings.Contains(err.Error(), "was not defined by any Entity on the Entity Stack") {
-			t.Fatalf("REGRESSION: forall context does not push entity onto stack: %v", err)
-		}
-		t.Fatalf("Execute: %v", err)
+func TestForallAllowRemove(t *testing.T) {
+	cases := map[string]int64{
+		"two_auth_one_not.xml": 2,
+		"empty_accounts.xml":   0,
+		"three_auth.xml":       3,
 	}
-
-	count := getCount(t, state)
-	if count != 0 {
-		t.Errorf("expected processed_count = 0 (empty array), got %d", count)
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := runForm(t, "FA_AllowRemove", input); got != want {
+				t.Errorf("FA_AllowRemove on %s: got %d, want %d", input, got, want)
+			}
+		})
 	}
 }
 
-// TestForAll_AllAuthorized verifies that with 3 authorized accounts, the forall
-// context iterates all three and processed_count ends up at 3.
-func TestForAll_AllAuthorized(t *testing.T) {
-	rs := forallSetup(t)
-	inputPath := filepath.Join(forallTestdataDir(t), "inputs", "three_auth.xml")
-	sess, state := forallSession(t, rs, inputPath)
-
-	if err := sess.Execute("Process_Accounts"); err != nil {
-		if strings.Contains(err.Error(), "was not defined by any Entity on the Entity Stack") {
-			t.Fatalf("REGRESSION: forall context does not push entity onto stack: %v", err)
-		}
-		t.Fatalf("Execute: %v", err)
+func TestForallWhere(t *testing.T) {
+	cases := map[string]int64{
+		"two_auth_one_not.xml": 2,
+		"empty_accounts.xml":   0,
+		"three_auth.xml":       3,
 	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := runForm(t, "FA_Where", input); got != want {
+				t.Errorf("FA_Where on %s: got %d, want %d", input, got, want)
+			}
+		})
+	}
+}
 
-	// 3 authorized × 1 increment each = 3
-	count := getCount(t, state)
-	if count != 3 {
-		t.Errorf("expected processed_count = 3 (three authorized accounts), got %d", count)
+func TestForallWhereAllowRemove(t *testing.T) {
+	cases := map[string]int64{
+		"two_auth_one_not.xml": 2,
+		"empty_accounts.xml":   0,
+		"three_auth.xml":       3,
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := runForm(t, "FA_WhereAllowRemove", input); got != want {
+				t.Errorf("FA_WhereAllowRemove on %s: got %d, want %d", input, got, want)
+			}
+		})
+	}
+}
+
+func TestForallInEntity(t *testing.T) {
+	cases := map[string]int64{
+		"two_auth_one_not.xml": 2,
+		"empty_accounts.xml":   0,
+		"three_auth.xml":       3,
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := runForm(t, "FA_InEntity", input); got != want {
+				t.Errorf("FA_InEntity on %s: got %d, want %d", input, got, want)
+			}
+		})
+	}
+}
+
+func TestForallInEntityAllowRemove(t *testing.T) {
+	cases := map[string]int64{
+		"two_auth_one_not.xml": 2,
+		"empty_accounts.xml":   0,
+		"three_auth.xml":       3,
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := runForm(t, "FA_InEntityAllowRemove", input); got != want {
+				t.Errorf("FA_InEntityAllowRemove on %s: got %d, want %d", input, got, want)
+			}
+		})
+	}
+}
+
+func TestForallInEntityWhere(t *testing.T) {
+	cases := map[string]int64{
+		"two_auth_one_not.xml": 2,
+		"empty_accounts.xml":   0,
+		"three_auth.xml":       3,
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := runForm(t, "FA_InEntityWhere", input); got != want {
+				t.Errorf("FA_InEntityWhere on %s: got %d, want %d", input, got, want)
+			}
+		})
 	}
 }

--- a/pkg/dtrules/authoring/testdata/forall/xml/forall_dt.xml
+++ b/pkg/dtrules/authoring/testdata/forall/xml/forall_dt.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <decision_tables>
 
-<!-- TABLE 1: Process_Accounts -->
+<!-- Form 1: forallSimple — `for all <array>`.
+     Condition filters inside the body: only authorized accounts increment.
+     2-auth-1-not → 2; empty → 0; all-auth → 3. -->
 <decision_table el_compiled="true">
-<table_name>Process_Accounts</table_name>
+<table_name>FA_Simple</table_name>
 <xls_file>forall_dt.xlsx</xls_file>
 <attribute_fields>
 <Type>ALL</Type>
@@ -13,21 +15,18 @@
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_comment>Iterate over all staking accounts</context_comment>
+<context_comment>forallSimple</context_comment>
 <context_dsl>for all calculation_context.accounts</context_dsl>
 <context_postfix></context_postfix>
 </context_details>
 </contexts>
-<initial_actions>
-</initial_actions>
+<initial_actions></initial_actions>
 <conditions>
 <condition_details>
 <condition_number>1</condition_number>
-<condition_comment>Account has staking authority</condition_comment>
+<condition_comment>authorized</condition_comment>
 <condition_dsl>staking_account.has_staking_authority = true</condition_dsl>
-<condition_postfix>
-staking_account.has_staking_authority
-</condition_postfix>
+<condition_postfix></condition_postfix>
 <condition_column column_number="1" column_value="Y"></condition_column>
 <condition_column column_number="2" column_value="N"></condition_column>
 </condition_details>
@@ -35,16 +34,257 @@ staking_account.has_staking_authority
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_comment>Increment count for authorized account</action_comment>
+<action_comment>count</action_comment>
 <action_dsl>set calculation_context.processed_count = calculation_context.processed_count + 1</action_dsl>
-<action_postfix>
-calculation_context.processed_count 1 + cvi /calculation_context.processed_count xdef
-</action_postfix>
+<action_postfix></action_postfix>
 <action_column column_number="1" column_value="X"></action_column>
 </action_details>
 </actions>
-<policy_statements>
-</policy_statements>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- Form 2: forallAllowRemove — `for all <array> allowing array to be removed`.
+     Same semantics and counts as forallSimple. -->
+<decision_table el_compiled="true">
+<table_name>FA_AllowRemove</table_name>
+<xls_file>forall_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>2</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>forallAllowRemove</context_comment>
+<context_dsl>for all calculation_context.accounts allowing array to be removed</context_dsl>
+<context_postfix></context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>authorized</condition_comment>
+<condition_dsl>staking_account.has_staking_authority = true</condition_dsl>
+<condition_postfix></condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>count</action_comment>
+<action_dsl>set calculation_context.processed_count = calculation_context.processed_count + 1</action_dsl>
+<action_postfix></action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- Form 3: forallWhere — `for all <array> where <bexpr>`.
+     Context filters to authorized accounts, body unconditionally increments.
+     Counts match forallSimple because the authorizing filter is equivalent.
+     Uses balance > 0 as a separate predicate to exercise the filter distinctly. -->
+<decision_table el_compiled="true">
+<table_name>FA_Where</table_name>
+<xls_file>forall_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>3</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>forallWhere</context_comment>
+<context_dsl>for all calculation_context.accounts where staking_account.has_staking_authority = true</context_dsl>
+<context_postfix></context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>always</condition_comment>
+<condition_dsl>staking_account.balance &gt;= 0</condition_dsl>
+<condition_postfix></condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>count</action_comment>
+<action_dsl>set calculation_context.processed_count = calculation_context.processed_count + 1</action_dsl>
+<action_postfix></action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- Form 4: forallWhereAllowRemove — same behavior as forallWhere. -->
+<decision_table el_compiled="true">
+<table_name>FA_WhereAllowRemove</table_name>
+<xls_file>forall_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>4</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>forallWhereAllowRemove</context_comment>
+<context_dsl>for all calculation_context.accounts where staking_account.has_staking_authority = true allowing array to be removed</context_dsl>
+<context_postfix></context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>always</condition_comment>
+<condition_dsl>staking_account.balance &gt;= 0</condition_dsl>
+<condition_postfix></condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>count</action_comment>
+<action_dsl>set calculation_context.processed_count = calculation_context.processed_count + 1</action_dsl>
+<action_postfix></action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- Form 5: forallInEntity — `for all accounts in calculation_context`.
+     `accounts` resolves because calculation_context is entitypush'd first.
+     Body filters by authorization. Same counts as forallSimple. -->
+<decision_table el_compiled="true">
+<table_name>FA_InEntity</table_name>
+<xls_file>forall_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>5</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>forallInEntity</context_comment>
+<context_dsl>for all accounts in calculation_context</context_dsl>
+<context_postfix></context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>authorized</condition_comment>
+<condition_dsl>staking_account.has_staking_authority = true</condition_dsl>
+<condition_postfix></condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>count</action_comment>
+<action_dsl>set calculation_context.processed_count = calculation_context.processed_count + 1</action_dsl>
+<action_postfix></action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- Form 6: forallInEntityAllowRemove — same as forallInEntity. -->
+<decision_table el_compiled="true">
+<table_name>FA_InEntityAllowRemove</table_name>
+<xls_file>forall_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>6</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>forallInEntityAllowRemove</context_comment>
+<context_dsl>for all accounts in calculation_context allowing array to be removed</context_dsl>
+<context_postfix></context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>authorized</condition_comment>
+<condition_dsl>staking_account.has_staking_authority = true</condition_dsl>
+<condition_postfix></condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+<condition_column column_number="2" column_value="N"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>count</action_comment>
+<action_dsl>set calculation_context.processed_count = calculation_context.processed_count + 1</action_dsl>
+<action_postfix></action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- Form 7: forallInEntityWhere — `for all accounts in calculation_context where <bexpr>`.
+     Context pushes calculation_context, filters by authorization, body always increments. -->
+<decision_table el_compiled="true">
+<table_name>FA_InEntityWhere</table_name>
+<xls_file>forall_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>7</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>forallInEntityWhere</context_comment>
+<context_dsl>for all accounts in calculation_context where staking_account.has_staking_authority = true</context_dsl>
+<context_postfix></context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>always</condition_comment>
+<condition_dsl>staking_account.balance &gt;= 0</condition_dsl>
+<condition_postfix></condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>count</action_comment>
+<action_dsl>set calculation_context.processed_count = calculation_context.processed_count + 1</action_dsl>
+<action_postfix></action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
 </decision_table>
 
 </decision_tables>

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -1623,14 +1623,121 @@ func (e *PostfixEmitter) VisitContextForallCtl(ctx *ContextForallCtlContext) int
 	return e.Visit(ctx.Forallctl())
 }
 
-// VisitForallSimple emits: dup <array> forall pop
-// Wrapping layer in compileContextsPostfix leaves the table body block on the
-// data stack. dup preserves it so forall (which pops body then array) has its
-// operands; pop then drains the duplicate.
+// Forall context emitters.
+//
+// compileContextsPostfix wraps each context around a table body block so that
+// entering our emit the data stack holds [body], where body is the compiled
+// { /TableName executetable }. forall has signature (body array --), so each
+// emit must leave the stack clean after iterating.
+//
+// forallSimple: dup body so forall can consume it, iterate, drop the dup.
+// forallWhere:  replace body with a filter { <bexpr> { dup execute } if }.
+//               Entering forall the stack is [body, filter, array]; forall
+//               consumes (filter, array) leaving [body]. During each iteration
+//               the element is on the entity stack, so <bexpr> resolves
+//               element attributes. When <bexpr> is true the filter runs
+//               `dup execute`, which re-pushes and invokes body without
+//               consuming the copy that survives to the next iteration.
+//               Final pop drops the surviving body.
+// forallInEntity: evaluate eexpr, entitypush to make its attributes reachable
+//               while arrayExpr and the body run, iterate via the simple
+//               form, then entitypop + pop to clean up.
+// *AllowRemove: authoring-time affirmation that the body may mutate the array;
+//               emits identically to its non-allowing counterpart.
+
+// VisitForallSimple: `for all <array>`.
 func (e *PostfixEmitter) VisitForallSimple(ctx *ForallSimpleContext) interface{} {
 	e.emit("dup")
 	e.Visit(ctx.ArrayExpr())
 	e.emit("forall")
+	e.emit("pop")
+	return nil
+}
+
+// VisitForallAllowRemove: `for all <array> allowing array to be removed`.
+func (e *PostfixEmitter) VisitForallAllowRemove(ctx *ForallAllowRemoveContext) interface{} {
+	e.emit("dup")
+	e.Visit(ctx.ArrayExpr())
+	e.emit("forall")
+	e.emit("pop")
+	return nil
+}
+
+// VisitForallWhere: `for all <array> where <bexpr>`.
+// `if` signature is (body test --), so push body block first then test.
+func (e *PostfixEmitter) VisitForallWhere(ctx *ForallWhereContext) interface{} {
+	e.emit("{")
+	e.emit("{")
+	e.emit("dup")
+	e.emit("execute")
+	e.emit("}")
+	e.Visit(ctx.Bexpr())
+	e.emit("if")
+	e.emit("}")
+	e.Visit(ctx.ArrayExpr())
+	e.emit("forall")
+	e.emit("pop")
+	return nil
+}
+
+// VisitForallWhereAllowRemove: `for all <array> where <bexpr> allowing array to be removed`.
+func (e *PostfixEmitter) VisitForallWhereAllowRemove(ctx *ForallWhereAllowRemoveContext) interface{} {
+	e.emit("{")
+	e.emit("{")
+	e.emit("dup")
+	e.emit("execute")
+	e.emit("}")
+	e.Visit(ctx.Bexpr())
+	e.emit("if")
+	e.emit("}")
+	e.Visit(ctx.ArrayExpr())
+	e.emit("forall")
+	e.emit("pop")
+	return nil
+}
+
+// VisitForallInEntity: `for all <array> in <entity>`.
+func (e *PostfixEmitter) VisitForallInEntity(ctx *ForallInEntityContext) interface{} {
+	e.Visit(ctx.Eexpr())
+	e.emit("entitypush")
+	e.emit("dup")
+	e.Visit(ctx.ArrayExpr())
+	e.emit("forall")
+	e.emit("pop")
+	e.emit("entitypop")
+	e.emit("pop")
+	return nil
+}
+
+// VisitForallInEntityAllowRemove: `for all <array> in <entity> allowing array to be removed`.
+func (e *PostfixEmitter) VisitForallInEntityAllowRemove(ctx *ForallInEntityAllowRemoveContext) interface{} {
+	e.Visit(ctx.Eexpr())
+	e.emit("entitypush")
+	e.emit("dup")
+	e.Visit(ctx.ArrayExpr())
+	e.emit("forall")
+	e.emit("pop")
+	e.emit("entitypop")
+	e.emit("pop")
+	return nil
+}
+
+// VisitForallInEntityWhere: `for all <array> in <entity> where <bexpr>`.
+func (e *PostfixEmitter) VisitForallInEntityWhere(ctx *ForallInEntityWhereContext) interface{} {
+	e.Visit(ctx.Eexpr())
+	e.emit("entitypush")
+	e.emit("{")
+	e.emit("{")
+	e.emit("dup")
+	e.emit("execute")
+	e.emit("}")
+	e.Visit(ctx.Bexpr())
+	e.emit("if")
+	e.emit("}")
+	e.Visit(ctx.ArrayExpr())
+	e.emit("forall")
+	e.emit("pop")
+	e.emit("entitypop")
 	e.emit("pop")
 	return nil
 }


### PR DESCRIPTION
## Summary

Completes #626. v1.6.5 added `VisitForallSimple` only; the other six labeled alternatives of `forallctl` still fell through to the base visitor, emitting nothing. Decision tables should never depend on hand-tuned postfix — the EL compiler must produce correct postfix for every documented form.

Emits (context position, stack entering the emit is `[body]`):

| Form | DSL | Postfix |
|---|---|---|
| forallSimple | `for all <arr>` | `dup <arr> forall pop` |
| forallAllowRemove | `... allowing array to be removed` | same |
| forallWhere | `for all <arr> where <bexpr>` | `{ { dup execute } <bexpr> if } <arr> forall pop` |
| forallWhereAllowRemove | `... where <bexpr> allowing ...` | same as forallWhere |
| forallInEntity | `for all <arr> in <ent>` | `<ent> entitypush dup <arr> forall pop entitypop pop` |
| forallInEntityAllowRemove | `... in <ent> allowing ...` | same as forallInEntity |
| forallInEntityWhere | `for all <arr> in <ent> where <bexpr>` | `<ent> entitypush { { dup execute } <bexpr> if } <arr> forall pop entitypop pop` |

The `allowing array to be removed` clause is an authoring affirmation that the body may mutate the array during iteration; it emits identically to the non-allowing counterpart because `opForall` captures the iterator slice at entry.

Note on the `if`-argument order: `opIf`'s signature is `(body test --)` — pop order is test first, then body — so the filter emit is `{ body-block } <bexpr> if`, not `<bexpr> { body-block } if`. My first draft had this reversed; all three where-variants now consistently push the body block before the test expression.

## Test plan

- [x] `pkg/dtrules/authoring/forall_test.go` — one test per form, each with three input fixtures (empty, two-of-three authorized, all authorized). 21 subtests total. Each asserts the #626 regression signature ("not defined by any Entity on the Entity Stack") is not present, and pins `processed_count` to the expected iteration count.
- [x] `make check` passes (full-module build + vet + scoped tests).
- [x] Verified compiled postfix for each form by printing: all seven DSL forms round-trip through the compiler to executable postfix with no hand editing.