### PR TITLE
test(el): refine bytesexpr DSL — all 12 labels pass (#640)

### DIFF
--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -37,18 +37,6 @@ blist	blistMulti	DSL sample needs refinement OR real emit fall-through — triag
 blist	blistOr	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 blistIc	blistIcMulti	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 blistIc	blistIcOr	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bytesexpr	bytesConcat	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bytesexpr	bytesCvBase58Check	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bytesexpr	bytesCvBech32	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bytesexpr	bytesCvBigInt	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bytesexpr	bytesCvHex	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bytesexpr	bytesKeccak256	DSL sample needs refinement OR real emit fall-through — triage in follow-up
-bytesexpr	bytesLiteral	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-bytesexpr	bytesParen	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-bytesexpr	bytesRipemd160	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-bytesexpr	bytesSha256	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-bytesexpr	bytesSha3	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-bytesexpr	bytesSlice	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 contextForTable	contextFor	real emit fall-through — Visit method missing or under-implemented; followup
 datestatement	dateAddDays	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 datestatement	dateAddMonths	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -102,3 +102,16 @@ dexpr	dateFirstOfMonth	condition	first of months of (date) "2020-01-01" is equal
 dexpr	dateEndOfMonth	condition	end of months of (date) "2020-01-01" is equal to (date) "2020-01-01"
 dexpr	dateEarliestAfter	condition	earliest of arr after (date) "2020-01-01" is equal to (date) "2020-01-01"
 dexpr	dateTableLookup	condition	(date) tbl("x") is equal to (date) "2020-01-01"
+bytesexpr	bytesLiteral	condition	0xab == 0xab
+bytesexpr	bytesTyped	condition	bs == 0xab
+bytesexpr	bytesParen	condition	(0xab) == 0xab
+bytesexpr	bytesConcat	condition	0xab + 0xab == 0xab
+bytesexpr	bytesSlice	condition	0xab from 1 to 2 == 0xab
+bytesexpr	bytesSha256	condition	sha256 of 0xab == 0xab
+bytesexpr	bytesKeccak256	condition	keccak256 of 0xab == 0xab
+bytesexpr	bytesRipemd160	condition	ripemd160 of 0xab == 0xab
+bytesexpr	bytesSha3	condition	sha3 of 0xab == 0xab
+bytesexpr	bytesCvHex	condition	bytes of hex "ab" == 0xab
+bytesexpr	bytesCvBase58Check	condition	bytes of base58check "x" == 0xab
+bytesexpr	bytesCvBech32	condition	bytes of bech32 "x" == 0xab
+bytesexpr	bytesCvBigInt	condition	bytes of bigint (bigint) 1 size 1 == 0xab


### PR DESCRIPTION
Closes #640. All bytesexpr Visit methods emit correctly; failures were DSL samples using `bytes==` instead of `==`. 130 → 118 known_fails remaining.