### PR TITLE
test(el): refine dateDays DSL (#638)

### DIFF
--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -13,7 +13,6 @@ blist	blistMulti	[E] helper — only reachable inside strexpr EQ blist; tested v
 blist	blistOr	[E] helper — only reachable inside strexpr EQ blist
 blistIc	blistIcMulti	[E] helper — only reachable inside strexpr EQ_IGNORE_CASE blistIc
 blistIc	blistIcOr	[E] helper — only reachable inside strexpr EQ_IGNORE_CASE blistIc
-dexpr	dateDays	[C] `( 5 days )` form — needs specific literal syntax
 done	conditionDebugAfter	[F] debug-after wiring — same
 done	conditionDebugBefore	[F] debug-before wiring — outer `done` alternative drops the debug emit
 done	contextDebugBefore	[F] debug-before in context — same

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -176,3 +176,4 @@ bexpr	boolThereIsNoInEntityWhere	condition	there is no account in account where 
 bexpr	boolThereIsNoInArrayWhere	condition	there is no account in accounts where true
 bexpr	boolEntityHasaWhere	condition	account has a "rel" where true
 bexpr	boolStartsWithAt	condition	"hello" at 2 starts with "llo"
+dexpr	dateDays	condition	(date) "2020-01-01" + (5 days) is equal to (date) "2020-01-06"


### PR DESCRIPTION
Closes dexpr/dateDays. `(5 days)` is an RInterval (produced by the `days` op) that adds to a date via `d+`. DSL refinement only — VisitDateDays already emits correctly.

53 → 52 known_fails remaining.