### PR TITLE
fix(el): type-aware field-mutation visitors (add/sub/inc/dec)

### DIFF
--- a/pkg/dtrules/compiler/bytecode_compiler.go
+++ b/pkg/dtrules/compiler/bytecode_compiler.go
@@ -96,6 +96,14 @@ func (c *Compiler) compileTokenToBytecode(bc *dtrules.BytecodeChunk, token strin
 		return nil
 	}
 
+	// Try as fixed-point (numeric token with an `fp`/`FP` suffix).
+	if hasFixedSuffix(token) {
+		if fp, err := dtrules.GetRFixedFromString(token); err == nil {
+			bc.EmitPushConstant(dtrules.NewValueObject(fp))
+			return nil
+		}
+	}
+
 	// Try as integer
 	if i, err := dtrules.GetRIntegerValueFromString(token); err == nil {
 		v, _ := i.LongValue()

--- a/pkg/dtrules/compiler/compiler.go
+++ b/pkg/dtrules/compiler/compiler.go
@@ -25,6 +25,16 @@ import (
 	"github.com/DTRules/DTRules/pkg/dtrules/operators"
 )
 
+// hasFixedSuffix reports whether token ends in an `fp` or `FP` suffix of at
+// least one preceding character. Used to detect fixed-point numeric literals
+// like "1.50000000fp" before attempting integer or double parsing.
+func hasFixedSuffix(token string) bool {
+	if len(token) < 3 {
+		return false
+	}
+	return strings.EqualFold(token[len(token)-2:], "fp")
+}
+
 // Compiler compiles postfix expressions into executable code.
 type Compiler struct {
 	session dtrules.Session
@@ -176,6 +186,13 @@ func (c *Compiler) compileToken(token string) (dtrules.Object, error) {
 		b, err := dtrules.NewRBytesFromHex(token)
 		if err == nil {
 			return b, nil
+		}
+	}
+
+	// Try as fixed-point (numeric token with an `fp`/`FP` suffix).
+	if hasFixedSuffix(token) {
+		if fp, err := dtrules.GetRFixedFromString(token); err == nil {
+			return fp, nil
 		}
 	}
 

--- a/pkg/dtrules/compiler/compiler_test.go
+++ b/pkg/dtrules/compiler/compiler_test.go
@@ -117,6 +117,41 @@ func TestCompileDouble(t *testing.T) {
 	}
 }
 
+func TestCompileFixedLiteral(t *testing.T) {
+	cases := []struct {
+		src  string
+		want string
+	}{
+		{"1.5fp", "1.50000000"},
+		{"-0.00000001fp", "-0.00000001"},
+		{"1000000FP", "1000000.00000000"},
+		{"0fp", "0.00000000"},
+	}
+	for _, c := range cases {
+		t.Run(c.src, func(t *testing.T) {
+			comp := newTestCompiler()
+			result, err := comp.Compile(c.src)
+			if err != nil {
+				t.Fatalf("Compile(%q): %v", c.src, err)
+			}
+			arr, err := result.ArrayValue()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(arr) != 1 {
+				t.Fatalf("expected 1 element, got %d", len(arr))
+			}
+			fp, ok := arr[0].(*dtrules.RFixed)
+			if !ok {
+				t.Fatalf("expected RFixed, got %T", arr[0])
+			}
+			if got := fp.StringValue(); got != c.want {
+				t.Errorf("compiled %q = %q, want %q", c.src, got, c.want)
+			}
+		})
+	}
+}
+
 func TestCompileString(t *testing.T) {
 	c := newTestCompiler()
 

--- a/pkg/dtrules/compiler/el/compiler_test.go
+++ b/pkg/dtrules/compiler/el/compiler_test.go
@@ -451,8 +451,9 @@ func TestBigIntComparisonOperators(t *testing.T) {
 }
 
 // TestBigIntComparisonWithLocalVariables tests comparison operations on local bigint variables.
-// The emitter is now type-aware and emits bigint operators when operands are known to be bigint.
-// Note: Equality uses streq when parsed as string comparison (depends on grammar rule match).
+// The emitter is now type-aware across the whole comparison family — BoolName{Eq,Neq}
+// dispatch to numeric compares when both operands resolve to a numeric type, so
+// bigint equality now uses b== rather than the stringwise streq fallback.
 func TestBigIntComparisonWithLocalVariables(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -461,12 +462,12 @@ func TestBigIntComparisonWithLocalVariables(t *testing.T) {
 		expected  string
 	}{
 		{
-			// Note: This uses streq because the parser sees two identifiers
-			// and defaults to string comparison for == operator
-			name:      "local bigint equality uses streq",
+			// BoolNameEq now detects the local-declared bigint type and emits
+			// a bigint compare instead of the old streq fallback.
+			name:      "local bigint equality uses bigint b==",
 			context:   "local bigint x = (bigint) 10;",
 			condition: "x == x",
-			expected:  "0 local@ 0 local@ streq",
+			expected:  "0 local@ 0 local@ b==",
 		},
 		{
 			// The emitter detects that x is bigint and emits b> operator

--- a/pkg/dtrules/compiler/el/edd_loader.go
+++ b/pkg/dtrules/compiler/el/edd_loader.go
@@ -149,6 +149,8 @@ func normalizeType(t string) string {
 		return TypeBigInt
 	case "bytes":
 		return TypeBytes
+	case "fixed":
+		return TypeFixed
 	default:
 		return t
 	}

--- a/pkg/dtrules/compiler/el/edd_loader.go
+++ b/pkg/dtrules/compiler/el/edd_loader.go
@@ -36,6 +36,7 @@ const (
 	TypeXmlValue = "xmlvalue"
 	TypeBigInt   = "bigint"
 	TypeBytes    = "bytes"
+	TypeFixed    = "fixed"
 )
 
 // EDDFile represents the root entity_data_dictionary element

--- a/pkg/dtrules/compiler/el/field_mutation_test.go
+++ b/pkg/dtrules/compiler/el/field_mutation_test.go
@@ -1,0 +1,234 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #686: the field-mutation visitors (add-to, subtract-from,
+// increment, decrement) emitted type-naive postfix regardless of the
+// declared field type. Integer targets got `+`/`-`, but fixed, bigint,
+// and double targets also got plain `+`/`-` — the operator called
+// LongValue() on the operand and stored back a truncated integer. The
+// `add N to field` statement for bare-IDENT targets was even worse: it
+// emitted just `value field` with no op, so the statement was a no-op
+// at runtime.
+//
+// This test matrix covers the 4 mutation statements × 4 numeric target
+// types = 16 cases, asserting each emits the right op family and that
+// the integer path still produces the historic plain-op output.
+
+func mutationSymbols() map[string]string {
+	return map[string]string{
+		"count":  TypeInteger,
+		"total":  TypeBigInt,
+		"rate":   TypeDouble,
+		"amount": TypeFixed,
+	}
+}
+
+type mutationCase struct {
+	dsl     string
+	mustHit []string // substrings that must appear in postfix
+	mustNot []string // substrings that must not appear
+}
+
+func runMutationCases(t *testing.T, cases []mutationCase) {
+	t.Helper()
+	c := NewCompiler()
+	c.SetSymbols(mutationSymbols())
+	for _, tc := range cases {
+		t.Run(tc.dsl, func(t *testing.T) {
+			postfix, err := c.CompileAction(tc.dsl)
+			if err != nil {
+				t.Fatalf("compile %q: %v", tc.dsl, err)
+			}
+			for _, want := range tc.mustHit {
+				if !strings.Contains(postfix, want) {
+					t.Errorf("expected %q in postfix, got: %s", want, postfix)
+				}
+			}
+			for _, bad := range tc.mustNot {
+				if strings.Contains(postfix, bad) {
+					t.Errorf("unexpected %q in postfix: %s", bad, postfix)
+				}
+			}
+		})
+	}
+}
+
+// TestFieldMutation_AddTo — `add <value> to <field>` across all four types.
+func TestFieldMutation_AddTo(t *testing.T) {
+	runMutationCases(t, []mutationCase{
+		{
+			dsl:     "add 1 to count",
+			mustHit: []string{"+", "/count xdef"},
+			mustNot: []string{"fp+", "b+", "f+", "cvfp", "cvbi", "cvr"},
+		},
+		{
+			dsl:     "add 1 to total",
+			mustHit: []string{"cvbi", "b+", "/total xdef"},
+			mustNot: []string{"fp+", " + "},
+		},
+		{
+			dsl:     "add 1.5 to rate",
+			mustHit: []string{"cvr", "f+", "/rate xdef"},
+			mustNot: []string{"fp+", "b+"},
+		},
+		{
+			dsl:     "add 1.5fp to amount",
+			mustHit: []string{"cvfp", "fp+", "/amount xdef"},
+			mustNot: []string{"swap addto", " + /", "b+", "f+"},
+		},
+	})
+}
+
+// TestFieldMutation_SubtractFrom — `subtract <value> from <field>` across
+// all four types.
+func TestFieldMutation_SubtractFrom(t *testing.T) {
+	runMutationCases(t, []mutationCase{
+		{
+			dsl:     "subtract 1 from count",
+			mustHit: []string{"swap", "-", "/count xdef"},
+			mustNot: []string{"fp-", "b-", "f-", "cvfp", "cvbi", "cvr"},
+		},
+		{
+			dsl:     "subtract 1 from total",
+			mustHit: []string{"cvbi", "b-", "/total xdef"},
+			mustNot: []string{"fp-"},
+		},
+		{
+			dsl:     "subtract 0.5 from rate",
+			mustHit: []string{"cvr", "f-", "/rate xdef"},
+			mustNot: []string{"fp-", "b-"},
+		},
+		{
+			dsl:     "subtract 0.5fp from amount",
+			mustHit: []string{"cvfp", "fp-", "/amount xdef"},
+			mustNot: []string{"b-", "f-"},
+		},
+	})
+}
+
+// TestFieldMutation_Increment — `increment <field>` across all four types.
+// This matrix also guards the double path, which was previously broken:
+// VisitIncrementDouble is almost never reached (typedLong wins), and
+// VisitIncrementLong (before the fix) emitted `field 1 + /field xdef` —
+// integer `+` on a double operand truncates to int64.
+func TestFieldMutation_Increment(t *testing.T) {
+	runMutationCases(t, []mutationCase{
+		{
+			dsl: "increment count",
+			// New unified pattern is `1 count + /count xdef` (value pushed
+			// first via emitOneForField, then the shared store-back helper).
+			// Semantically identical to the old `count 1 + /count xdef`
+			// since integer + is commutative.
+			mustHit: []string{"1 count", " + ", "/count xdef"},
+			mustNot: []string{"fp+", "b+", "f+", "cvfp", "cvbi", "cvr"},
+		},
+		{
+			dsl:     "increment total",
+			mustHit: []string{"cvbi", "b+", "/total xdef"},
+			mustNot: []string{"fp+"},
+		},
+		{
+			dsl:     "increment rate",
+			mustHit: []string{"1.0", "cvr", "f+", "/rate xdef"},
+			mustNot: []string{"fp+", "b+", "rate 1 +"},
+		},
+		{
+			dsl:     "increment amount",
+			mustHit: []string{"cvfp", "fp+", "/amount xdef"},
+			mustNot: []string{"b+", "f+", "amount 1 +"},
+		},
+	})
+}
+
+// TestFieldMutation_Decrement — parallel to Increment.
+func TestFieldMutation_Decrement(t *testing.T) {
+	runMutationCases(t, []mutationCase{
+		{
+			dsl: "decrement count",
+			// New unified pattern: `1 count swap - /count xdef` — swap
+			// ensures the subtract direction is `field - value`.
+			mustHit: []string{"1 count swap -", "/count xdef"},
+			mustNot: []string{"fp-", "b-", "f-", "cvfp", "cvbi"},
+		},
+		{
+			dsl:     "decrement total",
+			mustHit: []string{"cvbi", "b-", "/total xdef"},
+			mustNot: []string{"fp-"},
+		},
+		{
+			dsl:     "decrement rate",
+			mustHit: []string{"1.0", "cvr", "f-", "/rate xdef"},
+			mustNot: []string{"fp-", "rate 1 -"},
+		},
+		{
+			dsl:     "decrement amount",
+			mustHit: []string{"cvfp", "fp-", "/amount xdef"},
+			mustNot: []string{"amount 1 -"},
+		},
+	})
+}
+
+// TestFieldMutation_ColonRefTargets guards the possessive / colon-ref
+// variant: `add 1.5fp to wp.amount` also has to route through the
+// type-aware dispatch. This is the common shape in decision-table
+// authoring (entity.field references).
+func TestFieldMutation_ColonRefTargets(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{
+		"wp.count":  TypeInteger,
+		"wp.total":  TypeBigInt,
+		"wp.rate":   TypeDouble,
+		"wp.amount": TypeFixed,
+	})
+	cases := []mutationCase{
+		{
+			dsl:     "add 1.5fp to wp.amount",
+			mustHit: []string{"cvfp", "fp+", "/wp.amount xdef"},
+			mustNot: []string{"swap addto"},
+		},
+		{
+			dsl:     "subtract 1.5fp from wp.amount",
+			mustHit: []string{"cvfp", "fp-", "/wp.amount xdef"},
+		},
+		{
+			dsl:     "add 1 to wp.total",
+			mustHit: []string{"cvbi", "b+", "/wp.total xdef"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.dsl, func(t *testing.T) {
+			postfix, err := c.CompileAction(tc.dsl)
+			if err != nil {
+				t.Fatalf("compile %q: %v", tc.dsl, err)
+			}
+			for _, want := range tc.mustHit {
+				if !strings.Contains(postfix, want) {
+					t.Errorf("expected %q, got: %s", want, postfix)
+				}
+			}
+			for _, bad := range tc.mustNot {
+				if strings.Contains(postfix, bad) {
+					t.Errorf("unexpected %q: %s", bad, postfix)
+				}
+			}
+		})
+	}
+}

--- a/pkg/dtrules/compiler/el/fixed_test.go
+++ b/pkg/dtrules/compiler/el/fixed_test.go
@@ -123,14 +123,12 @@ func TestFixedNegation_EmitsFpNegate(t *testing.T) {
 	}
 }
 
-// TestFixedComparisonOperators exercises the full comparison family on the
-// VisitBoolInt* visitors that my refactor touched. `>=` and `<=` are the
-// paths this test is specifically guarding — they share the same dispatch
-// code as `>` and `<` (already covered) but route to distinct operators.
-//
-// Note: the grammar routes `!=` between two plain field refs to a string-
-// compare path (`streq not`), not BoolIntNeq, so that specific combination
-// is a separate concern tracked as a follow-up.
+// TestFixedComparisonOperators_AllEmitFpOps covers the full comparison
+// family. The `==` / `!=` cases specifically exercise the BoolName*
+// numeric-dispatch path (the grammar routes `field CMP field` through the
+// nexpr visitors regardless of type); `<`, `<=`, `>`, `>=` exercise the
+// iexpr-routed BoolInt* visitors. A dispatch typo on any of them would
+// fail.
 func TestFixedComparisonOperators_AllEmitFpOps(t *testing.T) {
 	c := NewCompiler()
 	c.SetSymbols(stakingFixedSymbols())
@@ -139,6 +137,8 @@ func TestFixedComparisonOperators_AllEmitFpOps(t *testing.T) {
 		dsl  string
 		want string
 	}{
+		{"wp.reward_per_block == wp.staker_balance", "fp=="},
+		{"wp.reward_per_block != wp.staker_balance", "fp!="},
 		{"wp.reward_per_block > wp.staker_balance", "fp>"},
 		{"wp.reward_per_block >= wp.staker_balance", "fp>="},
 		{"wp.reward_per_block < wp.staker_balance", "fp<"},
@@ -153,26 +153,87 @@ func TestFixedComparisonOperators_AllEmitFpOps(t *testing.T) {
 			if !strings.Contains(postfix, c2.want) {
 				t.Errorf("expected %s in postfix, got: %s", c2.want, postfix)
 			}
+			// The string-compare fallback must not leak in — that was the
+			// pre-fix behavior BoolName{Eq,Neq} had for numeric operands.
+			if strings.Contains(postfix, "streq") {
+				t.Errorf("unexpected streq for numeric compare: %s", postfix)
+			}
 		})
 	}
 }
 
-// TestIntegerNotEqual_UnchangedByFixedRefactor is a regression guard on my
-// VisitBoolIntNeq refactor: when both operands are plain integers, the
-// emitter must still fall back to the historic `== not` pattern, not
-// accidentally emit `fp!=` or `b!=`.
-func TestIntegerNotEqual_UnchangedByFixedRefactor(t *testing.T) {
+// TestBigIntComparison_NameDispatch guards that the numeric-name dispatch
+// also lights up for pure bigint comparisons — previously bigint == bigint
+// via two field refs fell through to streq (documented in the pre-fix
+// TestBigIntComparisonWithLocalVariables).
+func TestBigIntComparison_NameDispatch(t *testing.T) {
 	c := NewCompiler()
 	c.SetSymbols(map[string]string{
-		"ap.count":  "integer",
-		"ap.amount": "integer",
+		"bp.a": "bigint",
+		"bp.b": "bigint",
 	})
-	postfix, err := c.CompileCondition("ap.count != ap.amount")
+	cases := []struct {
+		dsl, want string
+	}{
+		{"bp.a == bp.b", "b=="},
+		{"bp.a != bp.b", "b!="},
+	}
+	for _, c2 := range cases {
+		t.Run(c2.want, func(t *testing.T) {
+			postfix, err := c.CompileCondition(c2.dsl)
+			if err != nil {
+				t.Fatalf("compile %q: %v", c2.dsl, err)
+			}
+			if !strings.Contains(postfix, c2.want) {
+				t.Errorf("expected %s, got: %s", c2.want, postfix)
+			}
+			if strings.Contains(postfix, "streq") {
+				t.Errorf("bigint compare must not emit streq: %s", postfix)
+			}
+		})
+	}
+}
+
+// TestMixedTypeComparison_PromotesToWidest verifies that a mixed numeric
+// comparison on the BoolName path picks the widest type and emits the
+// right cast on the narrower side.
+func TestMixedTypeComparison_PromotesToWidest(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{
+		"wp.amount": "fixed",
+		"ap.count":  "integer",
+	})
+	postfix, err := c.CompileCondition("wp.amount == ap.count")
 	if err != nil {
 		t.Fatalf("compile error: %v", err)
 	}
+	if !strings.Contains(postfix, "cvfp") {
+		t.Errorf("expected cvfp promotion in postfix, got: %s", postfix)
+	}
+	if !strings.Contains(postfix, "fp==") {
+		t.Errorf("expected fp== after promotion, got: %s", postfix)
+	}
+}
+
+// TestStringComparison_UnchangedByNumericDispatch is a regression guard on
+// BoolName{Eq,Neq}: string-vs-string name compares must still land on the
+// existing streq/`streq not` fallback. The numeric-dispatch branch is only
+// meant to intercept when BOTH operands are declared numeric.
+func TestStringComparison_UnchangedByNumericDispatch(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{
+		"p.first_name": "string",
+		"p.last_name":  "string",
+	})
+	postfix, err := c.CompileCondition("p.first_name != p.last_name")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if !strings.Contains(postfix, "streq") {
+		t.Errorf("string != must keep emitting streq: %s", postfix)
+	}
 	if strings.Contains(postfix, "fp!=") || strings.Contains(postfix, "b!=") {
-		t.Errorf("pure-int != must not emit fp!=/b!=: %s", postfix)
+		t.Errorf("string compare must not emit numeric ops: %s", postfix)
 	}
 }
 

--- a/pkg/dtrules/compiler/el/fixed_test.go
+++ b/pkg/dtrules/compiler/el/fixed_test.go
@@ -274,6 +274,28 @@ func TestFixedLiteral_PureFpArithmetic_UsesFpOps(t *testing.T) {
 	}
 }
 
+// TestIntegerNegation_EmitsNegate guards the pre-existing bug where
+// VisitIntNegate emitted `neg` — an operator name that was never
+// registered — so every rule doing `-<int_expr>` failed at runtime.
+// The fix was at the root: the emitter now emits `negate`, the operator
+// that actually exists. This test asserts the emission, not a runtime
+// alias, so any regression back to `neg` is caught at compile time.
+func TestIntegerNegation_EmitsNegate(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{"ap.count": "integer"})
+	postfix, err := c.CompileAction("set ap.count = - ap.count")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if !strings.Contains(postfix, "negate") {
+		t.Errorf("expected `negate` for integer negation, got: %s", postfix)
+	}
+	// Pin the regression: the old buggy emission would have a lone ` neg`.
+	if strings.Contains(postfix, " neg ") || strings.HasSuffix(postfix, " neg") {
+		t.Errorf("emitter regressed to unregistered `neg`: %s", postfix)
+	}
+}
+
 // TestStringComparison_UnchangedByNumericDispatch is a regression guard on
 // BoolName{Eq,Neq}: string-vs-string name compares must still land on the
 // existing streq/`streq not` fallback. The numeric-dispatch branch is only

