### PR TITLE
Detect duplicate decision-table names across XML files

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,6 +23,14 @@ jobs:
         run: go build -o /tmp/dtrules ./cmd/dtrules/
 
       - name: Verify TaxReturn
+        # TaxReturn ships with duplicate <table_name> entries across its per-
+        # table XML files and the legacy aggregate files. #722 added a
+        # compile-time gate that rejects those; the follow-up work to
+        # deduplicate TaxReturn uses the new `dtrules project diagnostics`
+        # surface and lands in a separate PR. The env-var escape hatch keeps
+        # this CI step green until then. Remove once TaxReturn is clean.
+        env:
+          DTRULES_ALLOW_DUPLICATE_TABLES: "1"
         run: /tmp/dtrules verify sampleprojects/TaxReturn
 
       - name: Verify KidAid (if excel/ present)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # DTRules Changelog
 
+## Unreleased
+
+- **Detect duplicate decision-table names across XML files** (#722). Decision
+  table names are keys for `perform`, `executetable`, the JSON CLI, MCP
+  server, and every consumer of `authoring.Project.Table(name)`. When two
+  files declared the same `<table_name>`, the loader previously picked one
+  by load order and silently dropped the rest. The fix is a three-layer
+  gate:
+
+  1. **Edit-time, tolerant.** `authoring.OpenProject` keeps loading
+     successfully but renames each duplicate after the first (by sorted
+     filepath order) to `<name>-1`, `<name>-2`, .... Every rename is
+     recorded as a `Diagnostic` (`Project.Diagnostics()`) and the new name
+     persists when `Project.Save()` runs — so the condition becomes visible
+     in git rather than being swallowed.
+  2. **JSON CLI / MCP surface.** `dtrules project diagnostics --project <path>`
+     emits the diagnostics list (exits 0 regardless of count). MCP gains a
+     matching `project_diagnostics` tool.
+  3. **Compile-time, strict.** `dtrules build`, `dtrules validate`, and
+     `dtrules verify` fail non-zero when any table name matches the
+     reserved `^(.+)-(\d+)$` marker or when two files declare the same
+     real name. The suffix is grammar-invalid as an `IDENT` (per the EL
+     grammar research on #722), so no rule author can accidentally
+     `perform` a dup marker.
+
+  Runtime loader behavior is unchanged — production rulesets that already
+  resolved duplicates before this release continue to load.
+
+  The TaxReturn sampleproject ships with pre-existing duplicates that
+  motivated this work; deduplicating them is tracked as a follow-up.
+  Tests that assert unrelated round-trip behavior over TaxReturn now set
+  `DTRULES_ALLOW_DUPLICATE_TABLES=1` to opt out of the compile-time
+  gate.
+
 ## v1.9.0 — 2026-04-24
 
 - **`for all X as <alias>` now executes at runtime** (#714). v1.8.1 shipped

--- a/cmd/dtrules/build.go
+++ b/cmd/dtrules/build.go
@@ -126,6 +126,14 @@ func (c *CLI) runBuild(args []string) int {
 		return 1
 	}
 
+	if findings, err := checkNoDupMarkers(xmlDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Error scanning for duplicate table names: %v\n", err)
+		return 1
+	} else if len(findings) > 0 {
+		writeDupFindings(os.Stderr, findings)
+		return 1
+	}
+
 	if opts.dryRun {
 		fmt.Printf("[dry-run] Would run %s-authored build in %s\n", path, absPath)
 		return c.runBuildDryRun(xmlDir, excelDir, path, opts)

--- a/cmd/dtrules/build_summary_test.go
+++ b/cmd/dtrules/build_summary_test.go
@@ -293,6 +293,9 @@ func TestBuildFromXML_ImportStepReportsNonZeroCounts(t *testing.T) {
 	if _, err := os.Stat(taxReturnDir); err != nil {
 		t.Skip("TaxReturn sample project not found")
 	}
+	// TaxReturn has unresolved duplicate <table_name> entries (tracked by #722);
+	// this test asserts unrelated import-step bookkeeping.
+	t.Setenv("DTRULES_ALLOW_DUPLICATE_TABLES", "1")
 	srcXMLDir := filepath.Join(taxReturnDir, "xml")
 	if _, err := os.Stat(srcXMLDir); err != nil {
 		t.Skip("TaxReturn xml dir not found")

--- a/cmd/dtrules/cli.go
+++ b/cmd/dtrules/cli.go
@@ -112,6 +112,8 @@ func (c *CLI) Run(args []string) int {
 		return c.runEDD(cmdArgs)
 	case "mcp":
 		return c.runMCP(cmdArgs)
+	case "project":
+		return c.runProject(cmdArgs)
 	case "help", "-h", "--help":
 		c.printUsage()
 		return 0
@@ -135,6 +137,7 @@ Commands:
   validate  Validate decision tables and EDD
   table     JSON-first decision-table read/write (for AI agents)
   edd       JSON-first entity data dictionary read/write (for AI agents)
+  project   Project-level JSON surface (diagnostics, ...)
   mcp       Run a Model Context Protocol server over stdio (for AI agents)
   docs      Show embedded documentation (for AI and developers)
   version   Show version information
@@ -634,6 +637,19 @@ func (c *CLI) runValidate(args []string) int {
 	fmt.Println()
 
 	exitCode := 0
+
+	// 0. Unique table names (compile-time gate for #722 `-N` markers).
+	if dirExists(c.xmlDir) {
+		findings, err := checkNoDupMarkers(c.xmlDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  ERROR: dup scan error: %v\n", err)
+			exitCode = 1
+		}
+		if len(findings) > 0 {
+			writeDupFindings(os.Stderr, findings)
+			exitCode = 1
+		}
+	}
 
 	// 1. Validate project structure
 	fmt.Println("Checking project structure...")

--- a/cmd/dtrules/dup_check.go
+++ b/cmd/dtrules/dup_check.go
@@ -1,0 +1,180 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// Compile-time gate for unresolved duplicate decision-table names.
+//
+// Two failure conditions:
+//   1. A table name matches the regex `^(.+)-(\d+)$` — the reserved suffix
+//      marker assigned by the authoring SDK when it detected a duplicate on a
+//      previous load. Its presence on disk means a human/agent still has to
+//      pick a final name.
+//   2. Two or more XML files declare the same literal <table_name> — the
+//      authoring SDK hasn't run yet and the rulesets are ambiguous.
+//
+// Both errors must fire from `dtrules build`, `dtrules validate`, and
+// `dtrules verify` before any downstream step runs.
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// dupSuffixRe matches table names auto-assigned when duplicates were
+// detected on a previous authoring-SDK load.
+var dupSuffixRe = regexp.MustCompile(`^(.+)-(\d+)$`)
+
+// dupCheckFinding is one duplicate/suffix violation. Only one of `Suffix`
+// (layer-1 marker survived on disk) or `Files` (two or more files still hold
+// the same real name) is populated for a given finding.
+type dupCheckFinding struct {
+	Name   string
+	Suffix bool
+	Files  []string
+}
+
+// Message renders the finding as the human-readable error the issue spec
+// mandates. A trailing newline is included.
+func (f dupCheckFinding) Message() string {
+	var b strings.Builder
+	if f.Suffix {
+		fmt.Fprintf(&b, "ERROR: decision table %q uses the `-N` suffix reserved\n", f.Name)
+		b.WriteString("for unresolved duplicates.\n")
+		if len(f.Files) > 0 {
+			fmt.Fprintf(&b, "  Defined in: %s\n", f.Files[0])
+		}
+		b.WriteString("\n")
+		b.WriteString("This name was auto-assigned when duplicates were detected on a previous load.\n")
+		b.WriteString("Rename this table (or delete it, or rename the conflicting copy) and remove\n")
+		b.WriteString("the `-N` suffix before building.\n")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "ERROR: decision table %q is declared in %d files:\n", f.Name, len(f.Files))
+	for _, f := range f.Files {
+		fmt.Fprintf(&b, "  - %s\n", f)
+	}
+	b.WriteString("\n")
+	b.WriteString("Open the project with the authoring SDK (dtrules project diagnostics) to\n")
+	b.WriteString("auto-assign a `-N` suffix to each duplicate, then rename or delete one of\n")
+	b.WriteString("them so every <table_name> is unique.\n")
+	return b.String()
+}
+
+// checkNoDupMarkers scans every _dt.xml under xmlDir and returns findings
+// for any table that either carries the `-N` marker or shares its name with
+// another table on disk. Findings are sorted by name for stable output.
+//
+// Setting DTRULES_ALLOW_DUPLICATE_TABLES=1 disables the check entirely. This
+// is an escape hatch for test fixtures that ship with pre-existing duplicates
+// and assert unrelated behavior; production callers should never set it.
+func checkNoDupMarkers(xmlDir string) ([]dupCheckFinding, error) {
+	if xmlDir == "" {
+		return nil, nil
+	}
+	if os.Getenv("DTRULES_ALLOW_DUPLICATE_TABLES") == "1" {
+		return nil, nil
+	}
+	if info, err := os.Stat(xmlDir); err != nil || !info.IsDir() {
+		return nil, nil
+	}
+
+	type entry struct {
+		name string
+		file string
+	}
+	var entries []entry
+
+	walkErr := filepath.WalkDir(xmlDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, "_dt.xml") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil // non-fatal: skip unreadable file
+		}
+		var root struct {
+			Tables []struct {
+				TableName string `xml:"table_name"`
+			} `xml:"decision_table"`
+		}
+		if err := xml.Unmarshal(data, &root); err != nil {
+			return nil // non-XML or malformed — other checks surface it
+		}
+		for _, t := range root.Tables {
+			if t.TableName == "" {
+				continue
+			}
+			entries = append(entries, entry{name: t.TableName, file: path})
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	byName := make(map[string][]string)
+	var order []string
+	for _, e := range entries {
+		if _, ok := byName[e.name]; !ok {
+			order = append(order, e.name)
+		}
+		byName[e.name] = append(byName[e.name], e.file)
+	}
+	sort.Strings(order)
+
+	var findings []dupCheckFinding
+	for _, name := range order {
+		files := byName[name]
+		if dupSuffixRe.MatchString(name) {
+			findings = append(findings, dupCheckFinding{
+				Name:   name,
+				Suffix: true,
+				Files:  files,
+			})
+			continue
+		}
+		if len(files) > 1 {
+			sort.Strings(files)
+			findings = append(findings, dupCheckFinding{
+				Name:  name,
+				Files: files,
+			})
+		}
+	}
+	return findings, nil
+}
+
+// writeDupFindings prints each finding to w, separating blocks with a blank
+// line.
+func writeDupFindings(w *os.File, findings []dupCheckFinding) {
+	for i, f := range findings {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprint(w, f.Message())
+	}
+}

--- a/cmd/dtrules/main.go
+++ b/cmd/dtrules/main.go
@@ -80,6 +80,7 @@ var subcommands = map[string]bool{
 	"table":    true,
 	"edd":      true,
 	"mcp":      true,
+	"project":  true,
 }
 
 func main() {

--- a/cmd/dtrules/mcp_test.go
+++ b/cmd/dtrules/mcp_test.go
@@ -169,7 +169,7 @@ func TestMCPToolsList(t *testing.T) {
 		"table_list": true, "table_get": true, "table_put": true,
 		"table_patch": true, "table_schema": true,
 		"edd_get": true, "edd_put": true, "edd_patch": true, "edd_schema": true,
-		"project_validate": true,
+		"project_validate": true, "project_diagnostics": true,
 	}
 	for _, tool := range tools {
 		tm := tool.(map[string]interface{})
@@ -350,6 +350,56 @@ func TestMCPTableSchema(t *testing.T) {
 	text, _ := content[0].(map[string]interface{})["text"].(string)
 	if !strings.Contains(text, "DTRulesTable") {
 		t.Errorf("expected TableJSON schema in response, got %q", text)
+	}
+}
+
+func TestMCPProjectDiagnostics(t *testing.T) {
+	dir := writeDupXMLProject(t, map[string][]string{
+		"001_a_dt.xml": {"Foo"},
+		"002_b_dt.xml": {"Foo"},
+	})
+	rpc := newMCPRPC(t, dir)
+	defer rpc.close()
+
+	resp := rpc.call("tools/call", map[string]interface{}{
+		"name":      "project_diagnostics",
+		"arguments": map[string]interface{}{},
+	})
+	result := mustResult(t, resp)
+	structured, ok := result["structuredContent"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected structuredContent, got %v", result)
+	}
+	diags, _ := structured["diagnostics"].([]interface{})
+	if len(diags) != 1 {
+		t.Fatalf("want 1 diagnostic, got %d: %+v", len(diags), diags)
+	}
+	d := diags[0].(map[string]interface{})
+	if d["kind"] != "duplicate_table" {
+		t.Errorf("kind = %v, want duplicate_table", d["kind"])
+	}
+	if d["original_name"] != "Foo" || d["assigned_name"] != "Foo-1" {
+		t.Errorf("unexpected diagnostic: %+v", d)
+	}
+}
+
+func TestMCPProjectDiagnosticsClean(t *testing.T) {
+	dir := copyProject(t, "../../sampleprojects/CHIP")
+	rpc := newMCPRPC(t, dir)
+	defer rpc.close()
+
+	resp := rpc.call("tools/call", map[string]interface{}{
+		"name":      "project_diagnostics",
+		"arguments": map[string]interface{}{},
+	})
+	result := mustResult(t, resp)
+	structured, ok := result["structuredContent"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected structuredContent, got %v", result)
+	}
+	diags, _ := structured["diagnostics"].([]interface{})
+	if len(diags) != 0 {
+		t.Errorf("CHIP project should have no duplicates, got %+v", diags)
 	}
 }
 

--- a/cmd/dtrules/mcp_tools.go
+++ b/cmd/dtrules/mcp_tools.go
@@ -95,6 +95,11 @@ func buildToolDefs() []mcpToolDef {
 			Description: "Run structural and EL-compliance validation on the project. Returns a structured report.",
 			InputSchema: schemaProjectOnly(),
 		},
+		{
+			Name:        "project_diagnostics",
+			Description: "Return authoring-time diagnostics (e.g. duplicate_table renames) for the project as JSON.",
+			InputSchema: schemaProjectOnly(),
+		},
 	}
 }
 
@@ -137,6 +142,8 @@ func (s *mcpServer) callTool(name string, args json.RawMessage) (map[string]inte
 		return mcpTextResult(eddSchemaJSON), nil
 	case "project_validate":
 		return s.toolProjectValidate(project)
+	case "project_diagnostics":
+		return s.toolProjectDiagnostics(project)
 	default:
 		return nil, newToolError("invalid_command", "check tools/list", fmt.Sprintf("unknown tool %q", name))
 	}
@@ -216,6 +223,18 @@ func (s *mcpServer) toolProjectValidate(project string) (map[string]interface{},
 		}
 	}
 	return mcpJSONResult(report)
+}
+
+func (s *mcpServer) toolProjectDiagnostics(project string) (map[string]interface{}, error) {
+	p, err := authoring.OpenProject(project)
+	if err != nil {
+		return nil, newToolError("io_error", "project must contain an xml/ directory", err.Error())
+	}
+	diags := p.Diagnostics()
+	if diags == nil {
+		diags = []authoring.Diagnostic{}
+	}
+	return mcpJSONResult(map[string]interface{}{"diagnostics": diags})
 }
 
 // --- write tools ---

--- a/cmd/dtrules/project_cmd.go
+++ b/cmd/dtrules/project_cmd.go
@@ -1,0 +1,84 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// `dtrules project …` — project-level JSON surface.
+//
+// Currently only one op: `diagnostics`. Exits 0 regardless of the diagnostic
+// count so CI pipelines can use it as an observation tool rather than a gate.
+// The compile-time gate lives in build/validate/verify.
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+// runProject dispatches `dtrules project ...`.
+func (c *CLI) runProject(args []string) int {
+	ctx := &tableCmdCtx{stdin: os.Stdin, stdout: os.Stdout, stderr: os.Stderr}
+	if len(args) == 0 {
+		c.printProjectUsage()
+		return 1
+	}
+	sub := args[0]
+	rest := args[1:]
+	ctx.projectPath, rest = parseProjectFlag(rest)
+
+	switch sub {
+	case "diagnostics":
+		return ctx.projectDiagnostics()
+	case "help", "-h", "--help":
+		c.printProjectUsage()
+		return 0
+	default:
+		_ = rest
+		return emitErr(ctx.stderr, 1, "invalid_command", "", "known: diagnostics",
+			fmt.Sprintf("unknown project subcommand %q", sub))
+	}
+}
+
+// projectDiagnostics emits authoring-time diagnostics (duplicate renames,
+// etc.) as JSON. Exits 0 even when diagnostics are present.
+func (ctx *tableCmdCtx) projectDiagnostics() int {
+	p, err := authoring.OpenProject(ctx.projectPath)
+	if err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "project must contain an xml/ directory", err.Error())
+	}
+	diags := p.Diagnostics()
+	if diags == nil {
+		diags = []authoring.Diagnostic{}
+	}
+	out := map[string]interface{}{"diagnostics": diags}
+	if err := writeJSON(ctx.stdout, out); err != nil {
+		return emitErr(ctx.stderr, 1, "io_error", "", "", err.Error())
+	}
+	return 0
+}
+
+func (c *CLI) printProjectUsage() {
+	fmt.Println(`Usage: dtrules project <command> [--project <path>]
+
+Commands:
+  diagnostics              Emit authoring-time diagnostics as JSON.
+                           Exits 0 regardless of diagnostic count — use
+                           dtrules validate/verify/build as the hard gate.
+
+Diagnostic kinds:
+  duplicate_table          A <table_name> collided with another on load;
+                           the second occurrence was renamed in memory to
+                           <original>-1, -2, ... and will persist on Save().`)
+}

--- a/cmd/dtrules/project_diag_test.go
+++ b/cmd/dtrules/project_diag_test.go
@@ -1,0 +1,295 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeDupXMLProject(t *testing.T, layout map[string][]string) string {
+	t.Helper()
+	root := t.TempDir()
+	xmlDir := filepath.Join(root, "xml")
+	if err := os.MkdirAll(xmlDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for name, tables := range layout {
+		var sb strings.Builder
+		sb.WriteString("<decision_tables>\n")
+		for _, n := range tables {
+			fmt.Fprintf(&sb, "  <decision_table><table_name>%s</table_name>"+
+				"<attribute_fields><type>FIRST</type></attribute_fields>"+
+				"</decision_table>\n", n)
+		}
+		sb.WriteString("</decision_tables>\n")
+		if err := os.WriteFile(filepath.Join(xmlDir, name), []byte(sb.String()), 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	return root
+}
+
+func runProjectCmd(t *testing.T, projectPath string, args []string) (stdout, stderr string, exit int) {
+	t.Helper()
+	var so, se bytes.Buffer
+	cmd := &tableCmdCtx{
+		stdin:       strings.NewReader(""),
+		stdout:      &so,
+		stderr:      &se,
+		projectPath: projectPath,
+	}
+	switch args[0] {
+	case "diagnostics":
+		exit = cmd.projectDiagnostics()
+	default:
+		t.Fatalf("unknown project subcommand %q", args[0])
+	}
+	return so.String(), se.String(), exit
+}
+
+func TestProjectDiagnosticsCLI_WithDuplicates(t *testing.T) {
+	root := writeDupXMLProject(t, map[string][]string{
+		"001_a_dt.xml": {"Foo"},
+		"002_b_dt.xml": {"Foo"},
+	})
+
+	out, _, code := runProjectCmd(t, root, []string{"diagnostics"})
+	if code != 0 {
+		t.Fatalf("exit %d, stdout=%s", code, out)
+	}
+
+	var got struct {
+		Diagnostics []struct {
+			Kind         string `json:"kind"`
+			OriginalName string `json:"original_name"`
+			AssignedName string `json:"assigned_name"`
+			File         string `json:"file"`
+		} `json:"diagnostics"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parse: %v\nstdout=%s", err, out)
+	}
+	if len(got.Diagnostics) != 1 {
+		t.Fatalf("want 1 diagnostic, got %d: %+v", len(got.Diagnostics), got.Diagnostics)
+	}
+	d := got.Diagnostics[0]
+	if d.Kind != "duplicate_table" || d.OriginalName != "Foo" || d.AssignedName != "Foo-1" {
+		t.Errorf("unexpected diagnostic: %+v", d)
+	}
+	if filepath.Base(d.File) != "002_b_dt.xml" {
+		t.Errorf("File base = %q, want 002_b_dt.xml", filepath.Base(d.File))
+	}
+}
+
+func TestProjectDiagnosticsCLI_Clean(t *testing.T) {
+	root := writeDupXMLProject(t, map[string][]string{
+		"a_dt.xml": {"Foo"},
+		"b_dt.xml": {"Bar"},
+	})
+
+	out, _, code := runProjectCmd(t, root, []string{"diagnostics"})
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	var got struct {
+		Diagnostics []interface{} `json:"diagnostics"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(got.Diagnostics) != 0 {
+		t.Errorf("want 0 diagnostics, got %d", len(got.Diagnostics))
+	}
+}
+
+// --- compile-time gate (Layer 3) ---
+
+func TestDupCheck_SuffixRejected(t *testing.T) {
+	root := writeDupXMLProject(t, map[string][]string{
+		"a_dt.xml": {"Foo", "Foo-1"},
+	})
+	findings, err := checkNoDupMarkers(filepath.Join(root, "xml"))
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(findings))
+	}
+	if !findings[0].Suffix || findings[0].Name != "Foo-1" {
+		t.Errorf("unexpected finding: %+v", findings[0])
+	}
+	if !strings.Contains(findings[0].Message(), "`-N` suffix") {
+		t.Errorf("message missing hint:\n%s", findings[0].Message())
+	}
+}
+
+func TestDupCheck_OnDiskDuplicateRejected(t *testing.T) {
+	root := writeDupXMLProject(t, map[string][]string{
+		"a_dt.xml": {"Foo"},
+		"b_dt.xml": {"Foo"},
+	})
+	findings, err := checkNoDupMarkers(filepath.Join(root, "xml"))
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("want 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Suffix {
+		t.Errorf("expected on-disk duplicate, got suffix finding: %+v", f)
+	}
+	if len(f.Files) != 2 {
+		t.Errorf("expected 2 files, got %d", len(f.Files))
+	}
+}
+
+func TestDupCheck_CleanProjectPasses(t *testing.T) {
+	root := writeDupXMLProject(t, map[string][]string{
+		"a_dt.xml": {"Foo"},
+		"b_dt.xml": {"Bar"},
+	})
+	findings, err := checkNoDupMarkers(filepath.Join(root, "xml"))
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("want 0 findings, got %+v", findings)
+	}
+}
+
+func TestValidateCLI_FailsOnSuffix(t *testing.T) {
+	root := writeDupXMLProject(t, map[string][]string{
+		"a_dt.xml": {"Foo-1"},
+	})
+	cli := NewCLI()
+	// Silence "validate" stdout by redirecting — the implementation prints
+	// directly via fmt. We just care about the exit code and the stderr
+	// containing the `-N` reject.
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout, os.Stderr = wOut, wErr
+	t.Cleanup(func() {
+		os.Stdout, os.Stderr = oldStdout, oldStderr
+	})
+
+	code := cli.runValidate([]string{"--project", root})
+
+	wOut.Close()
+	wErr.Close()
+	var outBuf, errBuf bytes.Buffer
+	_, _ = outBuf.ReadFrom(rOut)
+	_, _ = errBuf.ReadFrom(rErr)
+
+	if code == 0 {
+		t.Fatalf("expected non-zero exit, stdout=%s stderr=%s", outBuf.String(), errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "Foo-1") {
+		t.Errorf("stderr missing Foo-1:\n%s", errBuf.String())
+	}
+}
+
+func TestBuildCLI_FailsOnSuffix(t *testing.T) {
+	root := writeDupXMLProject(t, map[string][]string{
+		"a_dt.xml": {"Foo-1"},
+	})
+	cli := NewCLI()
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout, os.Stderr = wOut, wErr
+	t.Cleanup(func() {
+		os.Stdout, os.Stderr = oldStdout, oldStderr
+	})
+
+	code := cli.runBuild([]string{root})
+
+	wOut.Close()
+	wErr.Close()
+	var outBuf, errBuf bytes.Buffer
+	_, _ = outBuf.ReadFrom(rOut)
+	_, _ = errBuf.ReadFrom(rErr)
+
+	if code == 0 {
+		t.Fatalf("expected non-zero exit, stdout=%s stderr=%s", outBuf.String(), errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "Foo-1") {
+		t.Errorf("stderr missing Foo-1:\n%s", errBuf.String())
+	}
+}
+
+func TestVerifyCLI_FailsOnSuffix(t *testing.T) {
+	root := writeDupXMLProject(t, map[string][]string{
+		"a_dt.xml": {"Foo-1"},
+	})
+	cli := NewCLI()
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout, os.Stderr = wOut, wErr
+	t.Cleanup(func() {
+		os.Stdout, os.Stderr = oldStdout, oldStderr
+	})
+
+	code := cli.runVerify([]string{root})
+
+	wOut.Close()
+	wErr.Close()
+	var outBuf, errBuf bytes.Buffer
+	_, _ = outBuf.ReadFrom(rOut)
+	_, _ = errBuf.ReadFrom(rErr)
+
+	if code == 0 {
+		t.Fatalf("expected non-zero exit, stdout=%s stderr=%s", outBuf.String(), errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "Foo-1") {
+		t.Errorf("stderr missing Foo-1:\n%s", errBuf.String())
+	}
+}
+
+func TestValidateCLI_PassesWithoutSuffix(t *testing.T) {
+	root := writeDupXMLProject(t, map[string][]string{
+		"a_dt.xml": {"Foo"},
+	})
+	cli := NewCLI()
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout, os.Stderr = wOut, wErr
+	t.Cleanup(func() {
+		os.Stdout, os.Stderr = oldStdout, oldStderr
+	})
+
+	code := cli.runValidate([]string{"--project", root})
+
+	wOut.Close()
+	wErr.Close()
+	var outBuf, errBuf bytes.Buffer
+	_, _ = outBuf.ReadFrom(rOut)
+	_, _ = errBuf.ReadFrom(rErr)
+
+	// The validate command may still fail for other reasons (missing Excel, no
+	// edd, …) but the dup check itself must not contribute to the failure.
+	if strings.Contains(errBuf.String(), "`-N` suffix") {
+		t.Errorf("unexpected dup-check failure: code=%d stderr=%s", code, errBuf.String())
+	}
+}

--- a/cmd/dtrules/roundtrip_content_test.go
+++ b/cmd/dtrules/roundtrip_content_test.go
@@ -82,11 +82,18 @@ func hashDir(t *testing.T, root string) map[string]string {
 // All xlsx files are touched to be slightly older than xml files (so the sync
 // system sees "no change needed" by default), and callers can selectively
 // bump specific files newer.
+//
+// TaxReturn currently ships with duplicate <table_name> definitions across its
+// XML files (TaxReturn_dt.xml vs NNN_*_dt.xml) — this is the motivating bug
+// for issue #722 and will be resolved in a follow-up. These tests assert
+// unrelated round-trip behavior, so we opt out of the #722 compile-time gate
+// via DTRULES_ALLOW_DUPLICATE_TABLES until TaxReturn is deduplicated.
 func copyAndMakeFresh(t *testing.T) string {
 	t.Helper()
 	if _, err := os.Stat(taxReturnDir); err != nil {
 		t.Skip("TaxReturn sample project not found")
 	}
+	t.Setenv("DTRULES_ALLOW_DUPLICATE_TABLES", "1")
 	tmpDir := t.TempDir()
 	if err := copyDir(taxReturnDir, tmpDir); err != nil {
 		t.Fatalf("copyDir: %v", err)

--- a/cmd/dtrules/verify.go
+++ b/cmd/dtrules/verify.go
@@ -107,6 +107,17 @@ func (c *CLI) runVerify(args []string) int {
 
 	var failures []verifyFailure
 
+	// Check 0: unique table names (compile-time gate for #722 `-N` markers).
+	if dirExists(xmlDir) {
+		dupFindings, err := checkNoDupMarkers(xmlDir)
+		if err != nil {
+			failures = append(failures, verifyFailure{kind: "dup", message: fmt.Sprintf("dup scan error: %v", err)})
+		}
+		for _, f := range dupFindings {
+			failures = append(failures, verifyFailure{kind: "dup", message: strings.TrimRight(f.Message(), "\n")})
+		}
+	}
+
 	// Check 1: build idempotency
 	buildFails := checkBuildIdempotency(absPath, xmlDir, excelDir, opts)
 	failures = append(failures, buildFails...)

--- a/pkg/dtrules/authoring/diagnostics.go
+++ b/pkg/dtrules/authoring/diagnostics.go
@@ -1,0 +1,107 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"fmt"
+	"sort"
+)
+
+// DuplicateTableKind is the Diagnostic.Kind for a duplicate table rename.
+const DuplicateTableKind = "duplicate_table"
+
+// Diagnostic is a structured description of an authoring-time condition the
+// SDK resolved tolerantly. Callers can surface it in a UI / CLI without
+// having to re-derive the reason.
+type Diagnostic struct {
+	Kind         string `json:"kind"`
+	OriginalName string `json:"original_name"`
+	AssignedName string `json:"assigned_name"`
+	File         string `json:"file"`
+	Message      string `json:"message"`
+}
+
+// Diagnostics returns a snapshot of every authoring-time diagnostic recorded
+// since the project was opened. The slice is ordered by assigned name.
+func (p *Project) Diagnostics() []Diagnostic {
+	if p == nil {
+		return nil
+	}
+	out := make([]Diagnostic, len(p.diagnostics))
+	copy(out, p.diagnostics)
+	return out
+}
+
+// resolveDuplicateTableNames scans every loaded decision-table file for
+// duplicate <table_name> values and rewrites the in-memory name of each
+// duplicate (after the first, by sorted filepath order) to "<name>-1",
+// "<name>-2", ... Every rename is recorded as a Diagnostic.
+//
+// The first file to hold the name keeps the real name. Subsequent duplicates
+// are counted per original name, not globally. For example, if three files
+// define "Foo" and two define "Bar", the results are:
+//
+//	Foo, Foo-1, Foo-2, Bar, Bar-1
+func (p *Project) resolveDuplicateTableNames() {
+	type occurrence struct {
+		fileIndex  int
+		tableIndex int
+		path       string
+	}
+
+	// Gather files in sorted order for deterministic assignment.
+	order := make([]int, len(p.dtFiles))
+	for i := range order {
+		order[i] = i
+	}
+	sort.Slice(order, func(i, j int) bool {
+		return p.dtFiles[order[i]].path < p.dtFiles[order[j]].path
+	})
+
+	byName := make(map[string][]occurrence)
+	for _, fi := range order {
+		entry := &p.dtFiles[fi]
+		for ti := range entry.tables.Tables {
+			name := entry.tables.Tables[ti].TableName
+			byName[name] = append(byName[name], occurrence{
+				fileIndex:  fi,
+				tableIndex: ti,
+				path:       entry.path,
+			})
+		}
+	}
+
+	for name, occs := range byName {
+		if len(occs) < 2 {
+			continue
+		}
+		for i := 1; i < len(occs); i++ {
+			assigned := fmt.Sprintf("%s-%d", name, i)
+			occ := occs[i]
+			p.dtFiles[occ.fileIndex].tables.Tables[occ.tableIndex].TableName = assigned
+			p.diagnostics = append(p.diagnostics, Diagnostic{
+				Kind:         DuplicateTableKind,
+				OriginalName: name,
+				AssignedName: assigned,
+				File:         occ.path,
+				Message:      fmt.Sprintf("renamed from duplicate of %q; resolve by renaming or deleting one copy", name),
+			})
+		}
+	}
+
+	sort.Slice(p.diagnostics, func(i, j int) bool {
+		return p.diagnostics[i].AssignedName < p.diagnostics[j].AssignedName
+	})
+}

--- a/pkg/dtrules/authoring/diagnostics_test.go
+++ b/pkg/dtrules/authoring/diagnostics_test.go
@@ -1,0 +1,165 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+// dupTableXML returns a minimal decision-table XML wrapping the given names.
+func dupTableXML(names ...string) string {
+	body := "<decision_tables>\n"
+	for _, n := range names {
+		body += fmt.Sprintf("  <decision_table>\n"+
+			"    <table_name>%s</table_name>\n"+
+			"    <attribute_fields><type>FIRST</type></attribute_fields>\n"+
+			"  </decision_table>\n", n)
+	}
+	body += "</decision_tables>\n"
+	return body
+}
+
+// writeDupProject writes each (filename → table names) mapping into a fresh
+// xml/ under dir and returns the project root.
+func writeDupProject(t *testing.T, layout map[string][]string) string {
+	t.Helper()
+	root := t.TempDir()
+	xmlDir := filepath.Join(root, "xml")
+	if err := os.MkdirAll(xmlDir, 0755); err != nil {
+		t.Fatalf("mkdir xml: %v", err)
+	}
+	for name, tables := range layout {
+		path := filepath.Join(xmlDir, name)
+		if err := os.WriteFile(path, []byte(dupTableXML(tables...)), 0644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	return root
+}
+
+func TestDiagnostics_DuplicateTwoFiles(t *testing.T) {
+	root := writeDupProject(t, map[string][]string{
+		"001_first_dt.xml":  {"Foo"},
+		"002_second_dt.xml": {"Foo"},
+	})
+
+	p, err := authoring.OpenProject(root)
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+
+	if p.Table("Foo") == nil {
+		t.Fatalf("expected Foo to exist (first file keeps the real name)")
+	}
+	if p.Table("Foo-1") == nil {
+		t.Fatalf("expected Foo-1 to exist (second-file duplicate renamed)")
+	}
+
+	diags := p.Diagnostics()
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d: %+v", len(diags), diags)
+	}
+	d := diags[0]
+	if d.Kind != authoring.DuplicateTableKind {
+		t.Errorf("Kind = %q, want %q", d.Kind, authoring.DuplicateTableKind)
+	}
+	if d.OriginalName != "Foo" {
+		t.Errorf("OriginalName = %q, want %q", d.OriginalName, "Foo")
+	}
+	if d.AssignedName != "Foo-1" {
+		t.Errorf("AssignedName = %q, want %q", d.AssignedName, "Foo-1")
+	}
+	if filepath.Base(d.File) != "002_second_dt.xml" {
+		t.Errorf("File = %q, want 002_second_dt.xml", d.File)
+	}
+}
+
+func TestDiagnostics_DuplicateThreeFiles(t *testing.T) {
+	root := writeDupProject(t, map[string][]string{
+		"a_dt.xml": {"Foo"},
+		"b_dt.xml": {"Foo"},
+		"c_dt.xml": {"Foo"},
+	})
+
+	p, err := authoring.OpenProject(root)
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+
+	for _, name := range []string{"Foo", "Foo-1", "Foo-2"} {
+		if p.Table(name) == nil {
+			t.Errorf("expected table %q to exist", name)
+		}
+	}
+
+	diags := p.Diagnostics()
+	if len(diags) != 2 {
+		t.Fatalf("expected 2 diagnostics, got %d", len(diags))
+	}
+	if diags[0].AssignedName != "Foo-1" || diags[1].AssignedName != "Foo-2" {
+		t.Errorf("diagnostics not in assigned-name order: %+v", diags)
+	}
+}
+
+func TestDiagnostics_SaveAndReopenPersists(t *testing.T) {
+	root := writeDupProject(t, map[string][]string{
+		"001_a_dt.xml": {"Foo"},
+		"002_b_dt.xml": {"Foo"},
+	})
+
+	p1, err := authoring.OpenProject(root)
+	if err != nil {
+		t.Fatalf("OpenProject (first): %v", err)
+	}
+	if got := len(p1.Diagnostics()); got != 1 {
+		t.Fatalf("first open: want 1 diagnostic, got %d", got)
+	}
+	if err := p1.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	p2, err := authoring.OpenProject(root)
+	if err != nil {
+		t.Fatalf("OpenProject (second): %v", err)
+	}
+	// After save, the XML now holds "Foo" and "Foo-1" as real names; no diagnostics
+	// should fire on reopen because there are no true duplicates left on disk.
+	if got := len(p2.Diagnostics()); got != 0 {
+		t.Errorf("second open: want 0 diagnostics, got %d: %+v", got, p2.Diagnostics())
+	}
+	if p2.Table("Foo") == nil || p2.Table("Foo-1") == nil {
+		t.Errorf("expected both Foo and Foo-1 after reopen; tables=%v", p2.Tables())
+	}
+}
+
+func TestDiagnostics_NoDuplicatesMeansNoDiagnostics(t *testing.T) {
+	root := writeDupProject(t, map[string][]string{
+		"a_dt.xml": {"Foo"},
+		"b_dt.xml": {"Bar"},
+	})
+
+	p, err := authoring.OpenProject(root)
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+	if got := len(p.Diagnostics()); got != 0 {
+		t.Errorf("want 0 diagnostics, got %d: %+v", got, p.Diagnostics())
+	}
+}

--- a/pkg/dtrules/authoring/project.go
+++ b/pkg/dtrules/authoring/project.go
@@ -27,11 +27,12 @@ import (
 // Project holds all loaded decision tables for a DTRules project. It provides
 // a typed Go API for reading and mutating tables without touching XML directly.
 type Project struct {
-	xmlDir  string
-	dtFiles []dtFileEntry // one entry per loaded _dt.xml file
-	symbols map[string]string
-	edd     *EDD       // lazily loaded
-	execSt  *execState // lazily-created execution state; nil until first use
+	xmlDir      string
+	dtFiles     []dtFileEntry // one entry per loaded _dt.xml file
+	symbols     map[string]string
+	edd         *EDD         // lazily loaded
+	execSt      *execState   // lazily-created execution state; nil until first use
+	diagnostics []Diagnostic // authoring-time diagnostics (duplicate renames, etc.)
 }
 
 // dtFileEntry tracks a single decision-table XML file and its in-memory model.
@@ -61,6 +62,8 @@ func OpenProject(path string) (*Project, error) {
 	if err := p.loadDTFiles(xmlDir); err != nil {
 		return nil, err
 	}
+
+	p.resolveDuplicateTableNames()
 
 	return p, nil
 }


### PR DESCRIPTION
Closes #722. Edit-time tolerant + persistent rename + compile-time gate per the three-layer design.

## Summary

- **Layer 1 — Edit-time (authoring SDK).** `authoring.OpenProject` now scans for duplicate `<table_name>` values across files. The first occurrence (by sorted filepath) keeps the real name; subsequent duplicates are renamed to `<name>-1`, `<name>-2`, … and the rename persists when `Project.Save()` runs. `Project.Diagnostics()` returns `[]Diagnostic` describing every rename.
- **Layer 2 — JSON CLI / MCP surface.** New `dtrules project diagnostics --project <path>` emits the diagnostics as JSON (always exits 0). New MCP tool `project_diagnostics` wraps the same call.
- **Layer 3 — Compile-time (strict).** `dtrules build`, `dtrules validate`, `dtrules verify` all exit non-zero when any table name matches `^(.+)-(\d+)$` (the reserved marker) or when two files still declare the same literal name. Shared helper: `cmd/dtrules/dup_check.go:checkNoDupMarkers`.

Runtime loader is unchanged.

### Design decision (from the #722 issue comment)

`-N`, not `__dup1`. The EL grammar's `IDENT` disallows hyphens (`EL.g4:1150`), so `perform Foo-1` cannot parse — a feature, because it keeps the marker un-referenceable from a rule. `__dup1` would be grammatically valid, which is worse.

### TaxReturn sampleproject

Per issue instructions, this PR does NOT fix TaxReturn's duplicates. They surface when any of the new gates run against it. Two test files that exercise unrelated round-trip behavior over TaxReturn set `DTRULES_ALLOW_DUPLICATE_TABLES=1` via `t.Setenv` to opt out of the compile-time gate:

- `cmd/dtrules/roundtrip_content_test.go` — via the shared `copyAndMakeFresh` helper.
- `cmd/dtrules/build_summary_test.go` — `TestBuildFromXML_ImportStepReportsNonZeroCounts`.

The env var is an explicit escape hatch documented in `dup_check.go`; production callers should never set it. Deduplicating TaxReturn is a follow-up.

## Tests

- **Layer 1:** 4 tests in `pkg/dtrules/authoring/diagnostics_test.go` (two-file, three-file, save-reopen-persists, no-duplicates).
- **Layer 2:** `cmd/dtrules/project_diag_test.go` (2 CLI), `cmd/dtrules/mcp_test.go` (2 MCP incl. tools/list roster update).
- **Layer 3:** `cmd/dtrules/project_diag_test.go` (7 tests — scan helper + validate/build/verify end-to-end).

## Test plan
- [x] `go test ./pkg/dtrules/authoring/ -run "Diagnostic|Duplicate" -count=1 -v` — 4/4 PASS
- [x] `go test ./cmd/dtrules/ -run "Diagnostic|Duplicate|Dup|MCPProjectDiagnostics|TestValidateCLI|TestBuildCLI|TestVerifyCLI" -count=1 -v` — 11/11 PASS
- [x] `make check` — PASS
- [x] End-to-end smoke: `dtrules project diagnostics` and `dtrules validate` on a two-file duplicate fixture show the expected JSON and non-zero exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)