### PR TITLE
fix(el): set statement local vars + typed targets

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -2509,14 +2509,20 @@ func (e *PostfixEmitter) VisitStatement(ctx *StatementContext) interface{} {
 // Set Statement Visitors
 // ============================================================================
 
+// resolveSetTarget returns the declared type for a set-statement target. It
+// checks locals first (via mutationType) so `local fixed amount` dispatches
+// as fixed even if the EDD has an `amount` entity field, then falls back to
+// the grammar-inferred default when neither source has a declared type.
+func (e *PostfixEmitter) resolveSetTarget(name, defaultType string) string {
+	if t := e.mutationType(name); t != "" {
+		return t
+	}
+	return defaultType
+}
+
 func (e *PostfixEmitter) VisitSetInt(ctx *SetIntContext) interface{} {
 	e.Visit(ctx.Number())
-	// Look up the target field type, default to integer from grammar context
-	leftField := ctx.LeftIexpr().GetText()
-	fieldType := e.lookupType(leftField)
-	if fieldType == "" {
-		fieldType = TypeInteger
-	}
+	fieldType := e.resolveSetTarget(ctx.LeftIexpr().GetText(), TypeInteger)
 	if conv := e.typeConverter(fieldType); conv != "" {
 		e.emit(conv)
 	}
@@ -2526,12 +2532,7 @@ func (e *PostfixEmitter) VisitSetInt(ctx *SetIntContext) interface{} {
 
 func (e *PostfixEmitter) VisitSetFloat(ctx *SetFloatContext) interface{} {
 	e.Visit(ctx.Number())
-	// Look up the target field type, default to double from grammar context
-	leftField := ctx.LeftFexpr().GetText()
-	fieldType := e.lookupType(leftField)
-	if fieldType == "" {
-		fieldType = TypeDouble
-	}
+	fieldType := e.resolveSetTarget(ctx.LeftFexpr().GetText(), TypeDouble)
 	if conv := e.typeConverter(fieldType); conv != "" {
 		e.emit(conv)
 	}
@@ -2541,12 +2542,7 @@ func (e *PostfixEmitter) VisitSetFloat(ctx *SetFloatContext) interface{} {
 
 func (e *PostfixEmitter) VisitSetBool(ctx *SetBoolContext) interface{} {
 	e.Visit(ctx.Bexpr())
-	// Look up the target field type, default to boolean from grammar context
-	leftField := ctx.LeftBexpr().GetText()
-	fieldType := e.lookupType(leftField)
-	if fieldType == "" {
-		fieldType = TypeBoolean
-	}
+	fieldType := e.resolveSetTarget(ctx.LeftBexpr().GetText(), TypeBoolean)
 	if conv := e.typeConverter(fieldType); conv != "" {
 		e.emit(conv)
 	}
@@ -2556,12 +2552,7 @@ func (e *PostfixEmitter) VisitSetBool(ctx *SetBoolContext) interface{} {
 
 func (e *PostfixEmitter) VisitSetEntity(ctx *SetEntityContext) interface{} {
 	e.Visit(ctx.Eexpr())
-	// Look up the target field type, default to entity from grammar context
-	leftField := ctx.LeftEexpr().GetText()
-	fieldType := e.lookupType(leftField)
-	if fieldType == "" {
-		fieldType = TypeEntity
-	}
+	fieldType := e.resolveSetTarget(ctx.LeftEexpr().GetText(), TypeEntity)
 	if conv := e.typeConverter(fieldType); conv != "" {
 		e.emit(conv)
 	}
@@ -2571,12 +2562,7 @@ func (e *PostfixEmitter) VisitSetEntity(ctx *SetEntityContext) interface{} {
 
 func (e *PostfixEmitter) VisitSetString(ctx *SetStringContext) interface{} {
 	e.Visit(ctx.Strexpr())
-	// Look up the target field type, default to string from grammar context
-	leftField := ctx.LeftStrexpr().GetText()
-	fieldType := e.lookupType(leftField)
-	if fieldType == "" {
-		fieldType = TypeString
-	}
+	fieldType := e.resolveSetTarget(ctx.LeftStrexpr().GetText(), TypeString)
 	if conv := e.typeConverter(fieldType); conv != "" {
 		e.emit(conv)
 	}
@@ -2586,12 +2572,7 @@ func (e *PostfixEmitter) VisitSetString(ctx *SetStringContext) interface{} {
 
 func (e *PostfixEmitter) VisitSetDate(ctx *SetDateContext) interface{} {
 	e.Visit(ctx.Dexpr())
-	// Look up the target field type, default to date from grammar context
-	leftField := ctx.LeftDexpr().GetText()
-	fieldType := e.lookupType(leftField)
-	if fieldType == "" {
-		fieldType = TypeDate
-	}
+	fieldType := e.resolveSetTarget(ctx.LeftDexpr().GetText(), TypeDate)
 	if conv := e.typeConverter(fieldType); conv != "" {
 		e.emit(conv)
 	}
@@ -2599,45 +2580,38 @@ func (e *PostfixEmitter) VisitSetDate(ctx *SetDateContext) interface{} {
 	return nil
 }
 
+// Left*Simple visitors route through emitFieldStore so declared locals get
+// `<index> local!` while entity fields keep `/<name> xdef`. Without this,
+// `set <local> = ...` would error at runtime because xdef can't resolve a
+// name that isn't on the entity stack.
+
 func (e *PostfixEmitter) VisitLeftIexprSimple(ctx *LeftIexprSimpleContext) interface{} {
-	// Emit left value format: /<fieldname> xdef
-	e.emit("/" + ctx.TypedLong().GetText())
-	e.emit("xdef")
+	e.emitFieldStore(ctx.TypedLong().GetText())
 	return nil
 }
 
 func (e *PostfixEmitter) VisitLeftFexprSimple(ctx *LeftFexprSimpleContext) interface{} {
-	// Emit left value format: /<fieldname> xdef
-	e.emit("/" + ctx.TypedDouble().GetText())
-	e.emit("xdef")
+	e.emitFieldStore(ctx.TypedDouble().GetText())
 	return nil
 }
 
 func (e *PostfixEmitter) VisitLeftBexprSimple(ctx *LeftBexprSimpleContext) interface{} {
-	// Emit left value format: /<fieldname> xdef
-	e.emit("/" + ctx.TypedBoolean().GetText())
-	e.emit("xdef")
+	e.emitFieldStore(ctx.TypedBoolean().GetText())
 	return nil
 }
 
 func (e *PostfixEmitter) VisitLeftEexprSimple(ctx *LeftEexprSimpleContext) interface{} {
-	// Emit left value format: /<fieldname> xdef
-	e.emit("/" + ctx.TypedEntity().GetText())
-	e.emit("xdef")
+	e.emitFieldStore(ctx.TypedEntity().GetText())
 	return nil
 }
 
 func (e *PostfixEmitter) VisitLeftStrexprSimple(ctx *LeftStrexprSimpleContext) interface{} {
-	// Emit left value format: /<fieldname> xdef
-	e.emit("/" + ctx.TypedString().GetText())
-	e.emit("xdef")
+	e.emitFieldStore(ctx.TypedString().GetText())
 	return nil
 }
 
 func (e *PostfixEmitter) VisitLeftDexprSimple(ctx *LeftDexprSimpleContext) interface{} {
-	// Emit left value format: /<fieldname> xdef
-	e.emit("/" + ctx.TypedDate().GetText())
-	e.emit("xdef")
+	e.emitFieldStore(ctx.TypedDate().GetText())
 	return nil
 }
 
@@ -2957,7 +2931,7 @@ func (e *PostfixEmitter) VisitDecrementDouble(ctx *DecrementDoubleContext) inter
 func (e *PostfixEmitter) VisitSetStringFromName(ctx *SetStringFromNameContext) interface{} {
 	e.Visit(ctx.Nexpr())
 	fieldName := ctx.LeftStrexpr().GetText()
-	if e.lookupType(fieldName) == TypeBoolean {
+	if e.mutationType(fieldName) == TypeBoolean {
 		e.emit("cvb")
 	} else {
 		e.emit("cvs")
@@ -4766,12 +4740,7 @@ func (e *PostfixEmitter) VisitLocalBigIntDefined(ctx *LocalBigIntDefinedContext)
 
 func (e *PostfixEmitter) VisitSetBigInt(ctx *SetBigIntContext) interface{} {
 	e.Visit(ctx.Bigexpr())
-	// Look up the target field type, default to bigint from grammar context
-	leftField := ctx.LeftBigexpr().GetText()
-	fieldType := e.lookupType(leftField)
-	if fieldType == "" {
-		fieldType = TypeBigInt
-	}
+	fieldType := e.resolveSetTarget(ctx.LeftBigexpr().GetText(), TypeBigInt)
 	if conv := e.typeConverter(fieldType); conv != "" {
 		e.emit(conv)
 	}
@@ -4780,9 +4749,7 @@ func (e *PostfixEmitter) VisitSetBigInt(ctx *SetBigIntContext) interface{} {
 }
 
 func (e *PostfixEmitter) VisitLeftBigexprSimple(ctx *LeftBigexprSimpleContext) interface{} {
-	// Emit left value format: /<fieldname> xdef
-	e.emit("/" + ctx.TypedBigInt().GetText())
-	e.emit("xdef")
+	e.emitFieldStore(ctx.TypedBigInt().GetText())
 	return nil
 }
 

--- a/pkg/dtrules/compiler/el/set_statement_test.go
+++ b/pkg/dtrules/compiler/el/set_statement_test.go
@@ -1,0 +1,237 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #709: the set-statement visitors emitted `cvi /<name> xdef` even
+// when the target was a declared local of a different type. That silently
+// truncated fp/bigint values via cvi and errored at runtime because xdef
+// can't resolve a name that lives in a local-frame slot. These tests pin
+// the fix: dispatch the type converter against mutationType (local first,
+// then EDD) and route the store through emitFieldStore so locals land in
+// the frame via `<idx> local!`.
+
+// TestSetLocalFixed — the exact bug from #709: `set amount = 1.5fp` on a
+// `local fixed amount` must preserve the fp value and write to the local
+// frame. Before the fix this emitted `1.5fp cvi /amount xdef`.
+func TestSetLocalFixed(t *testing.T) {
+	got := compileWithLocalCtx(t,
+		"local fixed amount = 0.0fp;", "set amount = 1.5fp;")
+	want := []string{"1.5fp", "cvfp", "0 local!"}
+	notWant := []string{"cvi", "/amount xdef", " amount "}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("expected %q in postfix, got: %s", w, got)
+		}
+	}
+	for _, n := range notWant {
+		if strings.Contains(got, n) {
+			t.Errorf("unexpected %q in postfix: %s", n, got)
+		}
+	}
+}
+
+// TestSetLocalBigInt — bigint local assignment must stay on the bigint
+// grid (cvbi) rather than truncating via cvi.
+func TestSetLocalBigInt(t *testing.T) {
+	got := compileWithLocalCtx(t,
+		"local bigint n = (bigint) 0;", "set n = (bigint) 100;")
+	want := []string{"cvbi", "0 local!"}
+	notWant := []string{"/n xdef", "cvi"}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("expected %q in postfix, got: %s", w, got)
+		}
+	}
+	for _, n := range notWant {
+		if strings.Contains(got, n) {
+			t.Errorf("unexpected %q in postfix: %s", n, got)
+		}
+	}
+}
+
+// TestSetLocalDouble — double local assignment keeps the double coercion
+// and writes to the local-frame slot.
+func TestSetLocalDouble(t *testing.T) {
+	got := compileWithLocalCtx(t,
+		"local double d = 0.0;", "set d = 3.14;")
+	want := []string{"3.14", "cvd", "0 local!"}
+	notWant := []string{"/d xdef", "cvi", "cvfp"}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("expected %q in postfix, got: %s", w, got)
+		}
+	}
+	for _, n := range notWant {
+		if strings.Contains(got, n) {
+			t.Errorf("unexpected %q in postfix: %s", n, got)
+		}
+	}
+}
+
+// TestSetLocalLong — plain long local still gets cvi and local!, which
+// matches the int-default path but through the local-aware store.
+func TestSetLocalLong(t *testing.T) {
+	got := compileWithLocalCtx(t,
+		"local long i = 0;", "set i = 42;")
+	want := []string{"42", "cvi", "0 local!"}
+	notWant := []string{"/i xdef"}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("expected %q in postfix, got: %s", w, got)
+		}
+	}
+	for _, n := range notWant {
+		if strings.Contains(got, n) {
+			t.Errorf("unexpected %q in postfix: %s", n, got)
+		}
+	}
+}
+
+// TestSetLocalBool — boolean local assignment must use cvb and local!.
+func TestSetLocalBool(t *testing.T) {
+	got := compileWithLocalCtx(t,
+		"local boolean b = true;", "set b = false;")
+	want := []string{"0 local!"}
+	notWant := []string{"/b xdef"}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("expected %q in postfix, got: %s", w, got)
+		}
+	}
+	for _, n := range notWant {
+		if strings.Contains(got, n) {
+			t.Errorf("unexpected %q in postfix: %s", n, got)
+		}
+	}
+}
+
+// TestSetLocalString — string local assignment routes through local!.
+func TestSetLocalString(t *testing.T) {
+	got := compileWithLocalCtx(t,
+		`local string s = "";`, `set s = "hi";`)
+	want := []string{`"hi"`, "0 local!"}
+	notWant := []string{"/s xdef"}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("expected %q in postfix, got: %s", w, got)
+		}
+	}
+	for _, n := range notWant {
+		if strings.Contains(got, n) {
+			t.Errorf("unexpected %q in postfix: %s", n, got)
+		}
+	}
+}
+
+// TestSetLocalFixed_FromBigInt — cross-type promotion: a bigint RHS into
+// a fixed local must land as fixed. The converter emitted from the set
+// visitor is cvfp (the target's type), regardless of what the RHS was.
+func TestSetLocalFixed_FromBigInt(t *testing.T) {
+	got := compileWithLocalCtx(t,
+		"local fixed bal = 0.0fp;", "set bal = (bigint) 100;")
+	want := []string{"cvfp", "0 local!"}
+	notWant := []string{"/bal xdef"}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("expected %q in postfix, got: %s", w, got)
+		}
+	}
+	for _, n := range notWant {
+		if strings.Contains(got, n) {
+			t.Errorf("unexpected %q in postfix: %s", n, got)
+		}
+	}
+}
+
+// TestSetLocalMultiple — second local gets index 1 and uses that index
+// when set is invoked. Cross-checks the frame-slot dispatch.
+func TestSetLocalMultiple(t *testing.T) {
+	c := NewCompiler()
+	if _, err := c.CompileContext("local fixed amt = 0.0fp;"); err != nil {
+		t.Fatalf("CompileContext amt: %v", err)
+	}
+	if _, err := c.CompileContext("local fixed bal = 0.0fp;"); err != nil {
+		t.Fatalf("CompileContext bal: %v", err)
+	}
+	got, err := c.CompileAction("set bal = 2.5fp;")
+	if err != nil {
+		t.Fatalf("CompileAction: %v", err)
+	}
+	want := []string{"2.5fp", "cvfp", "1 local!"}
+	notWant := []string{"/bal xdef", "0 local!"}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("expected %q in postfix, got: %s", w, got)
+		}
+	}
+	for _, n := range notWant {
+		if strings.Contains(got, n) {
+			t.Errorf("unexpected %q in postfix: %s", n, got)
+		}
+	}
+}
+
+// TestSetEntityField_Regression — entity fields (no local shadow) must
+// still use the `/<name> xdef` form. Guards against accidentally breaking
+// the non-local path while wiring up local dispatch.
+func TestSetEntityField_Regression(t *testing.T) {
+	c := NewCompiler()
+	got, err := c.CompileAction("set some_field = 5;")
+	if err != nil {
+		t.Fatalf("CompileAction: %v", err)
+	}
+	want := []string{"5", "cvi", "/some_field", "xdef"}
+	notWant := []string{"local!", "local@"}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("expected %q in postfix, got: %s", w, got)
+		}
+	}
+	for _, n := range notWant {
+		if strings.Contains(got, n) {
+			t.Errorf("unexpected %q in postfix: %s", n, got)
+		}
+	}
+}
+
+// TestSetEntityField_FixedType — when the EDD symbol table marks a
+// field as fixed, the set must dispatch as fixed even with no local.
+// This exercises the same mutationType fallback path used by the
+// increment/addto helpers.
+func TestSetEntityField_FixedType(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{"balance": TypeFixed})
+	got, err := c.CompileAction("set balance = 1.5fp;")
+	if err != nil {
+		t.Fatalf("CompileAction: %v", err)
+	}
+	want := []string{"1.5fp", "cvfp", "/balance", "xdef"}
+	notWant := []string{"cvi", "local!"}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("expected %q in postfix, got: %s", w, got)
+		}
+	}
+	for _, n := range notWant {
+		if strings.Contains(got, n) {
+			t.Errorf("unexpected %q in postfix: %s", n, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #709

## Summary

The `set` statement's visitors looked up target types via `lookupType`, which is blind to locals. So `set amount = 1.5fp;` with `local fixed amount = 0.0fp;` emitted `1.5fp cvi /amount xdef` — `cvi` silently truncated the fp value and `xdef` erred at runtime because the local lives in a frame slot, not on the entity stack.

- Route set-statement type resolution through `mutationType` (locals first, then EDD) via a new `resolveSetTarget` helper in `postfix_emitter.go`.
- Route `VisitLeft{I,F,B,E,Str,D,Big}exprSimple` through `emitFieldStore`, so locals emit `<idx> local!` and entity fields still emit `/<name> xdef`. Same helpers #690/#693/#698 introduced for increment/addto/subfrom.
- Updated `VisitSet{Int,Float,Bool,Entity,String,Date,BigInt}` and `VisitSetStringFromName` to use the local-aware lookup.

**Release-blocker for v1.8.0** — fixes silent-corruption of `fp` (and `bigint`, `double`) assignments to local variables.

## Test plan

New file `pkg/dtrules/compiler/el/set_statement_test.go` pins ten cases:

- [x] `TestSetLocalFixed` — `set amount = 1.5fp;` on `local fixed amount` emits `1.5fp cvfp 0 local!` (the exact repro from #709)
- [x] `TestSetLocalBigInt` — bigint local stays on the bigint grid
- [x] `TestSetLocalDouble` — double local keeps `cvd`
- [x] `TestSetLocalLong` — long local uses `cvi` + `local!`
- [x] `TestSetLocalBool` / `TestSetLocalString` — bool/string locals
- [x] `TestSetLocalFixed_FromBigInt` — cross-type promotion: bigint RHS into fixed local
- [x] `TestSetLocalMultiple` — second local gets index 1, set dispatches to the right slot
- [x] `TestSetEntityField_Regression` — entity fields with no local still use `/name xdef`
- [x] `TestSetEntityField_FixedType` — EDD-declared fixed field dispatches as fixed

Verified:
```
make check > /tmp/check.log 2>&1 && tail -20 /tmp/check.log   # passed
go test ./pkg/dtrules/compiler/el/ -run "TestSet" -count=1 -v  # 10/10 pass
```

Repro from the bug report now emits `"1.5fp cvfp 0 local!"` (was `"1.5fp cvi /amount xdef"`).

Generated with [Claude Code](https://claude.com/claude-code)