### PR TITLE
fix(el): as-alias field access works at runtime (closes #714)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # DTRules Changelog
 
-## v1.9.1 — 2026-04-24
+## v1.9.0 — 2026-04-24
+
+- **`for all X as <alias>` now executes at runtime** (#714). v1.8.1 shipped
+  the `as`-alias grammar with compile-only tests; the emitted postfix
+  immediately consumed the table body once (via `null allocate execute
+  deallocate pop`) before the iteration started, so `alias.field` in the
+  body never saw a populated slot. The emit now reserves the slot with
+  `null allocate`, runs the wrapper per element inside the `for` loop, and
+  releases the slot afterwards. Three additional fixes land alongside:
+  `opGet` normalizes `/name` literals to the executable interned form
+  (matching `Find`) so `<N> local@ /<field> get` actually reads the
+  attribute; the loader resets the EL compiler's local-slot table between
+  tables so indices start at zero per table; and `VisitTypedXmlValue` now
+  runs the alias-access check, because the grammar routes bare IDENTs
+  through `typedXmlValue` inside `strexpr` (e.g. string concatenation).
+  Execution-based tests land in `pkg/dtrules/authoring/forall_as_runtime_test.go`.
 
 - **JSON-first CLI for decision tables and the EDD** (#716). Adds a
   `dtrules table` and `dtrules edd` subcommand surface that wraps the

--- a/pkg/dtrules/authoring/forall_as_runtime_test.go
+++ b/pkg/dtrules/authoring/forall_as_runtime_test.go
@@ -1,0 +1,214 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+	"github.com/DTRules/DTRules/pkg/dtrules/mapping"
+	"github.com/DTRules/DTRules/pkg/dtrules/operators"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// Issue #714 regression tests: `for all <arr> as <alias>` shipped in v1.8.1
+// with compile-only tests, and runtime field access through the alias failed.
+// These tests execute the compiled tables and assert concrete post-conditions.
+
+func forallAsTestdataDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+	return filepath.Join(filepath.Dir(file), "testdata", "forall_as")
+}
+
+func forallAsSetup(t *testing.T) *session.RuleSet {
+	t.Helper()
+	xmlDir := filepath.Join(forallAsTestdataDir(t), "xml")
+
+	rs := session.NewRuleSet("forall-as-test")
+
+	eddPath := filepath.Join(xmlDir, "forall_as_edd.xml")
+	eddFile, err := os.Open(eddPath)
+	if err != nil {
+		t.Fatalf("open EDD: %v", err)
+	}
+	defer eddFile.Close()
+	if err := rs.LoadEDD(eddFile); err != nil {
+		t.Fatalf("LoadEDD: %v", err)
+	}
+
+	dtPath := filepath.Join(xmlDir, "forall_as_dt.xml")
+	dtFile, err := os.Open(dtPath)
+	if err != nil {
+		t.Fatalf("open DT: %v", err)
+	}
+	defer dtFile.Close()
+	if err := rs.LoadDecisionTables(dtFile); err != nil {
+		t.Fatalf("LoadDecisionTables: %v", err)
+	}
+
+	return rs
+}
+
+func forallAsSession(t *testing.T, rs *session.RuleSet, inputFile string) (*session.RSession, *interpreter.DTState) {
+	t.Helper()
+	xmlDir := filepath.Join(forallAsTestdataDir(t), "xml")
+
+	sess, err := session.NewSession(rs)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+
+	state, ok := sess.GetState().(*interpreter.DTState)
+	if !ok {
+		t.Fatalf("unexpected state type %T", sess.GetState())
+	}
+	state.SetOperatorTable(operators.GetOperatorTable())
+
+	mapPath := filepath.Join(xmlDir, "forall_as_map.xml")
+	mapFile, err := os.Open(mapPath)
+	if err != nil {
+		t.Fatalf("open map: %v", err)
+	}
+	defer mapFile.Close()
+
+	dataFile, err := os.Open(inputFile)
+	if err != nil {
+		t.Fatalf("open data: %v", err)
+	}
+	defer dataFile.Close()
+
+	m := mapping.NewMapping(sess)
+	if err := m.LoadMapping(mapFile); err != nil {
+		t.Fatalf("LoadMapping: %v", err)
+	}
+	if err := m.LoadDataAndPushSingletons(dataFile); err != nil {
+		t.Fatalf("LoadDataAndPushSingletons: %v", err)
+	}
+
+	return sess, state
+}
+
+// calcCtx finds the calculation_context entity currently on the entity stack
+// and returns it. Fails the test if not found.
+func calcCtx(t *testing.T, state *interpreter.DTState) dtrules.Entity {
+	t.Helper()
+	for i := 0; i < state.EntityDepth(); i++ {
+		ent, err := state.EntityFetch(i)
+		if err != nil {
+			continue
+		}
+		if ent.GetName().StringValue() == "calculation_context" {
+			return ent
+		}
+	}
+	t.Fatalf("calculation_context not on entity stack")
+	return nil
+}
+
+func ctxInt(t *testing.T, state *interpreter.DTState, field string) int64 {
+	t.Helper()
+	ent := calcCtx(t, state)
+	val, err := ent.Get(dtrules.GetRName(field))
+	if err != nil || val == nil {
+		t.Fatalf("get %s: %v", field, err)
+	}
+	ri, err := val.RIntegerValue()
+	if err != nil {
+		t.Fatalf("%s not integer: %v", field, err)
+	}
+	n, err := ri.LongValue()
+	if err != nil {
+		t.Fatalf("%s not long: %v", field, err)
+	}
+	return n
+}
+
+func ctxString(t *testing.T, state *interpreter.DTState, field string) string {
+	t.Helper()
+	ent := calcCtx(t, state)
+	val, err := ent.Get(dtrules.GetRName(field))
+	if err != nil || val == nil {
+		t.Fatalf("get %s: %v", field, err)
+	}
+	return val.StringValue()
+}
+
+// runForallAs executes the given table against the three_accounts input.
+// The input has 3 accounts with balances 100, 200, 300 and labels A, B, C.
+func runForallAs(t *testing.T, table string) *interpreter.DTState {
+	t.Helper()
+	rs := forallAsSetup(t)
+	inputPath := filepath.Join(forallAsTestdataDir(t), "inputs", "three_accounts.xml")
+	sess, state := forallAsSession(t, rs, inputPath)
+	if err := sess.Execute(table); err != nil {
+		t.Fatalf("Execute %s: %v", table, err)
+	}
+	return state
+}
+
+// TestForallAs_BasicReadsAliasField: single as-alias iteration; the body
+// reads `acct.balance` and accumulates into calculation_context.total_balance.
+// Expected sum: 100+200+300 = 600.
+func TestForallAs_BasicReadsAliasField(t *testing.T) {
+	state := runForallAs(t, "FA_Basic")
+	got := ctxInt(t, state, "total_balance")
+	if got != 600 {
+		t.Errorf("FA_Basic: total_balance = %d, want 600", got)
+	}
+}
+
+// TestForallAs_WhereClauseReadsAliasField: the where-clause reads
+// acct.has_staking_authority and keeps only authorized accounts. The body
+// increments processed_count. Two accounts are authorized (A, C).
+func TestForallAs_WhereClauseReadsAliasField(t *testing.T) {
+	state := runForallAs(t, "FA_Where")
+	got := ctxInt(t, state, "processed_count")
+	if got != 2 {
+		t.Errorf("FA_Where: processed_count = %d, want 2", got)
+	}
+}
+
+// TestForallAs_NestedNonShadowing: nested iteration with distinct aliases.
+// Inner filters by inner_a.balance > outer_a.balance. With balances 100,200,300
+// and labels A,B,C, the pairs emitted (outer<inner) are:
+//   A<B, A<C, B<C
+// joined by ";" with a trailing ";".
+func TestForallAs_NestedNonShadowing(t *testing.T) {
+	state := runForallAs(t, "FA_Nested")
+	got := ctxString(t, state, "audit")
+	want := "A<B;A<C;B<C;"
+	if got != want {
+		t.Errorf("FA_Nested: audit = %q, want %q", got, want)
+	}
+}
+
+// TestForallAs_NonAliasRegression: the plain `for all <arr>` path (no alias)
+// must still push on the entity stack and resolve bare field names.
+// With balances 100, 200, 300 — all positive — total is 600.
+func TestForallAs_NonAliasRegression(t *testing.T) {
+	state := runForallAs(t, "FA_NoAlias")
+	got := ctxInt(t, state, "total_balance")
+	if got != 600 {
+		t.Errorf("FA_NoAlias: total_balance = %d, want 600", got)
+	}
+}

--- a/pkg/dtrules/authoring/testdata/forall_as/inputs/three_accounts.xml
+++ b/pkg/dtrules/authoring/testdata/forall_as/inputs/three_accounts.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<calculation_context>
+  <processed_count>0</processed_count>
+  <total_balance>0</total_balance>
+  <audit></audit>
+  <staking_account>
+    <has_staking_authority>true</has_staking_authority>
+    <balance>100</balance>
+    <label>A</label>
+  </staking_account>
+  <staking_account>
+    <has_staking_authority>false</has_staking_authority>
+    <balance>200</balance>
+    <label>B</label>
+  </staking_account>
+  <staking_account>
+    <has_staking_authority>true</has_staking_authority>
+    <balance>300</balance>
+    <label>C</label>
+  </staking_account>
+</calculation_context>

--- a/pkg/dtrules/authoring/testdata/forall_as/xml/forall_as_dt.xml
+++ b/pkg/dtrules/authoring/testdata/forall_as/xml/forall_as_dt.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+
+<!-- Form A: basic as-alias — read a field via the alias. -->
+<decision_table el_compiled="true">
+<table_name>FA_Basic</table_name>
+<xls_file>forall_as_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>1</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>as-alias</context_comment>
+<context_dsl>for all calculation_context.accounts as acct</context_dsl>
+<context_postfix></context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>always</condition_comment>
+<condition_dsl>acct.balance &gt; 0</condition_dsl>
+<condition_postfix></condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>sum balance</action_comment>
+<action_dsl>set calculation_context.total_balance = calculation_context.total_balance + acct.balance</action_dsl>
+<action_postfix></action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- Form B: as-alias with where-clause reading alias field. -->
+<decision_table el_compiled="true">
+<table_name>FA_Where</table_name>
+<xls_file>forall_as_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>2</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>as-alias where</context_comment>
+<context_dsl>for all calculation_context.accounts as acct where acct.has_staking_authority == true</context_dsl>
+<context_postfix></context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>always</condition_comment>
+<condition_dsl>acct.balance &gt;= 0</condition_dsl>
+<condition_postfix></condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>count</action_comment>
+<action_dsl>set calculation_context.processed_count = calculation_context.processed_count + 1</action_dsl>
+<action_postfix></action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- Form C: nested non-shadowing. Outer `parent`, inner `child`, pair them by label. -->
+<decision_table el_compiled="true">
+<table_name>FA_Nested</table_name>
+<xls_file>forall_as_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>3</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>outer</context_comment>
+<context_dsl>for all calculation_context.accounts as outer_a</context_dsl>
+<context_postfix></context_postfix>
+</context_details>
+<context_details>
+<context_number>2</context_number>
+<context_comment>inner</context_comment>
+<context_dsl>for all calculation_context.accounts as inner_a where inner_a.balance &gt; outer_a.balance</context_dsl>
+<context_postfix></context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>always</condition_comment>
+<condition_dsl>inner_a.balance &gt;= 0</condition_dsl>
+<condition_postfix></condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>record pair</action_comment>
+<action_dsl>set calculation_context.audit = calculation_context.audit + outer_a.label + "&lt;" + inner_a.label + ";"</action_dsl>
+<action_postfix></action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- Form D: regression — non-alias path still works. -->
+<decision_table el_compiled="true">
+<table_name>FA_NoAlias</table_name>
+<xls_file>forall_as_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>ALL</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>4</TABLE_NUMBER>
+</attribute_fields>
+<contexts>
+<context_details>
+<context_number>1</context_number>
+<context_comment>non-alias</context_comment>
+<context_dsl>for all calculation_context.accounts</context_dsl>
+<context_postfix></context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+<condition_details>
+<condition_number>1</condition_number>
+<condition_comment>always</condition_comment>
+<condition_dsl>staking_account.balance &gt; 0</condition_dsl>
+<condition_postfix></condition_postfix>
+<condition_column column_number="1" column_value="Y"></condition_column>
+</condition_details>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>sum balance</action_comment>
+<action_dsl>set calculation_context.total_balance = calculation_context.total_balance + staking_account.balance</action_dsl>
+<action_postfix></action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+</decision_tables>

--- a/pkg/dtrules/authoring/testdata/forall_as/xml/forall_as_edd.xml
+++ b/pkg/dtrules/authoring/testdata/forall_as/xml/forall_as_edd.xml
@@ -1,0 +1,15 @@
+<entity_data_dictionary version='2' xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+	<entity name='calculation_context' access='rw' comment=''>
+		<field name='calculation_context' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='accounts' type='array' subtype='staking_account' access='r' input='' default_value='' comment='Array of staking accounts'></field>
+		<field name='processed_count' type='integer' subtype='' access='rw' input='' default_value='0' comment='Count of processed accounts'></field>
+		<field name='total_balance' type='integer' subtype='' access='rw' input='' default_value='0' comment='Sum of balances'></field>
+		<field name='audit' type='string' subtype='' access='rw' input='' default_value='' comment='Pair-wise audit string'></field>
+	</entity>
+	<entity name='staking_account' access='rw' comment=''>
+		<field name='staking_account' type='entity' subtype='' access='r' input='' default_value='' comment='Self Reference'></field>
+		<field name='has_staking_authority' type='boolean' subtype='' access='rw' input='' default_value='false' comment='Whether this account has staking authority'></field>
+		<field name='balance' type='integer' subtype='' access='rw' input='' default_value='0' comment='Account balance'></field>
+		<field name='label' type='string' subtype='' access='rw' input='' default_value='' comment='Label'></field>
+	</entity>
+</entity_data_dictionary>

--- a/pkg/dtrules/authoring/testdata/forall_as/xml/forall_as_map.xml
+++ b/pkg/dtrules/authoring/testdata/forall_as/xml/forall_as_map.xml
@@ -1,0 +1,21 @@
+<mapping>
+	<XMLtoEDD>
+		<map>
+			<setattribute tag='processed_count' RAttribute='processed_count' enclosure='calculation_context' type='integer'></setattribute>
+			<setattribute tag='total_balance' RAttribute='total_balance' enclosure='calculation_context' type='integer'></setattribute>
+			<setattribute tag='audit' RAttribute='audit' enclosure='calculation_context' type='string'></setattribute>
+			<setattribute tag='has_staking_authority' RAttribute='has_staking_authority' enclosure='staking_account' type='boolean'></setattribute>
+			<setattribute tag='balance' RAttribute='balance' enclosure='staking_account' type='integer'></setattribute>
+			<setattribute tag='label' RAttribute='label' enclosure='staking_account' type='string'></setattribute>
+			<createentity entity='calculation_context' tag='calculation_context' id='processed_count'></createentity>
+			<createentity entity='staking_account' tag='staking_account' id='balance' list='accounts'></createentity>
+		</map>
+		<entities>
+			<entity name='calculation_context' number='1'></entity>
+			<entity name='staking_account' number='*'></entity>
+		</entities>
+		<initialization>
+			<initialentity entity='calculation_context' epush='true'></initialentity>
+		</initialization>
+	</XMLtoEDD>
+</mapping>

--- a/pkg/dtrules/compiler/el/compiler.go
+++ b/pkg/dtrules/compiler/el/compiler.go
@@ -53,6 +53,15 @@ func (c *Compiler) SetSymbols(symbols map[string]string) {
 	c.emitter.SetSymbols(symbols)
 }
 
+// ResetLocals clears per-table local variable state (names + slot indices).
+// Callers that reuse a Compiler across multiple tables must call this between
+// tables so slot indices don't bleed across independent compilation scopes.
+// Within a single table, locals persist across Context/Condition/Action calls
+// so a condition can see the slot declared by the context.
+func (c *Compiler) ResetLocals() {
+	c.emitter.ResetLocals()
+}
+
 // CollectionResolver maps an entity-type name (the element type of an array
 // field in the EDD) to the fully qualified `owner.field` path of the array
 // that contains entities of that type. If more than one collection holds

--- a/pkg/dtrules/compiler/el/forall_as_test.go
+++ b/pkg/dtrules/compiler/el/forall_as_test.go
@@ -33,7 +33,12 @@ func TestForallAs_BasicEmit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	want := "null allocate execute deallocate pop dup { 0 local! dup execute } taxpayer.incomes for pop"
+	// Shape (body is on top of data stack at entry):
+	//   null allocate              — reserve slot 0 (ctrl push null)
+	//   { 0 local! dup execute }   — wrapper: stash elem, dup body, run
+	//   <arr> for                  — iterate
+	//   deallocate pop pop         — release slot, drop null, drop body
+	want := "null allocate { 0 local! dup execute } taxpayer.incomes for deallocate pop pop"
 	if got != want {
 		t.Errorf("\nwant: %s\ngot:  %s", want, got)
 	}
@@ -56,7 +61,7 @@ func TestForallAs_WhereClause(t *testing.T) {
 	// The body should only run when the predicate holds, and the alias
 	// slot is populated BEFORE the predicate is evaluated so `inc.amount`
 	// resolves via the local slot.
-	want := "null allocate execute deallocate pop dup { 0 local! { dup execute } 0 local@ /amount get 0 > if } taxpayer.incomes for pop"
+	want := "null allocate { 0 local! { dup execute } 0 local@ /amount get 0 > if } taxpayer.incomes for deallocate pop pop"
 	if got != want {
 		t.Errorf("\nwant: %s\ngot:  %s", want, got)
 	}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -430,6 +430,16 @@ func (e *PostfixEmitter) Reset() {
 	e.errors = nil
 }
 
+// ResetLocals clears the local variable state (names + slot counter).
+// Call this between tables to prevent slot indices from bleeding across
+// independent compilation scopes. Within a single table — the context,
+// conditions, actions — locals must persist so `<alias>.<field>` in a
+// condition can see the slot declared in the context.
+func (e *PostfixEmitter) ResetLocals() {
+	e.locals = make(map[string]LocalVar)
+	e.localCnt = 0
+}
+
 // emit adds a token to the output.
 func (e *PostfixEmitter) emit(token string) {
 	if e.output.Len() > 0 {
@@ -1695,7 +1705,17 @@ func (e *PostfixEmitter) VisitStrTyped(ctx *StrTypedContext) interface{} {
 }
 
 func (e *PostfixEmitter) VisitTypedXmlValue(ctx *TypedXmlValueContext) interface{} {
-	e.emit(ctx.GetText())
+	name := ctx.GetText()
+	// Alias field access: `<alias>.<field>` where alias is a local entity
+	// slot declared by `for all X as alias` (#712, #714). Must be checked
+	// here because the grammar prefers typedXmlValue over typedString for
+	// bare IDENTs in strexpr, so `outer_a.label + ";"` routes here.
+	if e.emitAliasFieldAccess(name) {
+		return nil
+	}
+	if !e.emitLocalRef(name) {
+		e.emit(name)
+	}
 	return nil
 }
 
@@ -2126,7 +2146,7 @@ func (e *PostfixEmitter) VisitForallTypeEntitiesWhere(ctx *ForallTypeEntitiesWhe
 	return nil
 }
 
-// VisitForallAs: `for all <array> as <alias>` (#712).
+// VisitForallAs: `for all <array> as <alias>` (#712, #714).
 //
 // Binds each iteration entity to a local-entity slot named `alias` instead of
 // pushing it on the entity stack. This makes nested same-list iterations
@@ -2134,15 +2154,20 @@ func (e *PostfixEmitter) VisitForallTypeEntitiesWhere(ctx *ForallTypeEntitiesWhe
 // where child.parent_id == parent.id ... }` — both `parent.*` and `child.*`
 // resolve through distinct local slots.
 //
-// Emit shape:
+// The context wraps the table call so the data stack holds the body block on
+// entry: `{ /T executetable } <ctx-postfix>`. The shape below keeps the slot
+// reserved across the whole iteration (so `local!`/`local@` are valid every
+// element) and runs the body once per element, never once before the loop.
 //
-//	null allocate execute deallocate pop     # declare local entity slot N
-//	dup                                      # save outer body
-//	{ <N> local! dup execute }               # wrapper: stash element, run body
-//	<arr>
-//	for                                      # ( body array -- ), each iter
-//	                                         # pushes element on data stack
-//	pop                                      # drop the saved outer body
+// Emit shape (body is on top of data stack at entry):
+//
+//	null allocate                          # reserve slot N (ctrl push null)
+//	{ <N> local! dup execute }             # wrapper: stash elem, dup body, run
+//	<arr>                                  # iteration array
+//	for                                    # ( body array -- ), per iter:
+//	                                       #   pushes elem, runs wrapper
+//	deallocate pop                         # release slot, drop the null
+//	pop                                    # drop the body that survived `for`
 //
 // `for` is used instead of `forall` because `for` pushes the element on the
 // data stack, which the wrapper needs in order to store it into the alias
@@ -2157,10 +2182,6 @@ func (e *PostfixEmitter) VisitForallAs(ctx *ForallAsContext) interface{} {
 	idx := e.declareLocal(alias, TypeEntity)
 	e.emit("null")
 	e.emit("allocate")
-	e.emit("execute")
-	e.emit("deallocate")
-	e.emit("pop")
-	e.emit("dup")
 	e.emit("{")
 	e.emit(fmt.Sprintf("%d", idx))
 	e.emit("local!")
@@ -2169,11 +2190,13 @@ func (e *PostfixEmitter) VisitForallAs(ctx *ForallAsContext) interface{} {
 	e.emit("}")
 	e.Visit(ctx.ArrayExpr())
 	e.emit("for")
+	e.emit("deallocate")
+	e.emit("pop")
 	e.emit("pop")
 	return nil
 }
 
-// VisitForallAsWhere: `for all <array> as <alias> where <bexpr>` (#712).
+// VisitForallAsWhere: `for all <array> as <alias> where <bexpr>` (#712, #714).
 // Same binding shape as forallAs, but the body only runs when the predicate
 // holds. The predicate is evaluated AFTER the alias slot is populated so
 // `<alias>.<field>` references inside the where-clause resolve correctly.
@@ -2186,10 +2209,6 @@ func (e *PostfixEmitter) VisitForallAsWhere(ctx *ForallAsWhereContext) interface
 	idx := e.declareLocal(alias, TypeEntity)
 	e.emit("null")
 	e.emit("allocate")
-	e.emit("execute")
-	e.emit("deallocate")
-	e.emit("pop")
-	e.emit("dup")
 	e.emit("{")
 	e.emit(fmt.Sprintf("%d", idx))
 	e.emit("local!")
@@ -2202,6 +2221,8 @@ func (e *PostfixEmitter) VisitForallAsWhere(ctx *ForallAsWhereContext) interface
 	e.emit("}")
 	e.Visit(ctx.ArrayExpr())
 	e.emit("for")
+	e.emit("deallocate")
+	e.emit("pop")
 	e.emit("pop")
 	return nil
 }

--- a/pkg/dtrules/loader/dt.go
+++ b/pkg/dtrules/loader/dt.go
@@ -333,6 +333,13 @@ func (l *DTLoader) processTable(table *DTTable) error {
 	// Create the decision table using the builder
 	builder := decisiontable.NewBuilder(name.StringValue(), l.session)
 
+	// Each table has its own local-variable namespace. Clear any locals left
+	// over from the previous table so slot indices start at 0 — within this
+	// table, the context, conditions, and actions share the same emitter
+	// state so `<alias>.<field>` declared in the context resolves in the
+	// condition/action passes.
+	l.elCompiler.ResetLocals()
+
 	// Set table type
 	builder.SetTypeFromString(table.AttributeFields.GetType())
 

--- a/pkg/dtrules/operators/stack.go
+++ b/pkg/dtrules/operators/stack.go
@@ -477,7 +477,10 @@ func opEntityFetch(state dtrules.State) error {
 	return state.DataPush(entity.(dtrules.Object))
 }
 
-// opGet: ( entity attribute -- value ) gets attribute from entity
+// opGet: ( entity attribute -- value ) gets attribute from entity.
+// Literal names like `/balance` parse as non-executable RNames, but entity
+// attributes are keyed by the executable partner, so we normalize via
+// `GetRName(name.GetName())` to match — same convention as Find.
 func opGet(state dtrules.State) error {
 	nameObj, err := state.DataPop()
 	if err != nil {
@@ -495,7 +498,11 @@ func opGet(state dtrules.State) error {
 	if err != nil {
 		return err
 	}
-	value, err := entity.Get(name)
+	attrName := dtrules.GetRName(name.GetName())
+	if attrName == nil {
+		return dtrules.UndefinedError("Get", "invalid attribute name: "+name.GetName())
+	}
+	value, err := entity.Get(attrName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #714. v1.8.1 regression — as-alias compiled but didn't execute. Runtime tests added to prevent recurrence.

## Summary

- Fix emit: reserve the slot across the iteration (`null allocate { N local! dup execute } arr for deallocate pop pop`) instead of consuming the body once with a stray `execute` before the loop.
- Fix `opGet`: normalize the literal-name operand via `GetRName(name.GetName())` so `/balance` (non-executable) matches the entity's executable attribute key (same convention `Find` uses).
- Fix loader: reset the EL compiler's local-slot table between tables so alias indices start at 0 per table instead of growing unboundedly.
- Fix grammar dispatch: `VisitTypedXmlValue` now runs the alias-access check, because the parser prefers `typedXmlValue` over `typedString` for bare IDENTs inside `strexpr` (e.g., `outer_a.label + ";"`).

## Test plan

- [x] Added `pkg/dtrules/authoring/forall_as_runtime_test.go` — 4 execution-based tests (basic alias, where-clause alias, nested non-shadowing, non-alias regression pin) that actually run compiled tables and assert on result fields.
- [x] Updated two pinned-postfix tests in `pkg/dtrules/compiler/el/forall_as_test.go` to the new emit shape; the nested and collision tests are unchanged.
- [x] `make check` passes (full module build + vet + scoped tests).
- [x] Pre-existing `=` vs `==` failures in `TestForallInEntityWhere` / `TestDeleteCondition_RemainingConditionsStay` / tax-return suites are unrelated to this change (confirmed by re-running on main).

## Design constraints (from #712) preserved

- Alias iteration still uses `for` (not `forall`); the iteration entity is NEVER pushed on the entity stack.
- Alias is reached only through its local-entity slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)