### PR TITLE
test(el): emit postfix for 22 bexpr simple-op alternatives (#636)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -2585,6 +2585,119 @@ func (e *PostfixEmitter) VisitSetBoolFromName(ctx *SetBoolFromNameContext) inter
 	return nil
 }
 
+// Bexpr emitters — simple single-op translations.
+
+// String comparisons: emit `<l> <r> s<op>` using the s<, s>, s<=, s>= ops.
+func (e *PostfixEmitter) VisitBoolStrGt(ctx *BoolStrGtContext) interface{} {
+	e.Visit(ctx.Strexpr(0))
+	e.Visit(ctx.Strexpr(1))
+	e.emit("s>")
+	return nil
+}
+func (e *PostfixEmitter) VisitBoolStrLt(ctx *BoolStrLtContext) interface{} {
+	e.Visit(ctx.Strexpr(0))
+	e.Visit(ctx.Strexpr(1))
+	e.emit("s<")
+	return nil
+}
+func (e *PostfixEmitter) VisitBoolStrGte(ctx *BoolStrGteContext) interface{} {
+	e.Visit(ctx.Strexpr(0))
+	e.Visit(ctx.Strexpr(1))
+	e.emit("s>=")
+	return nil
+}
+func (e *PostfixEmitter) VisitBoolStrLte(ctx *BoolStrLteContext) interface{} {
+	e.Visit(ctx.Strexpr(0))
+	e.Visit(ctx.Strexpr(1))
+	e.emit("s<=")
+	return nil
+}
+
+// VisitBoolStartsWith: `<s1> starts with <s2>` → `<s1> <s2> startswith`.
+func (e *PostfixEmitter) VisitBoolStartsWith(ctx *BoolStartsWithContext) interface{} {
+	e.Visit(ctx.Strexpr(0))
+	e.Visit(ctx.Strexpr(1))
+	e.emit("startswith")
+	return nil
+}
+
+// VisitBoolMatches: `<s1> matches <s2>` → `<s1> <s2> regexmatch`.
+func (e *PostfixEmitter) VisitBoolMatches(ctx *BoolMatchesContext) interface{} {
+	e.Visit(ctx.Strexpr(0))
+	e.Visit(ctx.Strexpr(1))
+	e.emit("regexmatch")
+	return nil
+}
+
+// VisitBoolDateBetween: `<d1> is between <d2> and <d3>` →
+// `<d1> <d2> d>= <d1> <d3> d<= and`. Inclusive range on both endpoints.
+func (e *PostfixEmitter) VisitBoolDateBetween(ctx *BoolDateBetweenContext) interface{} {
+	e.Visit(ctx.Dexpr(0))
+	e.Visit(ctx.Dexpr(1))
+	e.emit("d>=")
+	e.Visit(ctx.Dexpr(0))
+	e.Visit(ctx.Dexpr(2))
+	e.emit("d<=")
+	e.emit("and")
+	return nil
+}
+
+// Entity in context: `<entity> is in context` → `/<entity> incontext`.
+func (e *PostfixEmitter) VisitBoolEntityInContext(ctx *BoolEntityInContextContext) interface{} {
+	e.emit("/" + ctx.TypedEntity().GetText())
+	e.emit("incontext")
+	return nil
+}
+func (e *PostfixEmitter) VisitBoolEntityNotInContext(ctx *BoolEntityNotInContextContext) interface{} {
+	e.emit("/" + ctx.TypedEntity().GetText())
+	e.emit("incontext")
+	e.emit("not")
+	return nil
+}
+func (e *PostfixEmitter) VisitBoolStrEntityInContext(ctx *BoolStrEntityInContextContext) interface{} {
+	e.Visit(ctx.Strexpr())
+	e.emit("incontext")
+	return nil
+}
+func (e *PostfixEmitter) VisitBoolStrEntityNotInContext(ctx *BoolStrEntityNotInContextContext) interface{} {
+	e.Visit(ctx.Strexpr())
+	e.emit("incontext")
+	e.emit("not")
+	return nil
+}
+
+// Rhetorical question forms (`does X?` / `is X?` / `was X?`) just evaluate
+// the wrapped bexpr.
+func (e *PostfixEmitter) VisitBoolDoesQuestion(ctx *BoolDoesQuestionContext) interface{} {
+	return e.Visit(ctx.Bexpr())
+}
+func (e *PostfixEmitter) VisitBoolIsQuestion(ctx *BoolIsQuestionContext) interface{} {
+	return e.Visit(ctx.Bexpr())
+}
+func (e *PostfixEmitter) VisitBoolWasQuestion(ctx *BoolWasQuestionContext) interface{} {
+	return e.Visit(ctx.Bexpr())
+}
+
+// (boolean) <indx-or-str> cast.
+func (e *PostfixEmitter) VisitBoolFromIndex(ctx *BoolFromIndexContext) interface{} {
+	e.Visit(ctx.IndxExpr())
+	e.emit("cvb")
+	return nil
+}
+func (e *PostfixEmitter) VisitBoolFromStr(ctx *BoolFromStrContext) interface{} {
+	e.Visit(ctx.Strexpr())
+	e.emit("cvb")
+	return nil
+}
+
+// Boolean array-at: `boolean <arr>[<i>]` → `<arr> <i> getat`.
+func (e *PostfixEmitter) VisitBoolArrayAt(ctx *BoolArrayAtContext) interface{} {
+	e.emit(ctx.TypedArray().GetText())
+	e.Visit(ctx.Iexpr())
+	e.emit("getat")
+	return nil
+}
+
 // Randomstatements emitters. Array mutation statements.
 
 // VisitRemoveAtIndex: `remove <iexpr> element from <arrayExpr> array`.

