### PR TITLE
docs: v1.8.0 user-facing docs for fixed-point + breakers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,48 +2,144 @@
 
 ## v1.8.0 — 2026-04-19
 
-Minor release. New numeric type for blockchain / token math.
+Minor release. Introduces the `fixed` numeric type for blockchain / token math,
+a first-class fp grammar front-end, and hardens the compiler / loader around
+type-aware mutations, `for all <type> entities`, and EOF anchoring. Two
+operator renames ship as breaking changes — see "Breaking changes" below.
 
-- **RFixed — 256-bit fixed-point type** (PR #684). Adds a new numeric
-  type `fixed` for amounts and rates on a 10⁻⁸ decimal grid. Signed
-  256-bit mantissa (~5.78 × 10⁵⁹ whole-token headroom), truncate-
-  toward-zero on multiply/divide, exact add/sub, symmetric overflow
-  bounds. Literal form `1.5fp`. StringValue always renders exactly 8
-  fractional digits so XML round-trips are bit-exact.
+## Breaking changes
 
-  Closes the precision gap that previously forced staking to use
-  float64: every intermediate stays on the grid, so the final total
-  can't drift from what the blockchain expects. Rejects `0.1` →
-  `0.09999999`-style snapping by requiring an explicit `cvfp` cast
-  for double operands; integer and bigint auto-promote exactly.
+- **`cvd` is now the double converter; `cvdate` is the new date converter**
+  (#694, PR #695). Historically `cvd` was the DATE cast. That was the only
+  cv* op whose target type didn't match its letter, and it confused every
+  type-dispatch path in the compiler (notably the v1.7.x set/field-mutation
+  family). `cvd` now means double; `cvr` is an alias retained for backward
+  compatibility in hand-written postfix; the date cast moved to the new
+  `cvdate` op. Any rule file that emits raw postfix (not EL) calling `cvd`
+  and expects date semantics WILL break — recompile from EL, or rename
+  `cvd` → `cvdate` in the stored postfix.
 
-  Full stack shipped in one PR:
+- **`sortarray asc=true` now produces ascending order** (#696, PR #701).
+  The flag semantics were inverted: `asc=true` previously produced a
+  descending sort and `asc=false` produced ascending. Both halves of the
+  comparator, and every call site in the test suite, were written against
+  that inversion, so the bug stayed hidden. Fixed to match the parameter
+  name. External rules that called `sortarray ... true` expecting
+  descending will see flipped output — swap the boolean. The implementation
+  also replaced the bubble sort with `sort.SliceStable` for stability and
+  complexity.
 
-  - **Type** (`pkg/dtrules/fixed.go`) — RFixed with Add/Sub/Mul/Div/
-    Neg/Abs/Trunc, Equals/Compare, and every Object-interface
-    conversion (IntValue/LongValue/DoubleValue/RIntegerValue/
-    RDoubleValue/RBigIntValue truncate toward zero).
+## Fixed-point (new type)
 
-  - **Operators** (`pkg/dtrules/operators/fixed.go`) — `fp+ fp- fp* fp/
-    fpabs fpnegate fptrunc fp== fp!= fp> fp>= fp< fp<= cvfp`.
+- **`RFixed` — 256-bit fixed-point type** (#684). Adds the `fixed` numeric
+  type for amounts and rates on a 10⁻⁸ decimal grid. Signed 256-bit
+  mantissa (~5.78 × 10⁵⁹ whole-token headroom), truncate-toward-zero on
+  multiply/divide, exact add/sub, symmetric overflow bounds. Literal form
+  `1.5fp`. StringValue always renders exactly 8 fractional digits so XML
+  and JSON round-trips are bit-exact.
 
-  - **Literal parsing** — `1.5fp` / `1.50000000FP` recognized by both
-    compile paths (bytecode and Object), with strict digit validation
-    (rejects `--1`, bare `fp`).
+  Closes the precision gap that previously forced staking to use float64:
+  every intermediate stays on the grid, so the final total can't drift
+  from what the blockchain expects. Rejects `0.1 → 0.09999999`-style
+  snapping by requiring an explicit `cvfp` cast for double operands;
+  integer and bigint auto-promote exactly.
 
-  - **EL dispatch** (`pkg/dtrules/compiler/el/postfix_emitter.go`) —
-    the whole 11-visitor integer family (Add/Sub/Mul/Div/Negate + six
-    comparisons) now shares `promoteArithType` + `emitWithType-
-    Conversion` helpers. Fixed > BigInt > Integer priority, with
-    `cvfp` promotion inserted automatically for mixed operands.
-    Per the labeled-alternative rule, the whole family was fixed at
-    once to avoid the partial-fix hazard from #675.
+  Runtime: RFixed value type with Add/Sub/Mul/Div/Neg/Abs/Trunc,
+  Equals/Compare, and every Object-interface conversion (truncate toward
+  zero). Operators: `fp+ fp- fp* fp/ fpabs fpnegate fptrunc fp== fp!=
+  fp> fp>= fp< fp<= cvfp`. EDD/XML/JSON loaders parse `type='fixed'`
+  fields and fp values from strings (never float64).
 
-  - **EDD / XML / JSON round-trip** — loader parses `type='fixed'`
-    fields and RFixed default values; runtime XML/JSON data paths
-    parse fp values from strings (never float64); entity Put coerces
-    int/bigint to fp and rejects double, matching the #675 principle
-    that silent down-coercion is always an error.
+- **`fpmin` / `fpmax` + type-aware Min/Max dispatch** (#688, PR #692).
+  Adds `fpmin` and `fpmax` ops, and teaches the EL `maximum`/`minimum`
+  visitors to dispatch by operand type so `the maximum of a and b` emits
+  `fpmax` when both are fp, `bmax` when both are bigint, and the existing
+  int/double dispatch otherwise.
+
+- **First-class fp grammar front-end** (#689, PR #699). Adds the
+  `FP_LITERAL` lexer token (`1.5fp`, `100.0FP`, etc.) and `fpexpr`
+  productions. `local fixed x` and `(fixed) expr` are now parsed in the
+  grammar itself rather than recognized ad-hoc. Strict digit validation
+  (at most 8 fractional digits; rejects `--1`, bare `fp`) moved into the
+  lexer.
+
+## Compiler / EL
+
+- **Type-aware field-mutation visitors** (#686, PR #690). The
+  increment/decrement/add-to/subtract-from action family now dispatches
+  by the target field's declared type — fp fields emit fp ops, bigint
+  fields emit bigint ops, double fields emit double ops. Previously
+  everything collapsed to integer with a trailing `cvi`, silently
+  truncating bigint and fp mutations. Per the labeled-alternative rule,
+  the whole family was fixed at once.
+
+- **Missing fexpr visitors** (#687, PR #691). Added visitors for the
+  double alternatives that had no `postfix_emitter.go` implementation:
+  `absolute value`, `rounded`, `rounded to N`, and `rounded … with
+  boundry B`. Previously the parser accepted these but the emitter
+  dropped the subtree, producing wrong postfix.
+
+- **Field-mutation visitors dispatch locals vs entity fields** (#693,
+  PR #698). The same mutation family now emits `N local!` for local
+  slots and `<field> xdef` for entity fields, rather than always
+  assuming entity-field semantics. Hand-written `increment myLocal`
+  code used to silently do nothing.
+
+- **`set` statement dispatches locals and typed targets** (#709, PR
+  #710). `set local = expr` now uses the local-slot machinery. Typed
+  entity-field assignments insert the correct conversion op based on
+  declared target type (including fp).
+
+- **`for all <type> entities` grammar + EDD resolver** (#703, PR #707).
+  The `forall` statement now accepts a type keyword (`for all customer
+  entities where …`). The resolver consults the EDD to enumerate all
+  entities of the given type from the current context.
+
+- **EOF anchor in the compiler** (#703, PR #708). The EL grammar now
+  requires EOF at the top of `done`, so trailing tokens after an
+  otherwise-valid statement produce a loud parse error instead of being
+  silently discarded. The broken context DSL in `context_details` that
+  this exposed was rewritten as part of the same PR.
+
+## Operators / runtime
+
+- See **Breaking changes** above for `cvd` / `cvdate` (#694, PR #695)
+  and `sortarray` (#696, PR #701).
+
+## Infrastructure / tests
+
+- **CI scope aligned with `make check`** (#700). CI now runs `go build
+  ./...` (full module) + `go vet` + the scoped test suite, matching the
+  project's local "done" signal. Also fixes a perform-table emit
+  discovered while bringing CI into line.
+
+- **Hotfix: `isFixedLiteralText` restored; fpmin/fpmax pinned in the
+  registration test** (#702). The operator-registration matrix now
+  includes every fp operator so additions can't regress silently.
+
+- **Excel directories generated for 7 XML-only sample projects** (#705,
+  PR #706). `dtrules build` now has a consistent starting point for
+  every sample.
+
+- **Behavior matrices** landed across the release covering all 233
+  operators, the full `cv*` conversion matrix, datetime, hash, stack,
+  bytes, entity, local-frame, sortarray, and string ordering. These
+  are the harness that caught the `cvd` and `sortarray` breakers.
+
+## Migration notes
+
+- **`cvd` in stored postfix**: recompile the rule set from EL, or rename
+  `cvd` → `cvdate` in any hand-authored postfix that relied on date
+  semantics. Rules whose `cvd` calls were always numeric (the vast
+  majority) need no change.
+- **`sortarray asc=true` / `asc=false`**: flip the flag. Rules that
+  relied on the previous inverted semantics were wrong-by-parameter-
+  name; the fix now matches the parameter's advertised meaning.
+- **Silent fp or bigint truncation in mutations**: if you had actions
+  like `increment bigint_field` or `add to fp_field 1.5fp` that
+  appeared to work but produced int64-truncated values, they will now
+  run at full precision. Verify expected values if those mutations are
+  tested against golden outputs.
 
 ## v1.7.3 — 2026-04-19
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ DTRules/
 │   ├── sync/           # Excel/XML synchronization
 │   ├── excel/          # Excel import/export
 │   ├── session/        # Rule execution sessions
-│   ├── operators/      # 179+ built-in operators
+│   ├── operators/      # 233+ built-in operators
 │   └── ...             # Core engine packages
 ├── examples/
 │   └── embedded-app/   # Example embedded application

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ DTRules is a production-ready rules engine that allows business analysts and pol
 - **High Performance** - 130x faster operator lookup, 24x faster arithmetic vs Java
 - **CLI Tool** - Validate, test, and execute rules from command line
 - **Bidirectional Sync** - Excel ↔ XML synchronization with change tracking
+- **Fixed-Point Decimals** - 256-bit `fixed` type for token, staking, and blockchain math without float drift (`dtrules docs fixed`)
 - **Embedded Documentation** - `dtrules docs` for AI and developers
 
 ### Production Use

--- a/cmd/dtrules/docs.go
+++ b/cmd/dtrules/docs.go
@@ -24,6 +24,7 @@ import (
 var docTopics = map[string]string{
 	"bigint":          docBigInt,
 	"bytes":           docBytes,
+	"fixed":           docFixed,
 	"el":              docEL,
 	"xml-format":      docXMLFormat,
 	"edd":             docEDD,
@@ -73,6 +74,7 @@ func printDocIndex() {
 	descriptions := map[string]string{
 		"bigint":          "Arbitrary-precision integer support for financial calculations",
 		"bytes":           "Immutable byte sequences with constant-time equality (blockchain / token use cases)",
+		"fixed":           "256-bit fixed-point type (10^-8 grid) for token/staking/blockchain decimal math",
 		"el":              "Expression Language syntax (REQUIRED for all tables)",
 		"xml-format":      "XML file format specification (EDD and DT)",
 		"edd":             "Entity Data Dictionary - defining entities and fields",
@@ -132,6 +134,7 @@ Literals
 --------
 Integer:       42     -7     0     1000000
 Double:        3.14   0.044  100.0
+Fixed:         1.5fp   0fp   100.0FP   (8-decimal fixed-point, see 'docs fixed')
 String:        "hello"   'single quoted'   "John's tax"
 Boolean:       true   false   default   otherwise   always
                perform when called
@@ -255,6 +258,67 @@ Cast to bigint:
     (bigint) 3.14                                from double (truncates)
 
 See 'dtrules docs bigint' for full bigint documentation.
+
+
+Fixed Expressions (fpexpr)
+---------------------------
+Fixed is a signed 256-bit fixed-point decimal type on a 10^-8 grid.
+Target use: token amounts, staking rewards, fee/rate math — any place
+float64 drift is unacceptable.
+
+Literal syntax:
+    1.5fp                          mantissa 150_000_000 (case-insensitive fp)
+    0fp                            zero
+    100.0FP                        mantissa 10_000_000_000
+    -0.00000001fp                  smallest negative value
+
+At most 8 fractional digits in a literal (more is a compile-time error).
+
+Arithmetic:
+    a + b                          addition (exact)
+    a - b                          subtraction (exact)
+    a * b                          multiplication (truncate toward zero)
+    a / b                          division (truncate toward zero)
+    -a                             negation
+    absolute value of a            absolute value
+
+Cast to fixed:
+    (fixed) 42                     from integer (exact, auto-scaled)
+    (fixed) myBigInt               from bigint (exact, range-checked)
+    (fixed) 3.14                   from double — explicit cast required
+    (fixed) "1.25"                 parse string
+
+Comparisons (exact mantissa compare — no epsilon needed):
+    a == b    a != b
+    a > b     a >= b
+    a < b     a <= b
+
+Fixed-specific operators:
+    fpmin a b                      minimum of two fp values
+    fpmax a b                      maximum of two fp values
+    fptrunc a                      truncate fractional part toward zero
+
+Mutating variants (action context):
+    add to myFixed 1.5fp
+    subtract from myFixed 0.25fp
+    multiply myFixed by 2fp
+    divide myFixed by 3fp
+    increment myFixed              adds 1.00000000
+    decrement myFixed              subtracts 1.00000000
+
+Local variable:
+    local fixed rate = 0.05fp
+    local fixed x
+
+EDD field declaration:
+    <field name="reward_rate" type="fixed" default_value="0.05fp"/>
+
+Interactions with other numerics:
+    int + fixed    -> fixed (exact)
+    bigint + fixed -> fixed (exact, range-checked)
+    double + fixed -> ERROR — use explicit (fixed) cast
+
+See 'dtrules docs fixed' for full fixed documentation.
 
 
 Bytes Expressions (bytesexpr)
@@ -1027,6 +1091,7 @@ Type      Default    Description                    Example Values
 string    ""         Text values                    "hello", "John Doe"
 integer   0          Whole numbers                  42, -7, 1000000
 double    0.0        Decimal numbers                3.14, -0.5, 100.0
+fixed     0.0fp      8-decimal fixed-point          1.5fp, 100.00000000fp
 boolean   false      True/false values              true, false
 date      null       Date values                    2024-01-15
 bigint    0          Arbitrary-precision integer    123456789012345678901234567890
@@ -1595,6 +1660,78 @@ Comparisons (same operators as integer/double):
     amount < other      amount <= other
 
 See 'dtrules docs bigint' for full bigint documentation.
+
+
+Fixed-Point Operators
+---------------------
+Fixed (` + "`fixed`" + `) is a signed 256-bit decimal type on a 10^-8 grid.
+Add/subtract are exact; multiply/divide truncate toward zero onto the
+grid. Mixed int/bigint operands auto-promote; double requires an
+explicit ` + "`(fixed)`" + ` cast.
+
+Arithmetic:
+    a + b                           addition (exact) → fp
+    a - b                           subtraction (exact) → fp
+    a * b                           multiplication (truncate toward zero) → fp
+    a / b                           division (truncate toward zero) → fp
+    -a                              unary negation → fp
+    absolute value of a             absolute value → fp
+
+Comparisons (exact mantissa compare):
+    a == b   a is equal to b                       → boolean
+    a != b   a is not equal to b                   → boolean
+    a > b    a is greater than b                   → boolean
+    a >= b   a is greater than or equal to b       → boolean
+    a < b    a is less than b                      → boolean
+    a <= b   a is less than or equal to b          → boolean
+
+Fixed-specific operators:
+    fpmin a b                       minimum of two fp values → fp
+    fpmax a b                       maximum of two fp values → fp
+    fptrunc a                       truncate fractional part toward zero → fp
+    fpabs a                         absolute value → fp
+    fpnegate a                      unary negation → fp
+
+Mutating shortcuts (action statements):
+    increment myFixed               myFixed += 1.00000000
+    decrement myFixed               myFixed -= 1.00000000
+    add to myFixed 1.5fp
+    subtract from myFixed 0.25fp
+    multiply myFixed by 2fp
+    divide myFixed by 3fp
+
+Cast to fixed:
+    (fixed) 42                      from integer (exact)
+    (fixed) myBigInt                from bigint (exact, range-checked)
+    (fixed) 3.14                    from double (truncate, explicit only)
+    (fixed) "1.25"                  parse decimal string
+
+Cast fixed to other types:
+    (long)   myFixed                fp → integer (truncate toward zero)
+    (double) myFixed                fp → double (may lose precision)
+    (bigint) myFixed                fp → bigint (truncate toward zero)
+    (string) myFixed                fp → string, always 8 fractional digits
+
+Internal operator reference (emitted by the EL compiler):
+
+    fp+, fpadd          Add two fp values (exact)
+    fp-, fpsub          Subtract two fp values (exact)
+    fp*, fpmul          Multiply two fp values (truncate toward zero)
+    fp/, fpdiv          Divide two fp values (truncate toward zero)
+    fpabs               Absolute value
+    fpnegate            Unary negation
+    fptrunc             Truncate fractional part toward zero
+    fpmin               Minimum of two fp values
+    fpmax               Maximum of two fp values
+    fp==                Equality
+    fp!=, fp<>          Inequality
+    fp>                 Greater than
+    fp>=                Greater than or equal
+    fp<                 Less than
+    fp<=                Less than or equal
+    cvfp                Cast top-of-stack to fp (int/bigint/double/string)
+
+See 'dtrules docs fixed' for the full fixed-point documentation.
 
 
 Bytes Operators
@@ -2403,6 +2540,263 @@ See Also
   dtrules docs edd         Entity field definitions
   dtrules docs operators   All operators including bigint
   dtrules docs bytes       Immutable byte sequences
+  dtrules docs fixed       Fixed-point decimal type
+`
+
+const docFixed = `Fixed - 256-bit Fixed-Point Decimals
+====================================
+
+Fixed (type keyword ` + "`fixed`" + `) is a signed 256-bit fixed-point numeric type
+backed by an integer mantissa on the 10^-8 grid. It exists for
+token amounts, staking rewards, fee/rate math, and any blockchain-adjacent
+calculation where float64 drift is unacceptable and bigint (integer-only)
+is insufficient.
+
+Precision: exactly 8 fractional digits (8-decimal fixed-point). The
+internal representation is an integer mantissa M with the implicit
+meaning M × 10^-8.
+
+Mantissa range: |M| < 2^255 — symmetric about zero so that negating any
+representable value is always representable.
+
+
+When to Use
+-----------
+- Token amounts with sub-integer precision (e.g. 1.50000000 ACME).
+- Staking reward math where each intermediate must stay on the
+  blockchain's fixed grid.
+- Rates, fees, percentages that need predictable decimal rounding.
+- Anywhere a double would silently snap (e.g. "0.1" stored as
+  0.09999999...) and corrupt an invariant.
+
+Use double (` + "`fexpr`" + `) for statistics, approximate scoring, or anything
+where rounding to 8 places is acceptable. Use bigint for exact integer
+arithmetic without a fractional part.
+
+
+Literal Syntax
+--------------
+A fp literal is a decimal number followed by a case-insensitive ` + "`fp`" + `
+suffix:
+
+    1.5fp                   mantissa 150_000_000
+    0fp                     zero, mantissa 0
+    100.0FP                 mantissa 10_000_000_000
+    -0.00000001fp           smallest negative value (mantissa -1)
+    12345.67890000fp        exact — trailing zeros preserved
+
+Rules:
+- The decimal point is optional (` + "`0fp`" + ` and ` + "`42fp`" + ` are valid).
+- At most 8 fractional digits — more is a compile-time error (no silent
+  truncation of a user-written literal).
+- The ` + "`fp`" + ` suffix is case-insensitive (` + "`FP`" + `, ` + "`Fp`" + `, ` + "`fP`" + ` all work).
+- No underscores or thousands separators.
+
+
+Local Variable Declarations
+---------------------------
+Declare a fp local with ` + "`local fixed`" + `:
+
+    local fixed x                    uninitialized (mantissa 0)
+    local fixed rate = 0.05fp
+    local fixed principal = (fixed) input.amount_string
+    local fixed earned = (fixed) 42
+
+Reads and writes go through the same slot machinery as other typed
+locals.
+
+
+Casts
+-----
+Explicit cast with ` + "`(fixed)`" + ` — the value on top of the stack becomes fp:
+
+    (fixed) 42                  integer to fp (exact, auto-scaled)
+    (fixed) myBigInt            bigint to fp (exact, range-checked)
+    (fixed) "1.25"              parse decimal string to fp
+    (fixed) 3.14                DOUBLE to fp — explicit cast required
+
+Double -> fixed REQUIRES the explicit ` + "`(fixed)`" + ` cast. There is no implicit
+promotion because most finite decimals (0.1, 0.2, 0.05, ...) have no exact
+float64 representation — silently snapping them to the fp grid would bake
+float error into a "precise" calculation. The cast truncates toward zero
+onto the 10^-8 grid and range-checks the mantissa.
+
+Integer -> fixed and bigint -> fixed DO auto-promote in mixed arithmetic,
+because both conversions are exact.
+
+Reverse casts:
+
+    (long) myFixed              fp to integer (truncate toward zero)
+    (double) myFixed            fp to double (may lose precision)
+    (bigint) myFixed            fp to bigint (truncate toward zero)
+    (string) myFixed            fp to string (always 8 fractional digits)
+
+
+Arithmetic Operators
+--------------------
+Standard arithmetic works on fp operands (mixed int/bigint are promoted
+via ` + "`cvfp`" + `):
+
+    a + b                       addition (exact)
+    a - b                       subtraction (exact)
+    a * b                       multiplication (truncate toward zero)
+    a / b                       division (truncate toward zero)
+    -a                          unary negation
+    absolute value of a         |a|
+
+Add and subtract cannot lose precision — mantissas are added/subtracted
+directly and only overflow is checked. Multiply and divide must rescale
+by 10^8; when the exact result has a ninth decimal digit, it is
+truncated toward zero (never rounded away from zero, never banker's-
+rounded). That rule is deliberate — it matches how on-chain fixed-point
+math typically settles.
+
+Mutating variants in action cells:
+
+    add to myFixed 1.5fp
+    subtract from myFixed 0.25fp
+    multiply myFixed by 2fp
+    divide myFixed by 3fp
+    increment myFixed           adds 1.00000000
+    decrement myFixed           subtracts 1.00000000
+
+Extra fp-specific operators:
+
+    fpabs                       absolute value
+    fpnegate                    unary negation
+    fptrunc                     truncate fractional part toward zero
+                                (result is fp with .00000000)
+    fpmin                       minimum of two fp values
+    fpmax                       maximum of two fp values
+
+All fp operators are registered with both symbolic (` + "`fp+`" + `) and word-
+form (` + "`fpadd`" + `) names — use whichever reads better in context.
+
+
+Comparison Operators
+--------------------
+Standard comparisons between fp operands:
+
+    a == b      fp equality
+    a != b      fp inequality
+    a > b
+    a >= b
+    a < b
+    a <= b
+
+Equality is exact mantissa comparison, so ` + "`0.10000000fp == 0.1fp`" + ` is
+true. Unlike double, there is no need for an epsilon.
+
+
+Conversion Helpers
+------------------
+The ` + "`cvfp`" + ` operator is the underlying cast operator — the EL
+compiler emits it whenever a ` + "`(fixed)`" + ` cast or auto-promotion is needed.
+Rarely needed at the EL level, but listed here for completeness:
+
+    cvfp                        top-of-stack value -> fp
+                                - fixed  : identity
+                                - int    : exact
+                                - bigint : exact (range-checked)
+                                - double : truncate toward zero on grid
+                                - string : parse decimal literal
+
+
+Interaction with Other Numeric Types
+------------------------------------
+Promotion rules in mixed arithmetic (fp + int, fp + bigint, etc.):
+
+    fixed + integer       -> fixed  (integer auto-promoted)
+    fixed + bigint        -> fixed  (bigint auto-promoted, range-checked)
+    fixed + double        -> ERROR: explicit (fixed) cast required
+
+When a ` + "`set`" + ` target is a fp field and the right-hand side is int or
+bigint, the compiler inserts ` + "`cvfp`" + ` automatically so the assignment is
+exact. When the RHS is double, the compiler rejects the assignment and
+asks for an explicit cast.
+
+
+Overflow and Error Semantics
+----------------------------
+- Add/subtract: overflow when the resulting mantissa crosses 2^255.
+  Returns a Math Exception; the value is NOT silently wrapped.
+- Multiply: the 256-bit product is scaled down by 10^8 with truncate-
+  toward-zero; if the final mantissa exceeds 2^255, overflow error.
+- Divide: division by zero raises a Math Exception.
+- Cast: a bigint or string whose value exceeds the 256-bit range raises
+  a Math Exception at cast time.
+- Cast from double: NaN or Inf raises a Math Exception.
+
+Rendering: ` + "`(string) myFixed`" + ` always emits the sign, the integer
+part, a decimal point, and exactly eight fractional digits. That means
+` + "`0.5fp`" + ` round-trips to ` + "`\"0.50000000\"`" + ` — bit-exact for XML / JSON
+storage.
+
+
+EDD Field Declaration
+---------------------
+<entity name="staking" readonly="false">
+    <field name="reward_rate"   type="fixed" default_value="0.05fp"/>
+    <field name="principal"     type="fixed" default_value="0fp"/>
+    <field name="total_reward"  type="fixed" default_value="0fp"/>
+</entity>
+
+Default values use the same literal syntax as EL source. The loader
+parses them once at startup; a malformed default is a load-time error.
+
+
+JSON / XML Round-Trip
+---------------------
+Fixed values are represented as decimal strings in JSON (never as numbers —
+native JSON numbers go through float64 and would lose precision):
+
+{
+    "staking": {
+        "reward_rate":  "0.05000000",
+        "principal":    "100.00000000",
+        "total_reward": "5.00000000"
+    }
+}
+
+The runtime parses strings directly into the mantissa without any float
+intermediate step. Output always renders 8 fractional digits.
+
+
+Example: Staking Reward Step
+----------------------------
+Context:
+    local fixed rate       = 0.05fp
+    local fixed principal  = (fixed) input.amount_string
+
+Action:
+    set result.reward = rate * principal
+
+For principal = 1000.00000000 and rate = 0.05000000, the result is
+50.00000000 — exact, grid-aligned, and bit-identical whether you
+compute it in EL, in Go, or on-chain.
+
+
+Best Practices
+--------------
+1. Use ` + "`fixed`" + ` for anything where "decimal precision" is a
+   correctness requirement, not just presentation.
+2. Store fp values as decimal strings in JSON and databases. Do NOT
+   serialize as a native number.
+3. Prefer ` + "`fpmin`" + ` / ` + "`fpmax`" + ` over manual ` + "`if`" + ` chains — the operators
+   are typed and won't accidentally fall back to integer comparison.
+4. If you must bring in a double (e.g. from legacy input), make the
+   ` + "`(fixed)`" + ` cast explicit and document the precision loss at that
+   boundary.
+5. Avoid chaining divides when you can factor them: ` + "`a * b / c`" + `
+   truncates once; ` + "`(a / c) * b`" + ` truncates twice.
+
+
+See Also
+--------
+  dtrules docs el          EL syntax reference
+  dtrules docs edd         Entity field definitions (fixed is a valid type)
+  dtrules docs operators   All operators including the fp* family
+  dtrules docs bigint      Arbitrary-precision integers
 `
 
 const docBytes = `Bytes - Immutable Byte Sequences

--- a/cmd/dtrules/docs_test.go
+++ b/cmd/dtrules/docs_test.go
@@ -147,3 +147,58 @@ func TestDocumentation_AuthoringInIndex(t *testing.T) {
 		t.Fatal("authoring topic not found in docTopics map")
 	}
 }
+
+func TestDocumentation_FixedTopic(t *testing.T) {
+	doc, ok := docTopics["fixed"]
+	if !ok {
+		t.Fatal("fixed topic not registered in docTopics")
+	}
+	if doc == "" {
+		t.Fatal("fixed topic is empty")
+	}
+	required := []string{"8-decimal", "1.5fp", "fp+", "cvfp", "(fixed)", "local fixed"}
+	for _, term := range required {
+		if !strings.Contains(doc, term) {
+			t.Errorf("fixed doc missing required term: %q", term)
+		}
+	}
+}
+
+func TestDocumentation_OperatorsHasFixedPointSection(t *testing.T) {
+	doc, ok := docTopics["operators"]
+	if !ok {
+		t.Fatal("operators topic not registered in docTopics")
+	}
+	required := []string{"Fixed-Point Operators", "fp+", "fpmin", "fpmax", "cvfp"}
+	for _, term := range required {
+		if !strings.Contains(doc, term) {
+			t.Errorf("operators doc missing required fixed-point term: %q", term)
+		}
+	}
+}
+
+func TestDocumentation_ELLiteralsMentionsFixed(t *testing.T) {
+	doc, ok := docTopics["el"]
+	if !ok {
+		t.Fatal("el topic not registered in docTopics")
+	}
+	if !strings.Contains(doc, "fp") {
+		t.Error("el doc literals section should mention fp suffix")
+	}
+	if !strings.Contains(doc, "1.5fp") {
+		t.Error("el doc should include a 1.5fp literal example")
+	}
+}
+
+func TestDocumentation_EDDTypeTableHasFixed(t *testing.T) {
+	doc, ok := docTopics["edd"]
+	if !ok {
+		t.Fatal("edd topic not registered in docTopics")
+	}
+	if !strings.Contains(doc, "fixed") {
+		t.Error("edd type table should list 'fixed'")
+	}
+	if !strings.Contains(doc, "0.0fp") {
+		t.Error("edd type table should show 0.0fp default")
+	}
+}

--- a/docs/EL-REFERENCE.md
+++ b/docs/EL-REFERENCE.md
@@ -451,7 +451,7 @@ Natural language forms (`is greater than`, `at or above`, etc.) compile identica
 #### Date from string
 
 **Syntax**: `(date) strexpr` or `date(strexpr)`
-**Semantics**: Parse a string into a date value. Postfix: `cvd`.
+**Semantics**: Parse a string into a date value. Postfix: `cvdate`.
 
 The parser accepts both pure dates and full timestamps. Formats tried in order:
 - RFC 3339 with nanoseconds: `2026-04-17T21:05:30.123456789Z`
@@ -462,10 +462,10 @@ The parser accepts both pure dates and full timestamps. Formats tried in order:
 Pure dates (midnight UTC) serialize back as `YYYY-MM-DD`; timestamps serialize as RFC 3339.
 
 **Example (EL)**: `(date)"2024-01-01" is before current date`
-**Compiled postfix**: `"2024-01-01" cvd currentdate d<`
+**Compiled postfix**: `"2024-01-01" cvdate currentdate d<`
 
 **Example (EL with timestamp)**: `(date)"2026-04-17T21:05:30Z" is before current date`
-**Compiled postfix**: `"2026-04-17T21:05:30Z" cvd currentdate d<`
+**Compiled postfix**: `"2026-04-17T21:05:30Z" cvdate currentdate d<`
 
 #### Date arithmetic (date plus/minus days/months/years)
 
@@ -965,7 +965,7 @@ The type-conversion operators used in set statements:
 | `boolean`   | `cvb`        |
 | `string`    | `cvs`        |
 | `entity`    | `cve`        |
-| `date`      | `cvd`        |
+| `date`      | `cvdate`     |
 | `bigint`    | `cvbi`       |
 | `fixed`     | `cvfp`       |
 

--- a/docs/EL-REFERENCE.md
+++ b/docs/EL-REFERENCE.md
@@ -30,7 +30,9 @@ Expression Language (EL) is the human-readable syntax used in DTRules condition,
    - [xml set attribute](#xml-set-attribute)
 8. [Map / Filter / Sum / There-is](#map--filter--sum--there-is)
 9. [Local Variables](#local-variables)
-10. [Grammar Appendix](#grammar-appendix)
+10. [Fixed Type](#fixed-type)
+11. [Bytes Type](#bytes-type)
+12. [Grammar Appendix](#grammar-appendix)
 
 ---
 
@@ -134,6 +136,7 @@ DTRules supports the following primitive and composite types. Each type keyword 
 | `string`            | UTF-8 string                             |
 | `date` / `time`     | Represented as milliseconds since epoch  |
 | `bigint` / `biginteger` | Arbitrary-precision integer          |
+| `fixed`             | 256-bit fixed-point, 8 decimal digits (see [Fixed Type](#fixed-type)) |
 | `bytes`             | Immutable byte sequence (hex, constant-time equality) |
 | `name`              | Symbol/name value (e.g., `$foo`)        |
 | `entity`            | Reference to a DTRules entity            |
@@ -218,6 +221,17 @@ EL supports standard arithmetic on integers, doubles, and bigints. The emitter m
 **Compiled postfix**: `result.large_amount constants.limit b>=`
 
 **BigInt equality**: uses `streq` (values compared as strings by default) or `b==` if both are bigint.
+
+#### Fixed-point arithmetic
+
+**Syntax**: `fpexpr OP fpexpr` where OP is `+`, `-`, `*`, `/`
+**Semantics**: Fixed-point arithmetic on a 10^-8 grid. Add/sub are exact; multiply/divide truncate toward zero. Postfix operators: `fp+`, `fp-`, `fp*`, `fp/`.
+**Example (EL)**: `staking.principal * staking.reward_rate >= 0fp` (both fields declared `fixed` in EDD)
+**Compiled postfix**: `staking.principal staking.reward_rate fp* 0fp fp>=`
+
+**Promotion**: mixed `int + fixed` or `bigint + fixed` auto-promote the non-fp operand through `cvfp` (exact). Mixed `double + fixed` is a compile-time error — use an explicit `(fixed)` cast.
+
+**Fixed equality**: uses `fp==` / `fp!=` on the mantissa directly — no epsilon. `0.10000000fp == 0.1fp` is true.
 
 #### Rounding
 
@@ -953,6 +967,7 @@ The type-conversion operators used in set statements:
 | `entity`    | `cve`        |
 | `date`      | `cvd`        |
 | `bigint`    | `cvbi`       |
+| `fixed`     | `cvfp`       |
 
 ---
 
@@ -1169,6 +1184,8 @@ local date myvar = current date
 local entity myvar = person
 local array myvar
 local bigint myvar = 1000000
+local fixed myvar
+local fixed myvar = 1.5fp
 local bytes myvar
 local bytes myvar = 0xdeadbeef
 ```
@@ -1183,6 +1200,7 @@ local bytes myvar = 0xdeadbeef
 | `local boolean myvar = true`    | `true cvb allocate execute deallocate pop` (slot 0)      |
 | `local entity myvar = person`   | `person cve allocate execute deallocate pop` (slot 0)    |
 | `local bigint myvar = 1000000`  | `1000000 cvbi allocate execute deallocate pop` (slot 0)  |
+| `local fixed myvar = 1.5fp`     | `1.5fp cvfp allocate execute deallocate pop` (slot 0)    |
 | `local bytes myvar`             | `null allocate execute deallocate pop` (slot 0)          |
 | `local bytes myvar = 0xdeadbeef` | `0xdeadbeef cvbytes allocate execute deallocate pop` (slot 0) |
 
@@ -1196,6 +1214,82 @@ Postfix: `0.0 cvr allocate execute deallocate pop`
 
 Action referencing it: `running_total + bracket.rate * result.taxable_income`
 → `0 local@ bracket.rate result.taxable_income * +`
+
+---
+
+## Fixed Type
+
+Fixed (`fixed`) is a signed 256-bit fixed-point decimal type on a 10^-8 grid. It exists for token amounts, staking rewards, and any blockchain-adjacent math where float64 drift is unacceptable. Internal representation is an integer mantissa M; the value is `M × 10^-8`. Mantissa range: `|M| < 2^255` (symmetric).
+
+For the full user-facing reference, see `dtrules docs fixed`.
+
+### Literal
+
+**Syntax**: `FP_LITERAL` — a decimal number followed by a case-insensitive `fp` suffix (`1.5fp`, `0fp`, `100.0FP`, `-0.00000001fp`). At most 8 fractional digits is a compile-time requirement; more is rejected by the lexer, not silently truncated.
+**Semantics**: Pushes an `RFixed` value with the parsed mantissa.
+
+**Example (EL)**: `staking.reward_rate >= 0.05fp` (reward_rate declared `fixed` in EDD)
+**Compiled postfix**: `staking.reward_rate 0.05fp fp>=`
+
+### Arithmetic
+
+**Syntax**: `fpexpr OP fpexpr` where OP is `+`, `-`, `*`, `/`.
+**Semantics**: Add/sub are exact; multiply/divide rescale by 10^8 and truncate toward zero.
+**Postfix operators**: `fp+`, `fp-`, `fp*`, `fp/`.
+
+**Example (EL)**: `principal * rate` (both `fixed`)
+**Compiled postfix**: `principal rate fp*`
+
+### Casts
+
+**Syntax**: `(fixed) expr`.
+**Semantics**: Emits `cvfp` after the operand. Accepts fixed (identity), integer (exact), bigint (exact, range-checked), double (truncate on grid — required to be explicit), and string (decimal parse).
+
+**Example (EL)**: `(fixed) input.amount_string` → `input.amount_string cvfp`
+**Example (EL)**: `(fixed) 42` → `42 cvfp`
+
+Reverse casts use the existing conversion ops:
+
+| Target type | Conversion op from fixed |
+|-------------|--------------------------|
+| `long`      | `cvi`                    |
+| `double`    | `cvd`                    |
+| `bigint`    | `cvbi`                   |
+| `string`    | `cvs` — always 8 fractional digits |
+
+### Comparison
+
+**Syntax**: standard comparison operators between two `fpexpr` operands.
+**Postfix operators**: `fp==`, `fp!=` (alias `fp<>`), `fp>`, `fp>=`, `fp<`, `fp<=`.
+**Semantics**: exact mantissa comparison.
+
+### Operators reference
+
+| EL form                           | Postfix     |
+|-----------------------------------|-------------|
+| `a + b`, `a - b`, `a * b`, `a / b` | `fp+`, `fp-`, `fp*`, `fp/` |
+| `-a`                              | `fpnegate`  |
+| `absolute value of a`             | `fpabs`     |
+| `fpmin a b`                       | `fpmin`     |
+| `fpmax a b`                       | `fpmax`     |
+| `(fixed) expr`                    | `cvfp`      |
+
+### Local variables
+
+```
+local fixed rate = 0.05fp
+local fixed principal
+```
+
+Compiled postfix: `0.05fp cvfp allocate execute deallocate pop`.
+
+### EDD declaration
+
+```xml
+<field name="reward_rate" type="fixed" default_value="0.05fp"/>
+```
+
+Defaults use the same literal syntax as EL source.
 
 ---
 
@@ -1386,6 +1480,7 @@ Key production names referenced in this document:
 | `iexpr`               | Integer expression                    |
 | `fexpr`               | Float (double) expression             |
 | `bigexpr`             | BigInt expression                     |
+| `fpexpr`              | Fixed-point expression                |
 | `strexpr`             | String expression                     |
 | `dexpr`               | Date expression                       |
 | `eexpr`               | Entity expression                     |
@@ -1442,5 +1537,6 @@ Key production names referenced in this document:
 | `leftDexpr`           | Date left-value                       |
 | `leftArrayRef`        | Array left-value                      |
 | `leftBigexpr`         | BigInt left-value                     |
+| `leftFpexpr`          | Fixed-point left-value                |
 
 See `EL.g4` for the complete grammar with all alternatives and lexer rules.

--- a/pkg/dtrules/operators/fixed.go
+++ b/pkg/dtrules/operators/fixed.go
@@ -87,7 +87,9 @@ func popFixedOne(state dtrules.State) (*dtrules.RFixed, error) {
 	return dtrules.PromoteToRFixed(a)
 }
 
-// opFixedAdd adds two fixed values: ( a b -- a+b )
+// opFixedAdd: ( a b -- a+b ) adds two RFixed values exactly.
+// Both operands must be fp; int/bigint are auto-promoted via popFixedPair.
+// Returns a Math Exception if the resulting mantissa exceeds |m| < 2^255.
 func opFixedAdd(state dtrules.State) error {
 	a, b, err := popFixedPair(state)
 	if err != nil {
@@ -100,7 +102,9 @@ func opFixedAdd(state dtrules.State) error {
 	return state.DataPush(r)
 }
 
-// opFixedSub subtracts two fixed values: ( a b -- a-b )
+// opFixedSub: ( a b -- a-b ) subtracts two RFixed values exactly.
+// Both operands must be fp; int/bigint are auto-promoted. Returns a
+// Math Exception if the resulting mantissa exceeds |m| < 2^255.
 func opFixedSub(state dtrules.State) error {
 	a, b, err := popFixedPair(state)
 	if err != nil {
@@ -113,7 +117,10 @@ func opFixedSub(state dtrules.State) error {
 	return state.DataPush(r)
 }
 
-// opFixedMul multiplies two fixed values with truncate-toward-zero: ( a b -- a*b )
+// opFixedMul: ( a b -- a*b ) multiplies two RFixed values with truncate-
+// toward-zero rescaling onto the 10^-8 grid. Both operands must be fp;
+// int/bigint are auto-promoted. Returns a Math Exception if the final
+// mantissa exceeds |m| < 2^255.
 func opFixedMul(state dtrules.State) error {
 	a, b, err := popFixedPair(state)
 	if err != nil {
@@ -126,7 +133,10 @@ func opFixedMul(state dtrules.State) error {
 	return state.DataPush(r)
 }
 
-// opFixedDiv divides two fixed values with truncate-toward-zero: ( a b -- a/b )
+// opFixedDiv: ( a b -- a/b ) divides two RFixed values with truncate-
+// toward-zero rescaling onto the 10^-8 grid. Both operands must be fp;
+// int/bigint are auto-promoted. Returns a Math Exception on divide by
+// zero or if the result exceeds |m| < 2^255.
 func opFixedDiv(state dtrules.State) error {
 	a, b, err := popFixedPair(state)
 	if err != nil {
@@ -139,7 +149,9 @@ func opFixedDiv(state dtrules.State) error {
 	return state.DataPush(r)
 }
 
-// opFixedAbs returns absolute value: ( a -- |a| )
+// opFixedAbs: ( a -- |a| ) returns the absolute value of an RFixed.
+// Because the mantissa range is symmetric (|m| < 2^255), abs is always
+// representable and never overflows.
 func opFixedAbs(state dtrules.State) error {
 	a, err := popFixedOne(state)
 	if err != nil {
@@ -148,7 +160,8 @@ func opFixedAbs(state dtrules.State) error {
 	return state.DataPush(a.Abs())
 }
 
-// opFixedNegate negates a fixed value: ( a -- -a )
+// opFixedNegate: ( a -- -a ) negates an RFixed. The mantissa range is
+// symmetric, so negation never overflows.
 func opFixedNegate(state dtrules.State) error {
 	a, err := popFixedOne(state)
 	if err != nil {
@@ -157,7 +170,9 @@ func opFixedNegate(state dtrules.State) error {
 	return state.DataPush(a.Neg())
 }
 
-// opFixedTrunc truncates fractional part toward zero: ( a -- trunc(a) )
+// opFixedTrunc: ( a -- trunc(a) ) truncates the fractional part toward
+// zero. Returns an RFixed whose mantissa is a multiple of 10^8 (i.e.
+// the value has exactly .00000000 fractional digits).
 func opFixedTrunc(state dtrules.State) error {
 	a, err := popFixedOne(state)
 	if err != nil {
@@ -166,7 +181,9 @@ func opFixedTrunc(state dtrules.State) error {
 	return state.DataPush(a.Trunc())
 }
 
-// opFixedMin returns the lesser of two fp values: ( a b -- min(a,b) )
+// opFixedMin: ( a b -- min(a,b) ) returns the lesser of two RFixed values.
+// Both operands must be fp; int/bigint are auto-promoted. When the two
+// values compare equal, the first operand (a) is returned.
 func opFixedMin(state dtrules.State) error {
 	a, b, err := popFixedPair(state)
 	if err != nil {
@@ -182,7 +199,9 @@ func opFixedMin(state dtrules.State) error {
 	return state.DataPush(b)
 }
 
-// opFixedMax returns the greater of two fp values: ( a b -- max(a,b) )
+// opFixedMax: ( a b -- max(a,b) ) returns the greater of two RFixed values.
+// Both operands must be fp; int/bigint are auto-promoted. When the two
+// values compare equal, the first operand (a) is returned.
 func opFixedMax(state dtrules.State) error {
 	a, b, err := popFixedPair(state)
 	if err != nil {
@@ -210,26 +229,33 @@ func opFixedCompare(state dtrules.State, want func(int) bool) error {
 	return state.DataPush(dtrules.GetRBoolean(want(c)))
 }
 
+// opFixedEqual: ( a b -- bool ) exact mantissa equality. Both operands
+// must be fp; int/bigint are auto-promoted.
 func opFixedEqual(state dtrules.State) error {
 	return opFixedCompare(state, func(c int) bool { return c == 0 })
 }
 
+// opFixedNotEqual: ( a b -- bool ) exact mantissa inequality.
 func opFixedNotEqual(state dtrules.State) error {
 	return opFixedCompare(state, func(c int) bool { return c != 0 })
 }
 
+// opFixedGreater: ( a b -- bool ) returns a > b.
 func opFixedGreater(state dtrules.State) error {
 	return opFixedCompare(state, func(c int) bool { return c > 0 })
 }
 
+// opFixedGreaterEqual: ( a b -- bool ) returns a >= b.
 func opFixedGreaterEqual(state dtrules.State) error {
 	return opFixedCompare(state, func(c int) bool { return c >= 0 })
 }
 
+// opFixedLess: ( a b -- bool ) returns a < b.
 func opFixedLess(state dtrules.State) error {
 	return opFixedCompare(state, func(c int) bool { return c < 0 })
 }
 
+// opFixedLessEqual: ( a b -- bool ) returns a <= b.
 func opFixedLessEqual(state dtrules.State) error {
 	return opFixedCompare(state, func(c int) bool { return c <= 0 })
 }


### PR DESCRIPTION
## Summary

Expands documentation ahead of the v1.8.0 tag. The `RFixed` fixed-point type shipped across PRs #684, #688, #689, #692, #699 but had zero user-facing documentation. This PR adds end-user coverage for fp and expands the v1.8.0 changelog to cover every PR on the line, with prominent "Breaking changes" callouts.

This is a docs-only PR — no runtime behavior changes.

## Topics added / expanded

| Target                            | Change                                                                                                                   |
|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------|
| `dtrules docs fixed` (NEW)        | When to use, literal syntax, casts, arithmetic, comparisons, conversion helpers, overflow, EDD, JSON, staking example, best practices. |
| `dtrules docs el`                 | Fixed literal row in Literals section; new `fpexpr` grammar production parallel to bigexpr/bytesexpr.                    |
| `dtrules docs operators`          | New Fixed-Point Operators section of equivalent depth to BigInt/Bytes; every `fp*` operator + `cvfp`.                    |
| `dtrules docs edd`                | `fixed` row in the field-types table.                                                                                    |
| `docs/EL-REFERENCE.md`            | Fixed Type section parallel to Bytes; `fpexpr` / `leftFpexpr` in grammar appendix; `cvfp` in conversion table; `local fixed` table row. |
| `README.md`                       | Fixed-Point Decimals bullet in Key Features.                                                                             |
| `CHANGELOG.md` v1.8.0             | Expanded from one-PR entry to a full release note covering fixed-point, compiler/EL, operators/runtime, infrastructure, tests, with migration notes. |
| `cmd/dtrules/docs_test.go`        | 4 new pinning tests for the `fixed` topic, the Fixed-Point Operators section, fp in EL literals, and the `fixed` row in the EDD type table. |
| `pkg/dtrules/operators/fixed.go`  | Op-level doc comments on every `opFixed*` / `opFp*` / `opCvFixed` mirroring bigint.go style (stack effect, operand rules, error semantics). |

## Breaking changes flagged

Both are surfaced prominently in the new CHANGELOG section; no code changes in this PR.

- **#694 / PR #695** — `cvd` is now the double converter; `cvdate` is the new date converter. Rule files that emit raw postfix calling `cvd` expecting DATE conversion will break. Migration: recompile from EL, or rename `cvd` → `cvdate` in stored postfix.
- **#696 / PR #701** — `sortarray asc=true` now produces ascending order (was inverted). Rules that relied on the inverted behavior will see flipped output. Migration: swap the boolean.

## Test plan

- [x] `make check` (full module build + vet + scoped tests) — green
- [x] `go test ./cmd/dtrules/ -run Documentation -count=1` — all doc-pinning tests pass including the four new ones
- [x] `dtrules docs fixed` renders and includes "8-decimal", "1.5fp", "fp+", "cvfp", "(fixed)", "local fixed"
- [x] `dtrules docs operators` contains "Fixed-Point Operators"
- [x] `dtrules docs` index lists `fixed`
- [x] `dtrules docs el` Literals section includes `1.5fp` row
- [x] `dtrules docs edd` field-type table contains `fixed` / `0.0fp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)