### PR TITLE
test(el): symbol-driven cvb for setStringFromName — known_fails at 0 (#635)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -2568,11 +2568,20 @@ func (e *PostfixEmitter) VisitDecrementDouble(ctx *DecrementDoubleContext) inter
 	return nil
 }
 
-// VisitSetStringFromName: `set <leftStrexpr> = <nexpr>`. Convert the resolved
-// name reference to a string.
+// VisitSetStringFromName: `set <left> = <nexpr>`. The parser commits to
+// this alternative for any IDENT target (setBoolFromName is structurally
+// indistinguishable at parse time), so disambiguate here: look up the
+// target field's type in the symbol table and emit the matching coercion
+// (cvb for bool, cvs otherwise). `leftStrexpr` / `leftBexpr` both resolve
+// to `/<name> xdef` so the left emit is identical regardless.
 func (e *PostfixEmitter) VisitSetStringFromName(ctx *SetStringFromNameContext) interface{} {
 	e.Visit(ctx.Nexpr())
-	e.emit("cvs")
+	fieldName := ctx.LeftStrexpr().GetText()
+	if e.lookupType(fieldName) == TypeBoolean {
+		e.emit("cvb")
+	} else {
+		e.emit("cvs")
+	}
 	e.Visit(ctx.LeftStrexpr())
 	return nil
 }

--- a/pkg/dtrules/compiler/el/testdata/grammar_helpers.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_helpers.tsv
@@ -28,3 +28,4 @@ arrayExpr2	arrayName	bexpr	helper: (array) NAME cast; reachable only in specific
 tablelist	tableListMulti	strexpr	hash tables removed — helper rule unreachable
 tablelist	tableListSingle	strexpr	hash tables removed — helper rule unreachable
 texpr	tableNew	strexpr	hash tables removed — texpr reachable only via typedTable lookup form
+setstatement	setBoolFromName	setstatement	unreachable grammar alt — parser commits to setStringFromName for any IDENT target; emit disambiguates via symbol-table type (cvb for bool, cvs otherwise)

--- a/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
+++ b/pkg/dtrules/compiler/el/testdata/grammar_known_fails.tsv
@@ -1,2 +1,1 @@
 rule	label	reason
-setstatement	setBoolFromName	[C] parser ambiguity with setStringFromName; requires symbol table to disambiguate


### PR DESCRIPTION
**266 → 0 known_fails.** 100% of grammar alternatives compile to valid postfix.

The last holdout was `setstatement/setBoolFromName` — unreachable in the LL(*) parse because ANTLR commits to setStringFromName first for any IDENT target. But the compiler has the symbol table. VisitSetStringFromName now looks up the target field's declared type and emits `cvb` for bool fields, `cvs` otherwise. Both `leftStrexpr` and `leftBexpr` emit `/<name> xdef` so the left side is identical regardless of which alt committed.

Verified:

    no symbols:         $tbl cvs /b xdef   (default)
    b declared bool:    $tbl cvb /b xdef
    s declared string:  $tbl cvs /s xdef

setBoolFromName moved to `grammar_helpers.tsv` as dead-grammar-alt with a note.