### PR TITLE
fix(loader): wire EDD symbol table into the DT loader's EL compiler

### DIFF
--- a/pkg/dtrules/loader/dt.go
+++ b/pkg/dtrules/loader/dt.go
@@ -50,6 +50,18 @@ func NewDTLoader(session dtrules.Session, factory *entity.Factory) *DTLoader {
 	}
 }
 
+// SetSymbols wires an EDD-derived symbol table (map of field name → type)
+// into the EL compiler so arithmetic type promotion (bigint × int → bigint,
+// etc.) can fire during runtime DSL compilation. Without this, the loader
+// compiles every EL expression as if all operands were integers and loses
+// access to the bigint / double / bytes promotion paths.
+//
+// Call this after `rs.LoadEDD(...)` and before `rs.LoadDecisionTables(...)`
+// so the symbol table is populated when tables are compiled.
+func (l *DTLoader) SetSymbols(symbols map[string]string) {
+	l.elCompiler.SetSymbols(symbols)
+}
+
 // Structures matching the DTRules decision table format (XML and JSON)
 
 // DTFile represents the root decision_tables element

--- a/pkg/dtrules/session/ruleset.go
+++ b/pkg/dtrules/session/ruleset.go
@@ -100,7 +100,32 @@ func (rs *RuleSet) LoadDecisionTables(r io.Reader) error {
 	}
 
 	dtLoader := loader.NewDTLoader(tempSession, rs.entityFactory)
+	// Build the symbol table from the EDD so the EL compiler can pick the
+	// right arithmetic dispatch (bigint × int → bigint, etc.) when the DSL
+	// references typed fields. Without this the compiler defaults to integer
+	// arithmetic for every iexpr × iexpr multiply and loses type promotion.
+	dtLoader.SetSymbols(rs.buildSymbolTable())
 	return dtLoader.Load(r)
+}
+
+// buildSymbolTable walks the entity factory's registered reference entities
+// and returns a flat map of "entity.field" and "field" → type-name suitable
+// for the EL compiler's SetSymbols.
+func (rs *RuleSet) buildSymbolTable() map[string]string {
+	symbols := map[string]string{}
+	for _, ent := range rs.entityFactory.GetRefEntities() {
+		entityName := ent.GetName().StringValue()
+		for _, entry := range ent.GetEntries() {
+			if entry.Type == nil {
+				continue
+			}
+			fieldName := entry.Attribute.StringValue()
+			typeName := entry.Type.GetName().StringValue()
+			symbols[fieldName] = typeName
+			symbols[entityName+"."+fieldName] = typeName
+		}
+	}
+	return symbols
 }
 
 // LoadFromDirectory loads all XML files from a directory.


### PR DESCRIPTION
The XML loader's EL compiler was never given the EDD-derived symbol table, so `getExprType()` defaulted every operand to `TypeInteger`. Arithmetic on bigint fields got compiled as integer math with a trailing `cvi`, silently truncating large products (staking-reward calculations that overflowed int64 produced wrong results).

Fix: `RuleSet.LoadDecisionTables` now walks the entity factory, builds a flat field-name → type map, and calls the new `DTLoader.SetSymbols`. The existing promotion logic (`VisitIntMul/Add/Sub/Div` + `emitWithBigIntConversion`) then fires correctly.

Probe:

    weekly_budget: bigint, withholding_rate_num: integer

    before: ctx.weekly_budget ctx.withholding_rate_num * cvi /ctx.result xdef
    after:  ctx.weekly_budget ctx.withholding_rate_num cvbi b* cvbi /ctx.result xdef

Same fix cascades to every other symbol-table-driven emit (VisitSetStringFromName's cvb/cvs, typed set/add field-type conversions) that was receiving an empty symbol table via this path.

## Test plan
- [x] `make check` green
- [x] Direct probe shows `b*` + double `cvbi` when operands are declared bigint × int
- [x] Existing TaxReturn / CorporateTax / sampleprojects loaders continue to work (they just get a populated symbol table for free)