--- a/pkg/dtrules/compiler/el/fixed_test.go
+++ b/pkg/dtrules/compiler/el/fixed_test.go
@@ -1,0 +1,125 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+func stakingFixedSymbols() map[string]string {
+	return map[string]string{
+		"wp.reward_per_block": "fixed",
+		"wp.staker_balance":   "fixed",
+		"wp.weekly_reward":    "fixed",
+		"wp.periods":          "integer",
+		"bp.treasury_fee":     "bigint",
+	}
+}
+
+// TestFixedArithmetic_EmitsFpOps verifies that when both operands are fixed,
+// the emitter picks fp-family operators.
+func TestFixedArithmetic_EmitsFpOps(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(stakingFixedSymbols())
+
+	postfix, err := c.CompileAction("set wp.weekly_reward = wp.reward_per_block * wp.staker_balance")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if !strings.Contains(postfix, "fp*") {
+		t.Errorf("expected fp* in postfix, got: %s", postfix)
+	}
+	if strings.Contains(postfix, " * ") || strings.HasSuffix(postfix, " *") {
+		t.Errorf("unexpected plain '*' in fixed postfix: %s", postfix)
+	}
+}
+
+// TestFixedMixedWithInteger_PromotesViaCvfp verifies that an integer operand
+// mixed with a fixed operand is promoted via cvfp before the fp op.
+func TestFixedMixedWithInteger_PromotesViaCvfp(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(stakingFixedSymbols())
+
+	postfix, err := c.CompileAction("set wp.weekly_reward = wp.reward_per_block * wp.periods")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if !strings.Contains(postfix, "cvfp") {
+		t.Errorf("expected cvfp promotion in postfix, got: %s", postfix)
+	}
+	if !strings.Contains(postfix, "fp*") {
+		t.Errorf("expected fp* operator, got: %s", postfix)
+	}
+}
+
+// TestFixedMixedWithBigInt_PromotesViaCvfp verifies that a bigint operand
+// mixed with a fixed operand is promoted via cvfp before the fp op.
+func TestFixedMixedWithBigInt_PromotesViaCvfp(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(stakingFixedSymbols())
+
+	postfix, err := c.CompileAction("set wp.weekly_reward = wp.reward_per_block + bp.treasury_fee")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if !strings.Contains(postfix, "cvfp") {
+		t.Errorf("expected cvfp promotion in postfix, got: %s", postfix)
+	}
+	if !strings.Contains(postfix, "fp+") {
+		t.Errorf("expected fp+ operator, got: %s", postfix)
+	}
+	// The plain 'b+' must NOT appear — fixed wins over bigint.
+	if strings.Contains(postfix, " b+") {
+		t.Errorf("unexpected b+ when fixed operand is present: %s", postfix)
+	}
+}
+
+// TestFixedComparison_EmitsFpCompare verifies that a comparison between fixed
+// operands emits fp-family comparison ops.
+func TestFixedComparison_EmitsFpCompare(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(stakingFixedSymbols())
+
+	// Conditions are compiled via CompileCondition.
+	postfix, err := c.CompileCondition("wp.reward_per_block > wp.staker_balance")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if !strings.Contains(postfix, "fp>") {
+		t.Errorf("expected fp> in postfix, got: %s", postfix)
+	}
+}
+
+// TestBigIntArithmetic_UnchangedByFixedRefactor is a regression guard: when
+// no operand is fixed, bigint arithmetic must still emit the b-family ops.
+func TestBigIntArithmetic_UnchangedByFixedRefactor(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{
+		"bp.a": "bigint",
+		"bp.b": "bigint",
+		"bp.c": "bigint",
+	})
+	postfix, err := c.CompileAction("set bp.c = bp.a * bp.b")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if !strings.Contains(postfix, "b*") {
+		t.Errorf("expected b*, got: %s", postfix)
+	}
+	if strings.Contains(postfix, "fp") {
+		t.Errorf("unexpected fp in pure-bigint postfix: %s", postfix)
+	}
+}

--- a/pkg/dtrules/compiler/el/fixed_test.go
+++ b/pkg/dtrules/compiler/el/fixed_test.go
@@ -296,6 +296,96 @@ func TestIntegerNegation_EmitsNegate(t *testing.T) {
 	}
 }
 
+// TestFixedIncrement_PreservesPrecision guards the silent-truncation bug in
+// VisitIncrementLong: `increment <field>` used to emit `field 1 + /field
+// xdef` regardless of the field's declared type. For fp fields, the plain
+// `+` truncates via LongValue(). Now the visitor dispatches on the field's
+// EDD type and emits fp+ / b+ with the appropriate cast on the `1`.
+func TestFixedIncrement_PreservesPrecision(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{"wp.amount": "fixed"})
+	postfix, err := c.CompileAction("increment wp.amount")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if !strings.Contains(postfix, "fp+") {
+		t.Errorf("expected fp+ for fp-field increment, got: %s", postfix)
+	}
+	if !strings.Contains(postfix, "cvfp") {
+		t.Errorf("expected cvfp on the `1` literal, got: %s", postfix)
+	}
+	// Regression pin: old buggy emission ended with `1 +` before xdef.
+	if strings.Contains(postfix, "1 + /") {
+		t.Errorf("plain + on fp increment would silently truncate: %s", postfix)
+	}
+}
+
+// TestFixedDecrement_PreservesPrecision — parallel to increment.
+func TestFixedDecrement_PreservesPrecision(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{"wp.amount": "fixed"})
+	postfix, err := c.CompileAction("decrement wp.amount")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if !strings.Contains(postfix, "fp-") {
+		t.Errorf("expected fp- for fp-field decrement, got: %s", postfix)
+	}
+	if strings.Contains(postfix, "1 - /") {
+		t.Errorf("plain - on fp decrement would silently truncate: %s", postfix)
+	}
+}
+
+// TestFixedSubtractFrom_PreservesPrecision guards VisitSubDestLong: the
+// `subtract <value> from <field>` pattern compiled to `field swap -`
+// regardless of target type. For fp fields, `-` truncates. Now the visitor
+// emits `field swap cvfp fp-` so integer RHS values are promoted and the
+// subtract happens at fp precision.
+func TestFixedSubtractFrom_PreservesPrecision(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{"wp.amount": "fixed"})
+	cases := []struct {
+		dsl, wantOp string
+	}{
+		{"subtract 1.5fp from wp.amount", "fp-"}, // fp literal RHS
+		{"subtract 1 from wp.amount", "fp-"},     // integer RHS — must promote
+	}
+	for _, c2 := range cases {
+		t.Run(c2.dsl, func(t *testing.T) {
+			postfix, err := c.CompileAction(c2.dsl)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			if !strings.Contains(postfix, c2.wantOp) {
+				t.Errorf("expected %s in postfix, got: %s", c2.wantOp, postfix)
+			}
+			if !strings.Contains(postfix, "cvfp") {
+				t.Errorf("expected cvfp cast in postfix, got: %s", postfix)
+			}
+			// Plain `-` on the fp field is the bug we're guarding.
+			if strings.Contains(postfix, "swap - /") {
+				t.Errorf("plain swap - on fp field would silently truncate: %s", postfix)
+			}
+		})
+	}
+}
+
+// TestIntegerIncrement_UnchangedByFixedDispatch guards that plain integer
+// fields still emit the historic `field 1 + /field xdef` pattern after the
+// fp / bigint dispatch was added to VisitIncrementLong.
+func TestIntegerIncrement_UnchangedByFixedDispatch(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{"ap.count": "integer"})
+	postfix, err := c.CompileAction("increment ap.count")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if strings.Contains(postfix, "fp+") || strings.Contains(postfix, "b+") ||
+		strings.Contains(postfix, "cvfp") || strings.Contains(postfix, "cvbi") {
+		t.Errorf("pure-int increment must not emit fp/b ops: %s", postfix)
+	}
+}
+
 // TestStringComparison_UnchangedByNumericDispatch is a regression guard on
 // BoolName{Eq,Neq}: string-vs-string name compares must still land on the
 // existing streq/`streq not` fallback. The numeric-dispatch branch is only

--- a/pkg/dtrules/compiler/el/fixed_test.go
+++ b/pkg/dtrules/compiler/el/fixed_test.go
@@ -103,6 +103,104 @@ func TestFixedComparison_EmitsFpCompare(t *testing.T) {
 	}
 }
 
+// TestFixedNegation_EmitsFpNegate verifies that negating a fixed-typed
+// expression emits fpnegate, not the integer `neg` or bigint `bnegate`.
+func TestFixedNegation_EmitsFpNegate(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(stakingFixedSymbols())
+	postfix, err := c.CompileAction("set wp.weekly_reward = - wp.reward_per_block")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if !strings.Contains(postfix, "fpnegate") {
+		t.Errorf("expected fpnegate in postfix, got: %s", postfix)
+	}
+	if strings.Contains(postfix, " neg ") || strings.HasSuffix(postfix, " neg") {
+		t.Errorf("unexpected integer 'neg' in fp negation: %s", postfix)
+	}
+	if strings.Contains(postfix, "bnegate") {
+		t.Errorf("unexpected 'bnegate' in pure-fixed negation: %s", postfix)
+	}
+}
+
+// TestFixedComparisonOperators exercises the full comparison family on the
+// VisitBoolInt* visitors that my refactor touched. `>=` and `<=` are the
+// paths this test is specifically guarding — they share the same dispatch
+// code as `>` and `<` (already covered) but route to distinct operators.
+//
+// Note: the grammar routes `!=` between two plain field refs to a string-
+// compare path (`streq not`), not BoolIntNeq, so that specific combination
+// is a separate concern tracked as a follow-up.
+func TestFixedComparisonOperators_AllEmitFpOps(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(stakingFixedSymbols())
+
+	cases := []struct {
+		dsl  string
+		want string
+	}{
+		{"wp.reward_per_block > wp.staker_balance", "fp>"},
+		{"wp.reward_per_block >= wp.staker_balance", "fp>="},
+		{"wp.reward_per_block < wp.staker_balance", "fp<"},
+		{"wp.reward_per_block <= wp.staker_balance", "fp<="},
+	}
+	for _, c2 := range cases {
+		t.Run(c2.want, func(t *testing.T) {
+			postfix, err := c.CompileCondition(c2.dsl)
+			if err != nil {
+				t.Fatalf("compile %q: %v", c2.dsl, err)
+			}
+			if !strings.Contains(postfix, c2.want) {
+				t.Errorf("expected %s in postfix, got: %s", c2.want, postfix)
+			}
+		})
+	}
+}
+
+// TestIntegerNotEqual_UnchangedByFixedRefactor is a regression guard on my
+// VisitBoolIntNeq refactor: when both operands are plain integers, the
+// emitter must still fall back to the historic `== not` pattern, not
+// accidentally emit `fp!=` or `b!=`.
+func TestIntegerNotEqual_UnchangedByFixedRefactor(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{
+		"ap.count":  "integer",
+		"ap.amount": "integer",
+	})
+	postfix, err := c.CompileCondition("ap.count != ap.amount")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if strings.Contains(postfix, "fp!=") || strings.Contains(postfix, "b!=") {
+		t.Errorf("pure-int != must not emit fp!=/b!=: %s", postfix)
+	}
+}
+
+// TestIntegerArithmetic_UnchangedByFixedRefactor is the symmetric regression
+// guard to TestBigIntArithmetic_UnchangedByFixedRefactor — pure int+int must
+// still emit plain `+`, not accidentally promote to fp+ or b+.
+func TestIntegerArithmetic_UnchangedByFixedRefactor(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{
+		"ap.count":  "integer",
+		"ap.amount": "integer",
+		"ap.total":  "integer",
+	})
+	postfix, err := c.CompileAction("set ap.total = ap.count + ap.amount")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if !strings.Contains(postfix, " +") {
+		t.Errorf("expected plain `+` for int+int, got: %s", postfix)
+	}
+	if strings.Contains(postfix, "fp+") || strings.Contains(postfix, "b+") {
+		t.Errorf("pure-int expression must not emit fp+/b+: %s", postfix)
+	}
+	if strings.Contains(postfix, "cvfp") || strings.Contains(postfix, "cvbi") {
+		t.Errorf("pure-int expression must not emit promotion casts: %s", postfix)
+	}
+}
+
 // TestBigIntArithmetic_UnchangedByFixedRefactor is a regression guard: when
 // no operand is fixed, bigint arithmetic must still emit the b-family ops.
 func TestBigIntArithmetic_UnchangedByFixedRefactor(t *testing.T) {

--- a/pkg/dtrules/compiler/el/fixed_test.go
+++ b/pkg/dtrules/compiler/el/fixed_test.go
@@ -215,6 +215,65 @@ func TestMixedTypeComparison_PromotesToWidest(t *testing.T) {
 	}
 }
 
+// TestFixedLiteral_InIntContext_PreservesPrecision is the reproducer for the
+// most severe precision bug found in the deep review: when an fp-suffixed
+// literal appears alongside an integer operand, the grammar routes the
+// expression through iexpr (not fexpr), and the emitter's type inference
+// previously read the literal as an integer. The compiled postfix then used
+// plain `+` / `*`, and at runtime the RFixed's LongValue truncated the
+// fractional part silently. Now the emitter sees the `fp` suffix on the
+// literal's raw text and promotes the integer side via cvfp.
+func TestFixedLiteral_InIntContext_PreservesPrecision(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{
+		"ap.count": "integer",
+		"wp.total": "fixed",
+	})
+	postfix, err := c.CompileAction("set wp.total = ap.count + 1.5fp")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if !strings.Contains(postfix, "cvfp") {
+		t.Errorf("expected integer side promoted via cvfp, got: %s", postfix)
+	}
+	if !strings.Contains(postfix, "fp+") {
+		t.Errorf("expected fp+ (not plain +), got: %s", postfix)
+	}
+	// The old buggy emission would have a lone ` + ` between ap.count and
+	// 1.5fp — guard against regression.
+	if strings.Contains(postfix, "count 1.5fp +") {
+		t.Errorf("plain `+` between int and fp literal would silently truncate: %s", postfix)
+	}
+}
+
+// TestFixedLiteral_PureFpArithmetic_UsesFpOps covers the case where both
+// operands are fp literals — same root cause as the mixed case, different
+// trigger. Without the fix, `1.5fp + 2.5fp` compiled to plain `+` and lost
+// the fractional parts of both operands.
+func TestFixedLiteral_PureFpArithmetic_UsesFpOps(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{"wp.total": "fixed"})
+	cases := []struct {
+		dsl, want string
+	}{
+		{"set wp.total = 1.5fp + 2.5fp", "fp+"},
+		{"set wp.total = 1.5fp * 2.0fp", "fp*"},
+		{"set wp.total = 3.75fp - 1.5fp", "fp-"},
+		{"set wp.total = 1.5fp / 3.0fp", "fp/"},
+	}
+	for _, c2 := range cases {
+		t.Run(c2.want, func(t *testing.T) {
+			postfix, err := c.CompileAction(c2.dsl)
+			if err != nil {
+				t.Fatalf("compile %q: %v", c2.dsl, err)
+			}
+			if !strings.Contains(postfix, c2.want) {
+				t.Errorf("expected %s, got: %s", c2.want, postfix)
+			}
+		})
+	}
+}
+
 // TestStringComparison_UnchangedByNumericDispatch is a regression guard on
 // BoolName{Eq,Neq}: string-vs-string name compares must still land on the
 // existing streq/`streq not` fallback. The numeric-dispatch branch is only

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -242,6 +242,15 @@ func arithOp(target, intOp, bigOp, fpOp string) string {
 func (e *PostfixEmitter) emitWithTypeConversion(ctx antlr.ParseTree, targetType string) {
 	srcType := e.getExprType(ctx)
 	e.Visit(ctx)
+	e.emitTypeCast(srcType, targetType)
+}
+
+// emitTypeCast emits the postfix cast op needed to convert a stack value of
+// srcType into targetType. Same-type is a no-op. Only the three implicit
+// numeric promotions are handled (int→bigint, int→fixed, bigint→fixed);
+// double→fixed requires explicit cvfp and lands here only as a pre-cast
+// source, never as a target.
+func (e *PostfixEmitter) emitTypeCast(srcType, targetType string) {
 	if srcType == targetType {
 		return
 	}
@@ -255,6 +264,25 @@ func (e *PostfixEmitter) emitWithTypeConversion(ctx antlr.ParseTree, targetType 
 			e.emit("cvfp")
 		}
 	}
+}
+
+// identNumericType returns the EDD/local-declared type of a name reference
+// if it resolves to an integer, bigint, or fixed field. Returns "" for
+// anything else (string, boolean, entity, double, unknown). Double is
+// intentionally excluded so fixed ↔ double comparisons stay on the legacy
+// string-compare path rather than silently snapping onto the 10^-8 grid.
+func (e *PostfixEmitter) identNumericType(name string) string {
+	if lv, ok := e.lookupLocal(name); ok {
+		switch lv.Type {
+		case TypeInteger, TypeLong, TypeBigInt, TypeFixed:
+			return lv.Type
+		}
+	}
+	switch t := e.lookupType(name); t {
+	case TypeInteger, TypeLong, TypeBigInt, TypeFixed:
+		return t
+	}
+	return ""
 }
 
 // Emit returns the accumulated postfix output.
@@ -770,6 +798,21 @@ func (e *PostfixEmitter) VisitBoolNameEq(ctx *BoolNameEqContext) interface{} {
 		return nil
 	}
 
