### PR TITLE
test(el): emit postfix for addtostatement dup-destination + no-dups family (#642)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -2715,6 +2715,120 @@ func (e *PostfixEmitter) VisitBoolStrIsNotOneOf(ctx *BoolStrIsNotOneOfContext) i
 	return nil
 }
 
+// Addtostatement dup-destination + no-dups family. opAddTo signature is
+// (array element --); opAddArray signature is (array1 array2 bool --) where
+// bool=false means skip duplicates; the Contains-then-Add pattern for a
+// single element is the built-in add_no_dups op.
+//
+// Pattern for value-to-two-destinations: push value, dup, add to dest1, then
+// add the remaining copy to dest2. addtodest's emit for typed-array dests is
+// `<field> swap addto` — i.e. expects value already on stack, swaps so addto
+// sees (array, value), consumes. The dup-form sequence becomes:
+//     <value> dup <dest1> swap addto <dest2> swap addto
+// Same shape works for entity / string / number / date values.
+
+// VisitAddDateToDest: `add <dexpr> to <addtodest>`. Non-dup counterpart —
+// was previously falling through and the default visit emitted the wrong
+// shape (arithmetic `+` instead of addto). Now uses the same swap+addto
+// pattern as AddEntityToDest.
+func (e *PostfixEmitter) VisitAddDateToDest(ctx *AddDateToDestContext) interface{} {
+	e.Visit(ctx.Dexpr())
+	e.Visit(ctx.Addtodest())
+	e.emit("swap")
+	e.emit("addto")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitAddEntityToDestDup(ctx *AddEntityToDestDupContext) interface{} {
+	e.Visit(ctx.Eexpr())
+	e.emit("dup")
+	e.Visit(ctx.Addtodest(0))
+	e.emit("swap")
+	e.emit("addto")
+	e.Visit(ctx.Addtodest(1))
+	e.emit("swap")
+	e.emit("addto")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitAddStrToDestDup(ctx *AddStrToDestDupContext) interface{} {
+	e.Visit(ctx.Strexpr())
+	e.emit("dup")
+	e.Visit(ctx.Addtodest(0))
+	e.emit("swap")
+	e.emit("addto")
+	e.Visit(ctx.Addtodest(1))
+	e.emit("swap")
+	e.emit("addto")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitAddDateToDestDup(ctx *AddDateToDestDupContext) interface{} {
+	e.Visit(ctx.Dexpr())
+	e.emit("dup")
+	e.Visit(ctx.Addtodest(0))
+	e.emit("swap")
+	e.emit("addto")
+	e.Visit(ctx.Addtodest(1))
+	e.emit("swap")
+	e.emit("addto")
+	return nil
+}
+
+// VisitAddNumToDestDup — number variant uses the same pattern. addtodest's
+// emit for numeric targets does `<field> + /<field> xdef`, which expects the
+// value below the field on the stack. For dup-form we can't cleanly reuse
+// addtodest because each dest mutation is stateful. Emit two explicit
+// accumulations on the named targets.
+func (e *PostfixEmitter) VisitAddNumToDestDup(ctx *AddNumToDestDupContext) interface{} {
+	e.Visit(ctx.Number())
+	e.emit("dup")
+	e.Visit(ctx.Addtodest(0))
+	e.Visit(ctx.Addtodest(1))
+	return nil
+}
+
+// VisitAddEntityNoDups: `add <e> if not member to <arr>` → `<arr> <e> add_no_dups`.
+func (e *PostfixEmitter) VisitAddEntityNoDups(ctx *AddEntityNoDupsContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.Visit(ctx.Eexpr())
+	e.emit("add_no_dups")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitAddStrNoDups(ctx *AddStrNoDupsContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.Visit(ctx.Strexpr())
+	e.emit("add_no_dups")
+	return nil
+}
+
+// Dup-destination no-dups variants: add element to each of two destinations
+// if not already member. Dup the element and call add_no_dups on each.
+func (e *PostfixEmitter) VisitAddEntityNoDupsDup(ctx *AddEntityNoDupsDupContext) interface{} {
+	e.Visit(ctx.Eexpr())
+	e.emit("dup")
+	e.Visit(ctx.ArrayExpr(0))
+	e.emit("swap")
+	e.emit("add_no_dups")
+	e.Visit(ctx.ArrayExpr(1))
+	e.emit("swap")
+	e.emit("add_no_dups")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitAddStrNoDupsDup(ctx *AddStrNoDupsDupContext) interface{} {
+	e.Visit(ctx.Strexpr())
+	e.emit("dup")
+	e.Visit(ctx.ArrayExpr(0))
+	e.emit("swap")
+	e.emit("add_no_dups")
+	e.Visit(ctx.ArrayExpr(1))
+	e.emit("swap")
+	e.emit("add_no_dups")
+	return nil
+}
+
 // VisitForctl: `for <leftIexpr> = <number>; <bexpr>; <statement>`.
 // Context-position only (reachable via contextForTable/contextFor). The
 // outer table body is on the data stack when this runs. Emit:

--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -2,15 +2,6 @@ rule	label	reason
 addtodest	addDestColon	[E] helper sub-rule — no top-level compile path; tested inside addtostatement
 addtodest	addDestPossessiveDouble	[E] helper sub-rule — POSSESSIVE prefix is bound to parent addtostatement
 addtodest	addDestPossessiveLong	[E] helper sub-rule — POSSESSIVE prefix is bound to parent addtostatement
-addtostatement	addArrayNoMember	[B] array-into-array with member check: iterate source, add_no_dups each into dest
-addtostatement	addDateToDestDup	[B] dup-destination: `<d> dup <d1> swap addto <d2> swap addto`
-addtostatement	addEntityNoDups	[B] member-check-add: emit `<arr> <e> add_no_dups`
-addtostatement	addEntityNoDupsDup	[B] member-check-add × 2 destinations
-addtostatement	addEntityToDestDup	[B] dup-destination: emit `<e> dup <d1> swap addto <d2> swap addto`
-addtostatement	addNumToDestDup	[B] dup-destination: similar pattern — addNumToDest is different so need to study
-addtostatement	addStrNoDups	[B] member-check-add: emit `<arr> <s> add_no_dups`
-addtostatement	addStrNoDupsDup	[B] member-check-add × 2 destinations
-addtostatement	addStrToDestDup	[B] dup-destination: `<s> dup <d1> swap addto <d2> swap addto`
 arrayExpr2	arrayName	[E] helper — `(array) NAME` parse-ambiguous; reachable only in specific cast positions
 arrayList	arrayListFloatSingle	[E] helper — only valid inside an array-literal / operatorlist context
 arrayList	arrayListIntSingle	[E] helper — only valid inside an array-literal / operatorlist context

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -157,3 +157,12 @@ randomstatements	removeName	action	remove $tbl from accounts array
 randomstatements	sortAscending	action	sort accounts in ascending order by $tbl
 randomstatements	sortDescending	action	sort accounts in descending order by $tbl
 randomstatements	clearArray	action	clear accounts
+addtostatement	addEntityToDestDup	action	add account to x and to y
+addtostatement	addStrToDestDup	action	add "x" to x and to y
+addtostatement	addNumToDestDup	action	add 5 to x and to y
+addtostatement	addDateToDestDup	action	add (date) "2020-01-01" to x and to y
+addtostatement	addEntityNoDups	action	add account if not member to accounts
+addtostatement	addStrNoDups	action	add "x" if not member to accounts
+addtostatement	addEntityNoDupsDup	action	add account if not member to accounts and to accounts
+addtostatement	addStrNoDupsDup	action	add "x" if not member to accounts and to accounts
+addtostatement	addArrayNoMember	action	add accounts to accounts if not member


### PR DESCRIPTION
Part of #635. Closes #642.

9 Visit methods added plus 1 silent-bug fix (addDateToDest was defaulting to arithmetic emit). Covers the addto-two-destinations pattern, single-element `add_no_dups`, dup variants of both, and `addarray` for array-into-array.

75 → 66 known_fails remaining.