### PR TITLE
chore(taxreturn): EL for easy entries in core 1040 tables (#494 part 1)

### DIFF
--- a/sampleprojects/TaxReturn/xml/TaxReturn_dt.xml
+++ b/sampleprojects/TaxReturn/xml/TaxReturn_dt.xml
@@ -690,7 +690,7 @@ Calculate_SE_Tax
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_comment>Calculate SE tax with proper SS wage base cap and Medicare component; Calculate SE tax: SS component (12.4% up to wage base) + Medicare component (2.9% all income)</action_comment>
+<action_comment>Calculate SE tax with proper SS wage base cap and Medicare component; Calculate SE tax: SS component (12.4% up to wage base) + Medicare component (2.9% all income). EL translation intentionally deferred: postfix uses dup/exch to reuse taxpayer.se_net_profit * se_income_multiplier, and fmin/fmax to cap at the remaining SS wage base; a straightforward EL rewrite would not reproduce this stack-manipulation pattern.</action_comment>
 <action_dsl />
 <action_postfix>
 taxpayer.se_net_profit se_income_multiplier f* dup

--- a/sampleprojects/TaxReturn/xml/TaxReturn_dt.xml
+++ b/sampleprojects/TaxReturn/xml/TaxReturn_dt.xml
@@ -681,7 +681,7 @@ Calculate_SE_Tax
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>SE net profit meets threshold for SE tax; taxpayer.se_net_profit &gt;= se_threshold</condition_comment>
-<condition_dsl />
+<condition_dsl>taxpayer.se_net_profit &gt;= se_threshold</condition_dsl>
 <condition_postfix>taxpayer.se_net_profit se_threshold &gt;=</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />


### PR DESCRIPTION
Part 1 of #494. **Closes #494.**

## Inventory

The 10 core 1040 orchestration tables named in #494 are already at 97% valid EL after the #383 / #722 / #726 cleanup series. The issue's "55 entries" count is stale — only 2 entries actually lack EL today, of which 1 is Easy and 1 is Hard (intentional hand-postfix).

| Table                         | good | easy | medium | hard |
|-------------------------------|------|------|--------|------|
| Compute_Tax_Return            | 22   | 0    | 0      | 0    |
| Calculate_Gross_Income        | 18   | 0    | 0      | 0    |
| Process_W2_Income             | 6    | 0    | 0      | 0    |
| Process_Self_Employment       | 5    | 0    | 0      | 0    |
| Calculate_SE_Tax              | 1    | 1    | 0      | 1    |
| Calculate_Vehicle_Deduction   | 5    | 0    | 0      | 0    |
| Process_Rental_Income         | 8    | 0    | 0      | 0    |
| Process_Other_Income          | 3    | 0    | 0      | 0    |
| Calculate_AGI_Adjustments     | 3    | 0    | 0      | 0    |
| Calculate_Deductions          | 4    | 0    | 0      | 0    |
| **Total**                     | **75** | **1** | **0** | **1** |

## Summary

- **1 Easy fix:** `Calculate_SE_Tax` condition 1 — wrote `taxpayer.se_net_profit >= se_threshold`. Re-compiled postfix verified byte-identical to the stored postfix via `authoring.CheckCondition`.
- **1 Hard (deferred):** `Calculate_SE_Tax` action 1 — kept as hand-postfix. The stored postfix uses `dup`/`exch` to reuse `taxpayer.se_net_profit * se_income_multiplier` and `fmin`/`fmax` to cap at the remaining SS wage base. A natural EL rewrite would not reproduce this stack-manipulation pattern. Added an inline note in the `<action_comment>` explaining the deferral so future readers don't try to "fix" it.
- **75 already-good:** entries verified via inventory script against XML source.

## Verification

- `dtrules project diagnostics --project sampleprojects/TaxReturn` → `{"diagnostics": []}`
- `dtrules verify sampleprojects/TaxReturn` → verified
- `make check` → check passed
- Tax tests (`TestTaxReturn|TestNewTaxScenarios`): identical pass/fail set vs. baseline (11 pre-existing failures; no drift)

## Next targets for follow-up agents

- #495-#500: other "Write EL for X tables" issues covering different table groupings
- #451-#456: related EL-authoring issues

## Test plan

- [x] `dtrules project diagnostics` clean
- [x] `dtrules verify` passes
- [x] `make check` passes
- [x] Tax-test pass/fail set unchanged vs. baseline
- [x] Re-compiled postfix byte-identical to stored postfix

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>