### PR TITLE
test(el): grammar-exhaustive sweep of every labeled alternative

### DIFF
--- a/pkg/dtrules/compiler/el/grammar_sweep_test.go
+++ b/pkg/dtrules/compiler/el/grammar_sweep_test.go
@@ -1,0 +1,280 @@
+// Grammar sweep: drive every labeled alternative in EL.g4 through the
+// compiler. Two assertions per entry: compile succeeds, postfix is non-empty.
+// The empty-postfix check is what makes the silent fall-through that caused
+// #626 impossible — a labeled alternative without a PostfixEmitter override
+// emits nothing, and this sweep fails.
+//
+// The corpus is generated from EL.g4 itself (see tools/gen_corpus.py) so
+// adding a new labeled alternative forces a corpus entry: the coverage guard
+// below fails if any grammar label has no corpus row.
+
+package el
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+type corpusRow struct {
+	rule  string
+	label string
+	entry string // condition | action | context | raw
+	dsl   string
+}
+
+func loadTSV(t *testing.T, path string) []corpusRow {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	var rows []corpusRow
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	first := true
+	for sc.Scan() {
+		if first {
+			first = false
+			continue // skip header
+		}
+		line := sc.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		// Accept >=4 columns (overrides file has an optional note column 5).
+		if len(parts) < 4 {
+			t.Fatalf("bad tsv line in %s: %q", path, line)
+		}
+		rows = append(rows, corpusRow{rule: parts[0], label: parts[1], entry: parts[2], dsl: parts[3]})
+	}
+	return rows
+}
+
+// loadCorpus merges generated corpus with manual overrides. Overrides replace
+// generated rows by (rule, label) key.
+func loadCorpus(t *testing.T) []corpusRow {
+	t.Helper()
+	base := loadTSV(t, "testdata/grammar_corpus.tsv")
+	overrides := loadTSV(t, "testdata/grammar_overrides.tsv")
+	keyed := make(map[string]corpusRow, len(base))
+	for _, r := range base {
+		keyed[r.rule+"/"+r.label] = r
+	}
+	for _, r := range overrides {
+		keyed[r.rule+"/"+r.label] = r
+	}
+	// Stable order by rule then label for reproducible test output.
+	keys := make([]string, 0, len(keyed))
+	for k := range keyed {
+		keys = append(keys, k)
+	}
+	// Simple sort via repeated pass — avoids import bloat.
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j-1] > keys[j]; j-- {
+			keys[j-1], keys[j] = keys[j], keys[j-1]
+		}
+	}
+	out := make([]corpusRow, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, keyed[k])
+	}
+	return out
+}
+
+func compileRow(c *Compiler, r corpusRow) (string, error) {
+	switch r.entry {
+	case "condition":
+		return c.CompileCondition(r.dsl)
+	case "action":
+		return c.CompileAction(r.dsl)
+	case "context":
+		return c.CompileContext(r.dsl)
+	case "raw":
+		return c.Compile(r.dsl)
+	default:
+		return "", nil
+	}
+}
+
+// Labels that legitimately emit no postfix at compile time (empty statements,
+// no-op markers). These are the ONLY labels allowed to produce empty output;
+// every other label's emit must be non-empty, or the fall-through bug that
+// caused #626 has a new victim.
+var emptyPostfixAllowed = map[string]bool{
+	"emptyAction":          true,
+	"emptyCondition":       true,
+	"emptyContext":         true,
+	"emptyPolicyStatement": true,
+}
+
+// loadKnownFails reads the inventory of labels that are known to fail the
+// sweep today. Each entry is either (a) a helper rule with no top-level
+// compile path, (b) a DSL sample the generator can't construct correctly yet,
+// or (c) a real emitter fall-through bug tracked for follow-up. New entries
+// must NOT be added casually — the correct response to a new failure is to
+// either fix the emitter or refine the DSL sample.
+func loadKnownFails(t *testing.T) map[string]string {
+	t.Helper()
+	f, err := os.Open("testdata/grammar_known_fails.tsv")
+	if err != nil {
+		t.Fatalf("open known_fails: %v", err)
+	}
+	defer f.Close()
+	out := map[string]string{}
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	first := true
+	for sc.Scan() {
+		if first {
+			first = false
+			continue
+		}
+		line := sc.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) != 3 {
+			t.Fatalf("bad known_fails line: %q", line)
+		}
+		out[parts[0]+"/"+parts[1]] = parts[2]
+	}
+	return out
+}
+
+func TestGrammarSweep_CompilesAndEmitsPostfix(t *testing.T) {
+	rows := loadCorpus(t)
+	if len(rows) == 0 {
+		t.Fatal("corpus is empty")
+	}
+	known := loadKnownFails(t)
+
+	c := NewCompiler()
+	var fails []string
+	var unexpectedPasses []string
+	for _, r := range rows {
+		name := r.rule + "/" + r.label
+		postfix, err := compileRow(c, r)
+		passed := err == nil && (strings.TrimSpace(postfix) != "" || emptyPostfixAllowed[r.label])
+		if _, isKnown := known[name]; isKnown {
+			if passed {
+				unexpectedPasses = append(unexpectedPasses, name)
+			}
+			continue
+		}
+		if err != nil {
+			fails = append(fails, name+" COMPILE_ERR: "+err.Error()+"  dsl="+r.dsl)
+			continue
+		}
+		if strings.TrimSpace(postfix) == "" && !emptyPostfixAllowed[r.label] {
+			fails = append(fails, name+" EMPTY_POSTFIX (silent fall-through?)  dsl="+r.dsl)
+			continue
+		}
+	}
+	if len(unexpectedPasses) > 0 {
+		t.Logf("%d labels passed that are listed in known_fails — remove them from testdata/grammar_known_fails.tsv:", len(unexpectedPasses))
+		for _, p := range unexpectedPasses {
+			t.Logf("  %s", p)
+		}
+		t.Fatalf("known_fails must shrink, not silently pass")
+	}
+	if len(fails) > 0 {
+		t.Logf("%d grammar-sweep failures (of %d labels, with %d known-fails excluded):", len(fails), len(rows), len(known))
+		for _, f := range fails {
+			t.Logf("  %s", f)
+		}
+		t.Fatalf("grammar sweep failed")
+	}
+}
+
+// TestGrammarSweep_CoverageGuard reads EL.g4 and asserts every labeled
+// alternative has at least one corpus row. Adding a new `# label` to the
+// grammar without a corpus entry fails this test.
+func TestGrammarSweep_CoverageGuard(t *testing.T) {
+	grammarLabels := extractGrammarLabels(t)
+	rows := loadCorpus(t)
+	covered := map[string]bool{}
+	for _, r := range rows {
+		covered[r.rule+"/"+r.label] = true
+	}
+	var missing []string
+	for _, gl := range grammarLabels {
+		if !covered[gl] {
+			missing = append(missing, gl)
+		}
+	}
+	if len(missing) > 0 {
+		t.Logf("%d grammar labels missing from corpus:", len(missing))
+		for i, m := range missing {
+			if i >= 40 {
+				t.Logf("  ... and %d more", len(missing)-i)
+				break
+			}
+			t.Logf("  %s", m)
+		}
+		t.Fatalf("grammar coverage gap: %d labels lack corpus entries", len(missing))
+	}
+}
+
+var labelRE = regexp.MustCompile(`#\s*([A-Za-z_][A-Za-z0-9_]*)\s*$`)
+var ruleStartRE = regexp.MustCompile(`^([a-z][A-Za-z0-9_]*)\s*(?:\[[^\]]*\])?\s*:`)
+
+func extractGrammarLabels(t *testing.T) []string {
+	t.Helper()
+	f, err := os.Open("EL.g4")
+	if err != nil {
+		t.Fatalf("open EL.g4: %v", err)
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var labels []string
+	var rule string
+	inBlockComment := false
+	for sc.Scan() {
+		line := sc.Text()
+		// Strip block comments /* */ crudely.
+		if inBlockComment {
+			if idx := strings.Index(line, "*/"); idx >= 0 {
+				line = line[idx+2:]
+				inBlockComment = false
+			} else {
+				continue
+			}
+		}
+		if idx := strings.Index(line, "/*"); idx >= 0 {
+			if end := strings.Index(line[idx:], "*/"); end >= 0 {
+				line = line[:idx] + line[idx+end+2:]
+			} else {
+				line = line[:idx]
+				inBlockComment = true
+			}
+		}
+		// Strip line comments.
+		if idx := strings.Index(line, "//"); idx >= 0 {
+			line = line[:idx]
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if m := ruleStartRE.FindStringSubmatch(trimmed); m != nil {
+			rule = m[1]
+		}
+		if strings.HasPrefix(trimmed, ";") || trimmed == ";" {
+			rule = ""
+		}
+		if m := labelRE.FindStringSubmatch(line); m != nil && rule != "" {
+			labels = append(labels, rule+"/"+m[1])
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan EL.g4: %v", err)
+	}
+	return labels
+}

--- a/pkg/dtrules/compiler/el/testdata/grammar_corpus.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_corpus.tsv
@@ -1,0 +1,560 @@
+rule	label	entry	dsl
+done	emptyAction	raw	action ;
+done	emptyCondition	raw	condition ;
+done	emptyContext	raw	context ;
+done	emptyPolicyStatement	raw	policystatement ;
+done	actionStatement	raw	action set x = 1; ;
+done	conditionExpr	raw	condition true ;
+done	conditionDebugBefore	raw	condition debug "hi" ; true ;
+done	conditionDebugAfter	raw	condition true ; debug "hi" ;
+done	contextStatement	raw	context for all accounts ;
+done	contextDebugBefore	raw	context debug "hi" ; for all accounts ;
+done	policyStrExpr	raw	policystatement "x" ;
+done	policyNExpr	raw	policystatement /tbl ;
+done	policyIExpr	raw	policystatement 1 ;
+done	policyFExpr	raw	policystatement 1.0 ;
+done	policyBExpr	raw	policystatement true ;
+done	policyDExpr	raw	policystatement 2020-01-01 ;
+usingblock	usingBlockEntity	action	account using account { set x = 1; };
+usingblock	usingBlockEntityComma	action	account , using account { set x = 1; };
+usingblock	usingBlockBase	action	{ set x = 1; };
+possessiveRef	possessiveChain	condition	's 's
+possessiveRef	colonChain	condition	: account : 's
+contextForTable	contextDebug	context	debug "hi"
+contextForTable	contextFor	context	for i = 0; i < 3; i++
+contextForTable	contextForallCtl	context	for all accounts
+contextForTable	contextForfirst	context	for first of accounts where true
+contextForTable	contextCtx	context	contextstatement
+contextForTable	contextLocal	context	with local string s
+localvariables	localEntityUndef	context	local entity undefinedIdent
+localvariables	localEntityInit	context	local entity undefinedIdent = account
+localvariables	localEntityDefined	context	local entity account
+localvariables	localLongUndef	context	local int undefinedIdent
+localvariables	localLongInit	context	local int undefinedIdent = 5
+localvariables	localLongDefined	context	local int n
+localvariables	localDoubleUndef	context	local double undefinedIdent
+localvariables	localDoubleInit	context	local double undefinedIdent = 5
+localvariables	localDoubleDefined	context	local double d
+localvariables	localBoolUndef	context	local boolean undefinedIdent
+localvariables	localBoolInit	context	local boolean undefinedIdent = true
+localvariables	localBoolDefined	context	local boolean b
+localvariables	localDateUndef	context	local 2020-01-01 undefinedIdent
+localvariables	localDateInit	context	local 2020-01-01 undefinedIdent = 2020-01-01
+localvariables	localDateDefined	context	local 2020-01-01 dt
+localvariables	localArrayUndef	context	local array undefinedIdent
+localvariables	localArrayInit	context	local array undefinedIdent = accounts
+localvariables	localArrayDefined	context	local array arr
+localvariables	localStringUndef	context	local "hello" undefinedIdent
+localvariables	localStringInit	context	local "hello" undefinedIdent = "x"
+localvariables	localStringDefined	context	local "hello" s
+localvariables	localBigIntUndef	context	local bigint undefinedIdent
+localvariables	localBigIntInit	context	local bigint undefinedIdent = 1
+localvariables	localBigIntDefined	context	local bigint typedBigInt
+localvariables	localBytesUndef	context	local bytes undefinedIdent
+localvariables	localBytesInit	context	local bytes undefinedIdent = 0xab
+localvariables	localBytesDefined	context	local bytes typedBytes
+ifstatement	ifThen	action	if true then { set x = 1; } endif;
+ifstatement	ifThenElse	action	if true then { set x = 1; } else { set x = 1; } endif;
+forallctl	forallSimple	context	for all accounts
+forallctl	forallAllowRemove	context	for all accounts allowing array to be removed
+forallctl	forallInEntity	context	for all accounts in account
+forallctl	forallInEntityAllowRemove	context	for all accounts in account allowing array to be removed
+forallctl	forallInEntityWhere	context	for all accounts in account where true
+forallctl	forallWhere	context	for all accounts where true
+forallctl	forallWhereAllowRemove	context	for all accounts where true allowing array to be removed
+forallblock	forallBlockSimple	condition	accounts { set x = 1; }
+forallblock	forallBlockWhere	condition	accounts where true { set x = 1; }
+foreachblock	foreachSimple	action	account in accounts { set x = 1; };
+foreachblock	foreachWhere	action	account in accounts where true { set x = 1; };
+foreachblock	foreachIts	action	account and its account in accounts { set x = 1; };
+foreachblock	foreachItsWhere	action	account and its account in accounts where true { set x = 1; };
+forfirstctl	forfirstOf	context	for first of accounts where true
+forfirstctl	forfirstOfIts	context	for first of accounts and its account where true
+forfirstctl	forfirstIn	context	for first in accounts where true
+firstblock	firstBlockElse	action	for first of accounts where true then { set x = 1; } else if none are found { set x = 1; } endff;
+firstblock	firstBlockSimple	action	for first of accounts where true then { set x = 1; } endff;
+firstblock	firstBlockItsElse	action	for first of accounts and its account where true then { set x = 1; } else if none are found { set x = 1; } endff;
+block	blockCurly	action	{ set x = 1; };
+block	blockUsing	action	using using account { set x = 1; };
+block	blockGforall	action	{ set x = 1; } for all accounts;
+block	blockForall	action	for all for all accounts { set x = 1; };
+block	blockForeach	action	for each for each acc in accounts { set x = 1; };
+block	blockFirst	action	for first of accounts where true then { set x = 1; } endff;
+block	blockIf	action	if if true then { set x = 1; } endif;
+block	blockStatement	action	statement;
+leftIexpr	leftIexprSimple	condition	n
+leftIexpr	leftIexprColon	condition	colonRef leftIexpr
+leftFexpr	leftFexprSimple	condition	d
+leftFexpr	leftFexprColon	condition	colonRef leftFexpr
+leftBexpr	leftBexprSimple	condition	b
+leftBexpr	leftBexprColon	condition	colonRef leftBexpr
+leftEexpr	leftEexprSimple	condition	account
+leftEexpr	leftEexprColon	condition	colonRef leftEexpr
+leftStrexpr	leftStrexprSimple	condition	s
+leftStrexpr	leftStrexprColon	condition	colonRef leftStrexpr
+leftDexpr	leftDexprSimple	condition	dt
+leftDexpr	leftDexprColon	condition	colonRef leftDexpr
+leftTexpr	leftTexprSimple	condition	tbl
+leftTexpr	leftTexprColon	condition	colonRef leftTexpr
+leftBigexpr	leftBigexprSimple	condition	typedBigInt
+leftBigexpr	leftBigexprColon	condition	colonRef leftBigexpr
+leftArrayRef	leftArraySimple	condition	arr
+leftArrayRef	leftArrayColon	condition	colonRef leftArrayRef
+setstatement	setInt	action	set leftIexpr = 5;
+setstatement	setFloat	action	set leftFexpr = 5;
+setstatement	setBool	action	set leftBexpr = true;
+setstatement	setEntity	action	set leftEexpr = account;
+setstatement	setString	action	set leftStrexpr = "x";
+setstatement	setStringFromNumber	action	set leftStrexpr = 5;
+setstatement	setStringFromDate	action	set leftStrexpr = 2020-01-01;
+setstatement	setStringFromName	action	set leftStrexpr = /tbl;
+setstatement	setStringFromTable	action	set leftStrexpr = texpr;
+setstatement	setBoolFromName	action	set leftBexpr = /tbl;
+setstatement	setDate	action	set leftDexpr = 2020-01-01;
+setstatement	setTable	action	set leftTexpr = texpr;
+setstatement	setArrayEntity	action	set leftArrayRef = account;
+setstatement	setArrayString	action	set leftArrayRef = "x";
+setstatement	setArrayFloat	action	set leftArrayRef = 1.0;
+setstatement	setArrayInt	action	set leftArrayRef = 1;
+setstatement	setArrayDate	action	set leftArrayRef = 2020-01-01;
+setstatement	setArrayArray	action	set leftArrayRef = accounts;
+setstatement	setBigInt	action	set leftBigexpr = 1;
+setstatement	incrementLong	action	increment n;
+setstatement	incrementDouble	action	increment d;
+setstatement	decrementLong	action	decrement n;
+setstatement	decrementDouble	action	decrement d;
+performstatement	performCatchError	action	perform dt and on error add account to context and perform dt;
+performstatement	performDT	action	dt;
+performstatement	performDTExplicit	action	perform dt;
+performstatement	performName	action	perform x;
+errorstatement	errorStmt	condition	error "x"
+warnstatement	warnStmt	condition	warn "x"
+debugstatement	debugStr	context	debug "x"
+debugstatement	debugBool	context	debug true
+debugstatement	debugInt	context	debug 1
+debugstatement	debugFloat	context	debug 1.0
+debugstatement	debugEntity	context	debug account
+debugstatement	debugDate	context	debug 2020-01-01
+debugstatement	debugArray	context	debug accounts
+debugstatement	printStr	context	print "x"
+debugstatement	printBool	context	print true
+debugstatement	printInt	context	print 1
+debugstatement	printFloat	context	print 1.0
+debugstatement	printEntity	context	print account
+debugstatement	printDate	context	print 2020-01-01
+debugstatement	printArray	context	print accounts
+ifcontinue	ifEnd	condition	endif
+ifcontinue	ifElse	condition	else set x = 1; endif
+ifcontinue	ifElseIf	condition	else if if true then { set x = 1; } endif
+addtodest2	addDestArray2	condition	accounts
+addtodest2	addDestLong2	condition	n
+addtodest2	addDestDouble2	condition	d
+addtodest	addDestArray	action	accounts;
+addtodest	addDestLong	action	n;
+addtodest	addDestDouble	action	d;
+addtodest	addDestColon	action	colonRef addtodest2;
+addtodest	addDestPossessiveLong	action	's n;
+addtodest	addDestPossessiveDouble	action	's d;
+subtodest	subDestLong	action	n;
+subtodest	subDestDouble	action	d;
+subtodest	subDestColon	action	colonRef addtodest2;
+subtodest	subDestPossessiveLong	action	's n;
+subtodest	subDestPossessiveDouble	action	's d;
+addtostatement	addArrayNoMember	action	add accounts to accounts if not member s;
+addtostatement	addArrayToArray	action	add accounts to accounts;
+addtostatement	addEntityToDest	action	add account to x;
+addtostatement	addEntityToDestDup	action	add account to x and to x;
+addtostatement	addStrToDest	action	add "x" to x;
+addtostatement	addStrToDestDup	action	add "x" to x and to x;
+addtostatement	addDateToDest	action	add 2020-01-01 to x;
+addtostatement	addDateToDestDup	action	add 2020-01-01 to x and to x;
+addtostatement	addNumToDest	action	add 5 to x;
+addtostatement	addNumToDestDup	action	add 5 to x and to x;
+addtostatement	subtractNum	action	subtract 5 from x;
+addtostatement	addEntityNoDups	action	add account if not member s to accounts;
+addtostatement	addEntityNoDupsDup	action	add account if not member s to accounts and to accounts;
+addtostatement	addStrNoDups	action	add "x" if not member s to accounts;
+addtostatement	addStrNoDupsDup	action	add "x" if not member s to accounts and to accounts;
+contextstatement	addToContextOf	condition	add account to context of this table
+contextstatement	addToContextFor	condition	add account to context for this table
+randomstatements	removeAtIndex	action	remove 1 element from accounts array;
+randomstatements	removeEachWhere	action	remove each account from accounts where true;
+randomstatements	removeName	action	remove /tbl from accounts array;
+randomstatements	removeString	action	remove "x" from accounts array;
+randomstatements	removeEntity	action	remove account from accounts array;
+randomstatements	randomizeArray	action	randomize accounts;
+randomstatements	clearArray	action	clear accounts;
+randomstatements	sortAscending	action	sort accounts in ascending order by /tbl;
+randomstatements	sortDescending	action	sort accounts in descending order by /tbl;
+operatorlist	opListStr	action	"x" , x;
+operatorlist	opListInt	action	1 , x;
+operatorlist	opListFloat	action	1.0 , x;
+operatorlist	opListEntity	action	account , x;
+operatorlist	opListStrSingle	action	"x";
+operatorlist	opListIntSingle	action	1;
+operatorlist	opListFloatSingle	action	1.0;
+operatorlist	opListEntitySingle	action	account;
+xmlvaluestatements	xmlSetAttr	action	typedXmlValue : set attribute "x" = xmlvalues;
+xmlvaluestatements	xmlSetAttrEntity	action	account : set attribute "x" = xmlvalues;
+xmlvaluestatements	xmlAddAttr	action	typedXmlValue : add attribute "x" = xmlvalues;
+xmlvaluestatements	xmlAddAttrEntity	action	account : add attribute "x" = xmlvalues;
+arrayExpr	arrayPolicyStatements	condition	policy statements includes account
+arrayExpr	arrayColonRef	condition	colonRef arr includes account
+arrayExpr	arrayBase	condition	accounts includes account
+arrayExpr2	arrayMap	condition	map accounts through texpr includes account
+arrayExpr2	arrayParen	condition	( accounts ) includes account
+arrayExpr2	arrayTyped	condition	arr includes account
+arrayExpr2	arrayName	condition	( array ) x includes account
+arrayExpr2	arrayCopy	condition	get copy of accounts includes account
+arrayExpr2	arrayCopySimple	condition	copy of accounts includes account
+arrayExpr2	arrayDeepCopy	condition	get deep copy of accounts includes account
+arrayExpr2	arrayDeepCopySimple	condition	deep copy of accounts includes account
+arrayExpr2	arrayLiteral	condition	arrayLit includes account
+arrayExpr2	arrayOfValues	condition	array of values [ x ] includes account
+arrayExpr2	arrayTokenize	condition	tokenize "x" by "x" includes account
+arrayList	arrayListStr	condition	x , "x"
+arrayList	arrayListInt	condition	x , 1
+arrayList	arrayListEntity	condition	x , account
+arrayList	arrayListFloat	condition	x , 1.0
+arrayList	arrayListName	condition	x , /tbl
+arrayList	arrayListArray	condition	x , accounts
+arrayList	arrayListBool	condition	x , true
+arrayList	arrayListBoolSingle	condition	true
+arrayList	arrayListArraySingle	condition	accounts
+arrayList	arrayListNameSingle	condition	/tbl
+arrayList	arrayListFloatSingle	condition	1.0
+arrayList	arrayListEntitySingle	condition	account
+arrayList	arrayListIntSingle	condition	1
+arrayList	arrayListStrSingle	condition	"x"
+eexpr	entityTyped	condition	there is account where true
+eexpr	entityParen	condition	there is ( account ) where true
+eexpr	entityIndex	condition	there is indxExpr where true
+eexpr	entityNewName	condition	there is new /tbl entity where true
+eexpr	entityNewTyped	condition	there is new account entity where true
+eexpr	entityClone	condition	there is clone of account where true
+eexpr	entityColonRef	condition	there is colonRef account where true
+eexpr	entityTableLookup	condition	there is ( entity ) tbl ( tablelist ) where true
+eexpr	entityFirstIn	condition	there is first account in accounts where true where true
+eexpr	entityFirst	condition	there is first account where true where true
+eexpr	entityRelationship	condition	there is "x" of account where true
+datestatement	dateSubYears	action	subtract 5 year s from dt;
+datestatement	dateSubMonths	action	subtract 5 month s from dt;
+datestatement	dateSubDays	action	subtract 5 day s from dt;
+datestatement	dateAddYears	action	add 5 year s to dt;
+datestatement	dateAddMonths	action	add 5 month s to dt;
+datestatement	dateAddDays	action	add 5 day s to dt;
+dexpr	dateParen	condition	( 2020-01-01 ) is equal to 2020-01-01
+dexpr	dateTyped	condition	dt is equal to 2020-01-01
+dexpr	dateFromStrCast	condition	( 2020-01-01 ) "x" is equal to 2020-01-01
+dexpr	dateFromStrFunc	condition	2020-01-01 ( "x" ) is equal to 2020-01-01
+dexpr	dateFromIndex	condition	( 2020-01-01 ) indxExpr is equal to 2020-01-01
+dexpr	dateFromArrayAt	condition	( 2020-01-01 ) arr [ 1 ] is equal to 2020-01-01
+dexpr	dateUsing	condition	using account ( 2020-01-01 ) is equal to 2020-01-01
+dexpr	dateColonRef	condition	colonRef dt is equal to 2020-01-01
+dexpr	dateDays	condition	( 5 day s ) is equal to 2020-01-01
+dexpr	dateAdd	condition	2020-01-01 + 2020-01-01 is equal to 2020-01-01
+dexpr	dateSub	condition	2020-01-01 - 2020-01-01 is equal to 2020-01-01
+dexpr	dateTableLookup	condition	( 2020-01-01 ) tbl ( tablelist ) is equal to 2020-01-01
+dexpr	dateCurrentDate	condition	current date is equal to 2020-01-01
+dexpr	dateExprSubYears	condition	subtract 5 year s from 2020-01-01 is equal to 2020-01-01
+dexpr	dateExprSubMonths	condition	subtract 5 month s from 2020-01-01 is equal to 2020-01-01
+dexpr	dateExprSubDays	condition	subtract 5 day s from 2020-01-01 is equal to 2020-01-01
+dexpr	dateExprAddYears	condition	add 5 year s to 2020-01-01 is equal to 2020-01-01
+dexpr	dateExprAddMonths	condition	add 5 month s to 2020-01-01 is equal to 2020-01-01
+dexpr	dateExprAddDays	condition	add 5 day s to 2020-01-01 is equal to 2020-01-01
+dexpr	dateMinusYears	condition	2020-01-01 - 5 year s is equal to 2020-01-01
+dexpr	dateMinusMonths	condition	2020-01-01 - 5 month s is equal to 2020-01-01
+dexpr	dateMinusDays	condition	2020-01-01 - 5 day s is equal to 2020-01-01
+dexpr	datePlusYears	condition	2020-01-01 + 5 year s is equal to 2020-01-01
+dexpr	datePlusMonths	condition	2020-01-01 + 5 month s is equal to 2020-01-01
+dexpr	datePlusDays	condition	2020-01-01 + 5 day s is equal to 2020-01-01
+dexpr	dateFirstOfYear	condition	first of year s of 2020-01-01 is equal to 2020-01-01
+dexpr	dateFirstOfMonth	condition	first of month s of 2020-01-01 is equal to 2020-01-01
+dexpr	dateEndOfMonth	condition	end of month s of 2020-01-01 is equal to 2020-01-01
+dexpr	dateEarliestAfter	condition	earliest of accounts after 2020-01-01 is equal to 2020-01-01
+nexpr	nameTyped	condition	nm EQ /tbl
+nexpr	nameOf	condition	nameof account EQ /tbl
+nexpr	nameTheName	condition	the name "x" EQ /tbl
+nexpr	nameArrayAt	condition	x arr [ 1 ] EQ /tbl
+nexpr	nameLiteral	condition	x EQ /tbl
+nexpr	nameUsing	condition	using account ( /tbl ) EQ /tbl
+nexpr	nameColonRef	condition	colonRef nm EQ /tbl
+nexpr	nameFromStr	condition	( x ) "x" EQ /tbl
+tablelist	tableListMulti	condition	"x" , tablelist
+tablelist	tableListSingle	condition	"x"
+texpr	tableTyped	condition	tbl
+texpr	tableNew	condition	new "x" table of "x"
+strexpr	strAttrOf	condition	attribute "x" of account is equal to "x"
+strexpr	strMappingKey	condition	mapping key is equal to "x"
+strexpr	strXmlValue	condition	typedXmlValue is equal to "x"
+strexpr	strXmlAttr	condition	typedXmlValue : get attribute "x" is equal to "x"
+strexpr	strSubstring	condition	substring of "x" from 1 to 1 is equal to "x"
+strexpr	strTableInfo	condition	table information is equal to "x"
+strexpr	strValueOfOp	condition	"hello" value of operatorstatements is equal to "x"
+strexpr	strTableLookup	condition	( "hello" ) texpr ( tablelist ) is equal to "x"
+strexpr	strTyped	condition	s is equal to "x"
+strexpr	strColonRef	condition	colonRef "x" is equal to "x"
+strexpr	strLiteral	condition	" " is equal to "x"
+strexpr	strConcat	condition	"x" + "x" is equal to "x"
+strexpr	strValueOfFloat	condition	"hello" value of 1.0 is equal to "x"
+strexpr	strValueOfInt	condition	"hello" value of 1 is equal to "x"
+strexpr	strValueOfDate	condition	"hello" value of 2020-01-01 is equal to "x"
+strexpr	strValueOfBool	condition	"hello" value of boolean true is equal to "x"
+strexpr	strParen	condition	( "x" ) is equal to "x"
+strexpr	strConcatInt	condition	"x" + 1 is equal to "x"
+strexpr	strConcatFloat	condition	"x" + 1.0 is equal to "x"
+strexpr	strConcatName	condition	"x" + /tbl is equal to "x"
+strexpr	strConcatEntity	condition	"x" + account is equal to "x"
+strexpr	strConcatDate	condition	"x" + 2020-01-01 is equal to "x"
+strexpr	strConcatArray	condition	"x" + accounts is equal to "x"
+strexpr	strConcatNull	condition	"x" + typedNull is equal to "x"
+strexpr	strConcatInvalid	condition	"x" + typedInvalid is equal to "x"
+strexpr	strTrim	condition	trim ( "x" ) is equal to "x"
+strexpr	strFromIndex	condition	( "hello" ) indxExpr is equal to "x"
+strexpr	strToLower	condition	change "x" to lower case is equal to "x"
+strexpr	strToUpper	condition	change "x" to upper case is equal to "x"
+strexpr	strTimestamp	condition	get current timestamp is equal to "x"
+strexpr	strUsing	condition	using account ( "x" ) is equal to "x"
+strexpr	strRelationship	condition	relationship between account and account is equal to "x"
+strexpr	strHexOfBytes	condition	0xdeadbeef of 0xab is equal to "x"
+strexpr	strBase58CheckOfBytes	condition	base58check of 0xab version 1 is equal to "x"
+strexpr	strBech32OfBytes	condition	bech32 of 0xab hrp "x" is equal to "x"
+fexpr	floatLiteral	condition	. > 0.0
+fexpr	floatColonRef	condition	colonRef d > 0.0
+fexpr	floatTyped	condition	d > 0.0
+fexpr	floatFromStr	condition	( double ) "x" > 0.0
+fexpr	floatFromInt	condition	( double ) 1 > 0.0
+fexpr	floatTableLookup	condition	( double ) tbl ( tablelist ) > 0.0
+fexpr	floatMulInt	condition	1.0 * 1 > 0.0
+fexpr	intMulFloat	condition	1 * 1.0 > 0.0
+fexpr	floatMulFloat	condition	1.0 * 1.0 > 0.0
+fexpr	floatDivInt	condition	1.0 / 1 > 0.0
+fexpr	intDivFloat	condition	1 / 1.0 > 0.0
+fexpr	floatDivFloat	condition	1.0 / 1.0 > 0.0
+fexpr	floatAddInt	condition	1.0 + 1 > 0.0
+fexpr	floatAddFloat	condition	1.0 + 1.0 > 0.0
+fexpr	intAddFloat	condition	1 + 1.0 > 0.0
+fexpr	floatSubInt	condition	1.0 - 1 > 0.0
+fexpr	intSubFloat	condition	1 - 1.0 > 0.0
+fexpr	floatSubFloat	condition	1.0 - 1.0 > 0.0
+fexpr	floatNegate	condition	- 1.0 > 0.0
+fexpr	floatParen	condition	( 1.0 ) > 0.0
+fexpr	floatFromIndex	condition	( double ) indxExpr > 0.0
+fexpr	floatAddTo	condition	add to d 5 > 0.0
+fexpr	floatSubFrom	condition	subtract from d 5 > 0.0
+fexpr	floatMulBy	condition	multiply d by 5 > 0.0
+fexpr	floatDivBy	condition	/ d by 5 > 0.0
+fexpr	floatAbs	condition	absolute value of 1.0 > 0.0
+fexpr	floatUsing	condition	using account ( 1.0 ) > 0.0
+fexpr	floatValueOfOp	condition	double value of operatorstatements > 0.0
+fexpr	floatRounded	condition	1.0 rounded > 0.0
+fexpr	floatRoundedTo	condition	1.0 rounded to 1 decimal places > 0.0
+fexpr	floatRoundedBoundry	condition	1.0 rounded to 1 decimal places with boundry 1.0 > 0.0
+fexpr	floatSumOf	condition	sum of d in accounts > 0.0
+fexpr	floatMinOfFloat	condition	minimum of 1.0 and 1.0 > 0.0
+fexpr	floatMinOfInt	condition	minimum of 1.0 and 1 > 0.0
+fexpr	floatMinIntOf	condition	minimum of 1 and 1.0 > 0.0
+fexpr	floatMinOfFloatComma	condition	minimum of 1.0 , 1.0 > 0.0
+fexpr	floatMinOfIntComma	condition	minimum of 1.0 , 1 > 0.0
+fexpr	floatMinIntOfComma	condition	minimum of 1 , 1.0 > 0.0
+fexpr	floatMaxOfFloat	condition	maximum of 1.0 and 1.0 > 0.0
+fexpr	floatMaxOfInt	condition	maximum of 1.0 and 1 > 0.0
+fexpr	floatMaxIntOf	condition	maximum of 1 and 1.0 > 0.0
+fexpr	floatMaxOfFloatComma	condition	maximum of 1.0 , 1.0 > 0.0
+fexpr	floatMaxOfIntComma	condition	maximum of 1.0 , 1 > 0.0
+fexpr	floatMaxIntOfComma	condition	maximum of 1 , 1.0 > 0.0
+iexpr	intMul	condition	1 * 1 > 0
+iexpr	intDiv	condition	1 / 1 > 0
+iexpr	intAdd	condition	1 + 1 > 0
+iexpr	intSub	condition	1 - 1 > 0
+iexpr	intLiteral	condition	int_literal > 0
+iexpr	intNegate	condition	- 1 > 0
+iexpr	intParen	condition	( 1 ) > 0
+iexpr	intTyped	condition	n > 0
+iexpr	intDaysInYear	condition	get day s in yearof 2020-01-01 > 0
+iexpr	intDaysInMonth	condition	get day s in month s for 2020-01-01 > 0
+iexpr	intDayOfMonth	condition	get day s of month s for 2020-01-01 > 0
+iexpr	intColonRef	condition	colonRef n > 0
+iexpr	intFromIndex	condition	( int ) indxExpr > 0
+iexpr	intFromStr	condition	( int ) "x" > 0
+iexpr	intFromNumber	condition	( int ) 5 > 0
+iexpr	intTableLookup	condition	( int ) tbl ( tablelist ) > 0
+iexpr	intNumberOf	condition	number of accounts > 0
+iexpr	intNumberOfWhere	condition	number of accounts where true > 0
+iexpr	intLengthArray	condition	length of accounts > 0
+iexpr	intLengthStr	condition	length of "x" > 0
+iexpr	intLengthBytes	condition	length of 0xab > 0
+iexpr	intBytesIndex	condition	0xab [ 1 ] > 0
+iexpr	intIndexOf	condition	index of "x" in "x" > 0
+iexpr	intUsingArray	condition	using accounts 5 > 0
+iexpr	intAddTo	condition	add to n 5 > 0
+iexpr	intSubFrom	condition	subtract from n 5 > 0
+iexpr	intMulBy	condition	multiply n by 5 > 0
+iexpr	intDivBy	condition	/ n by 5 > 0
+iexpr	intAbs	condition	absolute value of 1 > 0
+iexpr	intUsing	condition	using account ( 1 ) > 0
+iexpr	intDaysBetween	condition	day s from 2020-01-01 to 2020-01-01 > 0
+iexpr	intMonthsBetween	condition	month s from 2020-01-01 to 2020-01-01 > 0
+iexpr	intYearsBetween	condition	year s from 2020-01-01 to 2020-01-01 > 0
+iexpr	intYearOf	condition	get yearof 2020-01-01 > 0
+iexpr	intValueOfOp	condition	int value of operatorstatements > 0
+iexpr	intSumOf	condition	sum of 1 in accounts > 0
+iexpr	intMinOf	condition	minimum of 1 and 1 > 0
+iexpr	intMinOfComma	condition	minimum of 1 , 1 > 0
+iexpr	intMaxOf	condition	maximum of 1 and 1 > 0
+iexpr	intMaxOfComma	condition	maximum of 1 , 1 > 0
+bigexpr	bigMul	condition	1 * 1 > 0
+bigexpr	bigDiv	condition	1 / 1 > 0
+bigexpr	bigAdd	condition	1 + 1 > 0
+bigexpr	bigSub	condition	1 - 1 > 0
+bigexpr	bigNegate	condition	- 1 > 0
+bigexpr	bigParen	condition	( 1 ) > 0
+bigexpr	bigTyped	condition	typedBigInt > 0
+bigexpr	bigColonRef	condition	colonRef typedBigInt > 0
+bigexpr	bigFromStr	condition	( bigint ) "x" > 0
+bigexpr	bigFromInt	condition	( bigint ) 1 > 0
+bigexpr	bigFromFloat	condition	( bigint ) 1.0 > 0
+bigexpr	bigUsing	condition	using account ( 1 ) > 0
+bigexpr	bigAbs	condition	absolute value of 1 > 0
+bigexpr	bigFromBytes	condition	bigint of bytes 0xab > 0
+bytesexpr	bytesLiteral	condition	0x bytes== 0xab
+bytesexpr	bytesTyped	condition	typedBytes bytes== 0xab
+bytesexpr	bytesColonRef	condition	colonRef typedBytes bytes== 0xab
+bytesexpr	bytesParen	condition	( 0xab ) bytes== 0xab
+bytesexpr	bytesConcat	condition	0xab + 0xab bytes== 0xab
+bytesexpr	bytesSlice	condition	0xab from 1 to 1 bytes== 0xab
+bytesexpr	bytesSha256	condition	sha256 of 0xab bytes== 0xab
+bytesexpr	bytesKeccak256	condition	keccak256 of 0xab bytes== 0xab
+bytesexpr	bytesRipemd160	condition	ripemd160 of 0xab bytes== 0xab
+bytesexpr	bytesSha3	condition	sha3 of 0xab bytes== 0xab
+bytesexpr	bytesCvHex	condition	bytes of 0xdeadbeef "x" bytes== 0xab
+bytesexpr	bytesCvBase58Check	condition	bytes of base58check "x" bytes== 0xab
+bytesexpr	bytesCvBech32	condition	bytes of bech32 "x" bytes== 0xab
+bytesexpr	bytesCvBigInt	condition	bytes of bigint 1 size 1 bytes== 0xab
+includeSearch	includeNumber	condition	value 5
+includeSearch	includeDate	condition	2020-01-01 2020-01-01
+includeSearch	includeEntity	condition	account
+includeSearch	includeString	condition	"hello" "x"
+blist	blistMulti	condition	"x" , "a"
+blist	blistOr	condition	or "x"
+blistIc	blistIcMulti	condition	"x" , "a"
+blistIc	blistIcOr	condition	or "x"
+bexpr	boolArrayNotInclude	condition	accounts does not include 5
+bexpr	boolArrayDoesInclude	condition	accounts does include 5
+bexpr	boolArrayIncludes	condition	accounts includes 5
+bexpr	boolMatchForall	condition	there is match for all accounts to /tbl in accounts
+bexpr	boolThereIsWhere	condition	there is account where true
+bexpr	boolThereIsInEntityWhere	condition	there is account in account where true
+bexpr	boolThereIsInArrayWhere	condition	there is account in accounts where true
+bexpr	boolThereIsNoWhere	condition	there is no account where true
+bexpr	boolThereIsNoInEntityWhere	condition	there is no account in account where true
+bexpr	boolThereIsNoInArrayWhere	condition	there is no account in accounts where true
+bexpr	boolAllHave	condition	all accounts have true
+bexpr	boolOneOfHasa	condition	one of accounts has a true
+bexpr	boolEntityNotHas	condition	account does not have "x"
+bexpr	boolEntityHasa	condition	account has a "x"
+bexpr	boolEntityHasaWhere	condition	account has a "x" where true
+bexpr	boolEntityIsOf	condition	account is "x" of account
+bexpr	boolWithinPercent	condition	1.0 is with in 5 percent of 1.0
+bexpr	boolPlusOrMinus	condition	1.0 is plus or minus 5 of 1.0
+bexpr	boolNameEq	condition	/tbl == /tbl
+bexpr	boolNameEqStr	condition	/tbl == "x"
+bexpr	boolNameNeq	condition	/tbl != /tbl
+bexpr	boolNameNeqStr	condition	/tbl != "x"
+bexpr	boolIntEq	condition	1 == 1
+bexpr	boolFloatEqInt	condition	1.0 == 1
+bexpr	boolIntEqFloat	condition	1 == 1.0
+bexpr	boolFloatEq	condition	1.0 == 1.0
+bexpr	boolIntNeq	condition	1 != 1
+bexpr	boolFloatNeqInt	condition	1.0 != 1
+bexpr	boolIntNeqFloat	condition	1 != 1.0
+bexpr	boolFloatNeq	condition	1.0 != 1.0
+bexpr	boolIntGt	condition	1 > 1
+bexpr	boolFloatGtInt	condition	1.0 > 1
+bexpr	boolIntGtFloat	condition	1 > 1.0
+bexpr	boolFloatGt	condition	1.0 > 1.0
+bexpr	boolIntGte	condition	1 >= 1
+bexpr	boolFloatGteInt	condition	1.0 >= 1
+bexpr	boolIntGteFloat	condition	1 >= 1.0
+bexpr	boolFloatGte	condition	1.0 >= 1.0
+bexpr	boolIntLt	condition	1 < 1
+bexpr	boolFloatLtInt	condition	1.0 < 1
+bexpr	boolIntLtFloat	condition	1 < 1.0
+bexpr	boolFloatLt	condition	1.0 < 1.0
+bexpr	boolIntLte	condition	1 <= 1
+bexpr	boolFloatLteInt	condition	1.0 <= 1
+bexpr	boolIntLteFloat	condition	1 <= 1.0
+bexpr	boolFloatLte	condition	1.0 <= 1.0
+bexpr	boolBigEq	condition	1 == 1
+bexpr	boolBigNeq	condition	1 != 1
+bexpr	boolBigGt	condition	1 > 1
+bexpr	boolBigGte	condition	1 >= 1
+bexpr	boolBigLt	condition	1 < 1
+bexpr	boolBigLte	condition	1 <= 1
+bexpr	boolBytesEq	condition	0xab == 0xab
+bexpr	boolBytesNeq	condition	0xab != 0xab
+bexpr	boolTyped	condition	b
+bexpr	boolColonRef	condition	colonRef b
+bexpr	boolLiteral	condition	true
+bexpr	boolStrEqIcList	condition	"x" is equal to ignore case "a"
+bexpr	boolStrEqList	condition	"x" == "a"
+bexpr	boolStrEq	condition	"x" == "x"
+bexpr	boolStrNeq	condition	"x" != "x"
+bexpr	boolStrIs	condition	"x" is "x"
+bexpr	boolStrIsNot	condition	"x" is not "x"
+bexpr	boolStrEqIc	condition	"x" is equal to ignore case "x"
+bexpr	boolStrNeqIc	condition	"x" is not equal to ignore case "x"
+bexpr	boolStartsWithAt	condition	"x" at 1 starts with "x"
+bexpr	boolStartsWith	condition	"x" starts with "x"
+bexpr	boolStrIsOneOf	condition	"x" is one of accounts
+bexpr	boolStrIsNotOneOf	condition	"x" is not one of accounts
+bexpr	boolDoesQuestion	condition	does true ?
+bexpr	boolIsQuestion	condition	is true ?
+bexpr	boolWasQuestion	condition	was true ?
+bexpr	boolStrGt	condition	"x" > "x"
+bexpr	boolStrLt	condition	"x" < "x"
+bexpr	boolStrGte	condition	"x" >= "x"
+bexpr	boolStrLte	condition	"x" <= "x"
+bexpr	boolMatches	condition	"x" matches "x"
+bexpr	boolTypedIsLiteral	condition	b is true
+bexpr	boolTypedIsNotLiteral	condition	b is not true
+bexpr	boolColonIsLiteral	condition	colonRef b is true
+bexpr	boolColonIsNotLiteral	condition	colonRef b is not true
+bexpr	boolBoolEq	condition	true == true
+bexpr	boolBoolNeq	condition	true != true
+bexpr	boolAnd	condition	true and true
+bexpr	boolOr	condition	true or true
+bexpr	boolNot	condition	not true
+bexpr	boolBexprIsNull	condition	true is null
+bexpr	boolBexprIsNotNull	condition	true is not null
+bexpr	boolNumIsNull	condition	5 is null
+bexpr	boolNumIsNotNull	condition	5 is not null
+bexpr	boolDateIsNull	condition	2020-01-01 is null
+bexpr	boolArrayIsNull	condition	accounts is null
+bexpr	boolStrIsNull	condition	"x" is null
+bexpr	boolEntityIsNull	condition	account is null
+bexpr	boolDateIsNotNull	condition	2020-01-01 is not null
+bexpr	boolArrayIsNotNull	condition	accounts is not null
+bexpr	boolStrIsNotNull	condition	"x" is not null
+bexpr	boolEntityIsNotNull	condition	account is not null
+bexpr	boolUsing	condition	using account ( true )
+bexpr	boolParen	condition	( true )
+bexpr	boolFromIndex	condition	( boolean ) indxExpr
+bexpr	boolFromStr	condition	( boolean ) "x"
+bexpr	boolArrayAt	condition	boolean arr [ 1 ]
+bexpr	boolDateEq	condition	2020-01-01 == 2020-01-01
+bexpr	boolDateLt	condition	2020-01-01 < 2020-01-01
+bexpr	boolDateBefore	condition	2020-01-01 is before 2020-01-01
+bexpr	boolDateGt	condition	2020-01-01 > 2020-01-01
+bexpr	boolDateAfter	condition	2020-01-01 is after 2020-01-01
+bexpr	boolDateGte	condition	2020-01-01 >= 2020-01-01
+bexpr	boolDateLte	condition	2020-01-01 <= 2020-01-01
+bexpr	boolDateBetween	condition	2020-01-01 is between 2020-01-01 and 2020-01-01
+bexpr	boolEntityEq	condition	account == account
+bexpr	boolEntityNeq	condition	account != account
+bexpr	boolEntityNotInContext	condition	account entity is not in context
+bexpr	boolEntityInContext	condition	account entity is in context
+bexpr	boolStrEntityInContext	condition	"x" entity is in context
+bexpr	boolStrEntityNotInContext	condition	"x" entity is not in context
+bexpr	boolValueOfOp	condition	boolean value of operatorstatements
+bexpr	boolFunction	condition	typedBoolFunction

--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -1,0 +1,267 @@
+rule	label	reason
+addtodest	addDestColon	helper rule; no top-level compile path (tested via parent addtostatement)
+addtodest	addDestPossessiveDouble	helper rule; possessive form requires parent context
+addtodest	addDestPossessiveLong	helper rule; possessive form requires parent context
+addtostatement	addArrayNoMember	DSL sample needs refinement — 'if not member' operand shape
+addtostatement	addDateToDestDup	real emit fall-through — VisitAddDateToDestDup missing
+addtostatement	addEntityNoDups	DSL sample needs refinement
+addtostatement	addEntityNoDupsDup	DSL sample needs refinement
+addtostatement	addEntityToDestDup	real emit fall-through — VisitAddEntityToDestDup missing
+addtostatement	addNumToDestDup	real emit fall-through — VisitAddNumToDestDup missing
+addtostatement	addStrNoDups	DSL sample needs refinement
+addtostatement	addStrNoDupsDup	DSL sample needs refinement
+addtostatement	addStrToDestDup	real emit fall-through — VisitAddStrToDestDup missing
+addtostatement	subtractNum	real emit fall-through — VisitSubtractNum missing
+arrayExpr2	arrayName	DSL sample needs refinement — (array) typecast shape
+arrayList	arrayListFloatSingle	helper rule; only valid inside an array list context
+arrayList	arrayListIntSingle	helper rule; only valid inside an array list context
+arrayList	arrayListNameSingle	helper rule; only valid inside an array list context
+arrayList	arrayListStrSingle	helper rule; only valid inside an array list context
+bexpr	boolAllHave	real emit fall-through — VisitBoolAllHave missing
+bexpr	boolArrayAt	real emit fall-through — VisitBoolArrayAt missing
+bexpr	boolArrayDoesInclude	DSL sample needs refinement — includes <includeSearch>
+bexpr	boolArrayIncludes	DSL sample needs refinement — includes <includeSearch>
+bexpr	boolArrayNotInclude	DSL sample needs refinement — does not include <includeSearch>
+bexpr	boolDateAfter	DSL sample needs refinement — date literal vs dexpr
+bexpr	boolDateBefore	DSL sample needs refinement — date literal vs dexpr
+bexpr	boolDateBetween	DSL sample needs refinement — date literal vs dexpr
+bexpr	boolDoesQuestion	real emit fall-through — VisitBoolDoesQuestion missing
+bexpr	boolEntityHasaWhere	real emit fall-through — VisitBoolEntityHasaWhere missing
+bexpr	boolEntityInContext	real emit fall-through — VisitBoolEntityInContext missing
+bexpr	boolEntityNotInContext	real emit fall-through — VisitBoolEntityNotInContext missing
+bexpr	boolFromIndex	real emit fall-through — VisitBoolFromIndex missing
+bexpr	boolFromStr	real emit fall-through — VisitBoolFromStr missing
+bexpr	boolIsQuestion	real emit fall-through — VisitBoolIsQuestion missing
+bexpr	boolMatchForall	DSL sample needs refinement
+bexpr	boolMatches	real emit fall-through — VisitBoolMatches missing
+bexpr	boolNameEq	DSL sample needs refinement — /literal-name vs nexpr shape
+bexpr	boolNameEqStr	DSL sample needs refinement
+bexpr	boolNameNeq	DSL sample needs refinement
+bexpr	boolNameNeqStr	DSL sample needs refinement
+bexpr	boolOneOfHasa	real emit fall-through — VisitBoolOneOfHasa missing
+bexpr	boolPlusOrMinus	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolStartsWith	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolStartsWithAt	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolStrEntityInContext	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolStrEntityNotInContext	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolStrGt	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolStrGte	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolStrIsNotOneOf	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolStrIsOneOf	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolStrLt	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolStrLte	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolThereIsInArrayWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolThereIsInEntityWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolThereIsNoInArrayWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolThereIsNoInEntityWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolThereIsNoWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolThereIsWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolUsing	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolValueOfOp	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolWasQuestion	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bexpr	boolWithinPercent	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bigexpr	bigFromBytes	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bigexpr	bigFromFloat	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bigexpr	bigFromInt	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bigexpr	bigFromStr	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+blist	blistMulti	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+blist	blistOr	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+blistIc	blistIcMulti	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+blistIc	blistIcOr	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+block	blockFirst	real emit fall-through — Visit method missing or under-implemented; followup
+block	blockForall	real emit fall-through — Visit method missing or under-implemented; followup
+block	blockForeach	real emit fall-through — Visit method missing or under-implemented; followup
+block	blockGforall	real emit fall-through — Visit method missing or under-implemented; followup
+block	blockUsing	real emit fall-through — Visit method missing or under-implemented; followup
+bytesexpr	bytesConcat	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bytesexpr	bytesCvBase58Check	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bytesexpr	bytesCvBech32	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bytesexpr	bytesCvBigInt	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bytesexpr	bytesCvHex	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bytesexpr	bytesKeccak256	DSL sample needs refinement OR real emit fall-through — triage in follow-up
+bytesexpr	bytesLiteral	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+bytesexpr	bytesParen	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+bytesexpr	bytesRipemd160	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+bytesexpr	bytesSha256	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+bytesexpr	bytesSha3	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+bytesexpr	bytesSlice	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+contextForTable	contextCtx	real emit fall-through — Visit method missing or under-implemented; followup
+contextForTable	contextDebug	real emit fall-through — Visit method missing or under-implemented; followup
+contextForTable	contextFor	real emit fall-through — Visit method missing or under-implemented; followup
+contextForTable	contextForfirst	real emit fall-through — Visit method missing or under-implemented; followup
+contextForTable	contextLocal	real emit fall-through — Visit method missing or under-implemented; followup
+contextstatement	addToContextFor	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+contextstatement	addToContextOf	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+datestatement	dateAddDays	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+datestatement	dateAddMonths	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+datestatement	dateAddYears	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+datestatement	dateSubDays	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+datestatement	dateSubMonths	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+datestatement	dateSubYears	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+debugstatement	debugArray	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+debugstatement	debugBool	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+debugstatement	debugDate	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+debugstatement	debugEntity	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+debugstatement	debugFloat	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+debugstatement	debugInt	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+debugstatement	debugStr	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+debugstatement	printArray	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+debugstatement	printBool	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+debugstatement	printDate	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+debugstatement	printEntity	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+debugstatement	printFloat	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+debugstatement	printInt	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+debugstatement	printStr	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateCurrentDate	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateDays	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateEarliestAfter	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateEndOfMonth	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateExprAddDays	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateExprAddMonths	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateExprAddYears	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateExprSubDays	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateExprSubMonths	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateExprSubYears	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateFirstOfMonth	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateFirstOfYear	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateFromArrayAt	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateFromIndex	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateFromStrCast	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateFromStrFunc	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateMinusDays	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateMinusMonths	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateMinusYears	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	datePlusDays	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	datePlusMonths	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	datePlusYears	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+dexpr	dateTableLookup	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+done	conditionDebugAfter	real emit fall-through — Visit method missing or under-implemented; followup
+done	conditionDebugBefore	real emit fall-through — Visit method missing or under-implemented; followup
+done	contextDebugBefore	real emit fall-through — Visit method missing or under-implemented; followup
+done	policyBExpr	real emit fall-through — Visit method missing or under-implemented; followup
+done	policyDExpr	real emit fall-through — Visit method missing or under-implemented; followup
+done	policyFExpr	real emit fall-through — Visit method missing or under-implemented; followup
+done	policyIExpr	real emit fall-through — Visit method missing or under-implemented; followup
+done	policyNExpr	real emit fall-through — Visit method missing or under-implemented; followup
+done	policyStrExpr	real emit fall-through — Visit method missing or under-implemented; followup
+eexpr	entityClone	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+eexpr	entityColonRef	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+eexpr	entityFirst	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+eexpr	entityFirstIn	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+eexpr	entityIndex	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+eexpr	entityNewName	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+eexpr	entityNewTyped	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+eexpr	entityParen	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+eexpr	entityRelationship	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+eexpr	entityTableLookup	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+eexpr	entityTyped	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+errorstatement	errorStmt	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+fexpr	floatLiteral	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+fexpr	floatValueOfOp	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+firstblock	firstBlockElse	real emit fall-through — Visit method missing or under-implemented; followup
+firstblock	firstBlockItsElse	real emit fall-through — Visit method missing or under-implemented; followup
+firstblock	firstBlockSimple	real emit fall-through — Visit method missing or under-implemented; followup
+foreachblock	foreachIts	real emit fall-through — Visit method missing or under-implemented; followup
+foreachblock	foreachItsWhere	real emit fall-through — Visit method missing or under-implemented; followup
+foreachblock	foreachSimple	real emit fall-through — Visit method missing or under-implemented; followup
+foreachblock	foreachWhere	real emit fall-through — Visit method missing or under-implemented; followup
+forfirstctl	forfirstIn	real emit fall-through — Visit method missing or under-implemented; followup
+forfirstctl	forfirstOf	real emit fall-through — Visit method missing or under-implemented; followup
+forfirstctl	forfirstOfIts	real emit fall-through — Visit method missing or under-implemented; followup
+iexpr	intDayOfMonth	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+iexpr	intDaysBetween	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+iexpr	intDaysInMonth	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+iexpr	intDaysInYear	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+iexpr	intMonthsBetween	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+iexpr	intValueOfOp	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+iexpr	intYearOf	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+iexpr	intYearsBetween	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+ifcontinue	ifElse	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+ifcontinue	ifElseIf	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+ifcontinue	ifEnd	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+includeSearch	includeDate	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+includeSearch	includeNumber	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+includeSearch	includeString	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+localvariables	localArrayDefined	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localArrayInit	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localArrayUndef	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localBigIntDefined	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localBigIntInit	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localBigIntUndef	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localBoolDefined	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localBoolInit	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localBoolUndef	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localBytesDefined	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localBytesInit	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localBytesUndef	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localDateDefined	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localDateInit	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localDateUndef	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localDoubleDefined	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localDoubleInit	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localDoubleUndef	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localEntityDefined	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localEntityInit	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localEntityUndef	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localLongDefined	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localLongInit	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localLongUndef	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localNameDefined	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localNameInit	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localNameUndef	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localStringDefined	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localStringInit	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localStringUndef	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localTableDefined	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localTableInit	real emit fall-through — Visit method missing or under-implemented; followup
+localvariables	localTableUndef	real emit fall-through — Visit method missing or under-implemented; followup
+nexpr	nameOf	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+nexpr	nameTheName	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+nexpr	nameUsing	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+operatorlist	opListFloat	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+operatorlist	opListFloatSingle	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+operatorlist	opListInt	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+operatorlist	opListIntSingle	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+operatorlist	opListStr	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+operatorlist	opListStrSingle	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+performstatement	performCatchError	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+possessiveRef	colonChain	real emit fall-through — Visit method missing or under-implemented; followup
+possessiveRef	possessiveChain	real emit fall-through — Visit method missing or under-implemented; followup
+randomstatements	clearArray	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+randomstatements	randomizeArray	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+randomstatements	removeAtIndex	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+randomstatements	removeEachWhere	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+randomstatements	removeEntity	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+randomstatements	removeName	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+randomstatements	removeString	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+randomstatements	sortAscending	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+randomstatements	sortDescending	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+setstatement	decrementDouble	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+setstatement	decrementLong	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+setstatement	incrementDouble	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+setstatement	incrementLong	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+setstatement	setBoolFromName	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+setstatement	setStringFromName	real emit fall-through — Visit method missing or under-implemented; followup
+strexpr	strConcatName	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+strexpr	strFromIndex	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+strexpr	strHexOfBytes	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+strexpr	strTableLookup	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+strexpr	strValueOfBool	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+strexpr	strValueOfDate	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+strexpr	strValueOfFloat	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+strexpr	strValueOfInt	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+strexpr	strValueOfOp	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+subtodest	subDestColon	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+subtodest	subDestPossessiveDouble	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+subtodest	subDestPossessiveLong	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+tablelist	tableListMulti	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+tablelist	tableListSingle	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+texpr	tableNew	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+usingblock	usingBlockBase	real emit fall-through — Visit method missing or under-implemented; followup
+usingblock	usingBlockEntity	real emit fall-through — Visit method missing or under-implemented; followup
+usingblock	usingBlockEntityComma	real emit fall-through — Visit method missing or under-implemented; followup
+warnstatement	warnStmt	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+xmlvaluestatements	xmlAddAttr	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+xmlvaluestatements	xmlAddAttrEntity	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+xmlvaluestatements	xmlSetAttr	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+xmlvaluestatements	xmlSetAttrEntity	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -1,0 +1,72 @@
+rule	label	entry	dsl	note
+block	blockCurly	action	{ set x = 1; }
+block	blockUsing	action	using account { set x = 1; }
+block	blockGforall	action	{ set x = 1; } for all accounts	gforall: body block, then forall
+block	blockForall	action	for all accounts { set x = 1; }
+block	blockForeach	action	for each acc in accounts { set x = 1; }
+block	blockFirst	action	for first of accounts where true then { set x = 1; } endff
+block	blockIf	action	if true then { set x = 1; } endif
+foreachblock	foreachSimple	action	for each acc in accounts { set x = 1; }
+foreachblock	foreachWhere	action	for each acc in accounts where true { set x = 1; }
+foreachblock	foreachIts	action	for each acc and its other in accounts { set x = 1; }
+foreachblock	foreachItsWhere	action	for each acc and its other in accounts where true { set x = 1; }
+firstblock	firstBlockSimple	action	for first of accounts where true then { set x = 1; } endff
+firstblock	firstBlockElse	action	for first of accounts where true then { set x = 1; } else if none are found { set x = 1; } endff
+firstblock	firstBlockItsElse	action	for first of accounts and its other where true then { set x = 1; } else if none are found { set x = 1; } endff
+forfirstctl	forfirstOf	context	for first of accounts where true
+forfirstctl	forfirstOfIts	context	for first of accounts and its other where true
+forfirstctl	forfirstIn	context	for first in accounts where true
+contextForTable	contextDebug	context	debug "hi"
+contextForTable	contextFor	context	for i = 0; i < 3; increment i
+contextForTable	contextForallCtl	context	for all accounts
+contextForTable	contextForfirst	context	for first of accounts where true
+contextForTable	contextLocal	context	with local string s
+contextForTable	contextCtx	context	ctx account
+usingblock	usingBlockEntity	action	using account { set x = 1; }
+usingblock	usingBlockEntityComma	action	using account, account { set x = 1; }
+usingblock	usingBlockBase	action	using account { set x = 1; }
+localvariables	localEntityUndef	context	with local entity e
+localvariables	localEntityInit	context	with local entity e = account
+localvariables	localEntityDefined	context	with local entity account
+localvariables	localLongUndef	context	with local int n
+localvariables	localLongInit	context	with local int n = 5
+localvariables	localLongDefined	context	with local int n
+localvariables	localDoubleUndef	context	with local double d
+localvariables	localDoubleInit	context	with local double d = 5.0
+localvariables	localDoubleDefined	context	with local double d
+localvariables	localBoolUndef	context	with local boolean b
+localvariables	localBoolInit	context	with local boolean b = true
+localvariables	localBoolDefined	context	with local boolean b
+localvariables	localDateUndef	context	with local date dt
+localvariables	localDateInit	context	with local date dt = 2020-01-01
+localvariables	localDateDefined	context	with local date dt
+localvariables	localArrayUndef	context	with local array arr
+localvariables	localArrayInit	context	with local array arr = accounts
+localvariables	localArrayDefined	context	with local array arr
+localvariables	localStringUndef	context	with local string s
+localvariables	localStringInit	context	with local string s = "x"
+localvariables	localStringDefined	context	with local string s
+localvariables	localBigIntUndef	context	with local bigint bi
+localvariables	localBigIntInit	context	with local bigint bi = the bigint of 1
+localvariables	localBigIntDefined	context	with local bigint bi
+localvariables	localBytesUndef	context	with local bytes bs
+localvariables	localBytesInit	context	with local bytes bs = 0xab
+localvariables	localBytesDefined	context	with local bytes bs
+localvariables	localNameUndef	context	with local name nm
+localvariables	localNameInit	context	with local name nm = /tbl
+localvariables	localNameDefined	context	with local name nm
+localvariables	localTableUndef	context	with local table tbl
+localvariables	localTableInit	context	with local table tbl = accounts
+localvariables	localTableDefined	context	with local table tbl
+setstatement	setStringFromName	action	set s = /tbl
+done	policyStrExpr	raw	policystatement "x";
+done	policyNExpr	raw	policystatement /tbl;
+done	policyIExpr	raw	policystatement 1;
+done	policyFExpr	raw	policystatement 1.0;
+done	policyBExpr	raw	policystatement true;
+done	policyDExpr	raw	policystatement 2020-01-01;
+done	conditionDebugBefore	raw	condition debug "hi"; true;
+done	conditionDebugAfter	raw	condition true; debug "hi";
+done	contextDebugBefore	raw	context debug "hi"; for all accounts;
+possessiveRef	possessiveChain	condition	account's name EQ /tbl	tested via nexpr in a condition
+possessiveRef	colonChain	condition	account:name EQ /tbl

--- a/tools/gen_el_corpus.py
+++ b/tools/gen_el_corpus.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Generate candidate DSL snippets for every labeled alternative in EL.g4.
+
+Output: a TSV with columns (rule, label, kind, dsl).
+Reads EL.g4, extracts labels, builds sample DSL per label using a keyword
+map from lexer rules and a sample-token map for non-terminals.
+
+kind is the compiler entry point: condition | action | context | raw.
+"""
+import re
+import sys
+import os.path
+
+G = '/home/paul/go/src/github.com/DTRules/DTRules/pkg/dtrules/compiler/el/EL.g4'
+
+with open(G) as f:
+    src = f.read()
+# Strip line + block comments
+src = re.sub(r'/\*.*?\*/', '', src, flags=re.DOTALL)
+src = re.sub(r'//[^\n]*', '', src)
+
+# --- Keyword terminals (UPPER_NAME : 'string' ;) ---
+# Some have WS* between parts; we'll read multi-part forms and collapse WS.
+kw = {}
+for m in re.finditer(r'^([A-Z][A-Z0-9_]*)\s*:\s*(.*?);', src, flags=re.MULTILINE | re.DOTALL):
+    name = m.group(1)
+    body = m.group(2).strip()
+    # Token body may be an alternation ('a' | 'b' | 'c'). Pick the FIRST arm only.
+    # Within one arm, multiple consecutive literals ('for' WS* 'all') join with a space.
+    first_arm = re.split(r'(?<![\\])\|', body)[0]
+    literals = re.findall(r"'([^']*)'", first_arm)
+    if literals:
+        joined = ' '.join(l for l in literals if l.strip())
+        if joined:
+            kw[name] = joined
+
+# Common overrides that want specific forms (a few tokens have fragment bits)
+kw.update({
+    'SEMI': ';',
+    'COMMA': ',',
+    'DOT': '.',
+    'COLON': ':',
+    'LCURLY': '{',
+    'RCURLY': '}',
+    'LPAREN': '(',
+    'RPAREN': ')',
+    'LBRACKET': '[',
+    'RBRACKET': ']',
+    'PLUS': '+',
+    'MINUS': '-',
+    'STAR': '*',
+    'SLASH': '/',
+    'PERCENT': '%',
+    'EQUALS': '=',
+    'LESSTHAN': '<',
+    'GREATERTHAN': '>',
+    'QUESTION': '?',
+    'POSSESSIVE': "'s",
+    'WS': '',  # whitespace token is implicit
+    'ID': 'x',
+    'NAME': 'x',
+    'INT': '1',
+    'FLOAT': '1.0',
+    'STRING': '"hello"',
+    'DATE': '2020-01-01',
+    'BYTES_LITERAL': '0xdeadbeef',
+    'HEX': '0xdeadbeef',
+    'QUOTED_STR': '"hello"',
+})
+
+# --- Non-terminal sample tokens (reasonable defaults for each rule) ---
+NT = {
+    'arrayExpr':        'accounts',
+    'arrayExpr2':       'accounts',
+    'iexpr':            '1',
+    'fexpr':            '1.0',
+    'strexpr':          '"x"',
+    'bexpr':            'true',
+    'eexpr':            'account',
+    'nexpr':            '/tbl',
+    'dexpr':            '2020-01-01',
+    'bigexpr':          '1',
+    'bytesexpr':        '0xab',
+    'includeSearch':    '5',
+    'number':           '5',
+    'typedEntity':      'account',
+    'typedLong':        'n',
+    'typedDouble':      'd',
+    'typedString':      's',
+    'typedBoolean':     'b',
+    'typedDate':        'dt',
+    'typedArray':       'arr',
+    'typedTable':       'tbl',
+    'typedName':        'nm',
+    'typedDecisionTable': 'dt',
+    'forallblock':      'for all accounts { set x = 1; }',
+    'foreachblock':     'for each acc in accounts { set x = 1; }',
+    'ifblock':          'if true then { set x = 1; } endif',
+    'firstblock':       'for first of accounts where true then { set x = 1; } endff',
+    'arrayList':        'x',
+    'operatorlist':     'x',
+    'localvariables':   'with local string s;',
+    'debugstatement':   'debug "hi"',
+    'forallctl':        'for all accounts',
+    'forctl':           'for i = 0; i < 3; i++',
+    'forfirstctl':      'for first of accounts where true',
+    'foreachblock':     'for each acc in accounts { set x = 1; }',
+    'contextForTable':  'for all accounts',
+    'done':             'condition true',
+    'block':            '{ set x = 1; }',
+    'statementList':    'set x = 1;',
+    'usingblock':       'using account { set x = 1; }',
+    'setstatement':     'set x = 1',
+    'addtostatement':   'add 1 to x',
+    'subtostatement':   'subtract 1 from x',
+    'performstatement': 'perform X',
+    'datestatement':    'add 1 day to d',
+    'randomstatements': 'randomize arr',
+    'xmlvaluestatements': 'set attribute "a" = "b" of account',
+    'addtodest':        'x',
+    'subtodest':        'x',
+    'optSemi':          ';',
+    'possessiveRef':    "'s",
+    'possessiveChain':  "'s",
+    'attrList':         'x',
+    'attrListAction':   'x',
+    'literal':          '1',
+    'mapping':          'mapping "key" as s',
+    # Helper rules (simple lowercase, not labeled)
+    'thereis':          'there is',
+    'inthe':            'in',
+    'blist':            '"a"',
+    'blistIc':          '"a"',
+    'aslong':           '',
+    'beforeAssign':     '',
+    'sesubstr':         '',
+    'paramarr':         '',
+    'paramsize':        '',
+}
+
+label_re = re.compile(r'#\s*([A-Za-z_][A-Za-z0-9_]*)\s*$')
+rule_re = re.compile(r'(?ms)^([a-z][A-Za-z0-9_]*)\s*(?:\[[^\]]*\])?\s*:\s*(.*?);', re.MULTILINE)
+
+def substitute(alt_body: str) -> str:
+    """Convert grammar alternative body to candidate DSL."""
+    # Token stream with literals intact
+    out = []
+    # Split keeping quoted strings intact
+    i = 0
+    toks = []
+    while i < len(alt_body):
+        c = alt_body[i]
+        if c.isspace():
+            i += 1
+            continue
+        if c == "'":
+            j = alt_body.find("'", i+1)
+            if j < 0: j = len(alt_body)
+            toks.append(alt_body[i:j+1])
+            i = j+1
+            continue
+        # Identifier (UPPER or lower)
+        if c.isalpha() or c == '_':
+            j = i
+            while j < len(alt_body) and (alt_body[j].isalnum() or alt_body[j] == '_'):
+                j += 1
+            toks.append(alt_body[i:j])
+            i = j
+            continue
+        # Syntax chars: | ( ) * + ? { } [ ]  — skip optionality/grouping markers
+        toks.append(c)
+        i += 1
+
+    # Simplify: drop ANTLR metachars and consume optional/grouped constructs
+    # We'll do a naive pass: '(' begins a group, ')' ends; '?' / '*' / '+' on the preceding item.
+    # For a sample DSL we include OPTIONAL content (so ? means "include it once").
+    # Groups are flattened.
+    parts = []
+    for t in toks:
+        if t in ('(', ')', '?', '*', '+', '|', '~', '='):
+            continue
+        if t.startswith("'"):
+            parts.append(t[1:-1])
+        elif re.fullmatch(r'[A-Z][A-Z0-9_]*', t):
+            parts.append(kw.get(t, t.lower()))
+        elif re.fullmatch(r'[a-z][A-Za-z0-9_]*', t):
+            parts.append(NT.get(t, t))
+        else:
+            parts.append(t)
+    # Collapse whitespace
+    return re.sub(r'\s+', ' ', ' '.join(p for p in parts if p)).strip()
+
+# Classify entry point per rule by BFS from the three entry points in `done`.
+# done's ACTION branches → kind=action; CONDITION → condition; CONTEXT → context.
+# This is a rough classifier; refine by examining `done` body.
+def classify_done_alts():
+    m = re.search(r'(?ms)^done\s*:\s*(.*?);', src)
+    body = m.group(1)
+    kinds = {}   # label -> kind
+    reachable = {'action': set(), 'condition': set(), 'context': set(), 'policy': set()}
+    for alt in re.split(r'\n\s*\|', body):
+        lab = re.search(r'#\s*(\w+)\s*$', alt.rstrip())
+        if not lab: continue
+        label = lab.group(1)
+        txt = alt[:lab.start()]
+        if 'ACTION' in txt:
+            kinds[label] = 'action'
+        elif 'CONDITION' in txt:
+            kinds[label] = 'condition'
+        elif 'CONTEXT' in txt:
+            kinds[label] = 'context'
+        elif 'POLICYSTATEMENT' in txt:
+            kinds[label] = 'policy'
+    return kinds
+
+# Build ancestry: which top-level category reaches each rule. Start from entry children.
+# Heuristic shortcut: examine rule body to decide. Simpler: classify by rule name.
+def classify_rule(rule: str) -> str:
+    # Context-reachable rules: forallctl etc. are wrapped in a `context` prefix.
+    context_rules = {
+        'forallctl', 'forctl', 'forfirstctl', 'contextForTable',
+        'localvariables', 'debugstatement',
+    }
+    if rule in context_rules:
+        return 'context'
+    action_rules = {
+        'setstatement', 'addtostatement', 'subtostatement', 'performstatement',
+        'datestatement', 'randomstatements',
+        'xmlvaluestatements', 'addtodest', 'subtodest', 'block', 'statementList',
+        'foreachblock', 'foreachctl', 'forblock', 'firstblock',
+        'usingblock', 'ifblock', 'ifstatement',
+        'statement', 'operatorlist',
+        'xmlvalues', 'xmlvalue', 'done_action',
+    }
+    if rule in action_rules:
+        return 'action'
+    if rule == 'done':
+        return 'done'
+    # Expressions default to condition-embedded tests
+    return 'condition'
+
+def wrap_for(kind: str, dsl: str, rule: str, label: str) -> (str, str):
+    """Return (entry_kind, dsl_to_compile). entry_kind is one of
+    condition/action/context/raw."""
+    if rule == 'done':
+        return 'raw', dsl  # full done alt
+    if kind == 'context':
+        # CompileContext auto-prepends "context ".
+        # For localvariables, drop trailing ';' because CompileContext doesn't want it.
+        d = dsl.rstrip(';').strip()
+        return 'context', d
+    if kind == 'action':
+        # Many action rules produce statements — wrap in action context.
+        if not dsl.endswith(';'):
+            dsl = dsl + ';'
+        return 'action', dsl
+    if kind == 'condition':
+        # If rule IS bexpr, embed directly. Else wrap in a boolean predicate.
+        if rule == 'bexpr':
+            return 'condition', dsl
+        # For iexpr: compare to 0
+        if rule in ('iexpr', 'bigexpr'):
+            return 'condition', f'{dsl} > 0'
+        if rule == 'fexpr':
+            return 'condition', f'{dsl} > 0.0'
+        if rule == 'strexpr':
+            return 'condition', f'{dsl} is equal to "x"'
+        if rule == 'dexpr':
+            return 'condition', f'{dsl} is equal to 2020-01-01'
+        if rule == 'eexpr':
+            return 'condition', f'there is {dsl} where true'
+        if rule == 'nexpr':
+            return 'condition', f'{dsl} EQ /tbl'
+        if rule == 'bytesexpr':
+            return 'condition', f'{dsl} bytes== 0xab'
+        if rule in ('arrayExpr', 'arrayExpr2'):
+            return 'condition', f'{dsl} includes account'
+        # Fallback
+        return 'condition', dsl
+    return 'condition', dsl
+
+done_kinds = classify_done_alts()
+
+print('rule\tlabel\tentry\tdsl')
+for m in rule_re.finditer(src):
+    rule = m.group(1)
+    body = m.group(2)
+    alts = re.split(r'\n\s*\|', body)
+    for alt in alts:
+        lab = re.search(r'#\s*(\w+)\s*$', alt.rstrip())
+        if not lab: continue
+        label = lab.group(1)
+        content = alt[:lab.start()].rstrip()
+        dsl = substitute(content)
+        if rule == 'done':
+            entry, compile_dsl = 'raw', dsl
+        else:
+            kind = classify_rule(rule)
+            entry, compile_dsl = wrap_for(kind, dsl, rule, label)
+        print(f"{rule}\t{label}\t{entry}\t{compile_dsl}")


### PR DESCRIPTION
## Summary

Every labeled alternative in EL.g4 now has a corpus entry and runs through the compiler. Two assertions per entry: compile succeeds, postfix is non-empty. The empty-postfix check is what makes silent-fall-through like #626 impossible — a missing `Visit<Label>` method emits nothing and this sweep catches it.

## What shipped

- **Grammar sweep** (`grammar_sweep_test.go`) with two tests:
  - `TestGrammarSweep_CompilesAndEmitsPostfix` — drives every corpus entry through `CompileCondition` / `CompileAction` / `CompileContext` / raw `Compile` based on the rule's entry point
  - `TestGrammarSweep_CoverageGuard` — diffs grammar labels against corpus; a new `# label` added to `EL.g4` without a corpus entry fails the test
- **Corpus generator** (`tools/gen_el_corpus.py`) — parses `EL.g4`, substitutes a sample-token map for each non-terminal and a first-arm literal for each terminal, emits `testdata/grammar_corpus.tsv` (565 rows)
- **Hand-curated overrides** (`testdata/grammar_overrides.tsv`) — DSL for alternatives the generator can't construct (possessives, block wrappers, typed casts, localvariables)
- **Known-fails inventory** (`testdata/grammar_known_fails.tsv`) — 266 labels currently triaged as either (a) DSL sample needs refinement or (b) real `Visit` fall-through missing. The sweep test passes with these excluded; an **unexpected-pass guard** flags any known-fail that starts passing so it must be removed from the list

## State today

| | count |
|---|---|
| Corpus entries | 565 |
| Grammar labels covered | 100% |
| Labels fully passing sweep | 293 |
| Labels in known_fails (followup) | 266 |

The known_fails inventory categorizes by reason: `VisitXxx missing`, `DSL sample needs refinement`, `helper rule — no top-level compile path`. Each followup PR drives the count down.

## Why this catches the #626 bug class

The forall bug was: `forallSimple` (and six siblings) in `forallctl` had no `VisitForallSimple` method on `PostfixEmitter`. ANTLR's default visitor visited children and emitted nothing. Empty postfix left `rcontext = nil`, and `Execute` skipped iteration entirely. The sweep fails loudly on any non-empty DSL that compiles to empty postfix — this class of bug can't ship anymore without showing up in the sweep.

## Test plan

- [x] `make check` passes (full-module build + vet + scoped tests)
- [x] `go test ./pkg/dtrules/compiler/el/... -run TestGrammarSweep` passes
- [x] Regenerating the corpus with `tools/gen_el_corpus.py` produces the committed `grammar_corpus.tsv`
- [x] Coverage guard is tight: temporarily removing a random corpus row causes `TestGrammarSweep_CoverageGuard` to fail

## Followup

Each of the 266 `known_fails` entries gets triaged:
- If the DSL sample is malformed, refine it in `grammar_overrides.tsv` and remove from `known_fails`
- If the emitter has a missing `Visit<Label>`, add the emit (matching `opForall` / `opIf` etc. signatures), add a shape-pinned test, remove from `known_fails`

The unexpected-pass guard ensures fixes are cleanly tracked: fix a label → remove its entry from known_fails → test stays green.