--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -18,38 +18,17 @@ arrayList	arrayListIntSingle	helper rule; only valid inside an array list contex
 arrayList	arrayListNameSingle	helper rule; only valid inside an array list context
 arrayList	arrayListStrSingle	helper rule; only valid inside an array list context
 bexpr	boolAllHave	real emit fall-through — VisitBoolAllHave missing
-bexpr	boolArrayAt	real emit fall-through — VisitBoolArrayAt missing
-bexpr	boolArrayDoesInclude	DSL sample needs refinement — includes <includeSearch>
-bexpr	boolArrayIncludes	DSL sample needs refinement — includes <includeSearch>
-bexpr	boolArrayNotInclude	DSL sample needs refinement — does not include <includeSearch>
-bexpr	boolDateAfter	DSL sample needs refinement — date literal vs dexpr
-bexpr	boolDateBefore	DSL sample needs refinement — date literal vs dexpr
-bexpr	boolDateBetween	DSL sample needs refinement — date literal vs dexpr
-bexpr	boolDoesQuestion	real emit fall-through — VisitBoolDoesQuestion missing
 bexpr	boolEntityHasaWhere	real emit fall-through — VisitBoolEntityHasaWhere missing
-bexpr	boolEntityInContext	real emit fall-through — VisitBoolEntityInContext missing
-bexpr	boolEntityNotInContext	real emit fall-through — VisitBoolEntityNotInContext missing
-bexpr	boolFromIndex	real emit fall-through — VisitBoolFromIndex missing
-bexpr	boolFromStr	real emit fall-through — VisitBoolFromStr missing
-bexpr	boolIsQuestion	real emit fall-through — VisitBoolIsQuestion missing
 bexpr	boolMatchForall	DSL sample needs refinement
-bexpr	boolMatches	real emit fall-through — VisitBoolMatches missing
 bexpr	boolNameEq	DSL sample needs refinement — /literal-name vs nexpr shape
 bexpr	boolNameEqStr	DSL sample needs refinement
 bexpr	boolNameNeq	DSL sample needs refinement
 bexpr	boolNameNeqStr	DSL sample needs refinement
 bexpr	boolOneOfHasa	real emit fall-through — VisitBoolOneOfHasa missing
 bexpr	boolPlusOrMinus	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bexpr	boolStartsWith	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolStartsWithAt	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bexpr	boolStrEntityInContext	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bexpr	boolStrEntityNotInContext	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bexpr	boolStrGt	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bexpr	boolStrGte	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolStrIsNotOneOf	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolStrIsOneOf	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bexpr	boolStrLt	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bexpr	boolStrLte	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolThereIsInArrayWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolThereIsInEntityWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolThereIsNoInArrayWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
@@ -58,7 +37,6 @@ bexpr	boolThereIsNoWhere	DSL sample needs refinement OR real emit fall-through �
 bexpr	boolThereIsWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolUsing	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolValueOfOp	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bexpr	boolWasQuestion	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolWithinPercent	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bigexpr	bigFromBytes	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bigexpr	bigFromFloat	DSL sample needs refinement OR real emit fall-through — triage in follow-up

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -70,3 +70,9 @@ localvariables	localBytesUndef	context	local bytes x
 localvariables	localBytesInit	context	local bytes x = 0xab
 localvariables	localBytesDefined	context	local bytes x
 setstatement	setStringFromName	action	set s = $tbl
+bexpr	boolArrayIncludes	condition	accounts includes account
+bexpr	boolArrayDoesInclude	condition	accounts does include account
+bexpr	boolArrayNotInclude	condition	accounts does not include account
+bexpr	boolDateBefore	condition	(date) "2020-01-01" is before (date) "2020-01-02"
+bexpr	boolDateAfter	condition	(date) "2020-01-02" is after (date) "2020-01-01"
+bexpr	boolDateBetween	condition	(date) "2020-01-01" is between (date) "2020-01-01" and (date) "2020-01-02"


### PR DESCRIPTION
Part of #635. Partial progress on #636.

22 bexpr labels now pass: 16 new Visit methods + 6 DSL-sample refinements.

| Group | Labels | Kind |
|---|---|---|
| String compares | boolStrGt/Lt/Gte/Lte | Visit (s<, s>, s<=, s>=) |
| String ops | boolStartsWith, boolMatches | Visit (startswith, regexmatch) |
| Date between | boolDateBetween | Visit (`d >= lo and d <= hi`) |
| Entity context | boolEntity{In,NotIn}Context, boolStrEntity{In,NotIn}Context | Visit (incontext) |
| Rhetorical questions | boolDoesQuestion, boolIsQuestion, boolWasQuestion | Visit (emit bexpr) |
| Boolean casts | boolFromIndex, boolFromStr | Visit (cvb) |
| Array access | boolArrayAt | Visit (getat) |
| Array includes | boolArrayIncludes/DoesInclude/NotInclude | DSL refinement |
| Date compare | boolDateBefore/After | DSL refinement |

183 → 161 labels remaining.

## Test plan
- [x] Grammar sweep passes
- [x] `make check` green