### PR TITLE
test(el): emit postfix for eexpr (#641)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -2715,6 +2715,22 @@ func (e *PostfixEmitter) VisitBoolStrIsNotOneOf(ctx *BoolStrIsNotOneOfContext) i
 	return nil
 }
 
+// Eexpr emitters.
+
+// VisitEntityIndex: eexpr as an indxExpr (array/index form). Just delegate.
+func (e *PostfixEmitter) VisitEntityIndex(ctx *EntityIndexContext) interface{} {
+	return e.Visit(ctx.IndxExpr())
+}
+
+// VisitEntityColonRef: `<colonRef> <typedEntity>`. Emit colonRef postfix
+// followed by the entity name token (which resolves to the entity object at
+// runtime).
+func (e *PostfixEmitter) VisitEntityColonRef(ctx *EntityColonRefContext) interface{} {
+	e.Visit(ctx.ColonRef())
+	e.emit(ctx.TypedEntity().GetText())
+	return nil
+}
+
 // VisitBoolPlusOrMinus: `<f1> is plus or minus <n> of <f2>` →
 // `|f1 - f2| <= n`. The `number` may be int or float; `cvr` coerces to
 // double for the comparison.

--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -54,17 +54,9 @@ done	policyFExpr	real emit fall-through — Visit method missing or under-implem
 done	policyIExpr	real emit fall-through — Visit method missing or under-implemented; followup
 done	policyNExpr	real emit fall-through — Visit method missing or under-implemented; followup
 done	policyStrExpr	real emit fall-through — Visit method missing or under-implemented; followup
-eexpr	entityClone	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-eexpr	entityColonRef	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 eexpr	entityFirst	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 eexpr	entityFirstIn	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-eexpr	entityIndex	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-eexpr	entityNewName	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-eexpr	entityNewTyped	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-eexpr	entityParen	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-eexpr	entityRelationship	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 eexpr	entityTableLookup	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-eexpr	entityTyped	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 errorstatement	errorStmt	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 fexpr	floatLiteral	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 fexpr	floatValueOfOp	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -115,3 +115,11 @@ bytesexpr	bytesCvHex	condition	bytes of hex "ab" == 0xab
 bytesexpr	bytesCvBase58Check	condition	bytes of base58check "x" == 0xab
 bytesexpr	bytesCvBech32	condition	bytes of bech32 "x" == 0xab
 bytesexpr	bytesCvBigInt	condition	bytes of bigint (bigint) 1 size 1 == 0xab
+eexpr	entityTyped	condition	account == account
+eexpr	entityParen	condition	(account) == account
+eexpr	entityIndex	condition	account == account
+eexpr	entityNewName	condition	new account entity == account
+eexpr	entityNewTyped	condition	new account entity == account
+eexpr	entityClone	condition	clone of account == account
+eexpr	entityColonRef	condition	:account:account == account
+eexpr	entityRelationship	condition	"role" of account == account


### PR DESCRIPTION
Part of #635. Partial progress on #641.

8 of 11 eexpr labels fixed (2 new Visit methods + 6 DSL refinements). entityFirst/FirstIn/TableLookup remain in known_fails pending complex find-first and table-lookup cast implementation.

118 → 110 known_fails remaining.