### PR TITLE
fix(op): cvb — strict boolean coercion, explicit errors

### DIFF
--- a/pkg/dtrules/operators/cvb_test.go
+++ b/pkg/dtrules/operators/cvb_test.go
@@ -1,0 +1,128 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+
+package operators
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+)
+
+// runCvb pushes v onto a fresh state, runs cvb, returns the popped result
+// or the error.
+func runCvb(t *testing.T, v dtrules.Object) (*dtrules.RBoolean, error) {
+	t.Helper()
+	state := newTestState()
+	state.DataPush(v)
+	op, _ := Get(dtrules.GetRName("cvb"))
+	if err := op.Execute(state); err != nil {
+		return nil, err
+	}
+	res, err := state.DataPop()
+	if err != nil {
+		return nil, err
+	}
+	return res.(*dtrules.RBoolean), nil
+}
+
+func TestCvbBoolPassthrough(t *testing.T) {
+	b, err := runCvb(t, dtrules.True)
+	if err != nil || b != dtrules.True {
+		t.Errorf("cvb(true) = (%v, %v), want (true, nil)", b, err)
+	}
+	b, err = runCvb(t, dtrules.False)
+	if err != nil || b != dtrules.False {
+		t.Errorf("cvb(false) = (%v, %v), want (false, nil)", b, err)
+	}
+}
+
+func TestCvbStringAccepted(t *testing.T) {
+	trueStrings := []string{"true", "True", "TRUE", "yes", "YES", " y ", "t", "1"}
+	for _, s := range trueStrings {
+		b, err := runCvb(t, dtrules.NewRString(s))
+		if err != nil || b != dtrules.True {
+			t.Errorf("cvb(%q) = (%v, %v), want (true, nil)", s, b, err)
+		}
+	}
+	falseStrings := []string{"false", "False", "FALSE", "no", "NO", "n", "f", "0"}
+	for _, s := range falseStrings {
+		b, err := runCvb(t, dtrules.NewRString(s))
+		if err != nil || b != dtrules.False {
+			t.Errorf("cvb(%q) = (%v, %v), want (false, nil)", s, b, err)
+		}
+	}
+}
+
+func TestCvbStringRejected(t *testing.T) {
+	bad := []string{"", "maybe", "2", "truthy", "nope", " "}
+	for _, s := range bad {
+		_, err := runCvb(t, dtrules.NewRString(s))
+		if err == nil {
+			t.Errorf("cvb(%q) accepted; want error", s)
+		}
+	}
+}
+
+func TestCvbIntegerZeroIsFalse(t *testing.T) {
+	b, err := runCvb(t, dtrules.GetRIntegerValueFromInt(0))
+	if err != nil || b != dtrules.False {
+		t.Errorf("cvb(int 0) = (%v, %v), want (false, nil)", b, err)
+	}
+}
+
+func TestCvbIntegerNonzeroIsTrue(t *testing.T) {
+	for _, n := range []int{1, -1, 42, -999} {
+		b, err := runCvb(t, dtrules.GetRIntegerValueFromInt(n))
+		if err != nil || b != dtrules.True {
+			t.Errorf("cvb(int %d) = (%v, %v), want (true, nil)", n, b, err)
+		}
+	}
+}
+
+func TestCvbDoubleZeroIsFalse(t *testing.T) {
+	b, err := runCvb(t, dtrules.GetRDoubleValue(0.0))
+	if err != nil || b != dtrules.False {
+		t.Errorf("cvb(double 0.0) = (%v, %v), want (false, nil)", b, err)
+	}
+}
+
+func TestCvbDoubleNonzeroIsTrue(t *testing.T) {
+	for _, f := range []float64{1.0, -1.0, 0.5, -0.0001} {
+		b, err := runCvb(t, dtrules.GetRDoubleValue(f))
+		if err != nil || b != dtrules.True {
+			t.Errorf("cvb(double %v) = (%v, %v), want (true, nil)", f, b, err)
+		}
+	}
+}
+
+func TestCvbBigIntZeroIsFalse(t *testing.T) {
+	b, err := runCvb(t, dtrules.GetRBigIntValue(big.NewInt(0)))
+	if err != nil || b != dtrules.False {
+		t.Errorf("cvb(bigint 0) = (%v, %v), want (false, nil)", b, err)
+	}
+}
+
+func TestCvbBigIntNonzeroIsTrue(t *testing.T) {
+	for _, n := range []int64{1, -1, 1 << 40} {
+		b, err := runCvb(t, dtrules.GetRBigIntValue(big.NewInt(n)))
+		if err != nil || b != dtrules.True {
+			t.Errorf("cvb(bigint %d) = (%v, %v), want (true, nil)", n, b, err)
+		}
+	}
+}
+
+func TestCvbOtherTypesRejected(t *testing.T) {
+	// null: not a boolean-coercible type. Any non-{bool, string, int, double,
+	// bigint} should error.
+	_, err := runCvb(t, dtrules.GetRNull())
+	if err == nil {
+		t.Error("cvb(null) accepted; want error")
+	}
+}

