### PR TITLE
chore(taxreturn): EL for tax computation non-bracket entries (part 1 of #496)

### DIFF
--- a/sampleprojects/TaxReturn/xml/TaxReturn_dt.xml
+++ b/sampleprojects/TaxReturn/xml/TaxReturn_dt.xml
@@ -2132,8 +2132,8 @@ Calculate_Capital_Gains_Tax
 </action_details>
 <action_details>
 <action_number>3</action_number>
-<action_comment>Add SE tax from all taxpayers; set result.se_tax = the sum of taxpayer.se_tax for all taxpayers</action_comment>
-<action_dsl />
+<action_comment>Add SE tax from all taxpayers</action_comment>
+<action_dsl>set result.se_tax = sum of se_tax in job.taxpayers; add "  SE Tax (Schedule SE): $" + result.se_tax to job.audit_trail</action_dsl>
 <action_postfix>
 0.0 { se_tax + } job.taxpayers forall /result.se_tax xdef
 "  SE Tax (Schedule SE): $" result.se_tax cvs strconcat job.audit_trail swap addto
@@ -2205,8 +2205,8 @@ result.regular_tax result.capital_gains_tax f+ result.se_tax f+ result.niit_tax 
 <conditions>
 <condition_details>
 <condition_number>1</condition_number>
-<condition_comment>Married Filing Jointly; job.filing_status is equal to "MFJ" or job.filing_status is equal to "QSS"</condition_comment>
-<condition_dsl />
+<condition_comment>Married Filing Jointly or Qualifying Surviving Spouse</condition_comment>
+<condition_dsl>job.filing_status is equal to "MFJ" or job.filing_status is equal to "QSS"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq job.filing_status QSS streq or
 </condition_postfix>
@@ -5095,8 +5095,8 @@ result.taxable_income 0 local@ f- /result.ordinary_income_for_cg xdef
 <conditions>
 <condition_details>
 <condition_number>1</condition_number>
-<condition_comment>Has preferential rate income; result.ltcg_and_qualified_dividends &gt; 0</condition_comment>
-<condition_dsl />
+<condition_comment>Has preferential rate income (LTCG + qualified dividends &gt; 0)</condition_comment>
+<condition_dsl>result.total_long_term_gains + result.total_qualified_dividends &gt; 0</condition_dsl>
 <condition_postfix>
 result.total_long_term_gains result.total_qualified_dividends f+ 0 &gt;
 </condition_postfix>
@@ -5474,8 +5474,8 @@ job.filing_status MFS streq
 </condition_details>
 <condition_details>
 <condition_number>4</condition_number>
-<condition_comment>MAGI exceeds MFJ threshold ($250k); result.magi &gt; niit_threshold_mfj</condition_comment>
-<condition_dsl />
+<condition_comment>MAGI exceeds MFJ threshold ($250k)</condition_comment>
+<condition_dsl>result.magi_for_niit &gt; niit_threshold_mfj</condition_dsl>
 <condition_postfix>
 result.magi_for_niit niit_threshold_mfj &gt;
 </condition_postfix>
@@ -5489,8 +5489,8 @@ result.magi_for_niit niit_threshold_mfj &gt;
 </condition_details>
 <condition_details>
 <condition_number>5</condition_number>
-<condition_comment>MAGI exceeds MFS threshold ($125k); result.magi &gt; niit_threshold_mfs</condition_comment>
-<condition_dsl />
+<condition_comment>MAGI exceeds MFS threshold ($125k)</condition_comment>
+<condition_dsl>result.magi_for_niit &gt; niit_threshold_mfs</condition_dsl>
 <condition_postfix>
 result.magi_for_niit niit_threshold_mfs &gt;
 </condition_postfix>
@@ -5504,8 +5504,8 @@ result.magi_for_niit niit_threshold_mfs &gt;
 </condition_details>
 <condition_details>
 <condition_number>6</condition_number>
-<condition_comment>MAGI exceeds Single threshold ($200k); result.magi &gt; niit_threshold_single</condition_comment>
-<condition_dsl />
+<condition_comment>MAGI exceeds Single threshold ($200k)</condition_comment>
+<condition_dsl>result.magi_for_niit &gt; niit_threshold_single</condition_dsl>
 <condition_postfix>
 result.magi_for_niit niit_threshold_single &gt;
 </condition_postfix>
@@ -5554,8 +5554,8 @@ result.magi_for_niit niit_threshold_single f- result.net_investment_income fmin 
 </action_details>
 <action_details>
 <action_number>4</action_number>
-<action_comment>No NIIT - below threshold; MAGI below threshold - no NIIT</action_comment>
-<action_dsl />
+<action_comment>No NIIT - MAGI below threshold</action_comment>
+<action_dsl>set result.niit_tax = 0; add "  NIIT: $0 - MAGI below threshold" to job.audit_trail</action_dsl>
 <action_postfix>
 0.0 /result.niit_tax xdef
 "  NIIT: $0 - MAGI below threshold" job.audit_trail swap addto


### PR DESCRIPTION
Part 1 of #496. Bracket-math deferred to Part 2.

## Summary

Walked the 5 tax-computation tables in #496 and shipped EL DSL for the 7 non-bracket entries. The 24 bracket-math entries (Apply_Tax_Brackets_{MFJ,Single}, Apply_CG_Brackets_{MFJ,HOH,Single}, Calculate_AMT actions, Calculate_NIIT 3.8%-of-min actions) need a consistent progressive-tax / fmin EL pattern and are queued for Part 2.

## Inventory

| Table                       | conds | actions | non-bracket fixed | bracket-deferred |
|-----------------------------|-------|---------|-------------------|------------------|
| Calculate_Tax_Liability     | 1     | 8       | 1                 | 0                |
| Apply_Tax_Brackets          | 2     | 2       | 1                 | 0                |
| Apply_Tax_Brackets_MFJ      | 7     | 7       | 0                 | 14               |
| Apply_Tax_Brackets_Single   | 7     | 7       | 0                 | 14               |
| Calculate_Capital_Gains_Tax | 3     | 4       | 1                 | 0                |
| Apply_CG_Brackets_MFJ       | 2     | 3       | 0                 | 5                |
| Apply_CG_Brackets_HOH       | 2     | 3       | 0                 | 5                |
| Apply_CG_Brackets_Single    | 2     | 3       | 0                 | 5                |
| Calculate_NIIT              | 6     | 5       | 4                 | 3                |
| Calculate_AMT               | 2     | 3       | 0                 | 3                |

## Changes (7 entries, 14 lines)

- `Calculate_Tax_Liability` action 3 (sum SE tax across taxpayers):
  `set result.se_tax = sum of se_tax in job.taxpayers; add "  SE Tax (Schedule SE): \$" + result.se_tax to job.audit_trail`
- `Apply_Tax_Brackets` condition 1 (MFJ or QSS):
  `job.filing_status is equal to "MFJ" or job.filing_status is equal to "QSS"`
- `Calculate_Capital_Gains_Tax` condition 1 (preferential income > 0):
  `result.total_long_term_gains + result.total_qualified_dividends > 0`
- `Calculate_NIIT` conditions 4-6 (MAGI > niit_threshold_{mfj,mfs,single})
- `Calculate_NIIT` action 4 (no NIIT — set to 0 + audit line)

Stored `*_postfix` is left untouched per the established part-1/part-2 split; the runtime consumes postfix, so DSL-only edits don't change execution.

## Part 2 design notes

The 24 deferred entries break into two patterns that each need a deliberate EL design:

1. **Progressive bracket walk** (Apply_Tax_Brackets_{MFJ,Single}, Apply_CG_Brackets_{MFJ,HOH,Single}): conditions test `lower < taxable_income <= upper` and actions compute `(taxable_income - lower) * rate + flat_tax`. A consistent EL form here would also unblock the per-state bracket tables.
2. **fmin/fmax cap-and-floor math** (Calculate_NIIT actions 1-3 are `0.038 * min(NII, MAGI - threshold)`; Calculate_AMT actions 1-3 are exemption-phaseout + two-bracket + excess-over-regular). These could land alongside the bracket pattern since they share `the minimum of` / `the maximum of` idioms.

## Test plan

- [x] `dtrules project diagnostics --project sampleprojects/TaxReturn` → `{"diagnostics": []}`
- [x] `dtrules verify sampleprojects/TaxReturn` → exit 0
- [x] `go test ./pkg/dtrules/ -run TestTaxReturn -count=1` → same `TestTaxReturnResults` baseline failure as `main` (no scenario drift)
- [x] `make check` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)