### PR TITLE
feat(cli): JSON-first table/EDD API for AI (closes #716)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # DTRules Changelog
 
+## v1.9.1 — 2026-04-24
+
+- **JSON-first CLI for decision tables and the EDD** (#716). Adds a
+  `dtrules table` and `dtrules edd` subcommand surface that wraps the
+  existing `pkg/dtrules/authoring` SDK behind a JSON-in / JSON-out
+  interface optimized for AI agents.
+
+  Read:
+
+  ```
+  dtrules table list --project <path>
+  dtrules table get <name> --project <path>
+  dtrules table schema [--patch]
+  dtrules edd  get     --project <path>
+  dtrules edd  schema  [--patch]
+  ```
+
+  Write whole documents (EL is compiled and validated before save):
+
+  ```
+  dtrules table put <name> --project <path> < table.json
+  dtrules edd  put         --project <path> < edd.json
+  ```
+
+  Targeted patches — one op per invocation, keyed on `op`:
+
+  ```
+  echo '{"op":"set-condition-cell","condition_number":1,"column":2,"value":"Y"}' \
+    | dtrules table patch <name> --project <path>
+  ```
+
+  Table patch ops: `set-name`, `set-policy`, `set-condition-cell`,
+  `set-action-cell`, `add-column`, `update-column`, `delete-column`,
+  `add-condition`, `update-condition`, `update-condition-dsl`,
+  `delete-condition`, and the matching `*-action`,
+  `*-initial-action`, `*-context` families. EDD patch ops:
+  `add-entity`, `delete-entity`, `add-field`, `update-field`,
+  `delete-field`, `set-comment`.
+
+  Every non-zero exit writes a JSON error record to stderr with
+  `error` / `path` / `hint` / `detail` fields, so agents can react
+  without parsing prose. The MCP server over this surface ships
+  separately as #717.
+
 ## v1.8.1 — 2026-04-20
 
 - **`for all <array> as <alias>` iteration alias** (#712). Adds an `as

--- a/cmd/dtrules/cli.go
+++ b/cmd/dtrules/cli.go
@@ -106,6 +106,10 @@ func (c *CLI) Run(args []string) int {
 		return c.runVersion()
 	case "docs":
 		return c.runDocs(cmdArgs)
+	case "table":
+		return c.runTable(cmdArgs)
+	case "edd":
+		return c.runEDD(cmdArgs)
 	case "help", "-h", "--help":
 		c.printUsage()
 		return 0
@@ -127,6 +131,8 @@ Commands:
   sync      Synchronize Excel and XML files (status/check/auto)
   init      Initialize a DTRules project structure
   validate  Validate decision tables and EDD
+  table     JSON-first decision-table read/write (for AI agents)
+  edd       JSON-first entity data dictionary read/write (for AI agents)
   docs      Show embedded documentation (for AI and developers)
   version   Show version information
   help      Show this help message

--- a/cmd/dtrules/main.go
+++ b/cmd/dtrules/main.go
@@ -77,6 +77,8 @@ var subcommands = map[string]bool{
 	"version":  true,
 	"help":     true,
 	"docs":     true,
+	"table":    true,
+	"edd":      true,
 }
 
 func main() {

--- a/cmd/dtrules/schemas.go
+++ b/cmd/dtrules/schemas.go
@@ -1,0 +1,221 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// JSON Schemas (hand-written, draft-07) describing the DTO shapes and patch
+// op unions exposed by `dtrules table` and `dtrules edd`. Emitted verbatim
+// by the `schema` subcommand — keep these in sync with table_json.go /
+// table_patch.go when fields change.
+
+const tableSchemaJSON = `{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DTRulesTable",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "name":   {"type": "string"},
+    "policy": {"type": "string", "enum": ["FIRST", "ALL", "NONE", ""]},
+    "contexts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["dsl"],
+        "properties": {"dsl": {"type": "string"}}
+      }
+    },
+    "initial_actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["dsl"],
+        "properties": {"dsl": {"type": "string"}}
+      }
+    },
+    "conditions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["number", "dsl"],
+        "properties": {
+          "number":  {"type": "integer", "minimum": 1},
+          "comment": {"type": "string"},
+          "dsl":     {"type": "string"},
+          "columns": {
+            "type": "object",
+            "description": "map of column number (stringified) to Y/N/-",
+            "additionalProperties": {"type": "string", "enum": ["Y", "N", "-"]}
+          }
+        }
+      }
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["number", "dsl"],
+        "properties": {
+          "number":  {"type": "integer", "minimum": 1},
+          "comment": {"type": "string"},
+          "dsl":     {"type": "string"},
+          "columns": {
+            "type": "object",
+            "description": "map of column number (stringified) to bool (true = action fires on this column)",
+            "additionalProperties": {"type": "boolean"}
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+const tablePatchSchema = `{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DTRulesTablePatchOp",
+  "type": "object",
+  "required": ["op"],
+  "properties": {
+    "op": {
+      "type": "string",
+      "enum": [
+        "set-name",
+        "set-policy",
+        "set-condition-cell",
+        "set-action-cell",
+        "add-column",
+        "update-column",
+        "delete-column",
+        "add-condition",
+        "update-condition",
+        "update-condition-dsl",
+        "delete-condition",
+        "add-action",
+        "update-action",
+        "update-action-dsl",
+        "delete-action",
+        "add-initial-action",
+        "update-initial-action",
+        "delete-initial-action",
+        "add-context",
+        "update-context",
+        "delete-context"
+      ]
+    },
+    "column":           {"type": "integer", "minimum": 1},
+    "condition_number": {"type": "integer", "minimum": 1},
+    "action_number":    {"type": "integer", "minimum": 1},
+    "index":            {"type": "integer", "minimum": 0},
+    "value":            {"type": "string", "enum": ["Y", "N", "-"]},
+    "on":               {"type": "boolean"},
+    "name":             {"type": "string"},
+    "policy":           {"type": "string"},
+    "dsl":              {"type": "string"},
+    "comment":          {"type": "string"},
+    "conditions": {
+      "type": "object",
+      "description": "add-column / update-column: condition-number (stringified) to Y/N/-",
+      "additionalProperties": {"type": "string", "enum": ["Y", "N", "-"]}
+    },
+    "actions": {
+      "type": "array",
+      "description": "add-column / update-column: list of action numbers that fire on this column",
+      "items": {"type": "integer"}
+    },
+    "columns": {
+      "type": "object",
+      "description": "add-condition / update-condition: map of column number (stringified) to Y/N/-",
+      "additionalProperties": {"type": "string", "enum": ["Y", "N", "-"]}
+    },
+    "action_columns": {
+      "type": "object",
+      "description": "add-action / update-action: map of column number (stringified) to bool",
+      "additionalProperties": {"type": "boolean"}
+    }
+  }
+}
+`
+
+const eddSchemaJSON = `{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DTRulesEDD",
+  "type": "object",
+  "required": ["entities"],
+  "properties": {
+    "entities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {"type": "string"},
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name", "type"],
+              "properties": {
+                "name":    {"type": "string"},
+                "type":    {"type": "string", "enum": ["string", "integer", "long", "double", "boolean", "date", "bigint", "array", "entity"]},
+                "subtype": {"type": "string"},
+                "default": {"type": "string"},
+                "access":  {"type": "string", "enum": ["r", "rw", ""]},
+                "input":   {"type": "string"},
+                "comment": {"type": "string"}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+const eddPatchSchema = `{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DTRulesEDDPatchOp",
+  "type": "object",
+  "required": ["op"],
+  "properties": {
+    "op": {
+      "type": "string",
+      "enum": [
+        "add-entity",
+        "delete-entity",
+        "add-field",
+        "update-field",
+        "delete-field",
+        "set-comment"
+      ]
+    },
+    "entity":  {"type": "string"},
+    "name":    {"type": "string"},
+    "comment": {"type": "string"},
+    "field": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name":    {"type": "string"},
+        "type":    {"type": "string"},
+        "subtype": {"type": "string"},
+        "default": {"type": "string"},
+        "access":  {"type": "string"},
+        "input":   {"type": "string"},
+        "comment": {"type": "string"}
+      }
+    }
+  }
+}
+`

--- a/cmd/dtrules/table_cmd.go
+++ b/cmd/dtrules/table_cmd.go
@@ -1,0 +1,429 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// JSON-first CLI surface for decision tables and the EDD.
+//
+// Every command emits JSON on stdout; every non-zero exit writes a JSON
+// error record to stderr with the shape defined by jsonError.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+// jsonError is the single shape every non-zero exit writes to stderr.
+type jsonError struct {
+	Error  string `json:"error"`
+	Path   string `json:"path,omitempty"`
+	Hint   string `json:"hint,omitempty"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// tableCmdCtx holds the pieces each handler needs.
+type tableCmdCtx struct {
+	stdin       io.Reader
+	stdout      io.Writer
+	stderr      io.Writer
+	projectPath string
+}
+
+// emitErr writes a JSON error record to stderr and returns the exit code.
+func emitErr(w io.Writer, code int, errKind, path, hint, detail string) int {
+	e := jsonError{Error: errKind, Path: path, Hint: hint, Detail: detail}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(e)
+	return code
+}
+
+// writeJSON emits a value as indented JSON to stdout.
+func writeJSON(w io.Writer, v interface{}) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// parseProjectFlag pulls --project out of a flag slice, returning the value
+// and a copy of args with that flag removed. Defaults to ".".
+func parseProjectFlag(args []string) (projectPath string, rest []string) {
+	projectPath = "."
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--project" || args[i] == "-p" {
+			if i+1 < len(args) {
+				projectPath = args[i+1]
+				i++
+				continue
+			}
+		}
+		out = append(out, args[i])
+	}
+	return projectPath, out
+}
+
+// runTable dispatches `dtrules table ...`.
+func (c *CLI) runTable(args []string) int {
+	ctx := &tableCmdCtx{stdin: os.Stdin, stdout: os.Stdout, stderr: os.Stderr}
+	if len(args) == 0 {
+		c.printTableUsage()
+		return 1
+	}
+	sub := args[0]
+	rest := args[1:]
+	ctx.projectPath, rest = parseProjectFlag(rest)
+
+	switch sub {
+	case "list":
+		return ctx.tableList()
+	case "get":
+		return ctx.tableGet(rest)
+	case "put":
+		return ctx.tablePut(rest)
+	case "patch":
+		return ctx.tablePatch(rest)
+	case "schema":
+		return ctx.tableSchema(rest)
+	case "help", "-h", "--help":
+		c.printTableUsage()
+		return 0
+	default:
+		return emitErr(ctx.stderr, 1, "invalid_command", "", "known: list|get|put|patch|schema",
+			fmt.Sprintf("unknown table subcommand %q", sub))
+	}
+}
+
+// runEDD dispatches `dtrules edd ...`.
+func (c *CLI) runEDD(args []string) int {
+	ctx := &tableCmdCtx{stdin: os.Stdin, stdout: os.Stdout, stderr: os.Stderr}
+	if len(args) == 0 {
+		c.printEDDUsage()
+		return 1
+	}
+	sub := args[0]
+	rest := args[1:]
+	ctx.projectPath, rest = parseProjectFlag(rest)
+
+	switch sub {
+	case "get":
+		return ctx.eddGet()
+	case "put":
+		return ctx.eddPut()
+	case "patch":
+		return ctx.eddPatch()
+	case "schema":
+		return ctx.eddSchema(rest)
+	case "help", "-h", "--help":
+		c.printEDDUsage()
+		return 0
+	default:
+		return emitErr(ctx.stderr, 1, "invalid_command", "", "known: get|put|patch|schema",
+			fmt.Sprintf("unknown edd subcommand %q", sub))
+	}
+}
+
+// --- table handlers ---
+
+func (ctx *tableCmdCtx) openProject() (*authoring.Project, int) {
+	p, err := authoring.OpenProject(ctx.projectPath)
+	if err != nil {
+		return nil, emitErr(ctx.stderr, 1, "io_error", "", "project must contain an xml/ directory", err.Error())
+	}
+	return p, 0
+}
+
+func (ctx *tableCmdCtx) tableList() int {
+	p, code := ctx.openProject()
+	if code != 0 {
+		return code
+	}
+	names := p.Tables()
+	if names == nil {
+		names = []string{}
+	}
+	if err := writeJSON(ctx.stdout, map[string]interface{}{"tables": names}); err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "", err.Error())
+	}
+	return 0
+}
+
+func (ctx *tableCmdCtx) tableGet(rest []string) int {
+	name, code := ctx.requireName(rest, "table get <name>")
+	if code != 0 {
+		return code
+	}
+	p, code := ctx.openProject()
+	if code != 0 {
+		return code
+	}
+	t := p.Table(name)
+	if t == nil {
+		return emitErr(ctx.stderr, 1, "not_found", "", "check `dtrules table list`",
+			fmt.Sprintf("table %q not found", name))
+	}
+	if err := writeJSON(ctx.stdout, tableToJSON(t)); err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "", err.Error())
+	}
+	return 0
+}
+
+func (ctx *tableCmdCtx) tablePut(rest []string) int {
+	name, code := ctx.requireName(rest, "table put <name>")
+	if code != 0 {
+		return code
+	}
+	p, code := ctx.openProject()
+	if code != 0 {
+		return code
+	}
+	t := p.Table(name)
+	if t == nil {
+		// Allow creating a new table via put.
+		newT, err := p.AddTable(name)
+		if err != nil {
+			return emitErr(ctx.stderr, 1, "io_error", "", "", err.Error())
+		}
+		t = newT
+	}
+
+	var tj TableJSON
+	if code := decodeStdin(ctx, &tj); code != 0 {
+		return code
+	}
+	// Allow omitting the "name" field in input — the URL-ish argument wins.
+	if tj.Name == "" {
+		tj.Name = name
+	}
+	if err := tj.ApplyTo(t); err != nil {
+		return emitErr(ctx.stderr, 1, "compile_error", "", "an EL expression failed to compile", err.Error())
+	}
+	if err := p.Save(); err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "save failed", err.Error())
+	}
+	return writeOK(ctx, "updated", map[string]string{"table": tj.Name})
+}
+
+func (ctx *tableCmdCtx) tablePatch(rest []string) int {
+	name, code := ctx.requireName(rest, "table patch <name>")
+	if code != 0 {
+		return code
+	}
+	p, code := ctx.openProject()
+	if code != 0 {
+		return code
+	}
+	t := p.Table(name)
+	if t == nil {
+		return emitErr(ctx.stderr, 1, "not_found", "", "check `dtrules table list`",
+			fmt.Sprintf("table %q not found", name))
+	}
+	data, err := io.ReadAll(ctx.stdin)
+	if err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "", err.Error())
+	}
+	var patch tablePatch
+	if err := json.Unmarshal(data, &patch); err != nil {
+		return emitErr(ctx.stderr, 1, "parse_error", "", "patch input must be a JSON object", err.Error())
+	}
+	if err := patch.apply(t); err != nil {
+		return emitErr(ctx.stderr, 1, "invalid_patch", "", patch.hint(), err.Error())
+	}
+	if err := p.Save(); err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "save failed", err.Error())
+	}
+	return writeOK(ctx, "patched", map[string]string{"table": t.Name, "op": patch.Op})
+}
+
+func (ctx *tableCmdCtx) tableSchema(rest []string) int {
+	wantPatch := false
+	for _, a := range rest {
+		if a == "--patch" {
+			wantPatch = true
+		}
+	}
+	if wantPatch {
+		if _, err := ctx.stdout.Write([]byte(tablePatchSchema)); err != nil {
+			return emitErr(ctx.stderr, 1, "io_error", "", "", err.Error())
+		}
+		return 0
+	}
+	if _, err := ctx.stdout.Write([]byte(tableSchemaJSON)); err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "", err.Error())
+	}
+	return 0
+}
+
+// --- EDD handlers ---
+
+func (ctx *tableCmdCtx) eddGet() int {
+	p, code := ctx.openProject()
+	if code != 0 {
+		return code
+	}
+	if err := writeJSON(ctx.stdout, eddToJSON(p.EDD())); err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "", err.Error())
+	}
+	return 0
+}
+
+func (ctx *tableCmdCtx) eddPut() int {
+	p, code := ctx.openProject()
+	if code != 0 {
+		return code
+	}
+	var ej EDDJSON
+	if code := decodeStdin(ctx, &ej); code != 0 {
+		return code
+	}
+	if err := ej.ApplyTo(p.EDD()); err != nil {
+		return emitErr(ctx.stderr, 1, "invalid_patch", "", "EDD validation failed", err.Error())
+	}
+	if err := p.SaveEDD(); err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "save failed", err.Error())
+	}
+	return writeOK(ctx, "updated", map[string]string{"edd": "ok"})
+}
+
+func (ctx *tableCmdCtx) eddPatch() int {
+	p, code := ctx.openProject()
+	if code != 0 {
+		return code
+	}
+	data, err := io.ReadAll(ctx.stdin)
+	if err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "", err.Error())
+	}
+	var patch eddPatchOp
+	if err := json.Unmarshal(data, &patch); err != nil {
+		return emitErr(ctx.stderr, 1, "parse_error", "", "patch input must be a JSON object", err.Error())
+	}
+	if err := patch.apply(p.EDD()); err != nil {
+		return emitErr(ctx.stderr, 1, "invalid_patch", "", patch.hint(), err.Error())
+	}
+	if err := p.SaveEDD(); err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "save failed", err.Error())
+	}
+	return writeOK(ctx, "patched", map[string]string{"op": patch.Op})
+}
+
+func (ctx *tableCmdCtx) eddSchema(rest []string) int {
+	wantPatch := false
+	for _, a := range rest {
+		if a == "--patch" {
+			wantPatch = true
+		}
+	}
+	if wantPatch {
+		if _, err := ctx.stdout.Write([]byte(eddPatchSchema)); err != nil {
+			return emitErr(ctx.stderr, 1, "io_error", "", "", err.Error())
+		}
+		return 0
+	}
+	if _, err := ctx.stdout.Write([]byte(eddSchemaJSON)); err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "", err.Error())
+	}
+	return 0
+}
+
+// --- helpers ---
+
+// requireName pulls the first positional arg from rest, or returns an error
+// with the given usage hint.
+func (ctx *tableCmdCtx) requireName(rest []string, usage string) (string, int) {
+	for _, a := range rest {
+		if !strings.HasPrefix(a, "-") {
+			return a, 0
+		}
+	}
+	return "", emitErr(ctx.stderr, 1, "invalid_command", "", usage, "missing table name")
+}
+
+// decodeStdin reads stdin as JSON into v.
+func decodeStdin(ctx *tableCmdCtx, v interface{}) int {
+	data, err := io.ReadAll(ctx.stdin)
+	if err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "", err.Error())
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return emitErr(ctx.stderr, 1, "parse_error", "", "stdin was empty — pipe JSON in", "empty input")
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		return emitErr(ctx.stderr, 1, "parse_error", "", "stdin must be valid JSON", err.Error())
+	}
+	return 0
+}
+
+// writeOK emits {"status":"...","...":"..."} for simple success responses.
+func writeOK(ctx *tableCmdCtx, status string, extras map[string]string) int {
+	out := map[string]interface{}{"status": status}
+	for k, v := range extras {
+		out[k] = v
+	}
+	if err := writeJSON(ctx.stdout, out); err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "", err.Error())
+	}
+	return 0
+}
+
+// --- usage ---
+
+func (c *CLI) printTableUsage() {
+	fmt.Println(`Usage: dtrules table <command> [--project <path>]
+
+Commands:
+  list                     List decision-table names (JSON).
+  get <name>               Print one table as JSON.
+  put <name>               Replace a table from JSON on stdin.
+  patch <name>             Apply a JSON patch op on stdin.
+  schema                   Emit JSON Schema for a Table document.
+  schema --patch           Emit JSON Schema for a table patch op.
+
+Examples:
+  dtrules table list --project .
+  dtrules table get Compute_Eligibility --project .
+  dtrules table put NewTable --project . < table.json
+  echo '{"op":"set-condition-cell","condition_number":1,"column":2,"value":"Y"}' \
+    | dtrules table patch Compute_Eligibility --project .
+
+Patch operations:
+  set-name, set-policy,
+  set-condition-cell, set-action-cell,
+  add-column, update-column, delete-column,
+  add-condition, update-condition, update-condition-dsl, delete-condition,
+  add-action, update-action, update-action-dsl, delete-action,
+  add-initial-action, update-initial-action, delete-initial-action,
+  add-context, update-context, delete-context`)
+}
+
+func (c *CLI) printEDDUsage() {
+	fmt.Println(`Usage: dtrules edd <command> [--project <path>]
+
+Commands:
+  get                      Print the EDD as JSON.
+  put                      Replace the EDD from JSON on stdin.
+  patch                    Apply a JSON patch op on stdin.
+  schema                   Emit JSON Schema for an EDD document.
+  schema --patch           Emit JSON Schema for an EDD patch op.
+
+Patch operations:
+  add-entity, delete-entity,
+  add-field, update-field, delete-field,
+  set-comment`)
+}

--- a/cmd/dtrules/table_json.go
+++ b/cmd/dtrules/table_json.go
@@ -1,0 +1,330 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// DTO layer for the JSON table/EDD API.
+//
+// The live authoring SDK structs hold unexported fields (xml pointers,
+// symbol tables, project back-references) — those must not leak into JSON.
+// The types in this file are the stable, serialization-friendly shape that
+// `dtrules table get` emits and `dtrules table put` consumes.
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+// TableJSON is the JSON projection of a decision table.
+type TableJSON struct {
+	Name           string              `json:"name"`
+	Policy         string              `json:"policy,omitempty"`
+	Contexts       []ContextJSON       `json:"contexts,omitempty"`
+	InitialActions []InitialActionJSON `json:"initial_actions,omitempty"`
+	Conditions     []ConditionJSON     `json:"conditions,omitempty"`
+	Actions        []ActionJSON        `json:"actions,omitempty"`
+}
+
+// ContextJSON is a single context statement for a table.
+type ContextJSON struct {
+	DSL string `json:"dsl"`
+}
+
+// InitialActionJSON is a single initial-action statement.
+type InitialActionJSON struct {
+	DSL string `json:"dsl"`
+}
+
+// ConditionJSON mirrors authoring.Condition but uses string-keyed column maps
+// to survive JSON round-tripping (JSON object keys are always strings).
+type ConditionJSON struct {
+	Number  int               `json:"number"`
+	Comment string            `json:"comment,omitempty"`
+	DSL     string            `json:"dsl"`
+	Columns map[string]string `json:"columns,omitempty"`
+}
+
+// ActionJSON mirrors authoring.Action. Column bool is emitted literally.
+type ActionJSON struct {
+	Number  int             `json:"number"`
+	Comment string          `json:"comment,omitempty"`
+	DSL     string          `json:"dsl"`
+	Columns map[string]bool `json:"columns,omitempty"`
+}
+
+// EDDJSON is the JSON projection of an EDD (entity data dictionary).
+type EDDJSON struct {
+	Entities []EntityJSON `json:"entities"`
+}
+
+// EntityJSON holds the attribute list for one entity.
+type EntityJSON struct {
+	Name   string          `json:"name"`
+	Fields []AttributeJSON `json:"fields,omitempty"`
+}
+
+// AttributeJSON mirrors authoring.Attribute.
+type AttributeJSON struct {
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Subtype string `json:"subtype,omitempty"`
+	Default string `json:"default,omitempty"`
+	Access  string `json:"access,omitempty"`
+	Input   string `json:"input,omitempty"`
+	Comment string `json:"comment,omitempty"`
+}
+
+// tableToJSON converts an authoring.Table into its JSON-safe projection.
+func tableToJSON(t *authoring.Table) TableJSON {
+	out := TableJSON{
+		Name:   t.Name,
+		Policy: t.Policy,
+	}
+	for _, c := range t.Contexts {
+		out.Contexts = append(out.Contexts, ContextJSON{DSL: c.DSL})
+	}
+	for _, ia := range t.InitialActions {
+		out.InitialActions = append(out.InitialActions, InitialActionJSON{DSL: ia.DSL})
+	}
+	for _, c := range t.Conditions {
+		out.Conditions = append(out.Conditions, ConditionJSON{
+			Number:  c.Number,
+			Comment: c.Comment,
+			DSL:     c.DSL,
+			Columns: intStringMapToString(c.Columns),
+		})
+	}
+	for _, a := range t.Actions {
+		out.Actions = append(out.Actions, ActionJSON{
+			Number:  a.Number,
+			Comment: a.Comment,
+			DSL:     a.DSL,
+			Columns: intBoolMapToString(a.Columns),
+		})
+	}
+	return out
+}
+
+// eddToJSON projects an authoring.EDD to its JSON shape.
+func eddToJSON(e *authoring.EDD) EDDJSON {
+	out := EDDJSON{}
+	for _, ent := range e.Entities() {
+		ej := EntityJSON{Name: ent.Name}
+		for _, a := range ent.Attributes {
+			ej.Fields = append(ej.Fields, AttributeJSON{
+				Name:    a.Name,
+				Type:    a.Type,
+				Subtype: a.Subtype,
+				Default: a.Default,
+				Access:  a.Access,
+				Input:   a.Input,
+				Comment: a.Comment,
+			})
+		}
+		out.Entities = append(out.Entities, ej)
+	}
+	return out
+}
+
+// ApplyTo rebuilds the given authoring.Table in place to match this TableJSON.
+// Existing conditions/actions/contexts are cleared; new ones are added in the
+// order they appear. Every EL expression is compiled via the SDK's existing
+// validation, so invalid DSL fails here before Save is called.
+func (tj *TableJSON) ApplyTo(t *authoring.Table) error {
+	t.Name = tj.Name
+	t.Policy = tj.Policy
+
+	// Clear everything that we're about to rewrite, working from the back
+	// so we don't walk off the live slice as the SDK mutates it.
+	for i := len(t.Contexts) - 1; i >= 0; i-- {
+		if err := t.DeleteContext(i); err != nil {
+			return err
+		}
+	}
+	for i := len(t.InitialActions) - 1; i >= 0; i-- {
+		if err := t.DeleteInitialAction(i); err != nil {
+			return err
+		}
+	}
+	for len(t.Conditions) > 0 {
+		num := t.Conditions[len(t.Conditions)-1].Number
+		if err := t.DeleteCondition(num); err != nil {
+			return err
+		}
+	}
+	for len(t.Actions) > 0 {
+		num := t.Actions[len(t.Actions)-1].Number
+		if err := t.DeleteAction(num); err != nil {
+			return err
+		}
+	}
+
+	for i, c := range tj.Contexts {
+		if err := t.AddContext(authoring.Context{DSL: c.DSL}); err != nil {
+			return fmt.Errorf("contexts[%d]: %w", i, err)
+		}
+	}
+	for i, ia := range tj.InitialActions {
+		if err := t.AddInitialAction(authoring.InitialAction{DSL: ia.DSL}); err != nil {
+			return fmt.Errorf("initial_actions[%d]: %w", i, err)
+		}
+	}
+	for i, c := range tj.Conditions {
+		cols, err := stringMapToIntString(c.Columns)
+		if err != nil {
+			return fmt.Errorf("conditions[%d].columns: %w", i, err)
+		}
+		if err := t.AddCondition(authoring.Condition{
+			Number:  c.Number,
+			Comment: c.Comment,
+			DSL:     c.DSL,
+			Columns: cols,
+		}); err != nil {
+			return fmt.Errorf("conditions[%d]: %w", i, err)
+		}
+	}
+	for i, a := range tj.Actions {
+		cols, err := stringMapToIntBool(a.Columns)
+		if err != nil {
+			return fmt.Errorf("actions[%d].columns: %w", i, err)
+		}
+		if err := t.AddAction(authoring.Action{
+			Number:  a.Number,
+			Comment: a.Comment,
+			DSL:     a.DSL,
+			Columns: cols,
+		}); err != nil {
+			return fmt.Errorf("actions[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// ApplyTo rebuilds the EDD to match this EDDJSON. Entities not present in the
+// JSON are removed; entities present are re-added with their fields.
+func (ej *EDDJSON) ApplyTo(e *authoring.EDD) error {
+	existing := map[string]bool{}
+	for _, ent := range e.Entities() {
+		existing[ent.Name] = true
+	}
+	wanted := map[string]bool{}
+	for _, ent := range ej.Entities {
+		wanted[ent.Name] = true
+	}
+	for name := range existing {
+		if !wanted[name] {
+			if err := e.DeleteEntity(name); err != nil {
+				return fmt.Errorf("delete entity %q: %w", name, err)
+			}
+		}
+	}
+	for _, ent := range ej.Entities {
+		cur := e.Entity(ent.Name)
+		if cur == nil {
+			newEnt, err := e.AddEntity(ent.Name)
+			if err != nil {
+				return fmt.Errorf("add entity %q: %w", ent.Name, err)
+			}
+			cur = newEnt
+		} else {
+			// Clear existing attributes so we can rewrite them in the requested order.
+			for _, a := range cur.Attributes {
+				if err := cur.DeleteAttribute(a.Name); err != nil {
+					return fmt.Errorf("entity %q: %w", ent.Name, err)
+				}
+			}
+		}
+		for _, f := range ent.Fields {
+			if err := cur.AddAttribute(authoring.Attribute{
+				Name:    f.Name,
+				Type:    f.Type,
+				Subtype: f.Subtype,
+				Default: f.Default,
+				Access:  f.Access,
+				Input:   f.Input,
+				Comment: f.Comment,
+			}); err != nil {
+				return fmt.Errorf("entity %q field %q: %w", ent.Name, f.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+// intStringMapToString copies an int->string map to a string-keyed one,
+// sorting keys for stable JSON output.
+func intStringMapToString(in map[int]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	keys := make([]int, 0, len(in))
+	for k := range in {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	for _, k := range keys {
+		out[strconv.Itoa(k)] = in[k]
+	}
+	return out
+}
+
+func intBoolMapToString(in map[int]bool) map[string]bool {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(in))
+	keys := make([]int, 0, len(in))
+	for k := range in {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	for _, k := range keys {
+		out[strconv.Itoa(k)] = in[k]
+	}
+	return out
+}
+
+func stringMapToIntString(in map[string]string) (map[int]string, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make(map[int]string, len(in))
+	for k, v := range in {
+		n, err := strconv.Atoi(k)
+		if err != nil {
+			return nil, fmt.Errorf("column key %q is not an integer", k)
+		}
+		out[n] = v
+	}
+	return out, nil
+}
+
+func stringMapToIntBool(in map[string]bool) (map[int]bool, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make(map[int]bool, len(in))
+	for k, v := range in {
+		n, err := strconv.Atoi(k)
+		if err != nil {
+			return nil, fmt.Errorf("column key %q is not an integer", k)
+		}
+		out[n] = v
+	}
+	return out, nil
+}

--- a/cmd/dtrules/table_json_test.go
+++ b/cmd/dtrules/table_json_test.go
@@ -1,0 +1,440 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// copyProject duplicates a sampleproject into a tmp dir so tests can mutate
+// XML without touching the committed fixtures.
+func copyProject(t *testing.T, src string) string {
+	t.Helper()
+	dst := t.TempDir()
+	err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, path)
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	})
+	if err != nil {
+		t.Fatalf("copy project: %v", err)
+	}
+	return dst
+}
+
+// runTableCmd executes runTable against the given stdin and captures stdout/stderr.
+func runTableCmd(t *testing.T, projectPath string, args []string, stdin string) (stdout, stderr string, exit int) {
+	t.Helper()
+	var so, se bytes.Buffer
+	cmd := &tableCmdCtx{
+		stdin:       strings.NewReader(stdin),
+		stdout:      &so,
+		stderr:      &se,
+		projectPath: projectPath,
+	}
+	// Dispatch by hand so we bypass flag parsing — the caller supplies the
+	// project path directly.
+	exit = dispatchTable(cmd, args)
+	return so.String(), se.String(), exit
+}
+
+func runEDDCmd(t *testing.T, projectPath string, args []string, stdin string) (stdout, stderr string, exit int) {
+	t.Helper()
+	var so, se bytes.Buffer
+	cmd := &tableCmdCtx{
+		stdin:       strings.NewReader(stdin),
+		stdout:      &so,
+		stderr:      &se,
+		projectPath: projectPath,
+	}
+	exit = dispatchEDD(cmd, args)
+	return so.String(), se.String(), exit
+}
+
+// dispatchTable is the test-only dispatcher mirroring CLI.runTable without
+// the os.Std* wiring.
+func dispatchTable(ctx *tableCmdCtx, args []string) int {
+	if len(args) == 0 {
+		return emitErr(ctx.stderr, 1, "invalid_command", "", "", "missing subcommand")
+	}
+	switch args[0] {
+	case "list":
+		return ctx.tableList()
+	case "get":
+		return ctx.tableGet(args[1:])
+	case "put":
+		return ctx.tablePut(args[1:])
+	case "patch":
+		return ctx.tablePatch(args[1:])
+	case "schema":
+		return ctx.tableSchema(args[1:])
+	default:
+		return emitErr(ctx.stderr, 1, "invalid_command", "", "", "unknown subcommand")
+	}
+}
+
+func dispatchEDD(ctx *tableCmdCtx, args []string) int {
+	if len(args) == 0 {
+		return emitErr(ctx.stderr, 1, "invalid_command", "", "", "missing subcommand")
+	}
+	switch args[0] {
+	case "get":
+		return ctx.eddGet()
+	case "put":
+		return ctx.eddPut()
+	case "patch":
+		return ctx.eddPatch()
+	case "schema":
+		return ctx.eddSchema(args[1:])
+	default:
+		return emitErr(ctx.stderr, 1, "invalid_command", "", "", "unknown subcommand")
+	}
+}
+
+// --- tests ---
+
+func TestTableList(t *testing.T) {
+	dir := copyProject(t, "../../sampleprojects/CHIP")
+	out, _, code := runTableCmd(t, dir, []string{"list"}, "")
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	var got struct{ Tables []string }
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parse list: %v", err)
+	}
+	if len(got.Tables) == 0 {
+		t.Fatalf("expected tables, got none")
+	}
+}
+
+func TestTableGetJSON(t *testing.T) {
+	dir := copyProject(t, "../../sampleprojects/CHIP")
+	out, _, code := runTableCmd(t, dir, []string{"get", "Compute_Eligibility"}, "")
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	var tj TableJSON
+	if err := json.Unmarshal([]byte(out), &tj); err != nil {
+		t.Fatalf("parse table: %v", err)
+	}
+	if tj.Name != "Compute_Eligibility" {
+		t.Errorf("name %q", tj.Name)
+	}
+	if len(tj.Conditions) == 0 {
+		t.Errorf("expected conditions")
+	}
+}
+
+func TestTableRoundTripJSON(t *testing.T) {
+	// Round-trip via JSON (not XML) because the SDK's XML writer is not
+	// bytewise-stable across map iteration — see note in table_json.go.
+	dir := copyProject(t, "../../sampleprojects/CHIP")
+	out1, _, code := runTableCmd(t, dir, []string{"get", "Compute_Eligibility"}, "")
+	if code != 0 {
+		t.Fatalf("get1 exit %d", code)
+	}
+	if _, _, code := runTableCmd(t, dir, []string{"put", "Compute_Eligibility"}, out1); code != 0 {
+		t.Fatalf("put exit %d", code)
+	}
+	out2, _, code := runTableCmd(t, dir, []string{"get", "Compute_Eligibility"}, "")
+	if code != 0 {
+		t.Fatalf("get2 exit %d", code)
+	}
+	var a, b TableJSON
+	if err := json.Unmarshal([]byte(out1), &a); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(out2), &b); err != nil {
+		t.Fatal(err)
+	}
+	// Re-marshal both indented, compare strings. This hides any iteration
+	// order differences that cannot survive the native SDK structs.
+	raw1, _ := json.MarshalIndent(a, "", "  ")
+	raw2, _ := json.MarshalIndent(b, "", "  ")
+	if string(raw1) != string(raw2) {
+		t.Errorf("round-trip drift:\n--- first ---\n%s\n--- second ---\n%s", raw1, raw2)
+	}
+}
+
+func TestTablePutInvalidDSL(t *testing.T) {
+	dir := copyProject(t, "../../sampleprojects/CHIP")
+	badTable := TableJSON{
+		Name:   "Compute_Eligibility",
+		Policy: "FIRST",
+		Conditions: []ConditionJSON{
+			{Number: 1, DSL: "!!!this is not valid EL!!!"},
+		},
+		Actions: []ActionJSON{
+			{Number: 1, DSL: "perform Calculate_Individual_Income"},
+		},
+	}
+	payload, _ := json.Marshal(badTable)
+	_, se, code := runTableCmd(t, dir, []string{"put", "Compute_Eligibility"}, string(payload))
+	if code == 0 {
+		t.Fatalf("expected non-zero exit on invalid DSL")
+	}
+	var je jsonError
+	if err := json.Unmarshal([]byte(se), &je); err != nil {
+		t.Fatalf("stderr not JSON: %v\n%s", err, se)
+	}
+	if je.Error != "compile_error" {
+		t.Errorf("expected compile_error, got %q", je.Error)
+	}
+}
+
+func TestTableGetNotFound(t *testing.T) {
+	dir := copyProject(t, "../../sampleprojects/CHIP")
+	_, se, code := runTableCmd(t, dir, []string{"get", "NoSuchTable"}, "")
+	if code == 0 {
+		t.Fatalf("expected non-zero exit")
+	}
+	var je jsonError
+	if err := json.Unmarshal([]byte(se), &je); err != nil {
+		t.Fatalf("stderr not JSON: %v", err)
+	}
+	if je.Error != "not_found" {
+		t.Errorf("expected not_found, got %q", je.Error)
+	}
+}
+
+func TestTablePatchSetConditionCell(t *testing.T) {
+	dir := copyProject(t, "../../sampleprojects/CHIP")
+	patch := `{"op":"set-condition-cell","condition_number":1,"column":1,"value":"N"}`
+	_, se, code := runTableCmd(t, dir, []string{"patch", "Compute_Eligibility"}, patch)
+	if code != 0 {
+		t.Fatalf("patch exit %d stderr=%s", code, se)
+	}
+	// Re-get and check.
+	out, _, _ := runTableCmd(t, dir, []string{"get", "Compute_Eligibility"}, "")
+	var tj TableJSON
+	_ = json.Unmarshal([]byte(out), &tj)
+	found := false
+	for _, c := range tj.Conditions {
+		if c.Number == 1 {
+			if c.Columns["1"] != "N" {
+				t.Errorf("condition 1 column 1: want N got %q", c.Columns["1"])
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("condition 1 missing")
+	}
+}
+
+func TestTablePatchDeleteCondition(t *testing.T) {
+	dir := copyProject(t, "../../sampleprojects/CHIP")
+	patch := `{"op":"delete-condition","condition_number":2}`
+	_, se, code := runTableCmd(t, dir, []string{"patch", "Compute_Eligibility"}, patch)
+	if code != 0 {
+		t.Fatalf("patch exit %d stderr=%s", code, se)
+	}
+	out, _, _ := runTableCmd(t, dir, []string{"get", "Compute_Eligibility"}, "")
+	var tj TableJSON
+	_ = json.Unmarshal([]byte(out), &tj)
+	for _, c := range tj.Conditions {
+		if c.Number == 2 {
+			t.Fatalf("condition 2 should be deleted")
+		}
+	}
+	// Other conditions still present.
+	if len(tj.Conditions) < 2 {
+		t.Errorf("expected other conditions to survive")
+	}
+}
+
+func TestTablePatchAddColumn(t *testing.T) {
+	// Target table: use one that has no '*' columns so AddColumn's legal-
+	// value check accepts it.
+	dir := copyProject(t, "../../sampleprojects/CHIP")
+	out, _, _ := runTableCmd(t, dir, []string{"get", "Evaluate_CHIP_Eligibility"}, "")
+	var before TableJSON
+	_ = json.Unmarshal([]byte(out), &before)
+	if len(before.Conditions) == 0 {
+		t.Fatalf("fixture has no conditions")
+	}
+	// Build an add-column patch that supplies "N" for every condition.
+	// We can't use "-" because the SDK elides dash cells on serialize.
+	condsMap := map[string]string{}
+	for _, c := range before.Conditions {
+		condsMap[itoa(c.Number)] = "N"
+	}
+	patch := struct {
+		Op         string            `json:"op"`
+		Conditions map[string]string `json:"conditions"`
+		Actions    []int             `json:"actions"`
+	}{"add-column", condsMap, []int{}}
+	payload, _ := json.Marshal(patch)
+	_, se, code := runTableCmd(t, dir, []string{"patch", "Evaluate_CHIP_Eligibility"}, string(payload))
+	if code != 0 {
+		t.Fatalf("add-column exit %d stderr=%s", code, se)
+	}
+	// The new column should live at max+1.
+	maxCol := 0
+	for _, c := range before.Conditions {
+		for k := range c.Columns {
+			n := atoi(k)
+			if n > maxCol {
+				maxCol = n
+			}
+		}
+	}
+	out2, _, _ := runTableCmd(t, dir, []string{"get", "Evaluate_CHIP_Eligibility"}, "")
+	var after TableJSON
+	_ = json.Unmarshal([]byte(out2), &after)
+	newCol := maxCol + 1
+	for _, c := range after.Conditions {
+		if c.Columns[itoa(newCol)] == "" {
+			t.Errorf("condition %d has no value at column %d", c.Number, newCol)
+		}
+	}
+}
+
+func TestTableSchema(t *testing.T) {
+	dir := copyProject(t, "../../sampleprojects/CHIP")
+	out, _, code := runTableCmd(t, dir, []string{"schema"}, "")
+	if code != 0 {
+		t.Fatalf("schema exit %d", code)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("schema not valid JSON: %v", err)
+	}
+	if _, ok := m["$schema"]; !ok {
+		t.Errorf("schema missing $schema")
+	}
+	// Patch schema
+	outP, _, code := runTableCmd(t, dir, []string{"schema", "--patch"}, "")
+	if code != 0 {
+		t.Fatalf("schema --patch exit %d", code)
+	}
+	var mp map[string]interface{}
+	if err := json.Unmarshal([]byte(outP), &mp); err != nil {
+		t.Fatalf("patch schema not JSON: %v", err)
+	}
+	// Ensure enum list is present.
+	raw, _ := json.Marshal(mp)
+	for _, op := range []string{"set-condition-cell", "add-column", "delete-condition"} {
+		if !strings.Contains(string(raw), op) {
+			t.Errorf("patch schema missing op %q", op)
+		}
+	}
+}
+
+func TestTablePutInvalidJSON(t *testing.T) {
+	dir := copyProject(t, "../../sampleprojects/CHIP")
+	_, se, code := runTableCmd(t, dir, []string{"put", "Compute_Eligibility"}, "{not json}")
+	if code == 0 {
+		t.Fatalf("expected non-zero exit")
+	}
+	var je jsonError
+	if err := json.Unmarshal([]byte(se), &je); err != nil {
+		t.Fatalf("stderr not JSON: %v", err)
+	}
+	if je.Error != "parse_error" {
+		t.Errorf("expected parse_error, got %q", je.Error)
+	}
+}
+
+func TestEDDGet(t *testing.T) {
+	dir := copyProject(t, "../../sampleprojects/CHIP")
+	out, _, code := runEDDCmd(t, dir, []string{"get"}, "")
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	var ej EDDJSON
+	if err := json.Unmarshal([]byte(out), &ej); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(ej.Entities) == 0 {
+		t.Errorf("expected entities")
+	}
+}
+
+func TestEDDPatchAddEntity(t *testing.T) {
+	dir := copyProject(t, "../../sampleprojects/CHIP")
+	patch := `{"op":"add-entity","entity":"TestAuthoringEntity"}`
+	_, se, code := runEDDCmd(t, dir, []string{"patch"}, patch)
+	if code != 0 {
+		t.Fatalf("patch exit %d stderr=%s", code, se)
+	}
+	out, _, _ := runEDDCmd(t, dir, []string{"get"}, "")
+	if !strings.Contains(out, "TestAuthoringEntity") {
+		t.Errorf("new entity missing from edd get")
+	}
+}
+
+func TestEDDSchema(t *testing.T) {
+	dir := copyProject(t, "../../sampleprojects/CHIP")
+	out, _, code := runEDDCmd(t, dir, []string{"schema"}, "")
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("schema not JSON: %v", err)
+	}
+	if _, ok := m["$schema"]; !ok {
+		t.Errorf("schema missing $schema")
+	}
+}
+
+// itoa / atoi — small helpers kept local to the test file.
+func itoa(n int) string {
+	return string(formatInt(int64(n)))
+}
+
+func atoi(s string) int {
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+// formatInt avoids pulling strconv into the test just for Itoa.
+func formatInt(n int64) []byte {
+	if n == 0 {
+		return []byte("0")
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return buf[i:]
+}
+

--- a/cmd/dtrules/table_patch.go
+++ b/cmd/dtrules/table_patch.go
@@ -1,0 +1,373 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// Patch ops are a flat discriminated union keyed on "op". Each op carries
+// the arguments it needs as optional siblings; fields for other ops stay at
+// their zero value. This keeps the JSON shape trivial for AI callers and
+// cheap to unmarshal.
+
+import (
+	"fmt"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+// tablePatch is the wire shape for `dtrules table patch`.
+type tablePatch struct {
+	Op string `json:"op"`
+
+	// shared
+	Column          int    `json:"column,omitempty"`
+	ConditionNumber int    `json:"condition_number,omitempty"`
+	ActionNumber    int    `json:"action_number,omitempty"`
+	Index           int    `json:"index,omitempty"`
+	Value           string `json:"value,omitempty"`
+	On              bool   `json:"on,omitempty"`
+	Name            string `json:"name,omitempty"`
+	Policy          string `json:"policy,omitempty"`
+	DSL             string `json:"dsl,omitempty"`
+	Comment         string `json:"comment,omitempty"`
+
+	// column ops
+	Conditions map[string]string `json:"conditions,omitempty"`
+	Actions    []int             `json:"actions,omitempty"`
+
+	// add/update-condition whole-row
+	Columns map[string]string `json:"columns,omitempty"` // for condition
+	// add/update-action whole-row
+	ActionColumns map[string]bool `json:"action_columns,omitempty"`
+}
+
+func (p *tablePatch) hint() string {
+	return "see `dtrules table schema --patch` for the argument shape of each op"
+}
+
+// apply runs the requested patch op against t.
+func (p *tablePatch) apply(t *authoring.Table) error {
+	switch p.Op {
+	case "set-name":
+		if p.Name == "" {
+			return fmt.Errorf("set-name requires a non-empty \"name\"")
+		}
+		t.Name = p.Name
+		return nil
+
+	case "set-policy":
+		t.Policy = p.Policy
+		return nil
+
+	case "set-condition-cell":
+		return setConditionCell(t, p.ConditionNumber, p.Column, p.Value)
+
+	case "set-action-cell":
+		return setActionCell(t, p.ActionNumber, p.Column, p.On)
+
+	case "add-column":
+		conds, err := stringMapToIntString(p.Conditions)
+		if err != nil {
+			return err
+		}
+		return t.AddColumn(conds, p.Actions)
+
+	case "update-column":
+		if p.Column < 1 {
+			return fmt.Errorf("update-column requires column >= 1")
+		}
+		conds, err := stringMapToIntString(p.Conditions)
+		if err != nil {
+			return err
+		}
+		return t.UpdateColumn(p.Column, conds, p.Actions)
+
+	case "delete-column":
+		if p.Column < 1 {
+			return fmt.Errorf("delete-column requires column >= 1")
+		}
+		return t.DeleteColumn(p.Column)
+
+	case "add-condition":
+		cols, err := stringMapToIntString(p.Columns)
+		if err != nil {
+			return err
+		}
+		return t.AddCondition(authoring.Condition{
+			Number:  p.ConditionNumber,
+			Comment: p.Comment,
+			DSL:     p.DSL,
+			Columns: cols,
+		})
+
+	case "update-condition":
+		if p.ConditionNumber == 0 {
+			return fmt.Errorf("update-condition requires condition_number")
+		}
+		cols, err := stringMapToIntString(p.Columns)
+		if err != nil {
+			return err
+		}
+		return t.UpdateCondition(p.ConditionNumber, authoring.Condition{
+			Comment: p.Comment,
+			DSL:     p.DSL,
+			Columns: cols,
+		})
+
+	case "update-condition-dsl":
+		if p.ConditionNumber == 0 {
+			return fmt.Errorf("update-condition-dsl requires condition_number")
+		}
+		existing, err := findCondition(t, p.ConditionNumber)
+		if err != nil {
+			return err
+		}
+		return t.UpdateCondition(p.ConditionNumber, authoring.Condition{
+			Comment: existing.Comment,
+			DSL:     p.DSL,
+			Columns: existing.Columns,
+		})
+
+	case "delete-condition":
+		if p.ConditionNumber == 0 {
+			return fmt.Errorf("delete-condition requires condition_number")
+		}
+		return t.DeleteCondition(p.ConditionNumber)
+
+	case "add-action":
+		cols, err := stringMapToIntBool(p.ActionColumns)
+		if err != nil {
+			return err
+		}
+		return t.AddAction(authoring.Action{
+			Number:  p.ActionNumber,
+			Comment: p.Comment,
+			DSL:     p.DSL,
+			Columns: cols,
+		})
+
+	case "update-action":
+		if p.ActionNumber == 0 {
+			return fmt.Errorf("update-action requires action_number")
+		}
+		cols, err := stringMapToIntBool(p.ActionColumns)
+		if err != nil {
+			return err
+		}
+		return t.UpdateAction(p.ActionNumber, authoring.Action{
+			Comment: p.Comment,
+			DSL:     p.DSL,
+			Columns: cols,
+		})
+
+	case "update-action-dsl":
+		if p.ActionNumber == 0 {
+			return fmt.Errorf("update-action-dsl requires action_number")
+		}
+		existing, err := findAction(t, p.ActionNumber)
+		if err != nil {
+			return err
+		}
+		return t.UpdateAction(p.ActionNumber, authoring.Action{
+			Comment: existing.Comment,
+			DSL:     p.DSL,
+			Columns: existing.Columns,
+		})
+
+	case "delete-action":
+		if p.ActionNumber == 0 {
+			return fmt.Errorf("delete-action requires action_number")
+		}
+		return t.DeleteAction(p.ActionNumber)
+
+	case "add-initial-action":
+		return t.AddInitialAction(authoring.InitialAction{DSL: p.DSL})
+
+	case "update-initial-action":
+		return t.UpdateInitialAction(p.Index, authoring.InitialAction{DSL: p.DSL})
+
+	case "delete-initial-action":
+		return t.DeleteInitialAction(p.Index)
+
+	case "add-context":
+		return t.AddContext(authoring.Context{DSL: p.DSL})
+
+	case "update-context":
+		return t.UpdateContext(p.Index, authoring.Context{DSL: p.DSL})
+
+	case "delete-context":
+		return t.DeleteContext(p.Index)
+
+	default:
+		return fmt.Errorf("unknown op %q (see `dtrules table schema --patch`)", p.Op)
+	}
+}
+
+// setConditionCell uses UpdateCondition to flip a single cell — that exercises
+// the SDK's EL validation path, which is what we want.
+func setConditionCell(t *authoring.Table, num, col int, value string) error {
+	if num == 0 {
+		return fmt.Errorf("set-condition-cell requires condition_number")
+	}
+	if col < 1 {
+		return fmt.Errorf("set-condition-cell requires column >= 1")
+	}
+	if value != "Y" && value != "N" && value != "-" {
+		return fmt.Errorf("value must be one of Y, N, -")
+	}
+	existing, err := findCondition(t, num)
+	if err != nil {
+		return err
+	}
+	// Clone the column map so mutation stays local until UpdateCondition commits.
+	newCols := make(map[int]string, len(existing.Columns)+1)
+	for k, v := range existing.Columns {
+		newCols[k] = v
+	}
+	newCols[col] = value
+	return t.UpdateCondition(num, authoring.Condition{
+		Comment: existing.Comment,
+		DSL:     existing.DSL,
+		Columns: newCols,
+	})
+}
+
+func setActionCell(t *authoring.Table, num, col int, on bool) error {
+	if num == 0 {
+		return fmt.Errorf("set-action-cell requires action_number")
+	}
+	if col < 1 {
+		return fmt.Errorf("set-action-cell requires column >= 1")
+	}
+	existing, err := findAction(t, num)
+	if err != nil {
+		return err
+	}
+	newCols := make(map[int]bool, len(existing.Columns)+1)
+	for k, v := range existing.Columns {
+		newCols[k] = v
+	}
+	newCols[col] = on
+	return t.UpdateAction(num, authoring.Action{
+		Comment: existing.Comment,
+		DSL:     existing.DSL,
+		Columns: newCols,
+	})
+}
+
+func findCondition(t *authoring.Table, num int) (authoring.Condition, error) {
+	for _, c := range t.Conditions {
+		if c.Number == num {
+			return c, nil
+		}
+	}
+	return authoring.Condition{}, fmt.Errorf("condition number %d not found", num)
+}
+
+func findAction(t *authoring.Table, num int) (authoring.Action, error) {
+	for _, a := range t.Actions {
+		if a.Number == num {
+			return a, nil
+		}
+	}
+	return authoring.Action{}, fmt.Errorf("action number %d not found", num)
+}
+
+// --- EDD patch ---
+
+// eddPatchOp is the wire shape for `dtrules edd patch`.
+type eddPatchOp struct {
+	Op string `json:"op"`
+
+	Entity  string         `json:"entity,omitempty"`
+	Field   *AttributeJSON `json:"field,omitempty"`
+	Name    string         `json:"name,omitempty"`
+	Comment string         `json:"comment,omitempty"`
+}
+
+func (p *eddPatchOp) hint() string {
+	return "see `dtrules edd schema --patch` for the argument shape of each op"
+}
+
+func (p *eddPatchOp) apply(e *authoring.EDD) error {
+	switch p.Op {
+	case "add-entity":
+		if p.Entity == "" {
+			return fmt.Errorf("add-entity requires \"entity\"")
+		}
+		_, err := e.AddEntity(p.Entity)
+		return err
+
+	case "delete-entity":
+		if p.Entity == "" {
+			return fmt.Errorf("delete-entity requires \"entity\"")
+		}
+		return e.DeleteEntity(p.Entity)
+
+	case "add-field":
+		if p.Entity == "" || p.Field == nil {
+			return fmt.Errorf("add-field requires \"entity\" and \"field\"")
+		}
+		ent := e.Entity(p.Entity)
+		if ent == nil {
+			return fmt.Errorf("entity %q not found", p.Entity)
+		}
+		return ent.AddAttribute(attributeFromJSON(*p.Field))
+
+	case "update-field":
+		if p.Entity == "" || p.Field == nil || p.Field.Name == "" {
+			return fmt.Errorf("update-field requires \"entity\" and \"field.name\"")
+		}
+		ent := e.Entity(p.Entity)
+		if ent == nil {
+			return fmt.Errorf("entity %q not found", p.Entity)
+		}
+		return ent.UpdateAttribute(p.Field.Name, attributeFromJSON(*p.Field))
+
+	case "delete-field":
+		if p.Entity == "" || p.Name == "" {
+			return fmt.Errorf("delete-field requires \"entity\" and \"name\"")
+		}
+		ent := e.Entity(p.Entity)
+		if ent == nil {
+			return fmt.Errorf("entity %q not found", p.Entity)
+		}
+		return ent.DeleteAttribute(p.Name)
+
+	case "set-comment":
+		// Comment on a specific attribute; preserves all other fields.
+		if p.Entity == "" || p.Name == "" {
+			return fmt.Errorf("set-comment requires \"entity\" and \"name\"")
+		}
+		ent := e.Entity(p.Entity)
+		if ent == nil {
+			return fmt.Errorf("entity %q not found", p.Entity)
+		}
+		return ent.UpdateAttribute(p.Name, authoring.Attribute{Comment: p.Comment})
+
+	default:
+		return fmt.Errorf("unknown op %q (see `dtrules edd schema --patch`)", p.Op)
+	}
+}
+
+func attributeFromJSON(a AttributeJSON) authoring.Attribute {
+	return authoring.Attribute{
+		Name:    a.Name,
+		Type:    a.Type,
+		Subtype: a.Subtype,
+		Default: a.Default,
+		Access:  a.Access,
+		Input:   a.Input,
+		Comment: a.Comment,
+	}
+}


### PR DESCRIPTION
Closes #716. Part of v1.9.1.

## Summary

- Adds `dtrules table` and `dtrules edd` subcommands — JSON-in / JSON-out surface over the existing `pkg/dtrules/authoring` SDK, optimized for AI agents.
- No new SDK capabilities; this is a thin wrapper that emits DTOs and translates patch ops into existing SDK calls.
- New commands: `list`, `get`, `put`, `patch`, `schema` (with `--patch` variant) for both `table` and `edd`.
- Every non-zero exit writes a JSON error record (`error`/`path`/`hint`/`detail`) to stderr.

## Subcommand surface

Read:
```
dtrules table list --project <path>
dtrules table get <name> --project <path>
dtrules table schema [--patch]
dtrules edd  get     --project <path>
dtrules edd  schema  [--patch]
```

Write whole (EL compiled + validated before save):
```
dtrules table put <name> --project <path> < table.json
dtrules edd  put         --project <path> < edd.json
```

Targeted patch (one op per call):
```
echo '{"op":"set-condition-cell","condition_number":1,"column":2,"value":"Y"}' \
  | dtrules table patch <name> --project <path>
```

Table ops: `set-name`, `set-policy`, `set-condition-cell`, `set-action-cell`, `add/update/delete-column`, `add/update/delete-condition`, `update-condition-dsl`, matching `*-action`, `*-initial-action`, `*-context` families.

EDD ops: `add-entity`, `delete-entity`, `add-field`, `update-field`, `delete-field`, `set-comment`.

## Error shape

```json
{"error": "compile_error", "path": "", "hint": "an EL expression failed to compile", "detail": "parse error at offset 3: ..."}
```

Error kinds: `compile_error`, `not_found`, `invalid_patch`, `parse_error`, `io_error`, `invalid_command`.

## Tests

13 new tests in `cmd/dtrules/table_json_test.go`:
- `TestTableList`, `TestTableGetJSON`, `TestTableRoundTripJSON`
- `TestTablePutInvalidDSL`, `TestTableGetNotFound`, `TestTablePutInvalidJSON`
- `TestTablePatchSetConditionCell`, `TestTablePatchDeleteCondition`, `TestTablePatchAddColumn`
- `TestTableSchema`, `TestEDDGet`, `TestEDDPatchAddEntity`, `TestEDDSchema`

`make check` passes.

## Notes / SDK observations (not touched here)

- The authoring SDK's XML writer iterates `map[int]bool` for action columns, so byte-identical XML round-trips are not guaranteed. The round-trip test compares the JSON projection (sorted), not the XML bytes.
- The SDK elides `"-"` condition cells on serialize by design ("don't care"), so callers who supply `"-"` will see it dropped. Docs the enum in the schema but call out this caveat.
- `p.Save()` also reformats whitespace / attribute quoting slightly — pre-existing behavior.

## Test plan

- [x] `make check` passes
- [x] `go test ./cmd/dtrules/ -run "TestTable|TestEdd|TestEDD" -count=1` passes (13 tests)
- [x] Smoke test against `sampleprojects/CHIP`: `table list` / `get` / `schema` all produce valid JSON
- [ ] Reviewer: try `echo '{"op":"delete-condition","condition_number":1}' | dtrules table patch ... --project ./sampleprojects/CHIP` on a scratch copy

## Follow-up

MCP server over this surface ships as #717 (separate PR).