### PR TITLE
hotfix: restore isFixedLiteralText; pin fpmin/fpmax in registration test

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -1414,6 +1414,45 @@ func fexprIsFixed(e *PostfixEmitter, ctx interface{ GetText() string }) bool {
 	return e.lookupType(text) == TypeFixed
 }
 
+// isFixedLiteralText reports whether text is a valid fp literal like
+// "1.5fp", "0fp", or "100.0FP" — digit sequence (optional leading sign,
+// optional single dot) followed by a case-insensitive "fp" suffix.
+// Restored after #699 cleanup left a dangling caller in fexprIsFixed.
+func isFixedLiteralText(text string) bool {
+	if len(text) < 3 {
+		return false
+	}
+	if !strings.EqualFold(text[len(text)-2:], "fp") {
+		return false
+	}
+	body := text[:len(text)-2]
+	if body == "" {
+		return false
+	}
+	if body[0] == '-' || body[0] == '+' {
+		body = body[1:]
+	}
+	if body == "" {
+		return false
+	}
+	seenDot := false
+	seenDigit := false
+	for i := 0; i < len(body); i++ {
+		switch c := body[i]; {
+		case c >= '0' && c <= '9':
+			seenDigit = true
+		case c == '.':
+			if seenDot {
+				return false
+			}
+			seenDot = true
+		default:
+			return false
+		}
+	}
+	return seenDigit
+}
+
 // VisitFloatRounded / VisitFloatRoundedTo / VisitFloatRoundedBoundry:
 // the three `<fexpr> rounded [...]` grammar alternatives. The pre-fix
 // state was:

--- a/pkg/dtrules/operators/registration_test.go
+++ b/pkg/dtrules/operators/registration_test.go
@@ -167,6 +167,8 @@ func TestAllOperatorsRegistered(t *testing.T) {
 	"fp>",
 	"fp>=",
 	"fpabs",
+	"fpmax",
+	"fpmin",
 	"fpnegate",
 	"fptrunc",
 	"get",


### PR DESCRIPTION
## Summary

Main is broken after the big PR stack merge. Two tiny gaps slipped through:

1. **`isFixedLiteralText` referenced but undefined.** #699's cleanup dropped the helper, but `fexprIsFixed` (introduced in #684/#691) still calls it. Build error: `undefined: isFixedLiteralText`. Restore the helper — it's still needed by `fexprIsFixed` which inspects raw text, not parse-tree nodes.

2. **Registration pin-list missing fpmin/fpmax.** #692 added them; `TestAllOperatorsRegistered` (the full-list pin in #695's test batch) wasn't updated. Cardinality guard fires: `233 non-nil entries, this test enumerates 231`. Add the two.

Both are single-line omissions. `make check` passes locally now.

## Test plan

- [x] `go build ./...` succeeds
- [x] `make check` passes
- [x] `TestAllOperatorsRegistered` passes (231 → 233 entries, matches registry)