### PR TITLE
test(el): emit postfix for randomstatements + setstatement inc/dec/fromName (#644, #647)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -2524,6 +2524,136 @@ func (e *PostfixEmitter) VisitIfElseIf(ctx *IfElseIfContext) interface{} {
 	return nil
 }
 
+// Increment/decrement statements. typedLong/typedDouble is a name reference;
+// the emit fetches the current value, adjusts by 1, and stores back using the
+// same /<name> xdef pattern leftIexprSimple uses.
+
+func (e *PostfixEmitter) VisitIncrementLong(ctx *IncrementLongContext) interface{} {
+	name := ctx.TypedLong().GetText()
+	e.emit(name)
+	e.emit("1")
+	e.emit("+")
+	e.emit("/" + name)
+	e.emit("xdef")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitIncrementDouble(ctx *IncrementDoubleContext) interface{} {
+	name := ctx.TypedDouble().GetText()
+	e.emit(name)
+	e.emit("1.0")
+	e.emit("f+")
+	e.emit("/" + name)
+	e.emit("xdef")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitDecrementLong(ctx *DecrementLongContext) interface{} {
+	name := ctx.TypedLong().GetText()
+	e.emit(name)
+	e.emit("1")
+	e.emit("-")
+	e.emit("/" + name)
+	e.emit("xdef")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitDecrementDouble(ctx *DecrementDoubleContext) interface{} {
+	name := ctx.TypedDouble().GetText()
+	e.emit(name)
+	e.emit("1.0")
+	e.emit("f-")
+	e.emit("/" + name)
+	e.emit("xdef")
+	return nil
+}
+
+// VisitSetStringFromName: `set <leftStrexpr> = <nexpr>`. Convert the resolved
+// name reference to a string.
+func (e *PostfixEmitter) VisitSetStringFromName(ctx *SetStringFromNameContext) interface{} {
+	e.Visit(ctx.Nexpr())
+	e.emit("cvs")
+	e.Visit(ctx.LeftStrexpr())
+	return nil
+}
+
+// VisitSetBoolFromName: `set <leftBexpr> = <nexpr>`.
+func (e *PostfixEmitter) VisitSetBoolFromName(ctx *SetBoolFromNameContext) interface{} {
+	e.Visit(ctx.Nexpr())
+	e.emit("cvb")
+	e.Visit(ctx.LeftBexpr())
+	return nil
+}
+
+// Randomstatements emitters. Array mutation statements.
+
+// VisitRemoveAtIndex: `remove <iexpr> element from <arrayExpr> array`.
+// opRemoveAt signature: (array index --).
+func (e *PostfixEmitter) VisitRemoveAtIndex(ctx *RemoveAtIndexContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.Visit(ctx.Iexpr())
+	e.emit("removeat")
+	return nil
+}
+
+// VisitRemoveName: `remove <nexpr> from <arrayExpr> array`.
+// opRemove signature: (array element --).
+func (e *PostfixEmitter) VisitRemoveName(ctx *RemoveNameContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.Visit(ctx.Nexpr())
+	e.emit("remove")
+	return nil
+}
+
+// VisitRemoveString: `remove <strexpr> from <arrayExpr> array`.
+func (e *PostfixEmitter) VisitRemoveString(ctx *RemoveStringContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.Visit(ctx.Strexpr())
+	e.emit("remove")
+	return nil
+}
+
+// VisitRemoveEntity: `remove <eexpr> from <arrayExpr> array`.
+func (e *PostfixEmitter) VisitRemoveEntity(ctx *RemoveEntityContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.Visit(ctx.Eexpr())
+	e.emit("remove")
+	return nil
+}
+
+// VisitRandomizeArray: `randomize <arrayExpr>`.
+func (e *PostfixEmitter) VisitRandomizeArray(ctx *RandomizeArrayContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.emit("randomize")
+	return nil
+}
+
+// VisitClearArray: `clear <arrayExpr>`.
+func (e *PostfixEmitter) VisitClearArray(ctx *ClearArrayContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.emit("cleararray")
+	return nil
+}
+
+// VisitSortAscending: `sort <arrayExpr> in ascending order by <nexpr>`.
+// opSortEntities signature: (array name asc --).
+func (e *PostfixEmitter) VisitSortAscending(ctx *SortAscendingContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.Visit(ctx.Nexpr())
+	e.emit("true")
+	e.emit("sortentities")
+	return nil
+}
+
+// VisitSortDescending: `sort <arrayExpr> in descending order by <nexpr>`.
+func (e *PostfixEmitter) VisitSortDescending(ctx *SortDescendingContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.Visit(ctx.Nexpr())
+	e.emit("false")
+	e.emit("sortentities")
+	return nil
+}
+
 // Debugstatement emitters. `debug <expr>` and `print <expr>` each push one
 // value and call the corresponding operator. Per-type labels exist for
 // parser disambiguation; each has the same emit shape.

--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -156,21 +156,12 @@ operatorlist	opListStrSingle	triage — sweep surfaced this label as failing; ch
 performstatement	performCatchError	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 possessiveRef	colonChain	real emit fall-through — Visit method missing or under-implemented; followup
 possessiveRef	possessiveChain	real emit fall-through — Visit method missing or under-implemented; followup
-randomstatements	clearArray	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-randomstatements	randomizeArray	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-randomstatements	removeAtIndex	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+randomstatements	clearArray	unreachable via ordinary DSL — `clear <arr>` dispatches to clearstatement, not randomstatements.clearArray; DSL-path followup
 randomstatements	removeEachWhere	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-randomstatements	removeEntity	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-randomstatements	removeName	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-randomstatements	removeString	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-randomstatements	sortAscending	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-randomstatements	sortDescending	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-setstatement	decrementDouble	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-setstatement	decrementLong	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-setstatement	incrementDouble	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-setstatement	incrementLong	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-setstatement	setBoolFromName	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-setstatement	setStringFromName	real emit fall-through — Visit method missing or under-implemented; followup
+randomstatements	removeName	DSL refinement — nexpr literal /tbl not valid in remove-from-array position
+randomstatements	sortAscending	DSL refinement — nexpr /tbl not valid after by
+randomstatements	sortDescending	DSL refinement — nexpr /tbl not valid after by
+setstatement	setBoolFromName	parser-ambiguity with setStringFromName — requires declared bool symbol to disambiguate; DSL refinement followup
 strexpr	strConcatName	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 strexpr	strFromIndex	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 strexpr	strHexOfBytes	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -69,3 +69,4 @@ localvariables	localBigIntDefined	context	local bigint x
 localvariables	localBytesUndef	context	local bytes x
 localvariables	localBytesInit	context	local bytes x = 0xab
 localvariables	localBytesDefined	context	local bytes x
+setstatement	setStringFromName	action	set s = $tbl


### PR DESCRIPTION
Part of #635. Partial progress on #644 and #647.

10 Visit methods added, 1 DSL refinement. 192 → 183 labels remaining.

## Summary

**randomstatements** — 4 clean fixes (removeAtIndex, removeEntity, randomizeArray, removeString). Known-fails retained for 4 labels with deeper path issues (clearArray unreachable, remove/sort nexpr DSL refinements, removeEachWhere needs bespoke op).

**setstatement** — 6 emit methods added (increment/decrement × long/double, setStringFromName, setBoolFromName). setStringFromName ships with a DSL refinement ($tbl form); setBoolFromName retained in known_fails pending symbol-table context to disambiguate from setStringFromName.

## Test plan
- [x] Grammar sweep passes
- [x] `make check` green