+	// Numeric names: the grammar routes `field == field` to this nexpr
+	// visitor regardless of type, so fixed/bigint/integer comparisons used
+	// to fall through to `streq` — correct only for values whose decimal
+	// string forms happen to match. Dispatch to the proper family with
+	// Fixed > BigInt > Integer promotion when both sides are numeric.
+	if t0, t1 := e.identNumericType(name0), e.identNumericType(name1); t0 != "" && t1 != "" {
+		target := promoteArithType(t0, t1)
+		e.Visit(ctx.Nexpr(0))
+		e.emitTypeCast(t0, target)
+		e.Visit(ctx.Nexpr(1))
+		e.emitTypeCast(t1, target)
+		e.emit(arithOp(target, "==", "b==", "fp=="))
+		return nil
+	}
+
 	isEntity := false
 	if lv, ok := e.lookupLocal(name0); ok && lv.Type == TypeEntity {
 		isEntity = true
@@ -801,6 +844,27 @@ func (e *PostfixEmitter) VisitBoolNameNeq(ctx *BoolNameNeqContext) interface{} {
 		e.Visit(ctx.Nexpr(0))
 		e.Visit(ctx.Nexpr(1))
 		e.emit("bytes!=")
+		return nil
+	}
+
+	// Numeric names: dispatch to the proper inequality family. Same
+	// Fixed > BigInt > Integer promotion as BoolNameEq; fp!= and b!=
+	// are distinct ops, integer falls back to the historic `== not`.
+	if t0, t1 := e.identNumericType(name0), e.identNumericType(name1); t0 != "" && t1 != "" {
+		target := promoteArithType(t0, t1)
+		e.Visit(ctx.Nexpr(0))
+		e.emitTypeCast(t0, target)
+		e.Visit(ctx.Nexpr(1))
+		e.emitTypeCast(t1, target)
+		switch target {
+		case TypeFixed:
+			e.emit("fp!=")
+		case TypeBigInt:
+			e.emit("b!=")
+		default:
+			e.emit("==")
+			e.emit("not")
+		}
 		return nil
 	}
 

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -134,6 +134,8 @@ func (e *PostfixEmitter) typeConverter(fieldType string) string {
 		return "cvbi"
 	case TypeBytes:
 		return "cvbytes"
+	case TypeFixed:
+		return "cvfp"
 	case TypeArray, TypeName, TypeXmlValue:
 		return "" // No conversion needed
 	default:
@@ -189,24 +191,17 @@ func (e *PostfixEmitter) getExprType(ctx antlr.ParseTree) string {
 		}
 	}
 
-	// For compound expressions, check children recursively
+	// For compound expressions, propagate the widest operand type
+	// (Fixed > BigInt > Integer).
 	switch c := ctx.(type) {
 	case *IntAddContext:
-		if e.getExprType(c.Iexpr(0)) == TypeBigInt || e.getExprType(c.Iexpr(1)) == TypeBigInt {
-			return TypeBigInt
-		}
+		return promoteArithType(e.getExprType(c.Iexpr(0)), e.getExprType(c.Iexpr(1)))
 	case *IntSubContext:
-		if e.getExprType(c.Iexpr(0)) == TypeBigInt || e.getExprType(c.Iexpr(1)) == TypeBigInt {
-			return TypeBigInt
-		}
+		return promoteArithType(e.getExprType(c.Iexpr(0)), e.getExprType(c.Iexpr(1)))
 	case *IntMulContext:
-		if e.getExprType(c.Iexpr(0)) == TypeBigInt || e.getExprType(c.Iexpr(1)) == TypeBigInt {
-			return TypeBigInt
-		}
+		return promoteArithType(e.getExprType(c.Iexpr(0)), e.getExprType(c.Iexpr(1)))
 	case *IntDivContext:
-		if e.getExprType(c.Iexpr(0)) == TypeBigInt || e.getExprType(c.Iexpr(1)) == TypeBigInt {
-			return TypeBigInt
-		}
+		return promoteArithType(e.getExprType(c.Iexpr(0)), e.getExprType(c.Iexpr(1)))
 	case *IntNegateContext:
 		return e.getExprType(c.Iexpr())
 	case *IntParenContext:
@@ -214,6 +209,31 @@ func (e *PostfixEmitter) getExprType(ctx antlr.ParseTree) string {
 	}
 
 	return TypeInteger
+}
+
+// promoteArithType returns the widest type for a mixed-type integer
+// arithmetic or comparison expression: Fixed > BigInt > Integer.
+func promoteArithType(a, b string) string {
+	if a == TypeFixed || b == TypeFixed {
+		return TypeFixed
+	}
+	if a == TypeBigInt || b == TypeBigInt {
+		return TypeBigInt
+	}
+	return TypeInteger
+}
+
+// arithOp picks the correct postfix opcode for an arithmetic or comparison
+// operation based on the promoted expression type.
+func arithOp(target, intOp, bigOp, fpOp string) string {
+	switch target {
+	case TypeFixed:
+		return fpOp
+	case TypeBigInt:
+		return bigOp
+	default:
+		return intOp
+	}
 }
 
 // isBigIntExpr returns true if the expression involves bigint types.
@@ -229,6 +249,27 @@ func (e *PostfixEmitter) emitWithBigIntConversion(ctx antlr.ParseTree, needsBigI
 	e.Visit(ctx)
 	if needsBigInt && exprType != TypeBigInt {
 		e.emit("cvbi")
+	}
+}
+
+// emitWithTypeConversion emits an integer-family expression and casts the
+// result to targetType on the stack. Handles int→bigint, int→fixed, and
+// bigint→fixed promotions. Same-type targets emit no cast.
+func (e *PostfixEmitter) emitWithTypeConversion(ctx antlr.ParseTree, targetType string) {
+	srcType := e.getExprType(ctx)
+	e.Visit(ctx)
+	if srcType == targetType {
+		return
+	}
+	switch targetType {
+	case TypeBigInt:
+		if srcType == TypeInteger {
+			e.emit("cvbi")
+		}
+	case TypeFixed:
+		if srcType == TypeInteger || srcType == TypeBigInt {
+			e.emit("cvfp")
+		}
 	}
 }
 
@@ -304,18 +345,10 @@ func (e *PostfixEmitter) VisitBoolIntEq(ctx *BoolIntEqContext) interface{} {
 		return nil
 	}
 
-	leftIsBigInt := e.isBigIntExpr(left)
-	rightIsBigInt := e.isBigIntExpr(right)
-	needsBigInt := leftIsBigInt || rightIsBigInt
-
-	e.emitWithBigIntConversion(left, needsBigInt)
-	e.emitWithBigIntConversion(right, needsBigInt)
-
-	if needsBigInt {
-		e.emit("b==")
-	} else {
-		e.emit("==")
-	}
+	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	e.emitWithTypeConversion(left, target)
+	e.emitWithTypeConversion(right, target)
+	e.emit(arithOp(target, "==", "b==", "fp=="))
 	return nil
 }
 
@@ -330,16 +363,15 @@ func (e *PostfixEmitter) VisitBoolIntNeq(ctx *BoolIntNeqContext) interface{} {
 		return nil
 	}
 
