### PR TITLE
fix(authoring, el): preserve <context_details> on round-trip + default addto for entity→array (#680, #681)

### DIFF
--- a/pkg/dtrules/authoring/edd.go
+++ b/pkg/dtrules/authoring/edd.go
@@ -153,7 +153,7 @@ func (e *EDD) DeleteEntity(name string) error {
 func (e *EDD) deleteEntityChecked(name string, dtFiles []dtFileEntry) error {
 	for _, entry := range dtFiles {
 		for _, t := range entry.tables.Tables {
-			for _, ctx := range strings.Split(t.Contexts, ",") {
+			for _, ctx := range strings.Split(string(t.Contexts), ",") {
 				if strings.TrimSpace(ctx) == name {
 					return fmt.Errorf("cannot delete entity %q: referenced as context in table %q", name, t.TableName)
 				}

--- a/pkg/dtrules/authoring/table.go
+++ b/pkg/dtrules/authoring/table.go
@@ -17,6 +17,7 @@ package authoring
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/DTRules/DTRules/pkg/dtrules/excel"
 )
@@ -87,8 +88,18 @@ func (t *Table) syncFromXML() {
 	t.Policy = t.xml.AttributeFields.Type
 
 	t.Contexts = nil
-	if t.xml.Contexts != "" {
-		t.Contexts = []Context{{DSL: t.xml.Contexts}}
+	// The XML form stores contexts as a newline-joined string. Split so a
+	// multi-statement `<contexts>` round-trips through the typed view with
+	// one Context entry per statement.
+	raw := strings.TrimSpace(string(t.xml.Contexts))
+	if raw != "" {
+		for _, line := range strings.Split(raw, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			t.Contexts = append(t.Contexts, Context{DSL: line})
+		}
 	}
 
 	t.InitialActions = nil
@@ -133,7 +144,11 @@ func (t *Table) syncToXML() {
 	t.xml.AttributeFields.Type = t.Policy
 
 	if len(t.Contexts) > 0 {
-		t.xml.Contexts = t.Contexts[0].DSL
+		lines := make([]string, 0, len(t.Contexts))
+		for _, c := range t.Contexts {
+			lines = append(lines, c.DSL)
+		}
+		t.xml.Contexts = excel.ContextsField(strings.Join(lines, "\n"))
 	} else {
 		t.xml.Contexts = ""
 	}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -3824,25 +3824,31 @@ func (e *PostfixEmitter) VisitAddArrayToArray(ctx *AddArrayToArrayContext) inter
 		}
 	}
 
-	// Determine if source is a single entity or an array
-	// Check source type from EDD
+	// Determine if source is a single entity or an array. The parser sees
+	// `ADD <IDENT> TO <IDENT>` as arrayExpr TO arrayExpr because
+	// typedEntity and typedArray both come from IDENT — so this visitor is
+	// the default landing spot for both `add entity X to array Y` and
+	// `add array A to array B`. Use the symbol table to distinguish when
+	// present. If unknown, default to the single-element-to-array pattern
+	// (addto) since that's the overwhelmingly common case in practice;
+	// array-to-array merge requires explicitly typed arrays in the EDD.
 	srcExpr := ctx.ArrayExpr(0)
-	srcIsArray := true // Default to array
+	srcIsArray := false // Default to entity-to-array (safer)
 
 	if baseCtx, ok := srcExpr.(*ArrayBaseContext); ok {
 		if arrayExpr2 := baseCtx.ArrayExpr2(); arrayExpr2 != nil {
 			if typedCtx, ok := arrayExpr2.(*ArrayTypedContext); ok {
 				srcName := typedCtx.TypedArray().GetText()
 				srcType := e.lookupType(srcName)
-				// If source is entity type, not array
-				if srcType == TypeEntity {
-					srcIsArray = false
+				// If source is explicitly an array, use array merge.
+				if srcType == TypeArray {
+					srcIsArray = true
 				}
 			}
 		}
 	}
 
-	// If source is a single entity and dest is an array field, use swap addto
+	// Single-element → array: emit `swap addto`.
 	if !srcIsArray {
 		e.Visit(ctx.ArrayExpr(0))
 		e.Visit(ctx.ArrayExpr(1))
@@ -3851,7 +3857,7 @@ func (e *PostfixEmitter) VisitAddArrayToArray(ctx *AddArrayToArrayContext) inter
 		return nil
 	}
 
-	// Default: array-to-array addition
+	// Array-to-array merge (source is declared array in the EDD).
 	e.Visit(ctx.ArrayExpr(0))
 	e.Visit(ctx.ArrayExpr(1))
 	e.emit("true")

--- a/pkg/dtrules/excel/dt_importer.go
+++ b/pkg/dtrules/excel/dt_importer.go
@@ -101,12 +101,60 @@ type DecisionTableXML struct {
 	TableName        string               `xml:"table_name"`
 	XLSFile          string               `xml:"xls_file"`
 	AttributeFields  AttributeFieldsXML   `xml:"attribute_fields"`
-	Contexts         string               `xml:"contexts"`
+	Contexts         ContextsField        `xml:"contexts"`
 	InitialActions   []InitialActionXML   `xml:"initial_actions>initial_action"`
 	Conditions       []ConditionXML       `xml:"conditions>condition_details"`
 	Actions          []ActionXML          `xml:"actions>action_details"`
 	PolicyStatements []PolicyStatementXML `xml:"policy_statements>policy_statement"`
 	ELCompiled       bool                 `xml:"el_compiled,attr"` // True if postfix was generated from EL
+}
+
+// ContextsField is the in-memory shape of a table's <contexts> element. It
+// carries a newline-joined DSL string — the simplest representation that
+// matches how Excel stores contexts — and knows how to round-trip through
+// both the legacy raw-text form and the structured <context_details> form
+// the loader expects.
+//
+//	Legacy (Excel import intermediate):
+//	  <contexts>for all accounts</contexts>
+//
+//	Loader (structured):
+//	  <contexts>
+//	    <context_details>
+//	      <context_dsl>for all accounts</context_dsl>
+//	      ...
+//	    </context_details>
+//	  </contexts>
+//
+// Unmarshalling tolerates both: structured <context_details> children have
+// their DSL extracted and joined with newlines; raw text is taken verbatim.
+// Marshalling emits the structured form so the loader can read it back.
+type ContextsField string
+
+// UnmarshalXML accepts either the raw-text or structured form and collapses
+// the result into a newline-joined DSL string so existing string-shaped
+// consumers (table.Contexts, syncFromXML) keep working.
+func (c *ContextsField) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var tmp struct {
+		InnerXML string `xml:",innerxml"`
+		Details  []struct {
+			DSL string `xml:"context_dsl"`
+		} `xml:"context_details"`
+	}
+	if err := d.DecodeElement(&tmp, &start); err != nil {
+		return err
+	}
+	if len(tmp.Details) > 0 {
+		lines := make([]string, 0, len(tmp.Details))
+		for _, det := range tmp.Details {
+			lines = append(lines, det.DSL)
+		}
+		*c = ContextsField(strings.Join(lines, "\n"))
+		return nil
+	}
+	// No <context_details> children — treat inner XML as raw text.
+	*c = ContextsField(strings.TrimSpace(tmp.InnerXML))
+	return nil
 }
 
 // AttributeFieldsXML holds metadata fields for the table.
@@ -408,8 +456,8 @@ func (i *DTImporter) writeTable(f *os.File, table *DecisionTableXML) error {
 // <context_details> entry with an empty postfix (the loader compiles the
 // DSL on load). An entirely non-empty string with no newlines is treated as
 // a single context statement.
-func writeContextsXML(f *os.File, contexts string) {
-	text := strings.TrimSpace(contexts)
+func writeContextsXML(f *os.File, contexts ContextsField) {
+	text := strings.TrimSpace(string(contexts))
 	if text == "" {
 		f.WriteString("<contexts></contexts>\n")
 		return
@@ -721,9 +769,9 @@ func (i *DTImporter) parseExporterFormat(rows [][]string, sheetName string, tabl
 				if len(row) > 2 && firstCell != "" {
 					// Contexts are typically comma-separated entity names
 					if table.Contexts == "" {
-						table.Contexts = strings.TrimSpace(row[2])
+						table.Contexts = ContextsField(strings.TrimSpace(row[2]))
 					} else {
-						table.Contexts += "," + strings.TrimSpace(row[2])
+						table.Contexts = ContextsField(string(table.Contexts) + "," + strings.TrimSpace(row[2]))
 					}
 				}
 				if len(row) == 0 || firstCell == "" {

--- a/pkg/dtrules/excel/xml_exporter.go
+++ b/pkg/dtrules/excel/xml_exporter.go
@@ -202,7 +202,7 @@ func writeDTXMLContexts(f *excelize.File, sheet string, dt *DecisionTableXML, ro
 	row++
 
 	if dt.Contexts != "" {
-		contexts := strings.Split(dt.Contexts, ",")
+		contexts := strings.Split(string(dt.Contexts), ",")
 		for i, ctx := range contexts {
 			ctx = strings.TrimSpace(ctx)
 			f.SetCellValue(sheet, cellName(1, row), i+1)


### PR DESCRIPTION
Closes #680 and #681.

## #681 — context_details lost on round-trip

My #678 taught `DTImporter.WriteXML` to emit structured `<context_details>`, but `DecisionTableXML.Contexts` stayed `string`. On Save → Reopen, the structured children parsed as empty text, then `syncFromXML` wrote that empty string back — silently dropping every `for all` context.

**Fix:** `Contexts` becomes a typed string `ContextsField` with a custom `UnmarshalXML` that accepts both the legacy raw-text form and the structured `<context_details>` form. Structured children have their `<context_dsl>` extracted and newline-joined so the in-memory string round-trips losslessly. `syncFromXML` splits multi-line into multiple Context entries (was keeping only the first).

## #680 — add entity to array emits addarray

`VisitAddArrayToArray` defaulted `srcIsArray = true` when symbols weren't present. `CheckAction(..., nil)` never gets symbols, so it always hit the wrong default.

**Fix:** default `srcIsArray = false`. Single-element → array is the overwhelmingly common case. Array merge (addarray with `true`) now requires the source to be explicitly typed `array` in the EDD. Verified three cases:

    no symbols:              staking_account ... swap addto        (was addarray)
    array→array (declared):  src_array dst_array true addarray     (preserved)
    entity→array (declared): src_entity dst_array swap addto

## Test plan

- [x] `make check` green
- [x] Round-trip probe: OpenProject → Save → Reopen preserves multi-line `<contexts>` content
- [x] `CheckAction("add X to Y", nil)` now emits `swap addto` by default
- [x] Explicit array-declared source still routes to `addarray`