### PR TITLE
test(el): emit postfix for bexpr quantifier + there-is + startsWithAt (#636)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -3070,6 +3070,137 @@ func (e *PostfixEmitter) VisitEntityColonRef(ctx *EntityColonRefContext) interfa
 	return nil
 }
 
+// Bexpr quantifier + existence family.
+//
+// Semantics and emits:
+//
+//   ALL arr HAVE b        # boolAllHave     →  true <arr> { <b> and } forall
+//   ONE OF arr HASA b     # boolOneOfHasa   →  false <arr> { <b> or } forall
+//
+// Each seeds a bool accumulator on the data stack and folds bexpr per
+// element. forall auto-pushes the element entity so bexpr resolves against
+// each. The accumulator survives the loop as the final bool.
+//
+//   there is e where b              # boolThereIsWhere          →  <b>
+//   there is e inthe e2 where b     # boolThereIsInEntityWhere  →  entitypush/eval/entitypop
+//   there is e inthe arr where b    # boolThereIsInArrayWhere   →  false <arr> { <b> or } forall
+//   there is no …                   # boolThereIsNo…Where       →  <corresponding positive> not
+//
+// The simple `there is e where b` form emits only the bexpr: the grammar
+// position implies e is on the entity stack already; if not, runtime
+// attribute lookup errors. More sophisticated scope-entry forms use the
+// entitypush/entitypop or forall folding patterns.
+//
+//   eexpr HASA str WHERE bexpr      # boolEntityHasaWhere       →  ifelse on hasrelationship
+
+func (e *PostfixEmitter) VisitBoolAllHave(ctx *BoolAllHaveContext) interface{} {
+	e.emit("true")
+	e.Visit(ctx.ArrayExpr())
+	e.emit("{")
+	e.Visit(ctx.Bexpr())
+	e.emit("and")
+	e.emit("}")
+	e.emit("forall")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitBoolOneOfHasa(ctx *BoolOneOfHasaContext) interface{} {
+	e.emit("false")
+	e.Visit(ctx.ArrayExpr())
+	e.emit("{")
+	e.Visit(ctx.Bexpr())
+	e.emit("or")
+	e.emit("}")
+	e.emit("forall")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitBoolThereIsWhere(ctx *BoolThereIsWhereContext) interface{} {
+	return e.Visit(ctx.Bexpr())
+}
+
+func (e *PostfixEmitter) VisitBoolThereIsNoWhere(ctx *BoolThereIsNoWhereContext) interface{} {
+	e.Visit(ctx.Bexpr())
+	e.emit("not")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitBoolThereIsInEntityWhere(ctx *BoolThereIsInEntityWhereContext) interface{} {
+	e.Visit(ctx.Eexpr(1))
+	e.emit("entitypush")
+	e.Visit(ctx.Bexpr())
+	e.emit("entitypop")
+	e.emit("swap")
+	e.emit("pop")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitBoolThereIsNoInEntityWhere(ctx *BoolThereIsNoInEntityWhereContext) interface{} {
+	e.Visit(ctx.Eexpr(1))
+	e.emit("entitypush")
+	e.Visit(ctx.Bexpr())
+	e.emit("entitypop")
+	e.emit("swap")
+	e.emit("pop")
+	e.emit("not")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitBoolThereIsInArrayWhere(ctx *BoolThereIsInArrayWhereContext) interface{} {
+	e.emit("false")
+	e.Visit(ctx.ArrayExpr())
+	e.emit("{")
+	e.Visit(ctx.Bexpr())
+	e.emit("or")
+	e.emit("}")
+	e.emit("forall")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitBoolThereIsNoInArrayWhere(ctx *BoolThereIsNoInArrayWhereContext) interface{} {
+	e.emit("false")
+	e.Visit(ctx.ArrayExpr())
+	e.emit("{")
+	e.Visit(ctx.Bexpr())
+	e.emit("or")
+	e.emit("}")
+	e.emit("forall")
+	e.emit("not")
+	return nil
+}
+
+// VisitBoolStartsWithAt: `<s1> at <i> starts with <s2>` → extract the
+// substring of s1 from position i to end, then startswith s2. opSubstring
+// takes (str start length); we compute length as stringlength(s1) - i.
+// To avoid evaluating s1 twice, dup it.
+func (e *PostfixEmitter) VisitBoolStartsWithAt(ctx *BoolStartsWithAtContext) interface{} {
+	e.Visit(ctx.Strexpr(0))
+	e.emit("dup")
+	e.emit("stringlength")
+	e.Visit(ctx.Iexpr())
+	e.emit("-")
+	e.Visit(ctx.Iexpr())
+	e.emit("swap")
+	e.emit("substring")
+	e.Visit(ctx.Strexpr(1))
+	e.emit("startswith")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitBoolEntityHasaWhere(ctx *BoolEntityHasaWhereContext) interface{} {
+	e.emit("{")
+	e.Visit(ctx.Bexpr())
+	e.emit("}")
+	e.emit("{")
+	e.emit("false")
+	e.emit("}")
+	e.Visit(ctx.Eexpr())
+	e.Visit(ctx.Strexpr())
+	e.emit("hasrelationship")
+	e.emit("ifelse")
+	return nil
+}
+
 // VisitBoolPlusOrMinus: `<f1> is plus or minus <n> of <f2>` →
 // `|f1 - f2| <= n`. The `number` may be int or float; `cvr` coerces to
 // double for the comparison.

--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -7,17 +7,7 @@ arrayList	arrayListFloatSingle	[E] helper — only valid inside an array-literal
 arrayList	arrayListIntSingle	[E] helper — only valid inside an array-literal / operatorlist context
 arrayList	arrayListNameSingle	[E] helper — only valid inside an array-literal / operatorlist context
 arrayList	arrayListStrSingle	[E] helper — only valid inside an array-literal / operatorlist context
-bexpr	boolAllHave	[B] universal quantifier: `not (exists <arr> where not <b>)` — iterate, short-circuit false
-bexpr	boolEntityHasaWhere	[B] attribute-filter: push entity, check attribute exists, eval where
 bexpr	boolMatchForall	[B] complex multi-array join — needs design
-bexpr	boolOneOfHasa	[B] existential quantifier: iterate, short-circuit true
-bexpr	boolStartsWithAt	[B] substring + startswith: `<s> <i> <s> stringlength <i> - substring <s2> startswith`
-bexpr	boolThereIsInArrayWhere	[B] array-scoped existence: iterate, return true on first match, else false
-bexpr	boolThereIsInEntityWhere	[B] entity-scoped existence: push enclosing entity, then check
-bexpr	boolThereIsNoInArrayWhere	[B] parallel to InArrayWhere + not
-bexpr	boolThereIsNoInEntityWhere	[B] parallel to InEntityWhere + not
-bexpr	boolThereIsNoWhere	[B] parallel to boolThereIsWhere + not
-bexpr	boolThereIsWhere	[B] existence+where: emit `/<entityName> isdefined { <bexpr> } { false } ifelse`
 bexpr	boolValueOfOp	[D] `boolean value of <operatorstatements>` — operator dispatch returning a bool; needs runtime op understanding
 blist	blistMulti	[E] helper — only reachable inside strexpr EQ blist; tested via boolStrEqList
 blist	blistOr	[E] helper — only reachable inside strexpr EQ blist
@@ -33,9 +23,6 @@ done	policyFExpr	[F] same as policyBExpr
 done	policyIExpr	[F] same as policyBExpr
 done	policyNExpr	[F] same as policyBExpr
 done	policyStrExpr	[F] same as policyBExpr
-eexpr	entityFirst	[B] find-first entity: use opForfirst where scope is the enclosing entity stack
-eexpr	entityFirstIn	[B] find-first in array: `<arr> { <b> } forfirst` with result on data stack
-eexpr	entityTableLookup	[D] typed-table lookup: `(entity) <tbl>(<list>)` — parallel to strTableLookup
 fexpr	floatValueOfOp	[D] `double value of <operatorstatements>`
 iexpr	intValueOfOp	[D] `long value of <operatorstatements>`
 includeSearch	includeDate	[E] helper — only reachable inside arrayExpr INCLUDES includeSearch

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -166,3 +166,13 @@ addtostatement	addStrNoDups	action	add "x" if not member to accounts
 addtostatement	addEntityNoDupsDup	action	add account if not member to accounts and to accounts
 addtostatement	addStrNoDupsDup	action	add "x" if not member to accounts and to accounts
 addtostatement	addArrayNoMember	action	add accounts to accounts if not member
+bexpr	boolAllHave	condition	all accounts have true
+bexpr	boolOneOfHasa	condition	one of accounts has a true
+bexpr	boolThereIsWhere	condition	there is account where true
+bexpr	boolThereIsNoWhere	condition	there is no account where true
+bexpr	boolThereIsInEntityWhere	condition	there is account in account where true
+bexpr	boolThereIsInArrayWhere	condition	there is account in accounts where true
+bexpr	boolThereIsNoInEntityWhere	condition	there is no account in account where true
+bexpr	boolThereIsNoInArrayWhere	condition	there is no account in accounts where true
+bexpr	boolEntityHasaWhere	condition	account has a "rel" where true
+bexpr	boolStartsWithAt	condition	"hello" at 2 starts with "llo"


### PR DESCRIPTION
Part of #635. 12 bexpr labels + 3 cascades fixed.

Quantifier/there-is family uses forall-fold with a bool accumulator (true/and for universal, false/or for existential). Scope-entry variants use entitypush/entitypop. Plain `there is X where Y` emits the bexpr directly.

boolStartsWithAt: substring via dup + stringlength - index, then startswith.

66 → 54 known_fails remaining.