### PR TITLE
test(el): emit postfix for debugstatement, ifElseIf, contextstatement DSL fix (#639, #648)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -2513,6 +2513,92 @@ func (e *PostfixEmitter) VisitIfElse(ctx *IfElseContext) interface{} {
 	return nil
 }
 
+// VisitIfElseIf: `else if <ifblock>`. The outer ifblock's ifelse expects a
+// false-body; wrap the inner ifblock emit in `{ }` so it becomes a single
+// body that ifelse can execute. The inner ifblock itself emits its own
+// bexpr / { ... } / false-body / ifelse sequence recursively.
+func (e *PostfixEmitter) VisitIfElseIf(ctx *IfElseIfContext) interface{} {
+	e.emit("{")
+	e.Visit(ctx.Ifblock())
+	e.emit("}")
+	return nil
+}
+
+// Debugstatement emitters. `debug <expr>` and `print <expr>` each push one
+// value and call the corresponding operator. Per-type labels exist for
+// parser disambiguation; each has the same emit shape.
+
+func (e *PostfixEmitter) VisitDebugStr(ctx *DebugStrContext) interface{} {
+	e.Visit(ctx.Strexpr())
+	e.emit("debug")
+	return nil
+}
+func (e *PostfixEmitter) VisitDebugBool(ctx *DebugBoolContext) interface{} {
+	e.Visit(ctx.Bexpr())
+	e.emit("debug")
+	return nil
+}
+func (e *PostfixEmitter) VisitDebugInt(ctx *DebugIntContext) interface{} {
+	e.Visit(ctx.Iexpr())
+	e.emit("debug")
+	return nil
+}
+func (e *PostfixEmitter) VisitDebugFloat(ctx *DebugFloatContext) interface{} {
+	e.Visit(ctx.Fexpr())
+	e.emit("debug")
+	return nil
+}
+func (e *PostfixEmitter) VisitDebugEntity(ctx *DebugEntityContext) interface{} {
+	e.Visit(ctx.Eexpr())
+	e.emit("debug")
+	return nil
+}
+func (e *PostfixEmitter) VisitDebugDate(ctx *DebugDateContext) interface{} {
+	e.Visit(ctx.Dexpr())
+	e.emit("debug")
+	return nil
+}
+func (e *PostfixEmitter) VisitDebugArray(ctx *DebugArrayContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.emit("debug")
+	return nil
+}
+func (e *PostfixEmitter) VisitPrintStr(ctx *PrintStrContext) interface{} {
+	e.Visit(ctx.Strexpr())
+	e.emit("print")
+	return nil
+}
+func (e *PostfixEmitter) VisitPrintBool(ctx *PrintBoolContext) interface{} {
+	e.Visit(ctx.Bexpr())
+	e.emit("print")
+	return nil
+}
+func (e *PostfixEmitter) VisitPrintInt(ctx *PrintIntContext) interface{} {
+	e.Visit(ctx.Iexpr())
+	e.emit("print")
+	return nil
+}
+func (e *PostfixEmitter) VisitPrintFloat(ctx *PrintFloatContext) interface{} {
+	e.Visit(ctx.Fexpr())
+	e.emit("print")
+	return nil
+}
+func (e *PostfixEmitter) VisitPrintEntity(ctx *PrintEntityContext) interface{} {
+	e.Visit(ctx.Eexpr())
+	e.emit("print")
+	return nil
+}
+func (e *PostfixEmitter) VisitPrintDate(ctx *PrintDateContext) interface{} {
+	e.Visit(ctx.Dexpr())
+	e.emit("print")
+	return nil
+}
+func (e *PostfixEmitter) VisitPrintArray(ctx *PrintArrayContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.emit("print")
+	return nil
+}
+
 // ============================================================================
 // Relationship and Entity Tests
 // ============================================================================

--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -81,31 +81,14 @@ bytesexpr	bytesSha256	triage — sweep surfaced this label as failing; check if 
 bytesexpr	bytesSha3	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 bytesexpr	bytesSlice	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 contextForTable	contextCtx	real emit fall-through — Visit method missing or under-implemented; followup
-contextForTable	contextDebug	real emit fall-through — Visit method missing or under-implemented; followup
 contextForTable	contextFor	real emit fall-through — Visit method missing or under-implemented; followup
 contextForTable	contextLocal	real emit fall-through — Visit method missing or under-implemented; followup
-contextstatement	addToContextFor	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-contextstatement	addToContextOf	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 datestatement	dateAddDays	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 datestatement	dateAddMonths	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 datestatement	dateAddYears	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 datestatement	dateSubDays	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 datestatement	dateSubMonths	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 datestatement	dateSubYears	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-debugstatement	debugArray	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-debugstatement	debugBool	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-debugstatement	debugDate	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-debugstatement	debugEntity	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-debugstatement	debugFloat	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-debugstatement	debugInt	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-debugstatement	debugStr	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-debugstatement	printArray	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-debugstatement	printBool	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-debugstatement	printDate	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-debugstatement	printEntity	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-debugstatement	printFloat	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-debugstatement	printInt	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-debugstatement	printStr	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 dexpr	dateCurrentDate	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 dexpr	dateDays	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 dexpr	dateEarliestAfter	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
@@ -160,9 +143,6 @@ iexpr	intMonthsBetween	triage — sweep surfaced this label as failing; check if
 iexpr	intValueOfOp	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 iexpr	intYearOf	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 iexpr	intYearsBetween	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-ifcontinue	ifElse	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-ifcontinue	ifElseIf	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-ifcontinue	ifEnd	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 includeSearch	includeDate	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 includeSearch	includeNumber	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 includeSearch	includeString	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -70,3 +70,8 @@ done	conditionDebugAfter	raw	condition true; debug "hi";
 done	contextDebugBefore	raw	context debug "hi"; for all accounts;
 possessiveRef	possessiveChain	condition	account's name EQ /tbl	tested via nexpr in a condition
 possessiveRef	colonChain	condition	account:name EQ /tbl
+contextstatement	addToContextOf	context	add account to context of this table
+contextstatement	addToContextFor	context	add account to context for this table
+ifcontinue	ifEnd	action	if true then set x = 1; endif
+ifcontinue	ifElse	action	if true then set x = 1; else set y = 1; endif
+ifcontinue	ifElseIf	action	if true then set x = 1; else if false then set y = 1; endif


### PR DESCRIPTION
Part of #635. Closes #639. Partial progress on #648.

Adds 15 Visit methods and 5 DSL-sample refinements, bringing 247 → 227 labels remaining.

| Rule | Labels | Kind |
|---|---|---|
| debugstatement | 14 | Visit methods (debug* + print*) |
| ifcontinue/ifElseIf | 1 | Visit method — was silently dropping the elseif branch |
| contextstatement | 2 | DSL refinement (context not condition) |
| ifcontinue | 2 | DSL refinement (fragments need full if-statement) |
| contextForTable/contextDebug | 1 | Cascade: works now that debugstatement emits |

`opDebug` and `opPrint` each pop one value, so every debug/print variant emits `<expr> debug` or `<expr> print`. The ifElseIf wrap `{ <inner ifblock> }` lets the outer ifelse invoke the recursive chain.

## Test plan
- [x] Grammar sweep passes (227 known_fails remaining)
- [x] `make check` green
- [x] End-to-end probe: `if X then A else if Y then B endif` now compiles to `true { … } { false { … } {} ifelse } ifelse`