### PR TITLE
test(el): emit postfix for datestatement — all 6 labels pass (#647)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -2715,6 +2715,67 @@ func (e *PostfixEmitter) VisitBoolStrIsNotOneOf(ctx *BoolStrIsNotOneOfContext) i
 	return nil
 }
 
+// Datestatement emitters. Adjust a date field in place: fetch, compute new
+// date, store back. Subtract negates the count before calling adddays.
+
+func (e *PostfixEmitter) VisitDateAddDays(ctx *DateAddDaysContext) interface{} {
+	name := ctx.TypedDate().GetText()
+	e.emit(name)
+	e.Visit(ctx.Number())
+	e.emit("adddays")
+	e.emit("/" + name)
+	e.emit("xdef")
+	return nil
+}
+func (e *PostfixEmitter) VisitDateAddMonths(ctx *DateAddMonthsContext) interface{} {
+	name := ctx.TypedDate().GetText()
+	e.emit(name)
+	e.Visit(ctx.Number())
+	e.emit("addmonths")
+	e.emit("/" + name)
+	e.emit("xdef")
+	return nil
+}
+func (e *PostfixEmitter) VisitDateAddYears(ctx *DateAddYearsContext) interface{} {
+	name := ctx.TypedDate().GetText()
+	e.emit(name)
+	e.Visit(ctx.Number())
+	e.emit("addyears")
+	e.emit("/" + name)
+	e.emit("xdef")
+	return nil
+}
+func (e *PostfixEmitter) VisitDateSubDays(ctx *DateSubDaysContext) interface{} {
+	name := ctx.TypedDate().GetText()
+	e.emit(name)
+	e.Visit(ctx.Number())
+	e.emit("negate")
+	e.emit("adddays")
+	e.emit("/" + name)
+	e.emit("xdef")
+	return nil
+}
+func (e *PostfixEmitter) VisitDateSubMonths(ctx *DateSubMonthsContext) interface{} {
+	name := ctx.TypedDate().GetText()
+	e.emit(name)
+	e.Visit(ctx.Number())
+	e.emit("negate")
+	e.emit("addmonths")
+	e.emit("/" + name)
+	e.emit("xdef")
+	return nil
+}
+func (e *PostfixEmitter) VisitDateSubYears(ctx *DateSubYearsContext) interface{} {
+	name := ctx.TypedDate().GetText()
+	e.emit(name)
+	e.Visit(ctx.Number())
+	e.emit("negate")
+	e.emit("addyears")
+	e.emit("/" + name)
+	e.emit("xdef")
+	return nil
+}
+
 // Iexpr emitters — date-derived integer forms.
 
 func (e *PostfixEmitter) VisitIntDaysInYear(ctx *IntDaysInYearContext) interface{} {

--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -38,12 +38,6 @@ blist	blistOr	DSL sample needs refinement OR real emit fall-through — triage i
 blistIc	blistIcMulti	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 blistIc	blistIcOr	DSL sample needs refinement OR real emit fall-through — triage in follow-up
 contextForTable	contextFor	real emit fall-through — Visit method missing or under-implemented; followup
-datestatement	dateAddDays	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-datestatement	dateAddMonths	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-datestatement	dateAddYears	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-datestatement	dateSubDays	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-datestatement	dateSubMonths	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
-datestatement	dateSubYears	triage — sweep surfaced this label as failing; check if DSL sample is incorrect or if a Visit method is missing
 dexpr	dateDays	DSL refinement — `( 5 days )` form tricky; need literal days-count construction
 done	conditionDebugAfter	real emit fall-through — Visit method missing or under-implemented; followup
 done	conditionDebugBefore	real emit fall-through — Visit method missing or under-implemented; followup

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -136,3 +136,9 @@ strexpr	strValueOfInt	condition	string value of 1 is equal to "x"
 strexpr	strValueOfFloat	condition	string value of 1.0 is equal to "x"
 strexpr	strValueOfDate	condition	string value of (date) "2020-01-01" is equal to "x"
 strexpr	strValueOfBool	condition	string value of boolean true is equal to "x"
+datestatement	dateAddDays	action	add 5 days to dt
+datestatement	dateAddMonths	action	add 5 months to dt
+datestatement	dateAddYears	action	add 5 years to dt
+datestatement	dateSubDays	action	subtract 5 days from dt
+datestatement	dateSubMonths	action	subtract 5 months from dt
+datestatement	dateSubYears	action	subtract 5 years from dt


### PR DESCRIPTION
Part of #635. Partial progress on #647 (statement rules).

All 6 datestatement labels pass. Each emits `<name> <n> adddays|addmonths|addyears /<name> xdef`; Sub variants negate the count first.

98 → 92 known_fails remaining.