### PR TITLE
test(el): grind Category A + C — 16 labels pass (#635)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -2715,6 +2715,89 @@ func (e *PostfixEmitter) VisitBoolStrIsNotOneOf(ctx *BoolStrIsNotOneOfContext) i
 	return nil
 }
 
+// VisitForctl: `for <leftIexpr> = <number>; <bexpr>; <statement>`.
+// Context-position only (reachable via contextForTable/contextFor). The
+// outer table body is on the data stack when this runs. Emit:
+//   init: <number> cvi leftIexpr-assign
+//   loop: { dup execute <statement> } { <bexpr> } while pop
+// The body block dups the table body and executes it, then runs the
+// increment statement; the test block evaluates bexpr. After while consumes
+// body and test, the surviving outer body is dropped with pop.
+func (e *PostfixEmitter) VisitForctl(ctx *ForctlContext) interface{} {
+	// init — coerce number to int and assign via leftIexpr.
+	e.Visit(ctx.Number())
+	e.emit("cvi")
+	e.Visit(ctx.LeftIexpr())
+	// body block
+	e.emit("{")
+	e.emit("dup")
+	e.emit("execute")
+	e.Visit(ctx.Statement())
+	e.emit("}")
+	// test block
+	e.emit("{")
+	e.Visit(ctx.Bexpr())
+	e.emit("}")
+	e.emit("while")
+	e.emit("pop")
+	return nil
+}
+
+// Nexpr emitters.
+
+// VisitNameTheName: `the name <strexpr>` → `<strexpr> cvn`. Converts a string
+// into a name reference.
+func (e *PostfixEmitter) VisitNameTheName(ctx *NameTheNameContext) interface{} {
+	e.Visit(ctx.Strexpr())
+	e.emit("cvn")
+	return nil
+}
+
+// VisitNameUsing: `using <eexpr> ( <nexpr> )` — push eexpr onto entity stack,
+// resolve nexpr with it in scope, pop entity while preserving the name
+// value. Parallels boolUsing.
+func (e *PostfixEmitter) VisitNameUsing(ctx *NameUsingContext) interface{} {
+	e.Visit(ctx.Eexpr())
+	e.emit("entitypush")
+	e.Visit(ctx.Nexpr())
+	e.emit("entitypop")
+	e.emit("swap")
+	e.emit("pop")
+	return nil
+}
+
+// Subtodest emitters. Mirror addtodest but subtract. `<value> <subtodest>`
+// expects the rhs value on the stack, then runs field - value and stores.
+// Because `-` is a -b operator, we swap before subtracting to get field-value
+// rather than value-field.
+func (e *PostfixEmitter) VisitSubDestLong(ctx *SubDestLongContext) interface{} {
+	name := ctx.TypedLong().GetText()
+	e.emit(name)
+	e.emit("swap")
+	e.emit("-")
+	e.emit("/" + name)
+	e.emit("xdef")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitSubDestDouble(ctx *SubDestDoubleContext) interface{} {
+	name := ctx.TypedDouble().GetText()
+	e.emit(name)
+	e.emit("swap")
+	e.emit("f-")
+	e.emit("/" + name)
+	e.emit("xdef")
+	return nil
+}
+
+// VisitSubtractNum: `subtract <number> from <subtodest>` → push the number,
+// then delegate to subtodest which computes field - value and stores.
+func (e *PostfixEmitter) VisitSubtractNum(ctx *SubtractNumContext) interface{} {
+	e.Visit(ctx.Number())
+	e.Visit(ctx.Subtodest())
+	return nil
+}
+
 // Datestatement emitters. Adjust a date field in place: fetch, compute new
 // date, store back. Subtract negates the count before calling adddays.
 
@@ -2958,6 +3041,15 @@ func (e *PostfixEmitter) VisitRemoveEntity(ctx *RemoveEntityContext) interface{}
 func (e *PostfixEmitter) VisitRandomizeArray(ctx *RandomizeArrayContext) interface{} {
 	e.Visit(ctx.ArrayExpr())
 	e.emit("randomize")
+	return nil
+}
+
+// VisitClearstatement: `clear <arrayExpr>`. The statement-level alternative
+// takes precedence over randomstatements/clearArray in the parser, so we
+// mirror the clearArray emit here.
+func (e *PostfixEmitter) VisitClearstatement(ctx *ClearstatementContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.emit("cleararray")
 	return nil
 }
 

--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -11,7 +11,6 @@ addtostatement	addNumToDestDup	[B] dup-destination: similar pattern — addNumTo
 addtostatement	addStrNoDups	[B] member-check-add: emit `<arr> <s> add_no_dups`
 addtostatement	addStrNoDupsDup	[B] member-check-add × 2 destinations
 addtostatement	addStrToDestDup	[B] dup-destination: `<s> dup <d1> swap addto <d2> swap addto`
-addtostatement	subtractNum	[B] parallels addNumToDest but subtract; emit `<n> negate <subtodest>` where subtodest emits `<field> + /field xdef`
 arrayExpr2	arrayName	[E] helper — `(array) NAME` parse-ambiguous; reachable only in specific cast positions
 arrayList	arrayListFloatSingle	[E] helper — only valid inside an array-literal / operatorlist context
 arrayList	arrayListIntSingle	[E] helper — only valid inside an array-literal / operatorlist context
@@ -29,15 +28,10 @@ bexpr	boolThereIsNoInEntityWhere	[B] parallel to InEntityWhere + not
 bexpr	boolThereIsNoWhere	[B] parallel to boolThereIsWhere + not
 bexpr	boolThereIsWhere	[B] existence+where: emit `/<entityName> isdefined { <bexpr> } { false } ifelse`
 bexpr	boolValueOfOp	[D] `boolean value of <operatorstatements>` — operator dispatch returning a bool; needs runtime op understanding
-bigexpr	bigFromBytes	[A] trivial: emit `<bytesexpr> bytesbigint`
-bigexpr	bigFromFloat	[A] trivial: emit `<fexpr> cvbi`
-bigexpr	bigFromInt	[A] trivial: emit `<iexpr> cvbi`
-bigexpr	bigFromStr	[A] trivial: emit `<strexpr> cvbi`
 blist	blistMulti	[E] helper — only reachable inside strexpr EQ blist; tested via boolStrEqList
 blist	blistOr	[E] helper — only reachable inside strexpr EQ blist
 blistIc	blistIcMulti	[E] helper — only reachable inside strexpr EQ_IGNORE_CASE blistIc
 blistIc	blistIcOr	[E] helper — only reachable inside strexpr EQ_IGNORE_CASE blistIc
-contextForTable	contextFor	[A] delegates to forctl; Visit forctl missing — add trivial Visit
 dexpr	dateDays	[C] `( 5 days )` form — needs specific literal syntax
 done	conditionDebugAfter	[F] debug-after wiring — same
 done	conditionDebugBefore	[F] debug-before wiring — outer `done` alternative drops the debug emit
@@ -51,16 +45,11 @@ done	policyStrExpr	[F] same as policyBExpr
 eexpr	entityFirst	[B] find-first entity: use opForfirst where scope is the enclosing entity stack
 eexpr	entityFirstIn	[B] find-first in array: `<arr> { <b> } forfirst` with result on data stack
 eexpr	entityTableLookup	[D] typed-table lookup: `(entity) <tbl>(<list>)` — parallel to strTableLookup
-errorstatement	errorStmt	[A] trivial: emit `<strexpr> error`
-fexpr	floatLiteral	[C] float literal — corpus DSL "1.0" alone isn't a valid condition
 fexpr	floatValueOfOp	[D] `double value of <operatorstatements>`
 iexpr	intValueOfOp	[D] `long value of <operatorstatements>`
 includeSearch	includeDate	[E] helper — only reachable inside arrayExpr INCLUDES includeSearch
 includeSearch	includeNumber	[E] helper — only reachable inside arrayExpr INCLUDES includeSearch
 includeSearch	includeString	[E] helper — only reachable inside arrayExpr INCLUDES includeSearch
-nexpr	nameOf	[A] trivial: emit `<eexpr> entityname`
-nexpr	nameTheName	[A] trivial: emit `<strexpr> cvn`
-nexpr	nameUsing	[A] needs small think: push entity, evaluate nexpr, pop entity (parallel to boolUsing)
 operatorlist	opListFloat	[E] helper — only reachable inside DOUBLE VALUE OF operatorstatements
 operatorlist	opListFloatSingle	[E] helper — only reachable inside DOUBLE VALUE OF operatorstatements
 operatorlist	opListInt	[E] helper — only reachable inside LONG VALUE OF operatorstatements
@@ -70,13 +59,8 @@ operatorlist	opListStrSingle	[E] helper — only reachable inside STRING VALUE O
 performstatement	performCatchError	[D] try/catch around perform — uses performcatcherror op (exists); needs emit design
 possessiveRef	colonChain	[E] helper chain — `:Entity:field` nexpr form; reached via boolNameEq etc.
 possessiveRef	possessiveChain	[E] helper chain — `entity`s field` nexpr form; reached via boolNameEq etc.
-randomstatements	clearArray	[C] unreachable via action DSL — parser picks clearstatement which has no label; DSL refinement or grammar reorder
 randomstatements	removeEachWhere	[D] remove-while-iterating: no bespoke op; compose forallr + remove — complex
-randomstatements	removeName	[C] nexpr form: needs `$name` not `/tbl`
-randomstatements	sortAscending	[C] nexpr form: needs `$name` not `/tbl`
-randomstatements	sortDescending	[C] nexpr form: needs `$name` not `/tbl`
 setstatement	setBoolFromName	[C] parser ambiguity with setStringFromName; requires symbol table to disambiguate
-strexpr	strFromIndex	[C] indxExpr helper — test DSL needs a real array-index construction
 strexpr	strTableLookup	[D] typed-table lookup: `(string) <tbl>(<list>)` — needs table op
 strexpr	strValueOfOp	[D] `string value of <operatorstatements>`
 subtodest	subDestColon	[E] helper sub-rule — parallels addtodest/addDestColon
@@ -85,7 +69,6 @@ subtodest	subDestPossessiveLong	[E] helper sub-rule — parallels addtodest/addD
 tablelist	tableListMulti	[E] helper — only reachable inside typedTable LPAREN tablelist RPAREN
 tablelist	tableListSingle	[E] helper — only reachable inside typedTable LPAREN tablelist RPAREN
 texpr	tableNew	[D] `new <s> table of <s>` — newtable op exists, need emit
-warnstatement	warnStmt	[A] trivial: emit `<strexpr> log_warning`
 xmlvaluestatements	xmlAddAttr	[F] XML DOM mutation
 xmlvaluestatements	xmlAddAttrEntity	[F] XML DOM mutation
 xmlvaluestatements	xmlSetAttr	[F] XML DOM mutation — used for XML output mapping; not clear if runtime supports

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -17,7 +17,6 @@ forfirstctl	forfirstOf	context	for first of accounts where true
 forfirstctl	forfirstOfIts	context	for first of accounts and its other where true
 forfirstctl	forfirstIn	context	for first in accounts where true
 contextForTable	contextDebug	context	debug "hi"
-contextForTable	contextFor	context	for i = 0; i < 3; increment i
 contextForTable	contextForallCtl	context	for all accounts
 contextForTable	contextForfirst	context	for first of accounts where true
 contextForTable	contextLocal	context	local string s
@@ -142,3 +141,19 @@ datestatement	dateAddYears	action	add 5 years to dt
 datestatement	dateSubDays	action	subtract 5 days from dt
 datestatement	dateSubMonths	action	subtract 5 months from dt
 datestatement	dateSubYears	action	subtract 5 years from dt
+bigexpr	bigFromInt	condition	(bigint) 1 > (bigint) 0
+bigexpr	bigFromFloat	condition	(bigint) 1.0 > (bigint) 0
+bigexpr	bigFromStr	condition	(bigint) "1" > (bigint) 0
+bigexpr	bigFromBytes	condition	bigint of bytes 0xab > (bigint) 0
+contextForTable	contextFor	context	for i = 0; i < 3; increment i;
+errorstatement	errorStmt	action	error "msg"
+warnstatement	warnStmt	action	warn "msg"
+nexpr	nameOf	condition	nameof account == $tbl
+nexpr	nameTheName	condition	the name "x" == $tbl
+nexpr	nameUsing	condition	using account ( $tbl ) == $tbl
+fexpr	floatLiteral	condition	1.0 > 0.0
+strexpr	strFromIndex	condition	(string) arr[1] is equal to "x"
+randomstatements	removeName	action	remove $tbl from accounts array
+randomstatements	sortAscending	action	sort accounts in ascending order by $tbl
+randomstatements	sortDescending	action	sort accounts in descending order by $tbl
+randomstatements	clearArray	action	clear accounts


### PR DESCRIPTION
Part of #635. Closes 16 of 18 labels tagged [A] or [C] in `grammar_known_fails.tsv`.

91 → 75 labels remaining. Two [C] stay: setBoolFromName (parser ambiguity), dateDays (days-count literal form).

## Changes

| Kind | Labels | Notes |
|---|---|---|
| Visit (new) | forctl, subDestLong/Double, subtractNum, clearstatement | clearstatement needed dedicated emit because parser prefers it over randomstatements/clearArray |
| DSL refinement | bigFromInt/Float/Str/Bytes, contextFor, errorStmt, warnStmt, nameOf, nameTheName, nameUsing, floatLiteral, strFromIndex, randomstatements remove/sort/clear | Visits already worked — corpus DSL needed `(bigint) …` casts, `$name` nexpr form, etc. |

## Test plan
- [x] Grammar sweep passes
- [x] `make check` green