### PR TITLE
test(el): emit postfix for 9 more bexpr alternatives (#636)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -2698,6 +2698,68 @@ func (e *PostfixEmitter) VisitBoolArrayAt(ctx *BoolArrayAtContext) interface{} {
 	return nil
 }
 
+// VisitBoolStrIsOneOf: `<s> is one of <arr>` → `<arr> <s> memberof`.
+func (e *PostfixEmitter) VisitBoolStrIsOneOf(ctx *BoolStrIsOneOfContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.Visit(ctx.Strexpr())
+	e.emit("memberof")
+	return nil
+}
+
+// VisitBoolStrIsNotOneOf: `<s> is not one of <arr>` → `<arr> <s> memberof not`.
+func (e *PostfixEmitter) VisitBoolStrIsNotOneOf(ctx *BoolStrIsNotOneOfContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.Visit(ctx.Strexpr())
+	e.emit("memberof")
+	e.emit("not")
+	return nil
+}
+
+// VisitBoolPlusOrMinus: `<f1> is plus or minus <n> of <f2>` →
+// `|f1 - f2| <= n`. The `number` may be int or float; `cvr` coerces to
+// double for the comparison.
+func (e *PostfixEmitter) VisitBoolPlusOrMinus(ctx *BoolPlusOrMinusContext) interface{} {
+	e.Visit(ctx.Fexpr(0))
+	e.Visit(ctx.Fexpr(1))
+	e.emit("f-")
+	e.emit("fabs")
+	e.Visit(ctx.Number())
+	e.emit("cvr")
+	e.emit("f<=")
+	return nil
+}
+
+// VisitBoolWithinPercent: `<f1> is within <n> percent of <f2>` →
+// `|(f1 - f2) / f2| * 100 <= n`.
+func (e *PostfixEmitter) VisitBoolWithinPercent(ctx *BoolWithinPercentContext) interface{} {
+	e.Visit(ctx.Fexpr(0))
+	e.Visit(ctx.Fexpr(1))
+	e.emit("f-")
+	e.Visit(ctx.Fexpr(1))
+	e.emit("fdiv")
+	e.emit("fabs")
+	e.emit("100.0")
+	e.emit("f*")
+	e.Visit(ctx.Number())
+	e.emit("cvr")
+	e.emit("f<=")
+	return nil
+}
+
+// VisitBoolUsing: `using <eexpr> ( <bexpr> )` — push eexpr onto the entity
+// stack, evaluate bexpr, pop the entity while preserving the bool result.
+// entitypop pushes the popped entity onto the data stack, so we swap under
+// the bool and discard the entity with pop.
+func (e *PostfixEmitter) VisitBoolUsing(ctx *BoolUsingContext) interface{} {
+	e.Visit(ctx.Eexpr())
+	e.emit("entitypush")
+	e.Visit(ctx.Bexpr())
+	e.emit("entitypop")
+	e.emit("swap")
+	e.emit("pop")
+	return nil
+}
+
 // Randomstatements emitters. Array mutation statements.
 
 // VisitRemoveAtIndex: `remove <iexpr> element from <arrayExpr> array`.

--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -20,24 +20,15 @@ arrayList	arrayListStrSingle	helper rule; only valid inside an array list contex
 bexpr	boolAllHave	real emit fall-through — VisitBoolAllHave missing
 bexpr	boolEntityHasaWhere	real emit fall-through — VisitBoolEntityHasaWhere missing
 bexpr	boolMatchForall	DSL sample needs refinement
-bexpr	boolNameEq	DSL sample needs refinement — /literal-name vs nexpr shape
-bexpr	boolNameEqStr	DSL sample needs refinement
-bexpr	boolNameNeq	DSL sample needs refinement
-bexpr	boolNameNeqStr	DSL sample needs refinement
 bexpr	boolOneOfHasa	real emit fall-through — VisitBoolOneOfHasa missing
-bexpr	boolPlusOrMinus	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolStartsWithAt	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bexpr	boolStrIsNotOneOf	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bexpr	boolStrIsOneOf	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolThereIsInArrayWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolThereIsInEntityWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolThereIsNoInArrayWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolThereIsNoInEntityWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolThereIsNoWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolThereIsWhere	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bexpr	boolUsing	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bexpr	boolValueOfOp	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bexpr	boolWithinPercent	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bigexpr	bigFromBytes	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bigexpr	bigFromFloat	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 bigexpr	bigFromInt	DSL sample needs refinement OR real emit fall-through — triage in follow-up

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -76,3 +76,7 @@ bexpr	boolArrayNotInclude	condition	accounts does not include account
 bexpr	boolDateBefore	condition	(date) "2020-01-01" is before (date) "2020-01-02"
 bexpr	boolDateAfter	condition	(date) "2020-01-02" is after (date) "2020-01-01"
 bexpr	boolDateBetween	condition	(date) "2020-01-01" is between (date) "2020-01-01" and (date) "2020-01-02"
+bexpr	boolNameEq	condition	$a == $b
+bexpr	boolNameEqStr	condition	$a == "x"
+bexpr	boolNameNeq	condition	$a != $b
+bexpr	boolNameNeqStr	condition	$a != "x"


### PR DESCRIPTION
Part of #635. Partial progress on #636.

9 more bexpr labels pass: 4 DSL refinements (name comparisons) + 5 new Visit methods (StrIsOneOf/NotOneOf, Using, PlusOrMinus, WithinPercent).

161 → 152 known_fails remaining.

## Test plan
- [x] Grammar sweep passes
- [x] `make check` green