### PR TITLE
fix: authoring writes structured <context_details> + numberof emits length

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -1052,9 +1052,32 @@ func (e *PostfixEmitter) VisitIntParen(ctx *IntParenContext) interface{} {
 	return nil
 }
 
+// VisitIntNumberOf: `number of <arrayExpr>`. Uses the same runtime op as
+// `length of <arrayExpr>` — `length` — since there's no separate
+// `numberof` operator registered. Previously emitted `numberof`, which
+// resolved to an executable-name lookup and failed at runtime.
 func (e *PostfixEmitter) VisitIntNumberOf(ctx *IntNumberOfContext) interface{} {
 	e.Visit(ctx.ArrayExpr())
-	e.emit("numberof")
+	e.emit("length")
+	return nil
+}
+
+// VisitIntNumberOfWhere: `number of <arrayExpr> where <bexpr>` — count
+// elements matching bexpr. Emit a count-accumulator fold: seed 0, iterate
+// the array with forall (auto-pushes element entity), and for each element
+// increment the accumulator when bexpr is true.
+func (e *PostfixEmitter) VisitIntNumberOfWhere(ctx *IntNumberOfWhereContext) interface{} {
+	e.emit("0")
+	e.Visit(ctx.ArrayExpr())
+	e.emit("{")
+	e.Visit(ctx.Bexpr())
+	e.emit("{")
+	e.emit("1")
+	e.emit("+")
+	e.emit("}")
+	e.emit("if")
+	e.emit("}")
+	e.emit("forall")
 	return nil
 }
 

--- a/pkg/dtrules/excel/dt_importer.go
+++ b/pkg/dtrules/excel/dt_importer.go
@@ -338,8 +338,12 @@ func (i *DTImporter) writeTable(f *os.File, table *DecisionTableXML) error {
 	}
 	f.WriteString("</attribute_fields>\n")
 
-	// Contexts
-	f.WriteString(fmt.Sprintf("<contexts>%s</contexts>\n", xmlEscape(table.Contexts)))
+	// Contexts. The in-memory `Contexts` field is a raw newline-separated
+	// string (one DSL statement per line, as Excel stores it). The loader,
+	// however, expects a structured `<context_details>` form. Split on
+	// newlines and emit one <context_details> entry per non-empty line;
+	// the loader compiles the DSL to postfix at load time.
+	writeContextsXML(f, table.Contexts)
 
 	// Initial actions
 	f.WriteString("<initial_actions>\n")
@@ -398,6 +402,36 @@ func (i *DTImporter) writeTable(f *os.File, table *DecisionTableXML) error {
 }
 
 // xmlEscape escapes special XML characters.
+// writeContextsXML emits the <contexts>…</contexts> block in the structured
+// form the loader expects. Raw text with no statements produces a
+// self-empty element; each newline-separated non-empty line becomes a
+// <context_details> entry with an empty postfix (the loader compiles the
+// DSL on load). An entirely non-empty string with no newlines is treated as
+// a single context statement.
+func writeContextsXML(f *os.File, contexts string) {
+	text := strings.TrimSpace(contexts)
+	if text == "" {
+		f.WriteString("<contexts></contexts>\n")
+		return
+	}
+	f.WriteString("<contexts>\n")
+	num := 0
+	for _, line := range strings.Split(text, "\n") {
+		dsl := strings.TrimSpace(line)
+		if dsl == "" {
+			continue
+		}
+		num++
+		f.WriteString("<context_details>\n")
+		f.WriteString(fmt.Sprintf("<context_number>%d</context_number>\n", num))
+		f.WriteString("<context_comment></context_comment>\n")
+		f.WriteString(fmt.Sprintf("<context_dsl>%s</context_dsl>\n", xmlEscape(dsl)))
+		f.WriteString("<context_postfix></context_postfix>\n")
+		f.WriteString("</context_details>\n")
+	}
+	f.WriteString("</contexts>\n")
+}
+
 func xmlEscape(s string) string {
 	s = strings.ReplaceAll(s, "&", "&amp;")
 	s = strings.ReplaceAll(s, "<", "&lt;")


### PR DESCRIPTION
Two staking-reported bugs.

## 1. Authoring SDK wrote un-structured `<contexts>`

`DTImporter.WriteXML` emitted `<contexts>raw-text</contexts>` — the Excel-import intermediate form — but the loader expects `<context_details>` entries. Staking worked around it with a fix-contexts.py post-process.

Fix: split the raw Contexts string on newlines and emit one `<context_details>` entry per non-empty statement with an empty `<context_postfix>`. The loader compiles the DSL to postfix on load (via the v1.7.1 recompile-on-load path).

## 2. `number of <arr>` emitted `numberof` (no such op)

`VisitIntNumberOf` emitted `numberof` but the only registered op is `length`. The mismatched token resolved to an executable-name lookup and failed at runtime. Fix: emit `length`.

While here, also add `VisitIntNumberOfWhere` (`number of <arr> where <b>`) — count-accumulator fold with forall + conditional increment.

## Bug #3 already fixed

Staking's third report (`add entity to array` emitting `addarray`) was already fixed in v1.7.1: wiring the EDD symbol table into the loader's EL compiler lets `VisitAddArrayToArray`'s existing type-detection code see `srcType == TypeEntity` and emit `swap addto` instead of `addarray`.

## Test plan

- [x] `make check` green
- [x] Authoring SDK `Save` output parseable by loader (sampleproject-format `<context_details>`)
- [x] `number of accounts` compiles to `accounts length`
- [x] `number of accounts where <b>` compiles to a count-accumulator fold