--- a/pkg/dtrules/operators/stack.go
+++ b/pkg/dtrules/operators/stack.go
@@ -17,6 +17,7 @@ package operators
 
 import (
 	"log"
+	"strings"
 
 	"github.com/DTRules/DTRules/pkg/dtrules"
 )
@@ -658,16 +659,53 @@ func opCvr(state dtrules.State) error {
 }
 
 // opCvb: ( obj -- boolean ) converts to boolean
+// opCvb: ( obj -- boolean ) coerces to boolean with strict rules:
+//   - RBoolean: passthrough
+//   - string: case-insensitive "true"/"false"/"yes"/"no"/"y"/"n"/"t"/"f"/"0"/"1" → bool; else error
+//   - numeric (int / bigint / double): 0 → false, non-zero → true
+//   - any other type: error
+//
+// Replaces the older behavior that silently returned null on any coercion
+// failure. `(boolean) <expr>` now fails loudly on a value it can't interpret
+// rather than producing a mystery null downstream.
 func opCvb(state dtrules.State) error {
 	obj, err := state.DataPop()
 	if err != nil {
 		return err
 	}
-	v, err := obj.RBooleanValue()
-	if err != nil {
-		return state.DataPush(dtrules.GetRNull())
+	t := obj.Type()
+	switch t {
+	case dtrules.TypeBoolean:
+		return state.DataPush(obj)
+	case dtrules.TypeString:
+		s := strings.ToLower(strings.TrimSpace(obj.StringValue()))
+		switch s {
+		case "true", "yes", "y", "t", "1":
+			return state.DataPush(dtrules.True)
+		case "false", "no", "n", "f", "0":
+			return state.DataPush(dtrules.False)
+		}
+		return dtrules.TypeCheckError("cvb", "cannot coerce string "+obj.StringValue()+" to boolean")
+	case dtrules.TypeInteger:
+		i, err := obj.LongValue()
+		if err != nil {
+			return err
+		}
+		return state.DataPush(dtrules.GetRBoolean(i != 0))
+	case dtrules.TypeDouble:
+		d, err := obj.DoubleValue()
+		if err != nil {
+			return err
+		}
+		return state.DataPush(dtrules.GetRBoolean(d != 0))
+	case dtrules.TypeBigInt:
+		b, err := obj.RBigIntValue()
+		if err != nil {
+			return err
+		}
+		return state.DataPush(dtrules.GetRBoolean(b.BigIntValue().Sign() != 0))
 	}
-	return state.DataPush(v)
+	return dtrules.TypeCheckError("cvb", "cannot coerce "+t.GetName().StringValue()+" to boolean")
 }
 
 // opCve: ( obj -- entity ) converts to entity


### PR DESCRIPTION
Replaces `opCvb`'s silent-null behavior on coercion failure with strict rules:

| Input | Result |
|---|---|
| RBoolean | passthrough |
| `"true"`/`"yes"`/`"y"`/`"t"`/`"1"` (any case, trimmed) | true |
| `"false"`/`"no"`/`"n"`/`"f"`/`"0"` (any case, trimmed) | false |
| other strings | error |
| integer/double/bigint zero | false |
| integer/double/bigint non-zero | true |
| other types | error |

The old silent-null return hid data bugs downstream — a mystery null flowing through several ops before failing with "No Boolean value exists for this type." Now `(boolean) <expr>` fails loudly at the cast site.

10 new tests in `cvb_test.go` cover each case.