### PR TITLE
test(el): emit postfix for iexpr + strexpr (#645, #646)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -2715,6 +2715,87 @@ func (e *PostfixEmitter) VisitBoolStrIsNotOneOf(ctx *BoolStrIsNotOneOfContext) i
 	return nil
 }
 
+// Iexpr emitters — date-derived integer forms.
+
+func (e *PostfixEmitter) VisitIntDaysInYear(ctx *IntDaysInYearContext) interface{} {
+	e.Visit(ctx.Dexpr())
+	e.emit("getdaysinyear")
+	return nil
+}
+func (e *PostfixEmitter) VisitIntDaysInMonth(ctx *IntDaysInMonthContext) interface{} {
+	e.Visit(ctx.Dexpr())
+	e.emit("getdaysinmonth")
+	return nil
+}
+func (e *PostfixEmitter) VisitIntDayOfMonth(ctx *IntDayOfMonthContext) interface{} {
+	e.Visit(ctx.Dexpr())
+	e.emit("getdayofmonth")
+	return nil
+}
+func (e *PostfixEmitter) VisitIntDaysBetween(ctx *IntDaysBetweenContext) interface{} {
+	e.Visit(ctx.Dexpr(0))
+	e.Visit(ctx.Dexpr(1))
+	e.emit("daysbetween")
+	return nil
+}
+func (e *PostfixEmitter) VisitIntMonthsBetween(ctx *IntMonthsBetweenContext) interface{} {
+	e.Visit(ctx.Dexpr(0))
+	e.Visit(ctx.Dexpr(1))
+	e.emit("monthsbetween")
+	return nil
+}
+func (e *PostfixEmitter) VisitIntYearsBetween(ctx *IntYearsBetweenContext) interface{} {
+	e.Visit(ctx.Dexpr(0))
+	e.Visit(ctx.Dexpr(1))
+	e.emit("yearsbetween")
+	return nil
+}
+func (e *PostfixEmitter) VisitIntYearOf(ctx *IntYearOfContext) interface{} {
+	e.Visit(ctx.Dexpr())
+	e.emit("yearof")
+	return nil
+}
+
+// Strexpr emitters.
+
+// VisitStrConcatName: `<s> + <nexpr>` → `<s> <n> cvs concat`.
+func (e *PostfixEmitter) VisitStrConcatName(ctx *StrConcatNameContext) interface{} {
+	e.Visit(ctx.Strexpr())
+	e.Visit(ctx.Nexpr())
+	e.emit("cvs")
+	e.emit("concat")
+	return nil
+}
+
+// VisitStrFromIndex: `(string) <indx>` → `<indx> cvs`.
+func (e *PostfixEmitter) VisitStrFromIndex(ctx *StrFromIndexContext) interface{} {
+	e.Visit(ctx.IndxExpr())
+	e.emit("cvs")
+	return nil
+}
+
+// VisitStrValueOfInt / Float / Date / Bool: emit value-to-string cast.
+func (e *PostfixEmitter) VisitStrValueOfInt(ctx *StrValueOfIntContext) interface{} {
+	e.Visit(ctx.Iexpr())
+	e.emit("cvs")
+	return nil
+}
+func (e *PostfixEmitter) VisitStrValueOfFloat(ctx *StrValueOfFloatContext) interface{} {
+	e.Visit(ctx.Fexpr())
+	e.emit("cvs")
+	return nil
+}
+func (e *PostfixEmitter) VisitStrValueOfDate(ctx *StrValueOfDateContext) interface{} {
+	e.Visit(ctx.Dexpr())
+	e.emit("cvs")
+	return nil
+}
+func (e *PostfixEmitter) VisitStrValueOfBool(ctx *StrValueOfBoolContext) interface{} {
+	e.Visit(ctx.Bexpr())
+	e.emit("cvs")
+	return nil
+}
+
 // Eexpr emitters.
 
 // VisitEntityIndex: eexpr as an indxExpr (array/index form). Just delegate.

--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -60,14 +60,7 @@ eexpr	entityTableLookup	triage — sweep surfaced this label as failing; check i
 errorstatement	errorStmt	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 fexpr	floatLiteral	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 fexpr	floatValueOfOp	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-iexpr	intDayOfMonth	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-iexpr	intDaysBetween	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-iexpr	intDaysInMonth	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-iexpr	intDaysInYear	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-iexpr	intMonthsBetween	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 iexpr	intValueOfOp	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-iexpr	intYearOf	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-iexpr	intYearsBetween	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 includeSearch	includeDate	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 includeSearch	includeNumber	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 includeSearch	includeString	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
@@ -89,14 +82,8 @@ randomstatements	removeName	DSL refinement — nexpr literal /tbl not valid in r
 randomstatements	sortAscending	DSL refinement — nexpr /tbl not valid after by
 randomstatements	sortDescending	DSL refinement — nexpr /tbl not valid after by
 setstatement	setBoolFromName	parser-ambiguity with setStringFromName — requires declared bool symbol to disambiguate; DSL refinement followup
-strexpr	strConcatName	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-strexpr	strFromIndex	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-strexpr	strHexOfBytes	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
+strexpr	strFromIndex	DSL refinement — `(string) indxExpr` requires specific helper-rule context
 strexpr	strTableLookup	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-strexpr	strValueOfBool	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-strexpr	strValueOfDate	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-strexpr	strValueOfFloat	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-strexpr	strValueOfInt	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 strexpr	strValueOfOp	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 subtodest	subDestColon	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 subtodest	subDestPossessiveDouble	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -123,3 +123,16 @@ eexpr	entityNewTyped	condition	new account entity == account
 eexpr	entityClone	condition	clone of account == account
 eexpr	entityColonRef	condition	:account:account == account
 eexpr	entityRelationship	condition	"role" of account == account
+iexpr	intDaysInYear	condition	get days in yearof (date) "2020-01-01" > 0
+iexpr	intDaysInMonth	condition	get days in months for (date) "2020-01-01" > 0
+iexpr	intDayOfMonth	condition	get days of months for (date) "2020-01-01" > 0
+iexpr	intDaysBetween	condition	days from (date) "2020-01-01" to (date) "2020-01-01" > 0
+iexpr	intMonthsBetween	condition	months from (date) "2020-01-01" to (date) "2020-01-01" > 0
+iexpr	intYearsBetween	condition	years from (date) "2020-01-01" to (date) "2020-01-01" > 0
+iexpr	intYearOf	condition	get yearof (date) "2020-01-01" > 0
+strexpr	strConcatName	condition	"a" + $tbl is equal to "x"
+strexpr	strHexOfBytes	condition	hex of 0xab is equal to "x"
+strexpr	strValueOfInt	condition	string value of 1 is equal to "x"
+strexpr	strValueOfFloat	condition	string value of 1.0 is equal to "x"
+strexpr	strValueOfDate	condition	string value of (date) "2020-01-01" is equal to "x"
+strexpr	strValueOfBool	condition	string value of boolean true is equal to "x"


### PR DESCRIPTION
Part of #635. Partial progress on #645 and #646.

13 labels fixed (7 iexpr + 6 strexpr). 111 → 98 known_fails remaining.

## Test plan
- [x] Grammar sweep passes
- [x] `make check` green