### PR TITLE
refactor(op): replace bubble sort; fix sortarray asc semantic (#696)

### DIFF
--- a/pkg/dtrules/operators/array.go
+++ b/pkg/dtrules/operators/array.go
@@ -17,6 +17,7 @@ package operators
 
 import (
 	"math/rand"
+	"sort"
 
 	"github.com/DTRules/DTRules/pkg/dtrules"
 )
@@ -280,7 +281,8 @@ func opCopyElements(state dtrules.State) error {
 	return nil
 }
 
-// opSortArray: ( array boolean -- ) sorts array elements (ascending if boolean is true)
+// opSortArray: ( array boolean -- ) sorts array elements in place.
+// asc=true → ascending, asc=false → descending.
 func opSortArray(state dtrules.State) error {
 	ascObj, err := state.DataPop()
 	if err != nil {
@@ -299,29 +301,27 @@ func opSortArray(state dtrules.State) error {
 		return err
 	}
 
-	// Bubble sort
 	elements := arr.GetIterator()
-	size := len(elements)
-	direction := 1
-	if !asc {
-		direction = -1
-	}
-
-	for i := 0; i < size-1; i++ {
-		for j := 0; j < size-1-i; j++ {
-			cmp, err := elements[j+1].Compare(elements[j])
-			if err != nil {
-				return err
-			}
-			if cmp == direction {
-				elements[j], elements[j+1] = elements[j+1], elements[j]
-			}
+	var cmpErr error
+	sort.SliceStable(elements, func(i, j int) bool {
+		if cmpErr != nil {
+			return false
 		}
-	}
-	return nil
+		cmp, err := elements[i].Compare(elements[j])
+		if err != nil {
+			cmpErr = err
+			return false
+		}
+		if asc {
+			return cmp < 0
+		}
+		return cmp > 0
+	})
+	return cmpErr
 }
 
-// opSortEntities: ( array field boolean -- ) sorts entities by field value
+// opSortEntities: ( array field boolean -- ) sorts entities by field value in place.
+// asc=true → ascending, asc=false → descending.
 func opSortEntities(state dtrules.State) error {
 	ascObj, err := state.DataPop()
 	if err != nil {
@@ -350,45 +350,42 @@ func opSortEntities(state dtrules.State) error {
 	}
 
 	elements := arr.GetIterator()
-	size := len(elements)
-	greaterThan := 1
-	if !asc {
-		greaterThan = -1
-	}
-
-	for i := 0; i < size; i++ {
-		done := true
-		for j := 0; j < size-1-i; j++ {
-			e1, err := elements[j].REntityValue()
-			if err != nil {
-				return err
-			}
-			e2, err := elements[j+1].REntityValue()
-			if err != nil {
-				return err
-			}
-			v1, err := e1.Get(name)
-			if err != nil {
-				return err
-			}
-			v2, err := e2.Get(name)
-			if err != nil {
-				return err
-			}
-			cmp, err := v1.Compare(v2)
-			if err != nil {
-				return err
-			}
-			if cmp == greaterThan {
-				elements[j], elements[j+1] = elements[j+1], elements[j]
-				done = false
-			}
+	var cmpErr error
+	sort.SliceStable(elements, func(i, j int) bool {
+		if cmpErr != nil {
+			return false
 		}
-		if done {
-			return nil
+		e1, err := elements[i].REntityValue()
+		if err != nil {
+			cmpErr = err
+			return false
 		}
-	}
-	return nil
+		e2, err := elements[j].REntityValue()
+		if err != nil {
+			cmpErr = err
+			return false
+		}
+		v1, err := e1.Get(name)
+		if err != nil {
+			cmpErr = err
+			return false
+		}
+		v2, err := e2.Get(name)
+		if err != nil {
+			cmpErr = err
+			return false
+		}
+		cmp, err := v1.Compare(v2)
+		if err != nil {
+			cmpErr = err
+			return false
+		}
+		if asc {
+			return cmp < 0
+		}
+		return cmp > 0
+	})
+	return cmpErr
 }
 
 // opAddNoDups: ( array item -- ) adds item to array if not already present

--- a/pkg/dtrules/operators/misc_ops_test.go
+++ b/pkg/dtrules/operators/misc_ops_test.go
@@ -111,27 +111,23 @@ func arrayInts(t *testing.T, arr *dtrules.RArray) []int64 {
 	return out
 }
 
-// TestSortArrayAscendingDescending pins bubble-sort output for both
-// directions. Note the parameter sense is inverted from its name: the
-// sampleproject passes `false` to get ascending order (see
-// SyntaxTests/xml/syntaxexample_dt.xml: "earliest of cases after
-// currentDate" → `false sortarray for`). Pin that sense — a rewrite
-// that "fixes" the parameter name without updating the .xml would
-// silently flip sampleproject output.
+// TestSortArrayAscendingDescending — asc=true produces ascending,
+// asc=false produces descending. Matches the parameter name and the
+// cross-language "ascending" convention (Pandas sort_values(ascending=True)).
 func TestSortArrayAscendingDescending(t *testing.T) {
 	state := newTestState()
 	for _, tc := range []struct {
-		name  string
-		param bool
-		want  []int64
+		name string
+		asc  bool
+		want []int64
 	}{
-		{"false_produces_ascending", false, []int64{1, 2, 3, 5, 8}},
-		{"true_produces_descending", true, []int64{8, 5, 3, 2, 1}},
+		{"ascending", true, []int64{1, 2, 3, 5, 8}},
+		{"descending", false, []int64{8, 5, 3, 2, 1}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			arr := mustArray(t, state, 5, 3, 8, 1, 2)
 			state.DataPush(arr)
-			state.DataPush(dtrules.GetRBoolean(tc.param))
+			state.DataPush(dtrules.GetRBoolean(tc.asc))
 			o, _ := Get(dtrules.GetRName("sortarray"))
 			if err := o.Execute(state); err != nil {
 				t.Fatalf("sortarray: %v", err)

--- a/sampleprojects/SyntaxTests/repository/xml/syntaxexample_dt.xml
+++ b/sampleprojects/SyntaxTests/repository/xml/syntaxexample_dt.xml
@@ -860,7 +860,7 @@ effectiveDate endofmonth cvd /currentDate xdef
 <initial_action_requirement />
 <initial_action_dsl>set effectiveDate = earliest of cases after currentDate</initial_action_dsl>
 <initial_action_postfix>
-currentDate dup &gt;r { { pop pop i i } over i d&gt; if pop } cases dup false sortarray for r&gt; pop cvd /effectiveDate xdef  
+currentDate dup &gt;r { { pop pop i i } over i d&gt; if pop } cases dup true sortarray for r&gt; pop cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
 <conditions />
 <actions /></decision_table>

--- a/sampleprojects/SyntaxTests/xml/syntaxexample_dt.xml
+++ b/sampleprojects/SyntaxTests/xml/syntaxexample_dt.xml
@@ -1102,7 +1102,7 @@ effectiveDate endofmonth cvd /currentDate xdef
 <initial_action_requirement />
 <initial_action_dsl>set effectiveDate = earliest of cases after currentDate</initial_action_dsl>
 <initial_action_postfix>
-currentDate dup &gt;r { { pop pop i i } over i d&gt; if pop } cases dup false sortarray for r&gt; pop cvd /effectiveDate xdef  
+currentDate dup &gt;r { { pop pop i i } over i d&gt; if pop } cases dup true sortarray for r&gt; pop cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
 <conditions />
 <actions />
@@ -3879,7 +3879,7 @@ effectiveDate endofmonth cvd /currentDate xdef
 <initial_action_requirement />
 <initial_action_dsl>set effectiveDate = earliest of cases after currentDate</initial_action_dsl>
 <initial_action_postfix>
-currentDate dup &gt;r { { pop pop i i } over i d&gt; if pop } cases dup false sortarray for r&gt; pop cvd /effectiveDate xdef  
+currentDate dup &gt;r { { pop pop i i } over i d&gt; if pop } cases dup true sortarray for r&gt; pop cvd /effectiveDate xdef  
 </initial_action_postfix></initial_action_details></initial_actions>
 <conditions>
 <condition_details>


### PR DESCRIPTION
## Summary

- Replaces the hand-rolled bubble sort in `opSortArray` and `opSortEntities` with `sort.SliceStable` — lowers complexity from O(n²) to O(n log n) and cuts each function from ~30 lines to ~10.
- Fixes `sortarray`'s inverted `asc` parameter: `asc=true` now produces ascending order (matches the parameter name and the Pandas/pandas-style convention). `sortentities` already had the correct semantic, only its impl changed.
- Updates the 3 sampleproject callsites that previously worked around the bug by passing `false`:
  - `sampleprojects/SyntaxTests/xml/syntaxexample_dt.xml` (2 occurrences)
  - `sampleprojects/SyntaxTests/repository/xml/syntaxexample_dt.xml` (1 occurrence)

## Stacking

Stacked on `feature/issue-694-cvd-rename` so the pinned test that documents the bug (added in the cvd rename branch's test-coverage batch) can be flipped to expect the fixed semantic in this same PR. Rebase onto `main` after #694 lands.

## Test plan

- [x] `make check` passes
- [x] Pinned test `TestSortArrayAscendingDescending` updated to expect the fixed semantic (`asc=true` → ascending)
- [x] Pre-existing failures in `pkg/dtrules/` root (`translationTable` EDD loader issue) are unrelated to this change — confirmed by running the same tests on `main`

## Breaking change

External rule files that call `sortarray` will see flipped output. Single-token edit (`false`/`true`) to migrate. Only in-tree consumers are the 3 sampleproject callsites, all updated here.

Closes #696