### PR TITLE
test(el): emit final two [D] labels — down to 1 known_fail (#635)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -3413,6 +3413,59 @@ func (e *PostfixEmitter) VisitOperatorstatements(ctx *OperatorstatementsContext)
 	return nil
 }
 
+// VisitRemoveEachWhere: `remove each <eexpr> from <arrayExpr> where <bexpr>`
+// — iterate in reverse (forallr is safer under removal), and for each
+// element whose bexpr holds, call `remove(arr, element)`. We keep a second
+// copy of the array on the data stack below forallr's operands so the body
+// can reach it with `dup`; the element comes from the entity stack via
+// `0 entityfetch`.
+func (e *PostfixEmitter) VisitRemoveEachWhere(ctx *RemoveEachWhereContext) interface{} {
+	e.Visit(ctx.ArrayExpr())
+	e.emit("dup")
+	e.emit("{")
+	e.Visit(ctx.Bexpr())
+	e.emit("{")
+	e.emit("dup")
+	e.emit("0")
+	e.emit("entityfetch")
+	e.emit("remove")
+	e.emit("}")
+	e.emit("if")
+	e.emit("}")
+	e.emit("swap")
+	e.emit("forallr")
+	e.emit("pop")
+	return nil
+}
+
+// VisitBoolMatchForall: `there is match for all <arr1> to <nexpr> in <arr2>`
+// — every element of arr1 has a match in arr2 via the nexpr attribute.
+// Emitted as nested folds: outer AND-accumulator over arr1, inner OR-
+// accumulator over arr2 comparing y.<nexpr> to x (fetched from entity
+// stack at depth 1). Semantic approximation; runtime correctness depends
+// on the specific types of arr1/arr2/nexpr.
+func (e *PostfixEmitter) VisitBoolMatchForall(ctx *BoolMatchForallContext) interface{} {
+	e.emit("true")
+	e.Visit(ctx.ArrayExpr(0))
+	e.emit("{")
+	// Inner existence check over arr2
+	e.emit("false")
+	e.Visit(ctx.ArrayExpr(1))
+	e.emit("{")
+	e.Visit(ctx.Nexpr())     // y.<nexpr>
+	e.emit("1")              // depth 1 = outer element x
+	e.emit("entityfetch")
+	e.emit("==")
+	e.emit("or")
+	e.emit("}")
+	e.emit("forall")
+	// AND with outer accumulator
+	e.emit("and")
+	e.emit("}")
+	e.emit("forall")
+	return nil
+}
+
 // VisitPerformCatchError: `perform <T1> and onerror add <e> to context
 // and perform <T2>`. opPerformCatchError signature is (table errtable
 // errentity --), so push /<T1>, /<T2>, /<e> as literal names then call the op.

--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -1,4 +1,2 @@
 rule	label	reason
-bexpr	boolMatchForall	[D] complex multi-array join — `for each x in arr1, exists y in arr2 such that y.<nexpr> == x`; needs nested forall with inner-break primitive or accumulator gymnastics
-randomstatements	removeEachWhere	[D] remove-while-iterating: no bespoke op; compose forallr + remove — complex
 setstatement	setBoolFromName	[C] parser ambiguity with setStringFromName; requires symbol table to disambiguate

--- a/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_overrides.tsv
@@ -182,3 +182,4 @@ iexpr	intValueOfOp	condition	long value of cvi(1.0) > 0
 fexpr	floatValueOfOp	condition	double value of cvr(1) > 0.0
 strexpr	strValueOfOp	condition	string value of cvs(1) is equal to "1"
 done	policyNExpr	raw	policystatement $tbl;
+bexpr	boolMatchForall	condition	there is match for all accounts to $tbl in accounts


### PR DESCRIPTION
3 → 1 known_fail. Covers boolMatchForall (nested forall with and/or accumulators) and removeEachWhere (forallr + dup-reference + entityfetch + remove).

Only `setstatement/setBoolFromName` remains — parser ambiguity (grammar picks `setStringFromName` first). Needs grammar reorder or symbol-table context.