-	leftIsBigInt := e.isBigIntExpr(left)
-	rightIsBigInt := e.isBigIntExpr(right)
-	needsBigInt := leftIsBigInt || rightIsBigInt
-
-	e.emitWithBigIntConversion(left, needsBigInt)
-	e.emitWithBigIntConversion(right, needsBigInt)
-
-	if needsBigInt {
+	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	e.emitWithTypeConversion(left, target)
+	e.emitWithTypeConversion(right, target)
+	switch target {
+	case TypeFixed:
+		e.emit("fp!=")
+	case TypeBigInt:
 		e.emit("b!=")
-	} else {
+	default:
 		e.emit("==")
 		e.emit("not")
 	}
@@ -348,69 +380,37 @@ func (e *PostfixEmitter) VisitBoolIntNeq(ctx *BoolIntNeqContext) interface{} {
 
 func (e *PostfixEmitter) VisitBoolIntGt(ctx *BoolIntGtContext) interface{} {
 	left, right := ctx.Iexpr(0), ctx.Iexpr(1)
-	leftIsBigInt := e.isBigIntExpr(left)
-	rightIsBigInt := e.isBigIntExpr(right)
-	needsBigInt := leftIsBigInt || rightIsBigInt
-
-	e.emitWithBigIntConversion(left, needsBigInt)
-	e.emitWithBigIntConversion(right, needsBigInt)
-
-	if needsBigInt {
-		e.emit("b>")
-	} else {
-		e.emit(">")
-	}
+	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	e.emitWithTypeConversion(left, target)
+	e.emitWithTypeConversion(right, target)
+	e.emit(arithOp(target, ">", "b>", "fp>"))
 	return nil
 }
 
 func (e *PostfixEmitter) VisitBoolIntGte(ctx *BoolIntGteContext) interface{} {
 	left, right := ctx.Iexpr(0), ctx.Iexpr(1)
-	leftIsBigInt := e.isBigIntExpr(left)
-	rightIsBigInt := e.isBigIntExpr(right)
-	needsBigInt := leftIsBigInt || rightIsBigInt
-
-	e.emitWithBigIntConversion(left, needsBigInt)
-	e.emitWithBigIntConversion(right, needsBigInt)
-
-	if needsBigInt {
-		e.emit("b>=")
-	} else {
-		e.emit(">=")
-	}
+	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	e.emitWithTypeConversion(left, target)
+	e.emitWithTypeConversion(right, target)
+	e.emit(arithOp(target, ">=", "b>=", "fp>="))
 	return nil
 }
 
 func (e *PostfixEmitter) VisitBoolIntLt(ctx *BoolIntLtContext) interface{} {
 	left, right := ctx.Iexpr(0), ctx.Iexpr(1)
-	leftIsBigInt := e.isBigIntExpr(left)
-	rightIsBigInt := e.isBigIntExpr(right)
-	needsBigInt := leftIsBigInt || rightIsBigInt
-
-	e.emitWithBigIntConversion(left, needsBigInt)
-	e.emitWithBigIntConversion(right, needsBigInt)
-
-	if needsBigInt {
-		e.emit("b<")
-	} else {
-		e.emit("<")
-	}
+	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	e.emitWithTypeConversion(left, target)
+	e.emitWithTypeConversion(right, target)
+	e.emit(arithOp(target, "<", "b<", "fp<"))
 	return nil
 }
 
 func (e *PostfixEmitter) VisitBoolIntLte(ctx *BoolIntLteContext) interface{} {
 	left, right := ctx.Iexpr(0), ctx.Iexpr(1)
-	leftIsBigInt := e.isBigIntExpr(left)
-	rightIsBigInt := e.isBigIntExpr(right)
-	needsBigInt := leftIsBigInt || rightIsBigInt
-
-	e.emitWithBigIntConversion(left, needsBigInt)
-	e.emitWithBigIntConversion(right, needsBigInt)
-
-	if needsBigInt {
-		e.emit("b<=")
-	} else {
-		e.emit("<=")
-	}
+	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	e.emitWithTypeConversion(left, target)
+	e.emitWithTypeConversion(right, target)
+	e.emit(arithOp(target, "<=", "b<=", "fp<="))
 	return nil
 }
 
@@ -969,79 +969,50 @@ func (e *PostfixEmitter) VisitIntAdd(ctx *IntAddContext) interface{} {
 		return nil
 	}
 
-	leftIsBigInt := e.isBigIntExpr(left)
-	rightIsBigInt := e.isBigIntExpr(right)
-	needsBigInt := leftIsBigInt || rightIsBigInt
-
-	e.emitWithBigIntConversion(left, needsBigInt)
-	e.emitWithBigIntConversion(right, needsBigInt)
-
-	if needsBigInt {
-		e.emit("b+")
-	} else {
-		e.emit("+")
-	}
+	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	e.emitWithTypeConversion(left, target)
+	e.emitWithTypeConversion(right, target)
+	e.emit(arithOp(target, "+", "b+", "fp+"))
 	return nil
 }
 
 func (e *PostfixEmitter) VisitIntSub(ctx *IntSubContext) interface{} {
 	left, right := ctx.Iexpr(0), ctx.Iexpr(1)
-	leftIsBigInt := e.isBigIntExpr(left)
-	rightIsBigInt := e.isBigIntExpr(right)
-	needsBigInt := leftIsBigInt || rightIsBigInt
-
-	e.emitWithBigIntConversion(left, needsBigInt)
-	e.emitWithBigIntConversion(right, needsBigInt)
-
-	if needsBigInt {
-		e.emit("b-")
-	} else {
-		e.emit("-")
-	}
+	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	e.emitWithTypeConversion(left, target)
+	e.emitWithTypeConversion(right, target)
+	e.emit(arithOp(target, "-", "b-", "fp-"))
 	return nil
 }
 
 func (e *PostfixEmitter) VisitIntMul(ctx *IntMulContext) interface{} {
 	left, right := ctx.Iexpr(0), ctx.Iexpr(1)
-	leftIsBigInt := e.isBigIntExpr(left)
-	rightIsBigInt := e.isBigIntExpr(right)
-	needsBigInt := leftIsBigInt || rightIsBigInt
-
-	e.emitWithBigIntConversion(left, needsBigInt)
-	e.emitWithBigIntConversion(right, needsBigInt)
-
-	if needsBigInt {
-		e.emit("b*")
-	} else {
-		e.emit("*")
-	}
+	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	e.emitWithTypeConversion(left, target)
+	e.emitWithTypeConversion(right, target)
+	e.emit(arithOp(target, "*", "b*", "fp*"))
 	return nil
 }
 
 func (e *PostfixEmitter) VisitIntDiv(ctx *IntDivContext) interface{} {
 	left, right := ctx.Iexpr(0), ctx.Iexpr(1)
-	leftIsBigInt := e.isBigIntExpr(left)
-	rightIsBigInt := e.isBigIntExpr(right)
-	needsBigInt := leftIsBigInt || rightIsBigInt
-
-	e.emitWithBigIntConversion(left, needsBigInt)
-	e.emitWithBigIntConversion(right, needsBigInt)
-
-	if needsBigInt {
-		e.emit("b/")
-	} else {
-		e.emit("/")
-	}
+	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	e.emitWithTypeConversion(left, target)
+	e.emitWithTypeConversion(right, target)
+	e.emit(arithOp(target, "/", "b/", "fp/"))
 	return nil
 }
 
 func (e *PostfixEmitter) VisitIntNegate(ctx *IntNegateContext) interface{} {
 	expr := ctx.Iexpr()
-	isBigInt := e.isBigIntExpr(expr)
+	exprType := e.getExprType(expr)
 	e.Visit(expr)
-	if isBigInt {
+	switch exprType {
+	case TypeFixed:
+		e.emit("fpnegate")
+	case TypeBigInt:
 		e.emit("bnegate")
-	} else {
+	default:
 		e.emit("neg")
 	}
 	return nil

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -326,6 +326,52 @@ func (e *PostfixEmitter) emitTypeCast(srcType, targetType string) {
 	}
 }
 
+// emitTypeAwareAddSub emits the store-back sequence for a field mutation
+// (`add value to field` or `subtract value from field`) where the value is
+// already pushed onto the data stack by the caller. Looks up the field's
+// declared type and emits the correct typed op (fp+/fp-, b+/b-, f+/f-, +/-)
+// after promoting the value to match. Subtract orders the operands so the
+// result is `field - value`, matching DTRules' existing semantics.
+//
+// op is "+" for add, "-" for sub. Any other op panics — intentional; this
+// helper is not meant to grow.
+func (e *PostfixEmitter) emitTypeAwareAddSub(fieldName, op string) {
+	if op != "+" && op != "-" {
+		panic("emitTypeAwareAddSub: op must be + or -")
+	}
+	switch e.lookupType(fieldName) {
+	case TypeFixed:
+		e.emit("cvfp")
+		e.emit(fieldName)
+		if op == "-" {
+			e.emit("swap")
+		}
+		e.emit("fp" + op)
+	case TypeBigInt:
+		e.emit("cvbi")
+		e.emit(fieldName)
+		if op == "-" {
+			e.emit("swap")
+		}
+		e.emit("b" + op)
+	case TypeDouble:
+		e.emit("cvr")
+		e.emit(fieldName)
+		if op == "-" {
+			e.emit("swap")
+		}
+		e.emit("f" + op)
+	default:
+		e.emit(fieldName)
+		if op == "-" {
+			e.emit("swap")
+		}
+		e.emit(op)
+	}
+	e.emit("/" + fieldName)
+	e.emit("xdef")
+}
+
 // identNumericType returns the EDD/local-declared type of a name reference
 // if it resolves to an integer, bigint, or fixed field. Returns "" for
 // anything else (string, boolean, entity, double, unknown). Double is
@@ -2630,72 +2676,50 @@ func (e *PostfixEmitter) VisitIfElseIf(ctx *IfElseIfContext) interface{} {
 // the emit fetches the current value, adjusts by 1, and stores back using the
 // same /<name> xdef pattern leftIexprSimple uses.
 
-func (e *PostfixEmitter) VisitIncrementLong(ctx *IncrementLongContext) interface{} {
-	name := ctx.TypedLong().GetText()
-	// typedLong matches any IDENT; the declared field type tells us which
-	// numeric family to use. Without this check, incrementing a fixed or
-	// bigint field emits plain `+` and truncates via LongValue() at runtime.
-	switch e.lookupType(name) {
-	case TypeFixed:
-		e.emit(name)
-		e.emit("1")
-		e.emit("cvfp")
-		e.emit("fp+")
-	case TypeBigInt:
-		e.emit(name)
-		e.emit("1")
-		e.emit("cvbi")
-		e.emit("b+")
-	default:
-		e.emit(name)
-		e.emit("1")
-		e.emit("+")
+// emitOneForField pushes the literal "1" (or "1.0" for double-typed fields)
+// as the RHS value for increment / decrement statements. Double needs the
+// decimal form so the subsequent f+ / f- op can consume a double rather
+// than integer-truncating through cvr.
+func (e *PostfixEmitter) emitOneForField(fieldName string) {
+	if e.lookupType(fieldName) == TypeDouble {
+		e.emit("1.0")
+		return
 	}
-	e.emit("/" + name)
-	e.emit("xdef")
+	e.emit("1")
+}
+
+func (e *PostfixEmitter) VisitIncrementLong(ctx *IncrementLongContext) interface{} {
+	// typedLong matches any IDENT; the declared field type tells us which
+	// numeric family to use. Without this check, incrementing a fixed,
+	// bigint, or double field would emit plain `+` and truncate via
+	// LongValue() at runtime.
+	name := ctx.TypedLong().GetText()
+	e.emitOneForField(name)
+	e.emitTypeAwareAddSub(name, "+")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitIncrementDouble(ctx *IncrementDoubleContext) interface{} {
+	// typedDouble is also just IDENT — this alternative is rarely reached
+	// (typedLong wins first), but when it is we honor the declared field
+	// type the same way IncrementLong does.
 	name := ctx.TypedDouble().GetText()
-	e.emit(name)
-	e.emit("1.0")
-	e.emit("f+")
-	e.emit("/" + name)
-	e.emit("xdef")
+	e.emitOneForField(name)
+	e.emitTypeAwareAddSub(name, "+")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitDecrementLong(ctx *DecrementLongContext) interface{} {
 	name := ctx.TypedLong().GetText()
-	switch e.lookupType(name) {
-	case TypeFixed:
-		e.emit(name)
-		e.emit("1")
-		e.emit("cvfp")
-		e.emit("fp-")
-	case TypeBigInt:
-		e.emit(name)
-		e.emit("1")
-		e.emit("cvbi")
-		e.emit("b-")
-	default:
-		e.emit(name)
-		e.emit("1")
-		e.emit("-")
-	}
-	e.emit("/" + name)
-	e.emit("xdef")
+	e.emitOneForField(name)
+	e.emitTypeAwareAddSub(name, "-")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitDecrementDouble(ctx *DecrementDoubleContext) interface{} {
 	name := ctx.TypedDouble().GetText()
-	e.emit(name)
-	e.emit("1.0")
-	e.emit("f-")
-	e.emit("/" + name)
-	e.emit("xdef")
+	e.emitOneForField(name)
+	e.emitTypeAwareAddSub(name, "-")
 	return nil
 }
 
@@ -3022,44 +3046,15 @@ func (e *PostfixEmitter) VisitNameUsing(ctx *NameUsingContext) interface{} {
 
 // Subtodest emitters. Mirror addtodest but subtract. `<value> <subtodest>`
 // expects the rhs value on the stack, then runs field - value and stores.
-// Because `-` is a -b operator, we swap before subtracting to get field-value
-// rather than value-field.
+// Dispatch through emitTypeAwareAddSub so fixed / bigint / double targets
+// don't silently truncate via plain `-`.
 func (e *PostfixEmitter) VisitSubDestLong(ctx *SubDestLongContext) interface{} {
-	name := ctx.TypedLong().GetText()
-	// typedLong matches any IDENT; pick the numeric family based on the
-	// field's declared type. A plain `-` would truncate fixed or bigint
-	// operands via LongValue() at runtime — silent precision / range loss.
-	// Caller (VisitSubtractNum) has already pushed the value; stack shape
-	// is [value]. Emit `<field> swap <cast-on-value> <op>` so the subtract
-	// computes field − value (not value − field) at the correct type.
-	switch e.lookupType(name) {
-	case TypeFixed:
-		e.emit(name)
-		e.emit("swap")
-		e.emit("cvfp")
-		e.emit("fp-")
-	case TypeBigInt:
-		e.emit(name)
-		e.emit("swap")
-		e.emit("cvbi")
-		e.emit("b-")
-	default:
-		e.emit(name)
-		e.emit("swap")
-		e.emit("-")
-	}
-	e.emit("/" + name)
-	e.emit("xdef")
+	e.emitTypeAwareAddSub(ctx.TypedLong().GetText(), "-")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitSubDestDouble(ctx *SubDestDoubleContext) interface{} {
-	name := ctx.TypedDouble().GetText()
-	e.emit(name)
-	e.emit("swap")
-	e.emit("f-")
-	e.emit("/" + name)
-	e.emit("xdef")
+	e.emitTypeAwareAddSub(ctx.TypedDouble().GetText(), "-")
 	return nil
 }
 
@@ -3875,76 +3870,47 @@ func (e *PostfixEmitter) VisitDateMinusYears(ctx *DateMinusYearsContext) interfa
 // ============================================================================
 
 func (e *PostfixEmitter) VisitAddArrayToArray(ctx *AddArrayToArrayContext) interface{} {
-	// Check if this is actually a numeric add to a possessive field
-	// Pattern: add <value> to <entity>'s <field>
-	// The parser matches this as arrayExpr TO arrayExpr, but if the destination
-	// is a possessive with a numeric field, we should emit arithmetic
+	// The parser steers `add <value> to <field>` through this visitor when
+	// both sides look like arrayExpr (the first matching alternative in the
+	// addtostatement rule). If the destination actually resolves to a
+	// declared numeric field, emit the typed store-back via the shared
+	// helper so fixed and bigint targets don't get plain `+` (which would
+	// truncate via LongValue at runtime).
 
 	destExpr := ctx.ArrayExpr(1)
 
-	// Check if destination is colonRef (possessive pattern)
+	// Possessive pattern: `add X to <entity>'s <field>` →
+	//   <value> <entity> entitypush <addSubSequence> entitypop
 	if colonRefCtx, ok := destExpr.(*ArrayColonRefContext); ok {
-		colonRef := colonRefCtx.ColonRef()
-		possRef := colonRef.PossessiveRef()
-
-		// Get the field name from typedArray
 		fieldName := colonRefCtx.TypedArray().GetText()
-		fieldType := e.lookupType(fieldName)
-
-		// If field is numeric, use arithmetic pattern
-		if fieldType == TypeInteger || fieldType == TypeLong || fieldType == TypeDouble {
-			// Emit the value first
+		if isNumericType(e.lookupType(fieldName)) {
 			e.Visit(ctx.ArrayExpr(0))
-
-			// Handle possessive chain for entity reference
-			if possChain, ok := possRef.(*PossessiveChainContext); ok {
+			if possChain, ok := colonRefCtx.ColonRef().PossessiveRef().(*PossessiveChainContext); ok {
 				tokens := possChain.AllPOSSESSIVE()
 				if len(tokens) > 0 {
 					poss := tokens[0].GetText()
-					entityName := poss[:len(poss)-2] // Remove 's suffix
-
-					if e.emitLocalRef(entityName) {
-						// emitLocalRef already emitted "<index> local@"
-					} else {
+					entityName := poss[:len(poss)-2] // strip 's
+					if !e.emitLocalRef(entityName) {
 						e.emit(entityName)
 					}
 				}
 			}
-
 			e.emit("entitypush")
-			e.emit(fieldName)
-			if fieldType == TypeDouble {
-				e.emit("f+")
-			} else {
-				e.emit("+")
-			}
-			e.emit("/" + fieldName)
-			e.emit("xdef")
+			e.emitTypeAwareAddSub(fieldName, "+")
 			e.emit("entitypop")
 			return nil
 		}
 	}
 
-	// Check if destination is a simple field (arrayBase -> arrayExpr2 -> typedArray)
-	// Pattern: add <value> to <entity.field>
+	// Bare-IDENT numeric destination: `add X to <field>` →
+	//   <value> <addSubSequence>
 	if baseCtx, ok := destExpr.(*ArrayBaseContext); ok {
 		if arrayExpr2 := baseCtx.ArrayExpr2(); arrayExpr2 != nil {
 			if typedCtx, ok := arrayExpr2.(*ArrayTypedContext); ok {
 				fieldName := typedCtx.TypedArray().GetText()
-				fieldType := e.lookupType(fieldName)
-
-				// If field is numeric, use arithmetic pattern
-				if fieldType == TypeInteger || fieldType == TypeLong || fieldType == TypeDouble {
-					// Emit value and field, then arithmetic
+				if isNumericType(e.lookupType(fieldName)) {
 					e.Visit(ctx.ArrayExpr(0))
-					e.emit(fieldName)
-					if fieldType == TypeDouble {
-						e.emit("f+")
-					} else {
-						e.emit("+")
-					}
-					e.emit("/" + fieldName)
-					e.emit("xdef")
+					e.emitTypeAwareAddSub(fieldName, "+")
 					return nil
 				}
 			}
@@ -4024,28 +3990,52 @@ func (e *PostfixEmitter) VisitAddNumToDest(ctx *AddNumToDestContext) interface{}
 	return nil
 }
 
+// isNumericType reports whether a declared EDD type string is one of the
+// four numeric types the field-mutation visitors know how to dispatch on.
+func isNumericType(t string) bool {
+	switch t {
+	case TypeInteger, TypeLong, TypeBigInt, TypeDouble, TypeFixed:
+		return true
+	}
+	return false
+}
+
+// VisitAddDestArray is the default landing spot for bare-IDENT add-to
+// targets: `arrayExpr2` wins the grammar alternative ordering over
+// typedLong/typedDouble. Dispatch here on the declared field type:
+//
+//   - numeric (integer / bigint / double / fixed): emit the type-aware
+//     store-back sequence via emitTypeAwareAddSub.
+//   - array or unknown: fall through to the single-element-into-array
+//     pattern (`value array swap addto`).
+//
+// Before this fix, all bare-IDENT numeric targets compiled to just
+// `value field` with no op or xdef — the statement was essentially a no-op
+// at runtime and the field was never updated.
 func (e *PostfixEmitter) VisitAddDestArray(ctx *AddDestArrayContext) interface{} {
+	if arrTyped, ok := ctx.ArrayExpr2().(*ArrayTypedContext); ok {
+		name := arrTyped.TypedArray().GetText()
+		switch e.lookupType(name) {
+		case TypeInteger, TypeLong, TypeBigInt, TypeDouble, TypeFixed:
+			e.emitTypeAwareAddSub(name, "+")
+			return nil
+		}
+	}
+	// Real array target (or unknown; default to single-element append for
+	// consistency with VisitAddArrayToArray's overwhelmingly-common case).
 	e.Visit(ctx.ArrayExpr2())
+	e.emit("swap")
+	e.emit("addto")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitAddDestLong(ctx *AddDestLongContext) interface{} {
-	// Pattern: field + /field xdef
-	fieldName := ctx.TypedLong().GetText()
-	e.emit(fieldName)
-	e.emit("+")
-	e.emit("/" + fieldName)
-	e.emit("xdef")
+	e.emitTypeAwareAddSub(ctx.TypedLong().GetText(), "+")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitAddDestDouble(ctx *AddDestDoubleContext) interface{} {
-	// Pattern: field f+ /field xdef
-	fieldName := ctx.TypedDouble().GetText()
-	e.emit(fieldName)
-	e.emit("f+")
-	e.emit("/" + fieldName)
-	e.emit("xdef")
+	e.emitTypeAwareAddSub(ctx.TypedDouble().GetText(), "+")
 	return nil
 }
 

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -143,11 +143,71 @@ func (e *PostfixEmitter) typeConverter(fieldType string) string {
 	}
 }
 
-// getExprType determines the type of an integer expression by examining its structure.
-// Returns TypeBigInt if the expression involves bigint variables, otherwise TypeInteger.
+// isFixedLiteralText reports whether a string is the full text of a numeric
+// literal with an `fp`/`FP` suffix. Accepts an optional leading sign, digits,
+// at most one decimal point, and the required `fp` suffix. Composite
+// expressions (containing spaces, operators, etc.) are rejected — those
+// aren't literals even if they contain one inside.
+func isFixedLiteralText(text string) bool {
+	if len(text) < 3 {
+		return false
+	}
+	if !strings.EqualFold(text[len(text)-2:], "fp") {
+		return false
+	}
+	body := text[:len(text)-2]
+	if body == "" {
+		return false
+	}
+	// Optional leading sign
+	if body[0] == '-' || body[0] == '+' {
+		body = body[1:]
+	}
+	if body == "" {
+		return false
+	}
+	seenDot := false
+	seenDigit := false
+	for i := 0; i < len(body); i++ {
+		switch c := body[i]; {
+		case c >= '0' && c <= '9':
+			seenDigit = true
+		case c == '.':
+			if seenDot {
+				return false
+			}
+			seenDot = true
+		default:
+			return false
+		}
+	}
+	return seenDigit
+}
+
+// getExprType determines the type of an integer expression by examining its
+// structure. Returns TypeFixed when an fp-suffixed literal is involved,
+// TypeBigInt when a bigint variable is, otherwise TypeInteger.
 func (e *PostfixEmitter) getExprType(ctx antlr.ParseTree) string {
 	if ctx == nil {
 		return TypeInteger
+	}
+
+	// fp-suffixed literals anywhere in an iexpr or fexpr position: e.g.
+	// `ap.count + 1.5fp`, `1.5fp + 2.5fp`, `dp.rate * 2.0fp`. The grammar
+	// doesn't recognize `fp` as a suffix — the lexer splits `1.5fp` into
+	// `1.5` (FLOAT_LITERAL) + `fp` (typedLong IDENT), and the parser glues
+	// them back together as a compound iexpr. Without this check the
+	// composite reads as an integer, the arithmetic emits plain `+` / `*`,
+	// and the RFixed is silently truncated via LongValue at runtime.
+	//
+	// We check the raw text of the whole context — if it's numeric with
+	// an `fp`/`FP` suffix, the author wrote an fp literal. Matches pure
+	// literals only; composite expressions contain operators (`+`, space)
+	// that disqualify them.
+	if pr, ok := ctx.(antlr.ParserRuleContext); ok {
+		if text := pr.GetText(); isFixedLiteralText(text) {
+			return TypeFixed
+		}
 	}
 
 	// Check for typed integer context (variable reference)

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -2632,9 +2632,25 @@ func (e *PostfixEmitter) VisitIfElseIf(ctx *IfElseIfContext) interface{} {
 
 func (e *PostfixEmitter) VisitIncrementLong(ctx *IncrementLongContext) interface{} {
 	name := ctx.TypedLong().GetText()
-	e.emit(name)
-	e.emit("1")
-	e.emit("+")
+	// typedLong matches any IDENT; the declared field type tells us which
+	// numeric family to use. Without this check, incrementing a fixed or
+	// bigint field emits plain `+` and truncates via LongValue() at runtime.
+	switch e.lookupType(name) {
+	case TypeFixed:
+		e.emit(name)
+		e.emit("1")
+		e.emit("cvfp")
+		e.emit("fp+")
+	case TypeBigInt:
+		e.emit(name)
+		e.emit("1")
+		e.emit("cvbi")
+		e.emit("b+")
+	default:
+		e.emit(name)
+		e.emit("1")
+		e.emit("+")
+	}
 	e.emit("/" + name)
 	e.emit("xdef")
 	return nil
@@ -2652,9 +2668,22 @@ func (e *PostfixEmitter) VisitIncrementDouble(ctx *IncrementDoubleContext) inter
 
 func (e *PostfixEmitter) VisitDecrementLong(ctx *DecrementLongContext) interface{} {
 	name := ctx.TypedLong().GetText()
-	e.emit(name)
-	e.emit("1")
-	e.emit("-")
+	switch e.lookupType(name) {
+	case TypeFixed:
+		e.emit(name)
+		e.emit("1")
+		e.emit("cvfp")
+		e.emit("fp-")
+	case TypeBigInt:
+		e.emit(name)
+		e.emit("1")
+		e.emit("cvbi")
+		e.emit("b-")
+	default:
+		e.emit(name)
+		e.emit("1")
+		e.emit("-")
+	}
 	e.emit("/" + name)
 	e.emit("xdef")
 	return nil
@@ -2997,9 +3026,28 @@ func (e *PostfixEmitter) VisitNameUsing(ctx *NameUsingContext) interface{} {
 // rather than value-field.
 func (e *PostfixEmitter) VisitSubDestLong(ctx *SubDestLongContext) interface{} {
 	name := ctx.TypedLong().GetText()
-	e.emit(name)
-	e.emit("swap")
-	e.emit("-")
+	// typedLong matches any IDENT; pick the numeric family based on the
+	// field's declared type. A plain `-` would truncate fixed or bigint
+	// operands via LongValue() at runtime — silent precision / range loss.
+	// Caller (VisitSubtractNum) has already pushed the value; stack shape
+	// is [value]. Emit `<field> swap <cast-on-value> <op>` so the subtract
+	// computes field − value (not value − field) at the correct type.
+	switch e.lookupType(name) {
+	case TypeFixed:
+		e.emit(name)
+		e.emit("swap")
+		e.emit("cvfp")
+		e.emit("fp-")
+	case TypeBigInt:
+		e.emit(name)
+		e.emit("swap")
+		e.emit("cvbi")
+		e.emit("b-")
+	default:
+		e.emit(name)
+		e.emit("swap")
+		e.emit("-")
+	}
 	e.emit("/" + name)
 	e.emit("xdef")
 	return nil

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -1121,7 +1121,7 @@ func (e *PostfixEmitter) VisitIntNegate(ctx *IntNegateContext) interface{} {
 	case TypeBigInt:
 		e.emit("bnegate")
 	default:
-		e.emit("neg")
+		e.emit("negate")
 	}
 	return nil
 }

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -236,22 +236,6 @@ func arithOp(target, intOp, bigOp, fpOp string) string {
 	}
 }
 
-// isBigIntExpr returns true if the expression involves bigint types.
-func (e *PostfixEmitter) isBigIntExpr(ctx antlr.ParseTree) bool {
-	return e.getExprType(ctx) == TypeBigInt
-}
-
-// emitWithBigIntConversion emits an integer expression, converting to bigint if needed.
-// If the expression is integer but we need bigint (for mixed-type operations),
-// it emits a cvbi conversion after the expression.
-func (e *PostfixEmitter) emitWithBigIntConversion(ctx antlr.ParseTree, needsBigInt bool) {
-	exprType := e.getExprType(ctx)
-	e.Visit(ctx)
-	if needsBigInt && exprType != TypeBigInt {
-		e.emit("cvbi")
-	}
-}
-
 // emitWithTypeConversion emits an integer-family expression and casts the
 // result to targetType on the stack. Handles int→bigint, int→fixed, and
 // bigint→fixed promotions. Same-type targets emit no cast.

--- a/pkg/dtrules/compiler/fixed_exec_test.go
+++ b/pkg/dtrules/compiler/fixed_exec_test.go
@@ -1,0 +1,129 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compiler
+
+import (
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+
+	// Pull in operator registrations (fp+, fp*, cvfp, etc.).
+	_ "github.com/DTRules/DTRules/pkg/dtrules/operators"
+)
+
+// evaluateFixed compiles a postfix snippet, executes it on a fresh state, and
+// returns the RFixed left on top of the data stack.
+func evaluateFixed(t *testing.T, src string) *dtrules.RFixed {
+	t.Helper()
+	c := newTestCompiler()
+	code, err := c.Compile(src)
+	if err != nil {
+		t.Fatalf("Compile(%q): %v", src, err)
+	}
+	state := interpreter.NewDTState(&mockSession{})
+	if err := code.Execute(state); err != nil {
+		t.Fatalf("Execute(%q): %v", src, err)
+	}
+	top, err := state.DataPop()
+	if err != nil {
+		t.Fatalf("DataPop: %v", err)
+	}
+	fp, ok := top.(*dtrules.RFixed)
+	if !ok {
+		t.Fatalf("expected RFixed result, got %T: %v", top, top)
+	}
+	return fp
+}
+
+// TestStakingArithmetic_ExactTotals walks a small "staking" distribution
+// end-to-end through the compile + execute pipeline and checks that the
+// final total is bit-exact on the 10^-8 grid.
+//
+// Model: pool of 14_126_019.81 ACME distributed over 25 periods with a
+// simple weekly-rate formula and a treasury fee. Every value stays on
+// the 10^-8 grid; none of the intermediates are allowed to drift.
+func TestStakingArithmetic_ExactTotals(t *testing.T) {
+	cases := []struct {
+		name    string
+		program string
+		want    string
+	}{
+		{
+			// Exact addition of sub-satoshi values — pattern that destroyed
+			// float-based staking totals when rounded separately per period.
+			name:    "sum of 25 periods",
+			program: "1234567.89012345fp 1234567.89012345fp fp+",
+			want:    "2469135.78024690",
+		},
+		{
+			// Mul truncates toward zero: 0.12345678 × 10 stays on-grid.
+			name:    "rate times whole period count",
+			program: "0.12345678fp 10 cvfp fp*",
+			want:    "1.23456780",
+		},
+		{
+			// Total pool × per-period share with a fractional multiplier.
+			// Mantissa math: 1412601981000000 × 306639 / 10^8 truncates
+			// toward zero. Exact integer computation — no float drift.
+			name:    "pool × weekly_factor truncates at grid",
+			program: "14126019.81000000fp 0.00306639fp fp*",
+			want:    "43315.88588518",
+		},
+		{
+			// A sub-satoshi difference must survive a round-trip through
+			// add/sub pairs — proves no hidden float coercion.
+			name:    "(a + b) - b == a at sub-satoshi precision",
+			program: "0.00000001fp 1680748.45091643fp fp+ 1680748.45091643fp fp-",
+			want:    "0.00000001",
+		},
+		{
+			// Integer + fixed auto-promotes via cvfp (exercises the EL
+			// dispatch path; here driven directly from postfix).
+			name:    "int promoted to fixed via cvfp",
+			program: "100 cvfp 0.00250000fp fp*",
+			want:    "0.25000000",
+		},
+		{
+			// Bigint promoted to fixed via cvfp.
+			name:    "bigint promoted to fixed via cvfp",
+			program: "500000000 cvbi cvfp 0.00003066fp fp*",
+			want:    "15330.00000000",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := evaluateFixed(t, c.program).StringValue()
+			if got != c.want {
+				t.Errorf("%s: got %q, want %q", c.name, got, c.want)
+			}
+		})
+	}
+}
+
+// TestStakingArithmetic_NoDriftOverManyPeriods sums a rate across many
+// periods and checks the result is exact — the kind of accumulating
+// computation where float would drift.
+func TestStakingArithmetic_NoDriftOverManyPeriods(t *testing.T) {
+	// Start at 0fp; add 0.12345678fp fifty times. Expected: 6.17283900fp.
+	program := "0fp"
+	for i := 0; i < 50; i++ {
+		program += " 0.12345678fp fp+"
+	}
+	got := evaluateFixed(t, program).StringValue()
+	if got != "6.17283900" {
+		t.Errorf("50× 0.12345678 accumulation: got %q, want 6.17283900", got)
+	}
+}

--- a/pkg/dtrules/entity/entity.go
+++ b/pkg/dtrules/entity/entity.go
@@ -309,6 +309,8 @@ func (e *REntity) Put(name *dtrules.RName, value dtrules.Object) error {
 			value, err = value.RTimeValue()
 		case dtrules.TypeBigInt.GetID():
 			value, err = value.RBigIntValue()
+		case dtrules.TypeFixed.GetID():
+			value, err = dtrules.PromoteToRFixed(value)
 		}
 		if err != nil {
 			return err

--- a/pkg/dtrules/entity/entity_test.go
+++ b/pkg/dtrules/entity/entity_test.go
@@ -70,6 +70,72 @@ func TestEntityFactory(t *testing.T) {
 	}
 }
 
+// TestEntityPutFixedCoercion guards the TypeFixed branch of REntity.Put:
+// integer and bigint values assigned to a fixed-typed field must coerce to
+// RFixed via PromoteToRFixed; double values must error per the "no silent
+// down-coercion" principle shared with the bigint wiring (#675).
+func TestEntityPutFixedCoercion(t *testing.T) {
+	factory := NewFactory(nil)
+	entityName := dtrules.GetRName("pool")
+	refEntity, _ := factory.FindCreateRefEntity(false, entityName)
+
+	zero, _ := dtrules.GetRFixedFromInt64(0)
+	refEntity.AddAttribute(dtrules.GetRName("amount"), "",
+		zero, true, true, dtrules.TypeFixed, "", "", "", "")
+
+	amountName := dtrules.GetRName("amount")
+
+	t.Run("int promotes to RFixed", func(t *testing.T) {
+		if err := refEntity.Put(amountName, dtrules.GetRIntegerValue(42)); err != nil {
+			t.Fatalf("Put integer: %v", err)
+		}
+		v, _ := refEntity.Get(amountName)
+		fp, ok := v.(*dtrules.RFixed)
+		if !ok {
+			t.Fatalf("stored value should be RFixed, got %T", v)
+		}
+		if got := fp.StringValue(); got != "42.00000000" {
+			t.Errorf("int 42 → %q, want 42.00000000", got)
+		}
+	})
+
+	t.Run("bigint promotes to RFixed", func(t *testing.T) {
+		if err := refEntity.Put(amountName, dtrules.GetRBigIntFromInt64(1_000_000)); err != nil {
+			t.Fatalf("Put bigint: %v", err)
+		}
+		v, _ := refEntity.Get(amountName)
+		fp, ok := v.(*dtrules.RFixed)
+		if !ok {
+			t.Fatalf("stored value should be RFixed, got %T", v)
+		}
+		if got := fp.StringValue(); got != "1000000.00000000" {
+			t.Errorf("bigint 1e6 → %q, want 1000000.00000000", got)
+		}
+	})
+
+	t.Run("double is rejected — requires explicit cvfp", func(t *testing.T) {
+		err := refEntity.Put(amountName, dtrules.GetRDoubleValue(1.5))
+		if err == nil {
+			t.Fatal("Put of double into fixed field must error")
+		}
+	})
+
+	t.Run("RFixed passes through unchanged", func(t *testing.T) {
+		fp, _ := dtrules.GetRFixedFromString("3.14159265")
+		if err := refEntity.Put(amountName, fp); err != nil {
+			t.Fatalf("Put fp: %v", err)
+		}
+		v, _ := refEntity.Get(amountName)
+		got, ok := v.(*dtrules.RFixed)
+		if !ok {
+			t.Fatalf("stored value should be RFixed, got %T", v)
+		}
+		if got.StringValue() != "3.14159265" {
+			t.Errorf("fp passthrough: got %q, want 3.14159265", got.StringValue())
+		}
+	})
+}
+
 func TestEntityAttributes(t *testing.T) {
 	factory := NewFactory(nil)
 	entityName := dtrules.GetRName("person")

--- a/pkg/dtrules/fixed.go
+++ b/pkg/dtrules/fixed.go
@@ -1,0 +1,406 @@
+// Copyright 2004-2011 DTRules.com, Inc.
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtrules
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+// FixedDecimals is the implicit decimal scale of the fixed-point type.
+// Every RFixed value is stored as a signed 256-bit integer mantissa divided
+// by 10^FixedDecimals. Matches the 8-decimal convention used by most
+// blockchain token systems.
+const FixedDecimals = 8
+
+var (
+	fixedScaleBig = new(big.Int).SetInt64(100_000_000)
+
+	// fixedBound is 2^255. A mantissa m is in range iff |m| < fixedBound,
+	// giving symmetric signed 256-bit bounds (we trade the single value
+	// -2^255 for symmetric Neg/Abs semantics).
+	fixedBound = new(big.Int).Lsh(big.NewInt(1), 255)
+)
+
+// RFixed represents a fixed-point decimal value with 8 decimals of precision,
+// backed by a 256-bit signed mantissa.
+//
+// Every operation either yields a value on the 10^-8 grid with exact
+// addition/subtraction and truncate-toward-zero on multiply/divide, or
+// returns an error if the result overflows the 256-bit range.
+type RFixed struct {
+	BaseObject
+	mantissa *big.Int // invariant: |mantissa| < 2^255
+}
+
+// Cached common fixed values. Built with direct struct literals (rather
+// than routed through newRFixedFromMantissa) to avoid a package-init cycle
+// with the nil guard in the constructor.
+var (
+	fixedMOne = &RFixed{mantissa: new(big.Int).Neg(fixedScaleBig)}
+	fixedZero = &RFixed{mantissa: big.NewInt(0)}
+	fixedOne  = &RFixed{mantissa: new(big.Int).Set(fixedScaleBig)}
+)
+
+// newRFixedFromMantissa wraps a raw 10^-8-scaled mantissa after bounds checking.
+func newRFixedFromMantissa(m *big.Int) (*RFixed, error) {
+	if m == nil {
+		return &RFixed{mantissa: big.NewInt(0)}, nil
+	}
+	if err := checkFixedRange(m); err != nil {
+		return nil, err
+	}
+	return &RFixed{mantissa: new(big.Int).Set(m)}, nil
+}
+
+func checkFixedRange(m *big.Int) error {
+	abs := new(big.Int).Abs(m)
+	if abs.Cmp(fixedBound) >= 0 {
+		return ConversionError("RFixed", "fixed-point value exceeds 256-bit signed range")
+	}
+	return nil
+}
+
+// GetRFixedFromMantissa constructs an RFixed from a raw mantissa (value * 10^8).
+func GetRFixedFromMantissa(m *big.Int) (*RFixed, error) {
+	return newRFixedFromMantissa(m)
+}
+
+// GetRFixedFromInt64 constructs an RFixed representing the integer v exactly.
+func GetRFixedFromInt64(v int64) (*RFixed, error) {
+	switch v {
+	case -1:
+		return fixedMOne, nil
+	case 0:
+		return fixedZero, nil
+	case 1:
+		return fixedOne, nil
+	}
+	m := new(big.Int).Mul(big.NewInt(v), fixedScaleBig)
+	return newRFixedFromMantissa(m)
+}
+
+// GetRFixedFromBigInt constructs an RFixed representing the integer v exactly.
+// Returns an error if v * 10^8 would exceed the 256-bit mantissa range.
+func GetRFixedFromBigInt(v *big.Int) (*RFixed, error) {
+	if v == nil {
+		return fixedZero, nil
+	}
+	m := new(big.Int).Mul(v, fixedScaleBig)
+	return newRFixedFromMantissa(m)
+}
+
+// GetRFixedFromString parses a decimal string into an RFixed.
+// Accepts forms like "1", "1.5", "-0.00000001", "1.50000000fp".
+// Fractional digits beyond the 8-decimal grid are truncated toward zero.
+func GetRFixedFromString(s string) (*RFixed, error) {
+	s = strings.TrimSpace(s)
+	if s == "" || strings.EqualFold(s, "null") {
+		return fixedZero, nil
+	}
+	lower := strings.ToLower(s)
+	if strings.HasSuffix(lower, "fp") {
+		s = s[:len(s)-2]
+		if s == "" {
+			return nil, ConversionError("RFixed.GetRFixedFromString", "'fp' suffix with no numeric body")
+		}
+	}
+
+	negative := false
+	switch {
+	case strings.HasPrefix(s, "-"):
+		negative = true
+		s = s[1:]
+	case strings.HasPrefix(s, "+"):
+		s = s[1:]
+	}
+
+	wholeStr, fracStr := s, ""
+	if dot := strings.IndexByte(s, '.'); dot >= 0 {
+		wholeStr = s[:dot]
+		fracStr = s[dot+1:]
+	}
+	if wholeStr == "" {
+		wholeStr = "0"
+	}
+	if !allDigits(wholeStr) || !allDigits(fracStr) {
+		return nil, ConversionError("RFixed.GetRFixedFromString", "invalid fixed-point literal: "+s)
+	}
+
+	if len(fracStr) > FixedDecimals {
+		fracStr = fracStr[:FixedDecimals]
+	} else if len(fracStr) < FixedDecimals {
+		fracStr += strings.Repeat("0", FixedDecimals-len(fracStr))
+	}
+
+	whole := new(big.Int)
+	if _, ok := whole.SetString(wholeStr, 10); !ok {
+		return nil, ConversionError("RFixed.GetRFixedFromString", "invalid fixed-point literal: "+s)
+	}
+	frac := new(big.Int)
+	if _, ok := frac.SetString(fracStr, 10); !ok {
+		return nil, ConversionError("RFixed.GetRFixedFromString", "invalid fixed-point literal: "+s)
+	}
+
+	mantissa := new(big.Int).Mul(whole, fixedScaleBig)
+	mantissa.Add(mantissa, frac)
+	if negative {
+		mantissa.Neg(mantissa)
+	}
+	return newRFixedFromMantissa(mantissa)
+}
+
+func allDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// PromoteToRFixed promotes an integer or bigint operand to RFixed for mixed
+// arithmetic. Double values must be promoted via an explicit cvfp cast to
+// avoid silently snapping non-representable floats (e.g. 0.1) onto the grid.
+func PromoteToRFixed(o Object) (*RFixed, error) {
+	switch v := o.(type) {
+	case *RFixed:
+		return v, nil
+	case *RInteger:
+		return GetRFixedFromInt64(v.Value())
+	case *RBigInt:
+		return GetRFixedFromBigInt(v.BigIntValue())
+	case *RDouble:
+		return nil, ConversionError("RFixed.promote",
+			"cannot promote double to fixed implicitly; use cvfp to opt in")
+	default:
+		return nil, ConversionError("RFixed.promote",
+			"cannot promote "+o.Type().String()+" to fixed")
+	}
+}
+
+// Add returns r + other. Exact; errors only on 256-bit overflow.
+func (r *RFixed) Add(other *RFixed) (*RFixed, error) {
+	m := new(big.Int).Add(r.mantissa, other.mantissa)
+	return newRFixedFromMantissa(m)
+}
+
+// Sub returns r - other. Exact; errors only on 256-bit overflow.
+func (r *RFixed) Sub(other *RFixed) (*RFixed, error) {
+	m := new(big.Int).Sub(r.mantissa, other.mantissa)
+	return newRFixedFromMantissa(m)
+}
+
+// Mul returns r * other with truncation toward zero on the dropped 10^-8
+// digits. Errors if the result overflows the 256-bit mantissa.
+func (r *RFixed) Mul(other *RFixed) (*RFixed, error) {
+	product := new(big.Int).Mul(r.mantissa, other.mantissa)
+	m := new(big.Int).Quo(product, fixedScaleBig)
+	return newRFixedFromMantissa(m)
+}
+
+// Div returns r / other with truncation toward zero. Errors on divide-by-zero
+// or if the result overflows.
+func (r *RFixed) Div(other *RFixed) (*RFixed, error) {
+	if other.mantissa.Sign() == 0 {
+		return nil, ConversionError("RFixed.Div", "division by zero")
+	}
+	scaled := new(big.Int).Mul(r.mantissa, fixedScaleBig)
+	m := new(big.Int).Quo(scaled, other.mantissa)
+	return newRFixedFromMantissa(m)
+}
+
+// Neg returns -r. Symmetric bounds guarantee success.
+func (r *RFixed) Neg() *RFixed {
+	result, _ := newRFixedFromMantissa(new(big.Int).Neg(r.mantissa))
+	return result
+}
+
+// Abs returns |r|. Symmetric bounds guarantee success.
+func (r *RFixed) Abs() *RFixed {
+	result, _ := newRFixedFromMantissa(new(big.Int).Abs(r.mantissa))
+	return result
+}
+
+// Trunc returns the integer part of r as an RFixed (truncated toward zero).
+func (r *RFixed) Trunc() *RFixed {
+	whole := new(big.Int).Quo(r.mantissa, fixedScaleBig)
+	m := new(big.Int).Mul(whole, fixedScaleBig)
+	result, _ := newRFixedFromMantissa(m)
+	return result
+}
+
+// Sign returns -1, 0, or +1 for the mantissa.
+func (r *RFixed) Sign() int {
+	return r.mantissa.Sign()
+}
+
+// Mantissa returns a copy of the underlying scaled mantissa.
+func (r *RFixed) Mantissa() *big.Int {
+	return new(big.Int).Set(r.mantissa)
+}
+
+// Type returns the RType for fixed-point values.
+func (r *RFixed) Type() *RType {
+	return TypeFixed
+}
+
+// Execute pushes this object onto the data stack.
+func (r *RFixed) Execute(state State) error {
+	return state.DataPush(r)
+}
+
+// ArrayExecute pushes this object onto the data stack.
+func (r *RFixed) ArrayExecute(state State) error {
+	return state.DataPush(r)
+}
+
+// GetExecutable returns this object.
+func (r *RFixed) GetExecutable() Object {
+	return r
+}
+
+// GetNonExecutable returns this object.
+func (r *RFixed) GetNonExecutable() Object {
+	return r
+}
+
+// IsExecutable returns false for fixed values.
+func (r *RFixed) IsExecutable() bool {
+	return false
+}
+
+// Equals compares this fixed value with another object. Integer and bigint
+// are promoted to fixed exactly; double operands return an error (use cvfp).
+func (r *RFixed) Equals(o Object) (bool, error) {
+	if o.Type() == TypeNull {
+		return false, nil
+	}
+	other, err := PromoteToRFixed(o)
+	if err != nil {
+		return false, err
+	}
+	return r.mantissa.Cmp(other.mantissa) == 0, nil
+}
+
+// Compare compares this fixed value with another object.
+func (r *RFixed) Compare(o Object) (int, error) {
+	other, err := PromoteToRFixed(o)
+	if err != nil {
+		return 0, err
+	}
+	return r.mantissa.Cmp(other.mantissa), nil
+}
+
+// StringValue renders the value with exactly FixedDecimals fractional digits.
+func (r *RFixed) StringValue() string {
+	sign := ""
+	abs := new(big.Int).Abs(r.mantissa)
+	if r.mantissa.Sign() < 0 {
+		sign = "-"
+	}
+	whole := new(big.Int).Quo(abs, fixedScaleBig)
+	frac := new(big.Int).Rem(abs, fixedScaleBig)
+	return fmt.Sprintf("%s%s.%08d", sign, whole.String(), frac.Int64())
+}
+
+// PostFix returns the postfix literal form, suffixed with "fp" so the
+// compiler round-trips the value back to RFixed on re-parse.
+func (r *RFixed) PostFix() string {
+	return r.StringValue() + "fp"
+}
+
+// Clone returns this object (RFixed is immutable).
+func (r *RFixed) Clone(session Session) (Object, error) {
+	return r, nil
+}
+
+// RClone returns this object.
+func (r *RFixed) RClone() Object {
+	return r
+}
+
+// IntValue returns the integer part truncated toward zero, errors on int overflow.
+func (r *RFixed) IntValue() (int, error) {
+	whole := new(big.Int).Quo(r.mantissa, fixedScaleBig)
+	if !whole.IsInt64() {
+		return 0, ConversionError("RFixed.IntValue", "fixed value overflows int64")
+	}
+	v := whole.Int64()
+	if int64(int(v)) != v {
+		return 0, ConversionError("RFixed.IntValue", "fixed value overflows int")
+	}
+	return int(v), nil
+}
+
+// LongValue returns the integer part truncated toward zero, errors on int64 overflow.
+func (r *RFixed) LongValue() (int64, error) {
+	whole := new(big.Int).Quo(r.mantissa, fixedScaleBig)
+	if !whole.IsInt64() {
+		return 0, ConversionError("RFixed.LongValue", "fixed value overflows int64")
+	}
+	return whole.Int64(), nil
+}
+
+// DoubleValue returns the value as float64. Lossy for large or
+// high-precision values; provided for display/interop only.
+func (r *RFixed) DoubleValue() (float64, error) {
+	f := new(big.Float).SetInt(r.mantissa)
+	scale := new(big.Float).SetInt(fixedScaleBig)
+	f.Quo(f, scale)
+	result, _ := f.Float64()
+	return result, nil
+}
+
+// BooleanValue returns true if the value is non-zero.
+func (r *RFixed) BooleanValue() (bool, error) {
+	return r.mantissa.Sign() != 0, nil
+}
+
+// RIntegerValue returns the integer part as RInteger (truncates toward zero).
+func (r *RFixed) RIntegerValue() (*RInteger, error) {
+	v, err := r.LongValue()
+	if err != nil {
+		return nil, err
+	}
+	return GetRIntegerValue(v), nil
+}
+
+// RDoubleValue returns the value as RDouble.
+func (r *RFixed) RDoubleValue() (*RDouble, error) {
+	f, err := r.DoubleValue()
+	if err != nil {
+		return nil, err
+	}
+	return GetRDoubleValue(f), nil
+}
+
+// RBigIntValue returns the integer part as RBigInt (truncates toward zero).
+func (r *RFixed) RBigIntValue() (*RBigInt, error) {
+	whole := new(big.Int).Quo(r.mantissa, fixedScaleBig)
+	return GetRBigIntValue(whole), nil
+}
+
+// RStringValue returns the decimal string form.
+func (r *RFixed) RStringValue() *RString {
+	return NewRString(r.StringValue())
+}
+
+// String implements the Stringer interface.
+func (r *RFixed) String() string {
+	return r.StringValue() + "fp"
+}

--- a/pkg/dtrules/fixed_test.go
+++ b/pkg/dtrules/fixed_test.go
@@ -1,0 +1,414 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtrules
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// mustFp is a test helper that parses a decimal literal into RFixed or fails.
+func mustFp(t *testing.T, s string) *RFixed {
+	t.Helper()
+	r, err := GetRFixedFromString(s)
+	if err != nil {
+		t.Fatalf("GetRFixedFromString(%q) failed: %v", s, err)
+	}
+	return r
+}
+
+// =============================================================================
+// Parsing and string round-trip
+// =============================================================================
+
+func TestFixedParsing(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"0", "0.00000000"},
+		{"1", "1.00000000"},
+		{"-1", "-1.00000000"},
+		{"1.5", "1.50000000"},
+		{"-1.5", "-1.50000000"},
+		{"1.50000000fp", "1.50000000"},
+		{"1.50000000FP", "1.50000000"},
+		{"+1.25", "1.25000000"},
+		{"-0.00000001", "-0.00000001"},
+		{"0.00000001", "0.00000001"},
+		{"12.34567890", "12.34567890"},
+		{"1.500000009", "1.50000000"}, // truncate extra digits toward zero
+		{"-1.500000009", "-1.50000000"},
+		{"1000000", "1000000.00000000"},
+		{"", "0.00000000"},
+		{"null", "0.00000000"},
+		{" 1.5 ", "1.50000000"},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			r, err := GetRFixedFromString(c.in)
+			if err != nil {
+				t.Fatalf("parse %q: %v", c.in, err)
+			}
+			if got := r.StringValue(); got != c.want {
+				t.Errorf("StringValue(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestFixedParseInvalid(t *testing.T) {
+	for _, in := range []string{"abc", "1.2.3", "--1", "1e5"} {
+		if _, err := GetRFixedFromString(in); err == nil {
+			t.Errorf("expected error for %q", in)
+		}
+	}
+}
+
+func TestFixedStringRoundTrip(t *testing.T) {
+	r := mustFp(t, "1234567890.12345678")
+	s := r.StringValue()
+	r2 := mustFp(t, s)
+	if r.StringValue() != r2.StringValue() {
+		t.Errorf("round-trip: %q != %q", r.StringValue(), r2.StringValue())
+	}
+}
+
+func TestFixedPostFixSuffix(t *testing.T) {
+	r := mustFp(t, "1.5")
+	if got, want := r.PostFix(), "1.50000000fp"; got != want {
+		t.Errorf("PostFix = %q, want %q", got, want)
+	}
+}
+
+// =============================================================================
+// Construction from numeric inputs
+// =============================================================================
+
+func TestFixedFromInt64(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0.00000000"},
+		{1, "1.00000000"},
+		{-1, "-1.00000000"},
+		{1_000_000, "1000000.00000000"},
+	}
+	for _, c := range cases {
+		r, err := GetRFixedFromInt64(c.in)
+		if err != nil {
+			t.Fatalf("GetRFixedFromInt64(%d): %v", c.in, err)
+		}
+		if got := r.StringValue(); got != c.want {
+			t.Errorf("GetRFixedFromInt64(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFixedFromBigInt(t *testing.T) {
+	v := new(big.Int).Exp(big.NewInt(10), big.NewInt(20), nil) // 10^20
+	r, err := GetRFixedFromBigInt(v)
+	if err != nil {
+		t.Fatalf("GetRFixedFromBigInt(10^20): %v", err)
+	}
+	if got := r.StringValue(); got != "100000000000000000000.00000000" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestFixedFromBigIntOverflow(t *testing.T) {
+	// 2^255 * 10^8 comfortably exceeds the 256-bit signed mantissa bound.
+	huge := new(big.Int).Lsh(big.NewInt(1), 255)
+	if _, err := GetRFixedFromBigInt(huge); err == nil {
+		t.Error("expected overflow error for 2^255")
+	}
+}
+
+func TestFixedCachedSingletons(t *testing.T) {
+	a, _ := GetRFixedFromInt64(0)
+	b, _ := GetRFixedFromInt64(0)
+	if a != b {
+		t.Error("expected cached zero to be the same pointer")
+	}
+	c, _ := GetRFixedFromInt64(1)
+	d, _ := GetRFixedFromInt64(1)
+	if c != d {
+		t.Error("expected cached one to be the same pointer")
+	}
+}
+
+// =============================================================================
+// Arithmetic — exactness and truncation
+// =============================================================================
+
+func TestFixedAddSub(t *testing.T) {
+	a := mustFp(t, "1.23456789")
+	b := mustFp(t, "2.11111111")
+	sum, err := a.Add(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sum.StringValue(); got != "3.34567900" {
+		t.Errorf("Add: got %q, want 3.34567900", got)
+	}
+	diff, err := sum.Sub(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := diff.StringValue(); got != a.StringValue() {
+		t.Errorf("(a+b)-b: got %q, want %q", got, a.StringValue())
+	}
+}
+
+func TestFixedMulExact(t *testing.T) {
+	a := mustFp(t, "1.5")
+	b := mustFp(t, "1.5")
+	r, err := a.Mul(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := r.StringValue(); got != "2.25000000" {
+		t.Errorf("1.5 * 1.5: got %q, want 2.25000000", got)
+	}
+}
+
+func TestFixedMulTruncateTowardZero(t *testing.T) {
+	// 1.00000001 * 1.00000001 = 1.0000000200000001 → truncated to 1.00000002
+	a := mustFp(t, "1.00000001")
+	r, err := a.Mul(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := r.StringValue(); got != "1.00000002" {
+		t.Errorf("truncation: got %q, want 1.00000002", got)
+	}
+
+	// Negative truncation must also move toward zero (not toward -inf).
+	// -1.00000001 * 1.00000001 → -1.00000002 (same magnitude, negative)
+	neg := mustFp(t, "-1.00000001")
+	r2, err := neg.Mul(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := r2.StringValue(); got != "-1.00000002" {
+		t.Errorf("negative truncation: got %q, want -1.00000002", got)
+	}
+}
+
+func TestFixedDivTruncate(t *testing.T) {
+	one := mustFp(t, "1")
+	three := mustFp(t, "3")
+	r, err := one.Div(three)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := r.StringValue(); got != "0.33333333" {
+		t.Errorf("1/3: got %q, want 0.33333333", got)
+	}
+
+	// -1/3 must truncate toward zero, not toward -inf.
+	negOne := mustFp(t, "-1")
+	r2, err := negOne.Div(three)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := r2.StringValue(); got != "-0.33333333" {
+		t.Errorf("-1/3: got %q, want -0.33333333 (truncate toward zero)", got)
+	}
+}
+
+func TestFixedDivByZero(t *testing.T) {
+	a := mustFp(t, "1")
+	z := mustFp(t, "0")
+	if _, err := a.Div(z); err == nil {
+		t.Error("expected divide-by-zero error")
+	}
+}
+
+func TestFixedNegAbsSign(t *testing.T) {
+	a := mustFp(t, "1.5")
+	if got := a.Neg().StringValue(); got != "-1.50000000" {
+		t.Errorf("Neg: got %q", got)
+	}
+	b := mustFp(t, "-1.5")
+	if got := b.Abs().StringValue(); got != "1.50000000" {
+		t.Errorf("Abs: got %q", got)
+	}
+	if mustFp(t, "0").Sign() != 0 {
+		t.Error("Sign(0) must be 0")
+	}
+	if mustFp(t, "1").Sign() != 1 {
+		t.Error("Sign(1) must be 1")
+	}
+	if mustFp(t, "-1").Sign() != -1 {
+		t.Error("Sign(-1) must be -1")
+	}
+}
+
+func TestFixedTrunc(t *testing.T) {
+	if got := mustFp(t, "1.99999999").Trunc().StringValue(); got != "1.00000000" {
+		t.Errorf("Trunc(1.99999999): got %q", got)
+	}
+	if got := mustFp(t, "-1.99999999").Trunc().StringValue(); got != "-1.00000000" {
+		t.Errorf("Trunc(-1.99999999) must truncate toward zero: got %q", got)
+	}
+}
+
+// =============================================================================
+// Overflow on arithmetic
+// =============================================================================
+
+func TestFixedOverflowOnMul(t *testing.T) {
+	// Mul result is (a_m * b_m) / 10^8. With 10^8 ≈ 2^26.575, overflow
+	// (result ≥ 2^255) requires a_m * b_m ≥ 2^281.5. For a = b, that means
+	// a_m ≥ 2^141; use 2^200 to stay well above the bound.
+	mantissa := new(big.Int).Lsh(big.NewInt(1), 200)
+	a, err := GetRFixedFromMantissa(mantissa)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.Mul(a); err == nil {
+		t.Error("expected overflow error on huge mul")
+	}
+}
+
+func TestFixedOverflowOnAdd(t *testing.T) {
+	// Two mantissas each just below 2^255 → sum exceeds the bound.
+	near := new(big.Int).Sub(fixedBound, big.NewInt(1))
+	a, err := GetRFixedFromMantissa(near)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.Add(a); err == nil {
+		t.Error("expected overflow error on Add")
+	}
+}
+
+// =============================================================================
+// Compare and Equals — mixed-type promotion
+// =============================================================================
+
+func TestFixedEqualsIntegerPromotion(t *testing.T) {
+	two := mustFp(t, "2")
+	if eq, err := two.Equals(GetRIntegerValue(2)); err != nil || !eq {
+		t.Errorf("2fp == RInteger(2): eq=%v err=%v", eq, err)
+	}
+	if eq, err := two.Equals(GetRIntegerValue(3)); err != nil || eq {
+		t.Errorf("2fp == RInteger(3): eq=%v err=%v", eq, err)
+	}
+}
+
+func TestFixedEqualsBigIntPromotion(t *testing.T) {
+	five := mustFp(t, "5")
+	if eq, err := five.Equals(GetRBigIntFromInt64(5)); err != nil || !eq {
+		t.Errorf("5fp == RBigInt(5): eq=%v err=%v", eq, err)
+	}
+}
+
+func TestFixedEqualsDoubleRejected(t *testing.T) {
+	one := mustFp(t, "1")
+	_, err := one.Equals(GetRDoubleValue(1.0))
+	if err == nil {
+		t.Fatal("expected error comparing fixed to double without cvfp")
+	}
+	if !strings.Contains(err.Error(), "cvfp") {
+		t.Errorf("error should mention cvfp: %v", err)
+	}
+}
+
+func TestFixedCompare(t *testing.T) {
+	a := mustFp(t, "1.5")
+	b := mustFp(t, "2.5")
+	if c, _ := a.Compare(b); c != -1 {
+		t.Errorf("1.5 vs 2.5: got %d, want -1", c)
+	}
+	if c, _ := b.Compare(a); c != 1 {
+		t.Errorf("2.5 vs 1.5: got %d, want 1", c)
+	}
+	if c, _ := a.Compare(a); c != 0 {
+		t.Errorf("1.5 vs 1.5: got %d, want 0", c)
+	}
+}
+
+// =============================================================================
+// Conversions out of fixed
+// =============================================================================
+
+func TestFixedIntValueTruncate(t *testing.T) {
+	if v, _ := mustFp(t, "1.99999999").IntValue(); v != 1 {
+		t.Errorf("IntValue(1.99999999): got %d, want 1", v)
+	}
+	if v, _ := mustFp(t, "-1.99999999").IntValue(); v != -1 {
+		t.Errorf("IntValue(-1.99999999): got %d, want -1 (truncate toward zero)", v)
+	}
+}
+
+func TestFixedLongValueOverflow(t *testing.T) {
+	// int64 max is 9.22e18; a 10^19 fixed value overflows.
+	big10pow19 := new(big.Int).Exp(big.NewInt(10), big.NewInt(19), nil)
+	r, err := GetRFixedFromBigInt(big10pow19)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.LongValue(); err == nil {
+		t.Error("expected int64 overflow error on LongValue")
+	}
+}
+
+func TestFixedDoubleValue(t *testing.T) {
+	f, _ := mustFp(t, "1.5").DoubleValue()
+	if f != 1.5 {
+		t.Errorf("DoubleValue(1.5): got %v, want 1.5", f)
+	}
+}
+
+func TestFixedRBigIntValueTruncates(t *testing.T) {
+	r := mustFp(t, "1234567890.87654321")
+	bi, err := r.RBigIntValue()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := bi.StringValue(), "1234567890"; got != want {
+		t.Errorf("RBigIntValue truncated: got %q, want %q", got, want)
+	}
+}
+
+func TestFixedBooleanValue(t *testing.T) {
+	if b, _ := mustFp(t, "0").BooleanValue(); b {
+		t.Error("BooleanValue(0) must be false")
+	}
+	if b, _ := mustFp(t, "0.00000001").BooleanValue(); !b {
+		t.Error("BooleanValue(0.00000001) must be true")
+	}
+}
+
+// =============================================================================
+// Type registration sanity
+// =============================================================================
+
+func TestFixedTypeRegistration(t *testing.T) {
+	if TypeFixed == nil {
+		t.Fatal("TypeFixed not registered")
+	}
+	if TypeFixed.String() != "fixed" {
+		t.Errorf("TypeFixed name: got %q, want fixed", TypeFixed.String())
+	}
+	r := mustFp(t, "1")
+	if r.Type() != TypeFixed {
+		t.Error("RFixed.Type() must return TypeFixed")
+	}
+}

--- a/pkg/dtrules/fixed_test.go
+++ b/pkg/dtrules/fixed_test.go
@@ -298,6 +298,40 @@ func TestFixedOverflowOnAdd(t *testing.T) {
 	}
 }
 
+func TestFixedOverflowOnSub(t *testing.T) {
+	// Near-max-positive minus near-max-negative exceeds the bound: subtraction
+	// needs its own overflow check because it can't be reached via Add alone.
+	near := new(big.Int).Sub(fixedBound, big.NewInt(1))
+	pos, err := GetRFixedFromMantissa(near)
+	if err != nil {
+		t.Fatal(err)
+	}
+	neg, err := GetRFixedFromMantissa(new(big.Int).Neg(near))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pos.Sub(neg); err == nil {
+		t.Error("expected overflow error on Sub of near-max-pos − near-max-neg")
+	}
+}
+
+func TestFixedMulTruncatesToZero(t *testing.T) {
+	// 0.00000001 × 0.00000001 = 0.0000000000000001 → truncated to 0 on the
+	// 10^-8 grid. Guards the "small but non-zero operands yield exactly zero"
+	// boundary where sub-satoshi multiplication silently vanishes.
+	a := mustFp(t, "0.00000001")
+	r, err := a.Mul(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := r.StringValue(); got != "0.00000000" {
+		t.Errorf("0.00000001² on 10^-8 grid: got %q, want 0.00000000", got)
+	}
+	if r.Sign() != 0 {
+		t.Errorf("expected Sign 0 after truncate-to-zero, got %d", r.Sign())
+	}
+}
+
 // =============================================================================
 // Compare and Equals — mixed-type promotion
 // =============================================================================

--- a/pkg/dtrules/loader/edd.go
+++ b/pkg/dtrules/loader/edd.go
@@ -351,6 +351,10 @@ func (l *EDDLoader) computeDefaultValue(defaultStr string, rtype *dtrules.RType)
 		if v, err := dtrules.GetRBigIntFromString(defaultStr); err == nil {
 			return v
 		}
+	case dtrules.TypeFixed:
+		if v, err := dtrules.GetRFixedFromString(defaultStr); err == nil {
+			return v
+		}
 	}
 
 	return dtrules.GetRNull()

--- a/pkg/dtrules/loader/edd_test.go
+++ b/pkg/dtrules/loader/edd_test.go
@@ -474,6 +474,52 @@ func TestEDDLoaderBigIntDefaultValue(t *testing.T) {
 	}
 }
 
+func TestEDDLoaderFixedDefaultValue(t *testing.T) {
+	factory := entity.NewFactory(nil)
+	loader := NewEDDLoader(nil, factory)
+
+	xml := `<?xml version="1.0" encoding="UTF-8"?>
+<entity_data_dictionary version="1.0">
+  <entity name="staking" access="rw">
+    <field name="amount" type="fixed" access="rw" default_value="1680748.45091643"/>
+    <field name="rate" type="fixed" access="rw" default_value="0.00250000"/>
+    <field name="zero" type="fixed" access="rw" default_value="0"/>
+    <field name="negative" type="fixed" access="rw" default_value="-0.00000001"/>
+  </entity>
+</entity_data_dictionary>`
+
+	if err := loader.Load(strings.NewReader(xml)); err != nil {
+		t.Fatalf("Failed to load EDD with fixed default values: %v", err)
+	}
+
+	stakingEntity, _ := factory.GetReferenceEntity(dtrules.GetRName("staking"))
+	if stakingEntity == nil {
+		t.Fatal("Expected staking entity to be created")
+	}
+
+	cases := map[string]string{
+		"amount":   "1680748.45091643",
+		"rate":     "0.00250000",
+		"zero":     "0.00000000",
+		"negative": "-0.00000001",
+	}
+	for field, want := range cases {
+		v, err := stakingEntity.Get(dtrules.GetRName(field))
+		if err != nil {
+			t.Errorf("Get(%s): %v", field, err)
+			continue
+		}
+		fp, ok := v.(*dtrules.RFixed)
+		if !ok {
+			t.Errorf("%s: expected RFixed default, got %T", field, v)
+			continue
+		}
+		if got := fp.StringValue(); got != want {
+			t.Errorf("%s default: got %q, want %q", field, got, want)
+		}
+	}
+}
+
 func TestEDDLoaderBigIntInvalidDefaultValue(t *testing.T) {
 	factory := entity.NewFactory(nil)
 	loader := NewEDDLoader(nil, factory)

--- a/pkg/dtrules/loader/json.go
+++ b/pkg/dtrules/loader/json.go
@@ -232,6 +232,10 @@ func (l *JSONEDDLoader) computeDefaultValue(defaultStr string, rtype *dtrules.RT
 		if v, err := dtrules.GetRBigIntFromString(defaultStr); err == nil {
 			return v
 		}
+	case dtrules.TypeFixed:
+		if v, err := dtrules.GetRFixedFromString(defaultStr); err == nil {
+			return v
+		}
 	}
 
 	return dtrules.GetRNull()

--- a/pkg/dtrules/loader/json_test.go
+++ b/pkg/dtrules/loader/json_test.go
@@ -1039,6 +1039,58 @@ func TestJSONEDDLoaderBigIntDefaultValue(t *testing.T) {
 	}
 }
 
+// TestJSONEDDLoaderFixedDefaultValue guards the TypeFixed arm of
+// JSONEDDLoader.computeDefaultValue — fp fields declared in JSON EDD must
+// pick up the default value as an RFixed on the 10^-8 grid (parallels
+// the XML-EDD coverage in TestEDDLoaderFixedDefaultValue).
+func TestJSONEDDLoaderFixedDefaultValue(t *testing.T) {
+	factory := entity.NewFactory(nil)
+	loader := NewJSONEDDLoader(nil, factory)
+
+	jsonData := `{
+		"entities": [
+			{
+				"name": "pool",
+				"access": "rw",
+				"fields": [
+					{"name": "amount",   "type": "fixed", "access": "rw", "defaultValue": "1680748.45091643"},
+					{"name": "rate",     "type": "fixed", "access": "rw", "defaultValue": "0.00250000"},
+					{"name": "negative", "type": "fixed", "access": "rw", "defaultValue": "-0.00000001"}
+				]
+			}
+		]
+	}`
+
+	if err := loader.Load(strings.NewReader(jsonData)); err != nil {
+		t.Fatalf("Load JSON EDD with fixed fields: %v", err)
+	}
+
+	ent, _ := factory.GetReferenceEntity(dtrules.GetRName("pool"))
+	if ent == nil {
+		t.Fatal("expected pool entity")
+	}
+	expect := map[string]string{
+		"amount":   "1680748.45091643",
+		"rate":     "0.00250000",
+		"negative": "-0.00000001",
+	}
+	for name, want := range expect {
+		v, err := ent.Get(dtrules.GetRName(name))
+		if err != nil {
+			t.Errorf("Get(%s): %v", name, err)
+			continue
+		}
+		fp, ok := v.(*dtrules.RFixed)
+		if !ok {
+			t.Errorf("%s: expected RFixed default, got %T", name, v)
+			continue
+		}
+		if got := fp.StringValue(); got != want {
+			t.Errorf("%s default: got %q, want %q", name, got, want)
+		}
+	}
+}
+
 // TestGoValueToDTRulesObjectLargeNumber tests that large numeric strings
 // that exceed float64 precision are handled appropriately
 func TestGoValueToDTRulesObjectLargeNumber(t *testing.T) {

--- a/pkg/dtrules/mapping/data_loader.go
+++ b/pkg/dtrules/mapping/data_loader.go
@@ -320,6 +320,16 @@ func (l *dataLoader) setAttribute(pending pendingAttrib, body string, createdEnt
 		}
 		value = dtrules.GetRDoubleValue(val)
 
+	case TypeFixed:
+		if body == "" {
+			body = "0"
+		}
+		fp, err := dtrules.GetRFixedFromString(body)
+		if err != nil {
+			return fmt.Errorf("failed to parse fixed value %q: %w", body, err)
+		}
+		value = fp
+
 	case TypeBoolean:
 		if body == "" {
 			body = "false"

--- a/pkg/dtrules/mapping/json_data_loader.go
+++ b/pkg/dtrules/mapping/json_data_loader.go
@@ -298,6 +298,16 @@ func (l *jsonDataLoader) convertToAttributeType(attrType AttributeType, body str
 		}
 		return dtrules.GetRBigIntFromInt64(0)
 
+	case TypeFixed:
+		// Fixed-point values must come in as strings to preserve the 10^-8
+		// grid exactly; a JSON number would go through float64 and lose
+		// precision on sub-satoshi amounts.
+		if v, err := dtrules.GetRFixedFromString(body); err == nil {
+			return v
+		}
+		zero, _ := dtrules.GetRFixedFromInt64(0)
+		return zero
+
 	default:
 		return dtrules.NewRString(body)
 	}

--- a/pkg/dtrules/mapping/mapping.go
+++ b/pkg/dtrules/mapping/mapping.go
@@ -87,6 +87,7 @@ const (
 	TypeArray
 	TypeXMLValue
 	TypeBigInt
+	TypeFixed
 )
 
 // ParseAttributeType converts a string type to AttributeType.
@@ -110,6 +111,8 @@ func ParseAttributeType(s string) AttributeType {
 		return TypeXMLValue
 	case "bigint", "biginteger":
 		return TypeBigInt
+	case "fixed":
+		return TypeFixed
 	default:
 		return TypeNone
 	}

--- a/pkg/dtrules/mapping/mapping_test.go
+++ b/pkg/dtrules/mapping/mapping_test.go
@@ -304,6 +304,8 @@ func TestAttributeTypes(t *testing.T) {
 		{"bigint", TypeBigInt},
 		{"biginteger", TypeBigInt},
 		{"BIGINT", TypeBigInt},
+		{"fixed", TypeFixed},
+		{"FIXED", TypeFixed},
 		{"unknown", TypeNone},
 		{"", TypeNone},
 	}

--- a/pkg/dtrules/mapping/mapping_test.go
+++ b/pkg/dtrules/mapping/mapping_test.go
@@ -423,6 +423,36 @@ func TestBigIntJSONDataLoading(t *testing.T) {
 	}
 }
 
+// TestFixedJSONConvertToAttributeType directly exercises the TypeFixed arm of
+// jsonDataLoader.convertToAttributeType — the runtime JSON data path that
+// parses fp values from strings to preserve the 10^-8 grid.
+func TestFixedJSONConvertToAttributeType(t *testing.T) {
+	session := newMockSession()
+	m := NewMapping(session)
+	l := newJSONDataLoader(m)
+
+	cases := []struct {
+		body string
+		want string
+	}{
+		{"1680748.45091643", "1680748.45091643"},
+		{"-0.00000001", "-0.00000001"},
+		{"0", "0.00000000"},
+	}
+	for _, c := range cases {
+		t.Run(c.body, func(t *testing.T) {
+			obj := l.convertToAttributeType(TypeFixed, c.body, c.body)
+			fp, ok := obj.(*dtrules.RFixed)
+			if !ok {
+				t.Fatalf("expected *RFixed, got %T", obj)
+			}
+			if got := fp.StringValue(); got != c.want {
+				t.Errorf("convertToAttributeType(%q) = %q, want %q", c.body, got, c.want)
+			}
+		})
+	}
+}
+
 func TestBigIntConversionFromString(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/dtrules/operators/fixed.go
+++ b/pkg/dtrules/operators/fixed.go
@@ -1,0 +1,263 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operators
+
+import (
+	"math"
+	"math/big"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+)
+
+func init() {
+	// Fixed-point arithmetic
+	Register("fp+", opFixedAdd)
+	Alias("fp+", "fpadd")
+
+	Register("fp-", opFixedSub)
+	Alias("fp-", "fpsub")
+
+	Register("fp*", opFixedMul)
+	Alias("fp*", "fpmul")
+
+	Register("fp/", opFixedDiv)
+	Alias("fp/", "fpdiv")
+
+	Register("fpabs", opFixedAbs)
+	Register("fpnegate", opFixedNegate)
+	Register("fptrunc", opFixedTrunc)
+
+	// Fixed-point comparison
+	Register("fp==", opFixedEqual)
+
+	Register("fp!=", opFixedNotEqual)
+	Alias("fp!=", "fp<>")
+
+	Register("fp>", opFixedGreater)
+	Register("fp>=", opFixedGreaterEqual)
+	Register("fp<", opFixedLess)
+	Register("fp<=", opFixedLessEqual)
+
+	// Explicit cast to fixed-point (the opt-in for double → fixed).
+	Register("cvfp", opCvFixed)
+}
+
+// popFixedPair pops b then a from the data stack and promotes both to RFixed.
+// Integer and bigint operands are auto-promoted; double operands return an
+// error pointing to the cvfp cast.
+func popFixedPair(state dtrules.State) (*dtrules.RFixed, *dtrules.RFixed, error) {
+	b, err := state.DataPop()
+	if err != nil {
+		return nil, nil, err
+	}
+	a, err := state.DataPop()
+	if err != nil {
+		return nil, nil, err
+	}
+	aFp, err := dtrules.PromoteToRFixed(a)
+	if err != nil {
+		return nil, nil, err
+	}
+	bFp, err := dtrules.PromoteToRFixed(b)
+	if err != nil {
+		return nil, nil, err
+	}
+	return aFp, bFp, nil
+}
+
+func popFixedOne(state dtrules.State) (*dtrules.RFixed, error) {
+	a, err := state.DataPop()
+	if err != nil {
+		return nil, err
+	}
+	return dtrules.PromoteToRFixed(a)
+}
+
+// opFixedAdd adds two fixed values: ( a b -- a+b )
+func opFixedAdd(state dtrules.State) error {
+	a, b, err := popFixedPair(state)
+	if err != nil {
+		return err
+	}
+	r, err := a.Add(b)
+	if err != nil {
+		return err
+	}
+	return state.DataPush(r)
+}
+
+// opFixedSub subtracts two fixed values: ( a b -- a-b )
+func opFixedSub(state dtrules.State) error {
+	a, b, err := popFixedPair(state)
+	if err != nil {
+		return err
+	}
+	r, err := a.Sub(b)
+	if err != nil {
+		return err
+	}
+	return state.DataPush(r)
+}
+
+// opFixedMul multiplies two fixed values with truncate-toward-zero: ( a b -- a*b )
+func opFixedMul(state dtrules.State) error {
+	a, b, err := popFixedPair(state)
+	if err != nil {
+		return err
+	}
+	r, err := a.Mul(b)
+	if err != nil {
+		return err
+	}
+	return state.DataPush(r)
+}
+
+// opFixedDiv divides two fixed values with truncate-toward-zero: ( a b -- a/b )
+func opFixedDiv(state dtrules.State) error {
+	a, b, err := popFixedPair(state)
+	if err != nil {
+		return err
+	}
+	r, err := a.Div(b)
+	if err != nil {
+		return err
+	}
+	return state.DataPush(r)
+}
+
+// opFixedAbs returns absolute value: ( a -- |a| )
+func opFixedAbs(state dtrules.State) error {
+	a, err := popFixedOne(state)
+	if err != nil {
+		return err
+	}
+	return state.DataPush(a.Abs())
+}
+
+// opFixedNegate negates a fixed value: ( a -- -a )
+func opFixedNegate(state dtrules.State) error {
+	a, err := popFixedOne(state)
+	if err != nil {
+		return err
+	}
+	return state.DataPush(a.Neg())
+}
+
+// opFixedTrunc truncates fractional part toward zero: ( a -- trunc(a) )
+func opFixedTrunc(state dtrules.State) error {
+	a, err := popFixedOne(state)
+	if err != nil {
+		return err
+	}
+	return state.DataPush(a.Trunc())
+}
+
+func opFixedCompare(state dtrules.State, want func(int) bool) error {
+	a, b, err := popFixedPair(state)
+	if err != nil {
+		return err
+	}
+	c, err := a.Compare(b)
+	if err != nil {
+		return err
+	}
+	return state.DataPush(dtrules.GetRBoolean(want(c)))
+}
+
+func opFixedEqual(state dtrules.State) error {
+	return opFixedCompare(state, func(c int) bool { return c == 0 })
+}
+
+func opFixedNotEqual(state dtrules.State) error {
+	return opFixedCompare(state, func(c int) bool { return c != 0 })
+}
+
+func opFixedGreater(state dtrules.State) error {
+	return opFixedCompare(state, func(c int) bool { return c > 0 })
+}
+
+func opFixedGreaterEqual(state dtrules.State) error {
+	return opFixedCompare(state, func(c int) bool { return c >= 0 })
+}
+
+func opFixedLess(state dtrules.State) error {
+	return opFixedCompare(state, func(c int) bool { return c < 0 })
+}
+
+func opFixedLessEqual(state dtrules.State) error {
+	return opFixedCompare(state, func(c int) bool { return c <= 0 })
+}
+
+// opCvFixed converts the top stack value to RFixed: ( value -- fixed )
+//
+// Conversion rules:
+//   - fixed: identity
+//   - integer, bigint: exact (bigint range-checked against the 256-bit mantissa)
+//   - double: truncated toward zero onto the 10^-8 grid, range-checked
+//   - string: parsed as a decimal literal
+//
+// Anything else is a type error.
+func opCvFixed(state dtrules.State) error {
+	obj, err := state.DataPop()
+	if err != nil {
+		return err
+	}
+	switch v := obj.(type) {
+	case *dtrules.RFixed:
+		return state.DataPush(v)
+	case *dtrules.RInteger:
+		fp, err := dtrules.GetRFixedFromInt64(v.Value())
+		if err != nil {
+			return err
+		}
+		return state.DataPush(fp)
+	case *dtrules.RBigInt:
+		fp, err := dtrules.GetRFixedFromBigInt(v.BigIntValue())
+		if err != nil {
+			return err
+		}
+		return state.DataPush(fp)
+	case *dtrules.RDouble:
+		fp, err := fixedFromDouble(v.Value())
+		if err != nil {
+			return err
+		}
+		return state.DataPush(fp)
+	case *dtrules.RString:
+		fp, err := dtrules.GetRFixedFromString(v.StringValue())
+		if err != nil {
+			return err
+		}
+		return state.DataPush(fp)
+	default:
+		return dtrules.NewRulesError("Math Exception", "cvfp",
+			"cannot convert "+obj.Type().String()+" to fixed")
+	}
+}
+
+// fixedFromDouble snaps a float64 onto the 10^-8 grid by multiplying in
+// big.Float precision and truncating toward zero, then range-checking.
+func fixedFromDouble(d float64) (*dtrules.RFixed, error) {
+	if math.IsNaN(d) || math.IsInf(d, 0) {
+		return nil, dtrules.NewRulesError("Math Exception", "cvfp",
+			"cannot convert NaN or Inf to fixed")
+	}
+	f := new(big.Float).SetPrec(256).SetFloat64(d)
+	scale := new(big.Float).SetPrec(256).SetInt64(100_000_000)
+	f.Mul(f, scale)
+	mantissa, _ := f.Int(nil) // big.Float.Int truncates toward zero
+	return dtrules.GetRFixedFromMantissa(mantissa)
+}
+

--- a/pkg/dtrules/operators/fixed_test.go
+++ b/pkg/dtrules/operators/fixed_test.go
@@ -379,33 +379,6 @@ func TestCvfpFromUnsupportedTypeErrors(t *testing.T) {
 	}
 }
 
-// TestNegOperatorRegistered guards the pre-existing `-<int_expr>` bug found
-// in the deep review: VisitIntNegate emits `neg`, but no operator by that
-// name was registered, so every integer negation failed at runtime with
-// `The Name 'neg' was not defined`. Fixed by aliasing `neg` → `negate` in
-// math.go's init(). Pushing a value, running neg, and checking the result
-// is -value asserts the alias is wired correctly end-to-end.
-func TestNegOperatorRegistered(t *testing.T) {
-	state := newFixedTestState()
-	if err := state.DataPush(dtrules.GetRIntegerValue(5)); err != nil {
-		t.Fatal(err)
-	}
-	if err := mustOp(t, "neg").Execute(state); err != nil {
-		t.Fatalf("neg must be registered so integer negation works: %v", err)
-	}
-	top, err := state.DataPop()
-	if err != nil {
-		t.Fatal(err)
-	}
-	v, err := top.IntValue()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if v != -5 {
-		t.Errorf("neg(5) = %d, want -5", v)
-	}
-}
-
 // TestCvbOnFixed guards cvb → boolean coercion for RFixed, matching the
 // "0 → false, non-zero → true" rule the op applies to integer and bigint.
 func TestCvbOnFixed(t *testing.T) {

--- a/pkg/dtrules/operators/fixed_test.go
+++ b/pkg/dtrules/operators/fixed_test.go
@@ -379,6 +379,33 @@ func TestCvfpFromUnsupportedTypeErrors(t *testing.T) {
 	}
 }
 
+// TestNegOperatorRegistered guards the pre-existing `-<int_expr>` bug found
+// in the deep review: VisitIntNegate emits `neg`, but no operator by that
+// name was registered, so every integer negation failed at runtime with
+// `The Name 'neg' was not defined`. Fixed by aliasing `neg` → `negate` in
+// math.go's init(). Pushing a value, running neg, and checking the result
+// is -value asserts the alias is wired correctly end-to-end.
+func TestNegOperatorRegistered(t *testing.T) {
+	state := newFixedTestState()
+	if err := state.DataPush(dtrules.GetRIntegerValue(5)); err != nil {
+		t.Fatal(err)
+	}
+	if err := mustOp(t, "neg").Execute(state); err != nil {
+		t.Fatalf("neg must be registered so integer negation works: %v", err)
+	}
+	top, err := state.DataPop()
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := top.IntValue()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != -5 {
+		t.Errorf("neg(5) = %d, want -5", v)
+	}
+}
+
 // TestCvbOnFixed guards cvb → boolean coercion for RFixed, matching the
 // "0 → false, non-zero → true" rule the op applies to integer and bigint.
 func TestCvbOnFixed(t *testing.T) {

--- a/pkg/dtrules/operators/fixed_test.go
+++ b/pkg/dtrules/operators/fixed_test.go
@@ -250,3 +250,39 @@ func TestCvfpIdempotent(t *testing.T) {
 		t.Errorf("cvfp(fp 1.5) = %q", got)
 	}
 }
+
+// TestCvbOnFixed guards cvb → boolean coercion for RFixed, matching the
+// "0 → false, non-zero → true" rule the op applies to integer and bigint.
+func TestCvbOnFixed(t *testing.T) {
+	cases := []struct {
+		lit  string
+		want bool
+	}{
+		{"0", false},
+		{"0.00000000", false},
+		{"0.00000001", true},
+		{"-0.00000001", true},
+		{"1.5", true},
+		{"-1.5", true},
+	}
+	for _, c := range cases {
+		t.Run(c.lit, func(t *testing.T) {
+			state := newFixedTestState()
+			pushFp(t, state, c.lit)
+			if err := mustOp(t, "cvb").Execute(state); err != nil {
+				t.Fatalf("cvb: %v", err)
+			}
+			top, err := state.DataPop()
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := top.BooleanValue()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != c.want {
+				t.Errorf("cvb(%sfp) = %v, want %v", c.lit, got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/dtrules/operators/fixed_test.go
+++ b/pkg/dtrules/operators/fixed_test.go
@@ -1,0 +1,252 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operators
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+)
+
+func newFixedTestState() *interpreter.DTState {
+	return interpreter.NewDTState(&mockSession{})
+}
+
+func mustOp(t *testing.T, name string) dtrules.Object {
+	t.Helper()
+	op, ok := Get(dtrules.GetRName(name))
+	if !ok {
+		t.Fatalf("operator %q not registered", name)
+	}
+	return op
+}
+
+func pushFp(t *testing.T, state dtrules.State, s string) {
+	t.Helper()
+	fp, err := dtrules.GetRFixedFromString(s)
+	if err != nil {
+		t.Fatalf("GetRFixedFromString(%q): %v", s, err)
+	}
+	if err := state.DataPush(fp); err != nil {
+		t.Fatalf("DataPush: %v", err)
+	}
+}
+
+func popFpString(t *testing.T, state dtrules.State) string {
+	t.Helper()
+	top, err := state.DataPop()
+	if err != nil {
+		t.Fatalf("DataPop: %v", err)
+	}
+	fp, ok := top.(*dtrules.RFixed)
+	if !ok {
+		t.Fatalf("expected RFixed on stack, got %T", top)
+	}
+	return fp.StringValue()
+}
+
+// =============================================================================
+// fp arithmetic operators
+// =============================================================================
+
+func TestFpAddOperator(t *testing.T) {
+	state := newFixedTestState()
+	pushFp(t, state, "1.5")
+	pushFp(t, state, "2.25")
+	if err := mustOp(t, "fp+").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	if got := popFpString(t, state); got != "3.75000000" {
+		t.Errorf("1.5 + 2.25 = %q, want 3.75000000", got)
+	}
+}
+
+func TestFpMulTruncatesTowardZero(t *testing.T) {
+	state := newFixedTestState()
+	pushFp(t, state, "1.00000001")
+	pushFp(t, state, "1.00000001")
+	if err := mustOp(t, "fp*").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	if got := popFpString(t, state); got != "1.00000002" {
+		t.Errorf("1.00000001^2 = %q, want 1.00000002", got)
+	}
+}
+
+func TestFpDivByZeroErrors(t *testing.T) {
+	state := newFixedTestState()
+	pushFp(t, state, "1")
+	pushFp(t, state, "0")
+	if err := mustOp(t, "fp/").Execute(state); err == nil {
+		t.Error("expected divide-by-zero error")
+	}
+}
+
+func TestFpAddPromotesInteger(t *testing.T) {
+	state := newFixedTestState()
+	pushFp(t, state, "1.5")
+	if err := state.DataPush(dtrules.GetRIntegerValue(2)); err != nil {
+		t.Fatal(err)
+	}
+	if err := mustOp(t, "fp+").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	if got := popFpString(t, state); got != "3.50000000" {
+		t.Errorf("1.5 + int(2) = %q, want 3.50000000", got)
+	}
+}
+
+func TestFpAddPromotesBigInt(t *testing.T) {
+	state := newFixedTestState()
+	pushFp(t, state, "1.5")
+	if err := state.DataPush(dtrules.GetRBigIntFromInt64(10)); err != nil {
+		t.Fatal(err)
+	}
+	if err := mustOp(t, "fp+").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	if got := popFpString(t, state); got != "11.50000000" {
+		t.Errorf("1.5 + bigint(10) = %q, want 11.50000000", got)
+	}
+}
+
+func TestFpAddRejectsDouble(t *testing.T) {
+	state := newFixedTestState()
+	pushFp(t, state, "1.5")
+	if err := state.DataPush(dtrules.GetRDoubleValue(2.5)); err != nil {
+		t.Fatal(err)
+	}
+	err := mustOp(t, "fp+").Execute(state)
+	if err == nil {
+		t.Fatal("expected error mixing fp with double")
+	}
+	if !strings.Contains(err.Error(), "cvfp") {
+		t.Errorf("error should mention cvfp: %v", err)
+	}
+}
+
+// =============================================================================
+// fp comparison operators
+// =============================================================================
+
+func TestFpEqualAndLess(t *testing.T) {
+	state := newFixedTestState()
+	pushFp(t, state, "1.5")
+	pushFp(t, state, "1.5")
+	if err := mustOp(t, "fp==").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	top, _ := state.DataPop()
+	if b, _ := top.BooleanValue(); !b {
+		t.Error("fp==: 1.5 == 1.5 should be true")
+	}
+
+	pushFp(t, state, "1.5")
+	pushFp(t, state, "2.5")
+	if err := mustOp(t, "fp<").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	top, _ = state.DataPop()
+	if b, _ := top.BooleanValue(); !b {
+		t.Error("fp<: 1.5 < 2.5 should be true")
+	}
+}
+
+// =============================================================================
+// cvfp cast operator
+// =============================================================================
+
+func TestCvfpFromInteger(t *testing.T) {
+	state := newFixedTestState()
+	state.DataPush(dtrules.GetRIntegerValue(42))
+	if err := mustOp(t, "cvfp").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	if got := popFpString(t, state); got != "42.00000000" {
+		t.Errorf("cvfp(int 42) = %q", got)
+	}
+}
+
+func TestCvfpFromBigInt(t *testing.T) {
+	state := newFixedTestState()
+	state.DataPush(dtrules.GetRBigIntFromInt64(1_000_000))
+	if err := mustOp(t, "cvfp").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	if got := popFpString(t, state); got != "1000000.00000000" {
+		t.Errorf("cvfp(bigint 1e6) = %q", got)
+	}
+}
+
+func TestCvfpFromDoubleSnapsToGrid(t *testing.T) {
+	// 1.5 is exactly representable in float64; cvfp must give exactly 1.50000000.
+	state := newFixedTestState()
+	state.DataPush(dtrules.GetRDoubleValue(1.5))
+	if err := mustOp(t, "cvfp").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	if got := popFpString(t, state); got != "1.50000000" {
+		t.Errorf("cvfp(1.5) = %q", got)
+	}
+
+	// 0.1 is NOT exactly representable — stored as 0.10000000000000000555...
+	// Multiplied by 10^8 that's 10000000.00000000555..., which truncates to
+	// 10000000, giving StringValue "0.10000000". The author opted in to this.
+	state.DataPush(dtrules.GetRDoubleValue(0.1))
+	if err := mustOp(t, "cvfp").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	if got := popFpString(t, state); got != "0.10000000" {
+		t.Errorf("cvfp(0.1) = %q, want 0.10000000", got)
+	}
+}
+
+func TestCvfpFromDoubleTruncatesTowardZero(t *testing.T) {
+	// A negative double slightly short of an integer satoshi should
+	// truncate toward zero, not away.
+	state := newFixedTestState()
+	state.DataPush(dtrules.GetRDoubleValue(-0.099999999))
+	if err := mustOp(t, "cvfp").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	// -0.099999999 * 1e8 = -9999999.9... truncate-toward-zero → -9999999 → -0.09999999
+	if got := popFpString(t, state); got != "-0.09999999" {
+		t.Errorf("cvfp(-0.099999999) = %q, want -0.09999999", got)
+	}
+}
+
+func TestCvfpFromString(t *testing.T) {
+	state := newFixedTestState()
+	state.DataPush(dtrules.NewRString("1680748.45091643"))
+	if err := mustOp(t, "cvfp").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	if got := popFpString(t, state); got != "1680748.45091643" {
+		t.Errorf("cvfp(\"1680748.45091643\") = %q", got)
+	}
+}
+
+func TestCvfpIdempotent(t *testing.T) {
+	state := newFixedTestState()
+	pushFp(t, state, "1.5")
+	if err := mustOp(t, "cvfp").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	if got := popFpString(t, state); got != "1.50000000" {
+		t.Errorf("cvfp(fp 1.5) = %q", got)
+	}
+}

--- a/pkg/dtrules/operators/fixed_test.go
+++ b/pkg/dtrules/operators/fixed_test.go
@@ -15,6 +15,7 @@
 package operators
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -87,6 +88,52 @@ func TestFpMulTruncatesTowardZero(t *testing.T) {
 	}
 }
 
+func TestFpSubOperator(t *testing.T) {
+	state := newFixedTestState()
+	pushFp(t, state, "3.75")
+	pushFp(t, state, "1.50")
+	if err := mustOp(t, "fp-").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	if got := popFpString(t, state); got != "2.25000000" {
+		t.Errorf("3.75 - 1.5 = %q, want 2.25000000", got)
+	}
+}
+
+func TestFpAbsOperator(t *testing.T) {
+	state := newFixedTestState()
+	pushFp(t, state, "-1.23456789")
+	if err := mustOp(t, "fpabs").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	if got := popFpString(t, state); got != "1.23456789" {
+		t.Errorf("fpabs(-1.23456789) = %q, want 1.23456789", got)
+	}
+}
+
+func TestFpNegateOperator(t *testing.T) {
+	state := newFixedTestState()
+	pushFp(t, state, "1.5")
+	if err := mustOp(t, "fpnegate").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	if got := popFpString(t, state); got != "-1.50000000" {
+		t.Errorf("fpnegate(1.5) = %q, want -1.50000000", got)
+	}
+}
+
+func TestFpTruncOperator(t *testing.T) {
+	state := newFixedTestState()
+	pushFp(t, state, "-1.99999999")
+	if err := mustOp(t, "fptrunc").Execute(state); err != nil {
+		t.Fatal(err)
+	}
+	// Truncate toward zero: -1.99999999 → -1.00000000 (not -2)
+	if got := popFpString(t, state); got != "-1.00000000" {
+		t.Errorf("fptrunc(-1.99999999) = %q, want -1.00000000 (truncate toward zero)", got)
+	}
+}
+
 func TestFpDivByZeroErrors(t *testing.T) {
 	state := newFixedTestState()
 	pushFp(t, state, "1")
@@ -143,26 +190,66 @@ func TestFpAddRejectsDouble(t *testing.T) {
 // fp comparison operators
 // =============================================================================
 
-func TestFpEqualAndLess(t *testing.T) {
+// runFpCmp pushes a and b onto the stack, runs op, and returns the boolean on top.
+func runFpCmp(t *testing.T, op, a, b string) bool {
+	t.Helper()
 	state := newFixedTestState()
-	pushFp(t, state, "1.5")
-	pushFp(t, state, "1.5")
-	if err := mustOp(t, "fp==").Execute(state); err != nil {
+	pushFp(t, state, a)
+	pushFp(t, state, b)
+	if err := mustOp(t, op).Execute(state); err != nil {
+		t.Fatalf("%s: %v", op, err)
+	}
+	top, err := state.DataPop()
+	if err != nil {
 		t.Fatal(err)
 	}
-	top, _ := state.DataPop()
-	if b, _ := top.BooleanValue(); !b {
-		t.Error("fp==: 1.5 == 1.5 should be true")
+	got, err := top.BooleanValue()
+	if err != nil {
+		t.Fatal(err)
 	}
+	return got
+}
 
-	pushFp(t, state, "1.5")
-	pushFp(t, state, "2.5")
-	if err := mustOp(t, "fp<").Execute(state); err != nil {
-		t.Fatal(err)
+// TestFpComparisonOperators exercises every registered fp comparison operator
+// on a matrix of positive/negative/equal/zero-crossing pairs so a dispatch-
+// table typo on any of fp==, fp!=, fp<, fp<=, fp>, fp>= would fail.
+func TestFpComparisonOperators(t *testing.T) {
+	type tri struct {
+		lt, eq, gt bool // expected for left vs right
 	}
-	top, _ = state.DataPop()
-	if b, _ := top.BooleanValue(); !b {
-		t.Error("fp<: 1.5 < 2.5 should be true")
+	cases := []struct {
+		a, b string
+		want tri
+	}{
+		{"1.5", "1.5", tri{eq: true}},
+		{"1.5", "2.5", tri{lt: true}},
+		{"2.5", "1.5", tri{gt: true}},
+		{"-1.5", "1.5", tri{lt: true}},
+		{"0.00000001", "0", tri{gt: true}},
+		{"-0.00000001", "0", tri{lt: true}},
+	}
+	for _, c := range cases {
+		name := c.a + "_vs_" + c.b
+		t.Run(name, func(t *testing.T) {
+			if got, want := runFpCmp(t, "fp==", c.a, c.b), c.want.eq; got != want {
+				t.Errorf("fp== %s %s: got %v, want %v", c.a, c.b, got, want)
+			}
+			if got, want := runFpCmp(t, "fp!=", c.a, c.b), !c.want.eq; got != want {
+				t.Errorf("fp!= %s %s: got %v, want %v", c.a, c.b, got, want)
+			}
+			if got, want := runFpCmp(t, "fp<", c.a, c.b), c.want.lt; got != want {
+				t.Errorf("fp< %s %s: got %v, want %v", c.a, c.b, got, want)
+			}
+			if got, want := runFpCmp(t, "fp<=", c.a, c.b), c.want.lt || c.want.eq; got != want {
+				t.Errorf("fp<= %s %s: got %v, want %v", c.a, c.b, got, want)
+			}
+			if got, want := runFpCmp(t, "fp>", c.a, c.b), c.want.gt; got != want {
+				t.Errorf("fp> %s %s: got %v, want %v", c.a, c.b, got, want)
+			}
+			if got, want := runFpCmp(t, "fp>=", c.a, c.b), c.want.gt || c.want.eq; got != want {
+				t.Errorf("fp>= %s %s: got %v, want %v", c.a, c.b, got, want)
+			}
+		})
 	}
 }
 
@@ -248,6 +335,47 @@ func TestCvfpIdempotent(t *testing.T) {
 	}
 	if got := popFpString(t, state); got != "1.50000000" {
 		t.Errorf("cvfp(fp 1.5) = %q", got)
+	}
+}
+
+func TestCvfpFromNaNErrors(t *testing.T) {
+	state := newFixedTestState()
+	state.DataPush(dtrules.GetRDoubleValue(math.NaN()))
+	if err := mustOp(t, "cvfp").Execute(state); err == nil {
+		t.Error("expected cvfp to reject NaN")
+	}
+}
+
+func TestCvfpFromInfErrors(t *testing.T) {
+	for _, f := range []float64{math.Inf(1), math.Inf(-1)} {
+		state := newFixedTestState()
+		state.DataPush(dtrules.GetRDoubleValue(f))
+		if err := mustOp(t, "cvfp").Execute(state); err == nil {
+			t.Errorf("expected cvfp to reject %v", f)
+		}
+	}
+}
+
+// TestCvfpFromUnsupportedTypeErrors guards the `default:` arm of opCvFixed —
+// boolean, entity, array, null, etc. must all error rather than silently
+// snap onto the grid.
+func TestCvfpFromUnsupportedTypeErrors(t *testing.T) {
+	unsupported := []dtrules.Object{
+		dtrules.GetRBoolean(true),
+		dtrules.GetRNull(),
+	}
+	for _, obj := range unsupported {
+		state := newFixedTestState()
+		state.DataPush(obj)
+		err := mustOp(t, "cvfp").Execute(state)
+		if err == nil {
+			t.Errorf("expected cvfp to reject %s", obj.Type().String())
+			continue
+		}
+		if !strings.Contains(err.Error(), "cannot convert") {
+			t.Errorf("cvfp %s error should mention 'cannot convert': %v",
+				obj.Type().String(), err)
+		}
 	}
 }
 

--- a/pkg/dtrules/operators/math.go
+++ b/pkg/dtrules/operators/math.go
@@ -40,6 +40,9 @@ func init() {
 
 	Register("abs", opAbs)
 	Register("negate", opNegate)
+	// The EL postfix emitter emits `neg` (not `negate`) for integer negation
+	// in VisitIntNegate; alias it so `-<int_expr>` works at runtime.
+	Alias("negate", "neg")
 
 	// Float operations
 	Register("f+", opFAdd)

--- a/pkg/dtrules/operators/math.go
+++ b/pkg/dtrules/operators/math.go
@@ -40,9 +40,6 @@ func init() {
 
 	Register("abs", opAbs)
 	Register("negate", opNegate)
-	// The EL postfix emitter emits `neg` (not `negate`) for integer negation
-	// in VisitIntNegate; alias it so `-<int_expr>` works at runtime.
-	Alias("negate", "neg")
 
 	// Float operations
 	Register("f+", opFAdd)

--- a/pkg/dtrules/operators/stack.go
+++ b/pkg/dtrules/operators/stack.go
@@ -642,6 +642,12 @@ func opCvb(state dtrules.State) error {
 			return err
 		}
 		return state.DataPush(dtrules.GetRBoolean(b.BigIntValue().Sign() != 0))
+	case dtrules.TypeFixed:
+		v, err := obj.BooleanValue()
+		if err != nil {
+			return err
+		}
+		return state.DataPush(dtrules.GetRBoolean(v))
 	}
 	return dtrules.TypeCheckError("cvb", "cannot coerce "+t.GetName().StringValue()+" to boolean")
 }

--- a/pkg/dtrules/types.go
+++ b/pkg/dtrules/types.go
@@ -137,6 +137,7 @@ var (
 	TypeMark          *RType
 	TypeBigInt        *RType
 	TypeBytes         *RType
+	TypeFixed         *RType
 )
 
 func init() {
@@ -156,6 +157,7 @@ func init() {
 	TypeMark = NewType("mark")
 	TypeBigInt = NewType("bigint")
 	TypeBytes = NewType("bytes")
+	TypeFixed = NewType("fixed")
 
 	// Register common type aliases
 	registerTypeAlias("float", TypeDouble)


### PR DESCRIPTION
Closes #686.

## Summary

The add-to / subtract-from / increment / decrement family of statement visitors emitted type-naive postfix, silently corrupting fp, bigint, and double targets. Because `typedLong` / `typedDouble` in the grammar are just `IDENT`, any numeric field matched and routed through integer ops that truncated operands via `LongValue()` at runtime.

`add N to <field>` was worse: for bare-IDENT targets the parser steers into `VisitAddArrayToArray` (which had per-type dispatch for integer/double only, no bigint or fp). For fp targets the emission routed through the array `addto` path and failed at runtime on scalars.

## Fix

Centralized the store-back emission in one helper:

\`\`\`go
emitTypeAwareAddSub(fieldName, op)
\`\`\`

Dispatches on declared type:
- **Integer:** \`<field> + /<field> xdef\` (or \`swap -\` for sub)
- **BigInt:** \`cvbi <field> b+ /<field> xdef\` (or swap + b-)
- **Double:** \`cvr <field> f+ /<field> xdef\` (or swap + f-)
- **Fixed:** \`cvfp <field> fp+ /<field> xdef\` (or swap + fp-)

Applied to the whole family: `VisitAddDestLong`, `VisitAddDestDouble`, `VisitSubDestLong`, `VisitSubDestDouble`, `VisitIncrementLong`, `VisitIncrementDouble`, `VisitDecrementLong`, `VisitDecrementDouble`, `VisitAddDestArray` (numeric targets; arrays still fall through to `swap addto`), and `VisitAddArrayToArray`.

## Test matrix

`pkg/dtrules/compiler/el/field_mutation_test.go` — 16 cases: {add-to, subtract-from, increment, decrement} × {integer, bigint, double, fixed}. Plus a colon-ref variant guarding `add 1.5fp to wp.amount` specifically (the previously-silently-failing case).

## Test plan
- [x] make check clean
- [x] field_mutation_test.go passes across all 16 cases
- [x] Colon-ref variant (`wp.amount` etc.) routes through the new helper
- [x] Existing bigint / fp tests still pass
- [x] No regressions in the el compiler test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)