### PR TITLE
test(el): helper-rule exemption + elstmterror for deprecated hash-table forms (#635)

### DIFF
--- a/pkg/dtrules/compiler/el/grammar_sweep_test.go
+++ b/pkg/dtrules/compiler/el/grammar_sweep_test.go
@@ -113,16 +113,31 @@ var emptyPostfixAllowed = map[string]bool{
 }
 
 // loadKnownFails reads the inventory of labels that are known to fail the
-// sweep today. Each entry is either (a) a helper rule with no top-level
-// compile path, (b) a DSL sample the generator can't construct correctly yet,
-// or (c) a real emitter fall-through bug tracked for follow-up. New entries
-// must NOT be added casually — the correct response to a new failure is to
-// either fix the emitter or refine the DSL sample.
+// sweep today. Each entry is either a DSL sample the generator can't
+// construct correctly yet, or a real emitter fall-through bug tracked for
+// follow-up. New entries must NOT be added casually — the correct response
+// to a new failure is to either fix the emitter or refine the DSL sample.
 func loadKnownFails(t *testing.T) map[string]string {
+	return loadTSV3(t, "testdata/grammar_known_fails.tsv")
+}
+
+// loadHelpers reads the grammar helper-rule exemption list. Helper labels
+// are grammar fragments (e.g. blist, arrayList, includeSearch) that can't
+// be compiled directly from a top-level DSL entry point — they live inside
+// other rules. The sweep skips direct compile for helpers, and the coverage
+// guard treats them as covered so adding them to the grammar doesn't force
+// a bogus corpus entry.
+func loadHelpers(t *testing.T) map[string]string {
+	return loadTSV3(t, "testdata/grammar_helpers.tsv")
+}
+
+// loadTSV3 is a shared reader for the 3-column TSV files (rule, label, notes)
+// plus an optional 4th column that's ignored here.
+func loadTSV3(t *testing.T, path string) map[string]string {
 	t.Helper()
-	f, err := os.Open("testdata/grammar_known_fails.tsv")
+	f, err := os.Open(path)
 	if err != nil {
-		t.Fatalf("open known_fails: %v", err)
+		t.Fatalf("open %s: %v", path, err)
 	}
 	defer f.Close()
 	out := map[string]string{}
@@ -138,11 +153,16 @@ func loadKnownFails(t *testing.T) map[string]string {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		parts := strings.SplitN(line, "\t", 3)
-		if len(parts) != 3 {
-			t.Fatalf("bad known_fails line: %q", line)
+		parts := strings.SplitN(line, "\t", 4)
+		if len(parts) < 3 {
+			t.Fatalf("bad line in %s: %q", path, line)
 		}
-		out[parts[0]+"/"+parts[1]] = parts[2]
+		// Concatenate anything past column 2 as the reason.
+		reason := parts[2]
+		if len(parts) == 4 {
+			reason = parts[2] + " — " + parts[3]
+		}
+		out[parts[0]+"/"+parts[1]] = reason
 	}
 	return out
 }
@@ -153,12 +173,18 @@ func TestGrammarSweep_CompilesAndEmitsPostfix(t *testing.T) {
 		t.Fatal("corpus is empty")
 	}
 	known := loadKnownFails(t)
+	helpers := loadHelpers(t)
 
 	c := NewCompiler()
 	var fails []string
 	var unexpectedPasses []string
 	for _, r := range rows {
 		name := r.rule + "/" + r.label
+		// Helpers can't be top-level compiled; their coverage is via the
+		// parent-rule labels that wrap them. Skip direct compile assertion.
+		if _, isHelper := helpers[name]; isHelper {
+			continue
+		}
 		postfix, err := compileRow(c, r)
 		passed := err == nil && (strings.TrimSpace(postfix) != "" || emptyPostfixAllowed[r.label])
 		if _, isKnown := known[name]; isKnown {

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -3403,6 +3403,24 @@ func (e *PostfixEmitter) VisitPrintArray(ctx *PrintArrayContext) interface{} {
 // Relationship and Entity Tests
 // ============================================================================
 
+// VisitStrTableLookup / VisitTableNew — the hash-table ops were removed;
+// the grammar still parses these forms. Emit an elstmterror so the compile
+// succeeds (non-empty postfix) but the runtime raises a clear error.
+
+func (e *PostfixEmitter) VisitStrTableLookup(ctx *StrTableLookupContext) interface{} {
+	e.emit("\"hash tables removed — (string) table-lookup unsupported\"")
+	e.emit("elstmterror")
+	e.emit("\"\"")
+	return nil
+}
+
+func (e *PostfixEmitter) VisitTableNew(ctx *TableNewContext) interface{} {
+	e.emit("\"hash tables removed — `new X table of Y` unsupported\"")
+	e.emit("elstmterror")
+	e.emit("newarray")
+	return nil
+}
+
 // VisitBoolEntityIsOf: `<e1> is <type> of <e2>` — the findmatch/relationship
 // lookup op this used to call was removed alongside the hash-table ops. The
 // emit now produces an elstmterror so the form parses but errors at runtime

--- a/pkg/dtrules/compiler/el/testdata/grammar_helpers.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_helpers.tsv
@@ -1,0 +1,30 @@
+rule	label	parent_rule	reason
+addtodest	addDestColon	addtostatement	helper: colon-ref addto destination; reached only inside ADD ... TO addtodest
+addtodest	addDestPossessiveLong	addtostatement	helper: 's prefix addto destination
+addtodest	addDestPossessiveDouble	addtostatement	helper: 's prefix addto destination
+subtodest	subDestColon	addtostatement	helper: colon-ref subtract destination
+subtodest	subDestPossessiveLong	addtostatement	helper: 's prefix subtract destination
+subtodest	subDestPossessiveDouble	addtostatement	helper: 's prefix subtract destination
+arrayList	arrayListFloatSingle	arrayExpr	helper: single-element array literal fragment
+arrayList	arrayListIntSingle	arrayExpr	helper: single-element array literal fragment
+arrayList	arrayListNameSingle	arrayExpr	helper: single-element array literal fragment
+arrayList	arrayListStrSingle	arrayExpr	helper: single-element array literal fragment
+blist	blistMulti	bexpr	helper: strexpr EQ blist list multi-item form (via boolStrEqList)
+blist	blistOr	bexpr	helper: strexpr EQ blist OR form
+blistIc	blistIcMulti	bexpr	helper: strexpr EQ_IGNORE_CASE blistIc multi-item form (via boolStrEqIcList)
+blistIc	blistIcOr	bexpr	helper: strexpr EQ_IGNORE_CASE blistIc OR form
+includeSearch	includeDate	bexpr	helper: array INCLUDES includeSearch date variant (via boolArrayIncludes)
+includeSearch	includeNumber	bexpr	helper: array INCLUDES includeSearch number variant
+includeSearch	includeString	bexpr	helper: array INCLUDES includeSearch string variant
+operatorlist	opListFloat	bexpr	helper: VALUE OF operatorstatements list-item helper
+operatorlist	opListFloatSingle	bexpr	helper: VALUE OF operatorstatements single-item helper
+operatorlist	opListInt	bexpr	helper: VALUE OF operatorstatements list-item helper
+operatorlist	opListIntSingle	bexpr	helper: VALUE OF operatorstatements single-item helper
+operatorlist	opListStr	bexpr	helper: VALUE OF operatorstatements list-item helper
+operatorlist	opListStrSingle	bexpr	helper: VALUE OF operatorstatements single-item helper
+possessiveRef	possessiveChain	bexpr	helper: 's chain nexpr form (via boolNameEq/Neq)
+possessiveRef	colonChain	bexpr	helper: :Entity:field nexpr form (via boolNameEq/Neq)
+arrayExpr2	arrayName	bexpr	helper: (array) NAME cast; reachable only in specific cast positions
+tablelist	tableListMulti	strexpr	hash tables removed — helper rule unreachable
+tablelist	tableListSingle	strexpr	hash tables removed — helper rule unreachable
+texpr	tableNew	strexpr	hash tables removed — texpr reachable only via typedTable lookup form

--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -1,18 +1,6 @@
 rule	label	reason
-addtodest	addDestColon	[E] helper sub-rule — no top-level compile path; tested inside addtostatement
-addtodest	addDestPossessiveDouble	[E] helper sub-rule — POSSESSIVE prefix is bound to parent addtostatement
-addtodest	addDestPossessiveLong	[E] helper sub-rule — POSSESSIVE prefix is bound to parent addtostatement
-arrayExpr2	arrayName	[E] helper — `(array) NAME` parse-ambiguous; reachable only in specific cast positions
-arrayList	arrayListFloatSingle	[E] helper — only valid inside an array-literal / operatorlist context
-arrayList	arrayListIntSingle	[E] helper — only valid inside an array-literal / operatorlist context
-arrayList	arrayListNameSingle	[E] helper — only valid inside an array-literal / operatorlist context
-arrayList	arrayListStrSingle	[E] helper — only valid inside an array-literal / operatorlist context
 bexpr	boolMatchForall	[D] complex multi-array join — `for each x in arr1, exists y in arr2 such that y.<nexpr> == x`; needs nested forall with inner-break primitive or accumulator gymnastics
 bexpr	boolValueOfOp	[D] `boolean value of <operatorstatements>` — operator dispatch returning a bool; needs runtime op understanding
-blist	blistMulti	[E] helper — only reachable inside strexpr EQ blist; tested via boolStrEqList
-blist	blistOr	[E] helper — only reachable inside strexpr EQ blist
-blistIc	blistIcMulti	[E] helper — only reachable inside strexpr EQ_IGNORE_CASE blistIc
-blistIc	blistIcOr	[E] helper — only reachable inside strexpr EQ_IGNORE_CASE blistIc
 done	conditionDebugAfter	[F] debug-after wiring — same
 done	conditionDebugBefore	[F] debug-before wiring — outer `done` alternative drops the debug emit
 done	contextDebugBefore	[F] debug-before in context — same
@@ -24,28 +12,10 @@ done	policyNExpr	[F] same as policyBExpr
 done	policyStrExpr	[F] same as policyBExpr
 fexpr	floatValueOfOp	[D] `double value of <operatorstatements>`
 iexpr	intValueOfOp	[D] `long value of <operatorstatements>`
-includeSearch	includeDate	[E] helper — only reachable inside arrayExpr INCLUDES includeSearch
-includeSearch	includeNumber	[E] helper — only reachable inside arrayExpr INCLUDES includeSearch
-includeSearch	includeString	[E] helper — only reachable inside arrayExpr INCLUDES includeSearch
-operatorlist	opListFloat	[E] helper — only reachable inside DOUBLE VALUE OF operatorstatements
-operatorlist	opListFloatSingle	[E] helper — only reachable inside DOUBLE VALUE OF operatorstatements
-operatorlist	opListInt	[E] helper — only reachable inside LONG VALUE OF operatorstatements
-operatorlist	opListIntSingle	[E] helper — only reachable inside LONG VALUE OF operatorstatements
-operatorlist	opListStr	[E] helper — only reachable inside STRING VALUE OF operatorstatements
-operatorlist	opListStrSingle	[E] helper — only reachable inside STRING VALUE OF operatorstatements
 performstatement	performCatchError	[D] try/catch around perform — uses performcatcherror op (exists); needs emit design
-possessiveRef	colonChain	[E] helper chain — `:Entity:field` nexpr form; reached via boolNameEq etc.
-possessiveRef	possessiveChain	[E] helper chain — `entity`s field` nexpr form; reached via boolNameEq etc.
 randomstatements	removeEachWhere	[D] remove-while-iterating: no bespoke op; compose forallr + remove — complex
 setstatement	setBoolFromName	[C] parser ambiguity with setStringFromName; requires symbol table to disambiguate
-strexpr	strTableLookup	[X] hash tables removed — grammar parses but runtime ops deleted
 strexpr	strValueOfOp	[D] `string value of <operatorstatements>`
-subtodest	subDestColon	[E] helper sub-rule — parallels addtodest/addDestColon
-subtodest	subDestPossessiveDouble	[E] helper sub-rule — parallels addtodest/addDestPossessiveDouble
-subtodest	subDestPossessiveLong	[E] helper sub-rule — parallels addtodest/addDestPossessiveLong
-tablelist	tableListMulti	[X] hash tables removed — grammar parses but helper rule unreachable
-tablelist	tableListSingle	[X] hash tables removed — grammar parses but helper rule unreachable
-texpr	tableNew	[X] hash tables removed — grammar parses but runtime ops deleted
 xmlvaluestatements	xmlAddAttr	[F] XML DOM mutation
 xmlvaluestatements	xmlAddAttrEntity	[F] XML DOM mutation
 xmlvaluestatements	xmlSetAttr	[F] XML DOM mutation — used for XML output mapping; not clear if runtime supports

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -177,3 +177,4 @@ bexpr	boolThereIsNoInArrayWhere	condition	there is no account in accounts where 
 bexpr	boolEntityHasaWhere	condition	account has a "rel" where true
 bexpr	boolStartsWithAt	condition	"hello" at 2 starts with "llo"
 dexpr	dateDays	condition	(date) "2020-01-01" + (5 days) is equal to (date) "2020-01-06"
+strexpr	strTableLookup	condition	(string) tbl("a") is equal to "x"


### PR DESCRIPTION
Introduces `grammar_helpers.tsv` — a list of labels that are grammar fragments not reachable from a top-level compile entry (addtodest, subtodest, arrayList, blist, blistIc, includeSearch, operatorlist, possessiveRef, arrayExpr2/arrayName, tablelist, texpr/tableNew). The sweep now skips direct-compile assertion for these since they live only inside parent rules — the parent rule labels already exercise them via DSL that triggers the helper productions.

26 [E] helper labels moved from known_fails to helpers. Coverage guard unchanged: helpers are still in the corpus, so they count as covered.

Adds two `elstmterror` Visit emits for forms whose runtime ops were removed in #668:
- `strTableLookup`: `(string) <tbl>(<list>)` emits a clear error
- `tableNew` (helper): `new <s> table of <s>`

`boolEntityIsOf` got the same treatment in #669.

## State

- 51 → 21 known_fails (only [C], [D], [F] remain)
- [E] 26 labels now in helpers (not known_fails)
- [X] 4 labels either emit elstmterror or moved to helpers