### PR TITLE
chore(taxreturn): EL for East North Central state tables

### DIFF
--- a/sampleprojects/TaxReturn/xml/states/IL_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/IL_dt.xml
@@ -57,7 +57,7 @@ num_people 1 &gt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate IL tax with exemptions; Calculate Illinois AGI, apply exemptions, calculate tax at 4.95%</action_comment>
-<action_dsl />
+<action_dsl>Calculate Illinois tax: subtract retirement income, apply personal exemptions, then 4.95% flat rate</action_dsl>
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 result.agi local@ il_retirement_subtraction &gt;
@@ -80,7 +80,7 @@ result.il_taxable_income il_tax_rate f* /result.il_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No exemptions - unlikely case; Calculate IL tax without exemptions</action_comment>
-<action_dsl />
+<action_dsl>Calculate Illinois tax at 4.95% flat rate without personal exemptions</action_dsl>
 <action_postfix>
 "  Illinois AGI: $" result.il_agi cvs strconcat job.audit_trail swap addto
 result.il_agi 0 fmax /result.il_taxable_income xdef

--- a/sampleprojects/TaxReturn/xml/states/IN_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/IN_dt.xml
@@ -27,7 +27,7 @@
 <xls_file>IN.xlsx</xls_file>
 <attribute_fields>
 <Type>FIRST</Type>
-<COMMENTS>Indiana state income tax calculation. Implements flat 3.00% tax structure with personal exemptions per IN tax code (2025).</COMMENTS>
+<COMMENTS>Indiana state income tax calculation. Implements flat 3.00% tax structure with personal exemptions per IN tax code (2025). Skeleton table: needs authorship. Bracket/rate constants and personal exemption logic not yet researched or wired up; the conditions/actions blocks are intentionally empty pending follow-up. See issue #459 and Indiana Department of Revenue references before implementing.</COMMENTS>
 <TABLE_NUMBER>41500</TABLE_NUMBER>
 </attribute_fields>
 <contexts></contexts>

--- a/sampleprojects/TaxReturn/xml/states/MI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MI_dt.xml
@@ -69,7 +69,7 @@ job.state "MI" streq not
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate MI tax with flat 4.25% rate; Calculate Michigan deductions, exemptions, and apply 4.25% flat tax rate</action_comment>
-<action_dsl />
+<action_dsl>Calculate Michigan tax: apply itemized or age-67+ standard deduction, personal exemptions, retirement subtraction, then 4.25% flat rate</action_dsl>
 <action_postfix>
 0.0 /result.mi_deduction xdef
 result.deduction_used "itemized" streq {

--- a/sampleprojects/TaxReturn/xml/states/OH_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/OH_dt.xml
@@ -67,7 +67,7 @@ num_people 1 &gt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate OH tax with exemptions; Calculate Ohio AGI, apply tiered exemptions, calculate progressive tax</action_comment>
-<action_dsl />
+<action_dsl>Calculate Ohio tax: apply AGI-tiered personal exemption per person, then progressive brackets (0%, 2.75%, 3.125%)</action_dsl>
 <action_postfix>
 "  Starting Federal AGI: $" result.oh_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 result.oh_agi oh_exemption_phaseout_threshold f&gt;= if
@@ -115,7 +115,7 @@ result.oh_bracket_1_tax result.oh_bracket_2_tax f+ result.oh_bracket_3_tax f+ /r
 <action_details>
 <action_number>2</action_number>
 <action_comment>No exemptions - unlikely case; Calculate OH tax without exemptions</action_comment>
-<action_dsl />
+<action_dsl>Calculate Ohio tax using progressive brackets (0%, 2.75%, 3.125%) without personal exemptions</action_dsl>
 <action_postfix>
 "  Ohio AGI: $" result.oh_agi cvs strconcat job.audit_trail swap addto
 result.oh_agi 0 fmax /result.oh_taxable_income xdef

--- a/sampleprojects/TaxReturn/xml/states/WI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/WI_dt.xml
@@ -51,7 +51,7 @@ result.agi /result.wi_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Filing status is MFJ</condition_comment>
-<condition_dsl>job.filing_status is equal to "married_joint"</condition_dsl>
+<condition_dsl>Filing status is Married Filing Jointly</condition_dsl>
 <condition_postfix>
 job.filing_status married_joint streq
 </condition_postfix>
@@ -63,7 +63,7 @@ job.filing_status married_joint streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate WI tax for Married Filing Jointly; Calculate Wisconsin tax using MFJ brackets and deductions</action_comment>
-<action_dsl />
+<action_dsl>Calculate Wisconsin tax for MFJ: apply age-67+ retirement exclusion, MFJ standard deduction, then progressive MFJ brackets (3.5%, 4.4%, 5.3%, 6.2%, 7.65%)</action_dsl>
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 0 local@ wi_retirement_subtraction &gt;
@@ -102,7 +102,7 @@ wi_tax /result.wi_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate WI tax for Single or MFS; Calculate Wisconsin tax using Single/MFS brackets and deductions</action_comment>
-<action_dsl />
+<action_dsl>Calculate Wisconsin tax for Single or MFS: apply age-67+ retirement exclusion (halved for MFS), Single/MFS standard deduction, then progressive Single/MFS brackets (3.5%, 4.4%, 5.3%, 6.2%, 7.65%)</action_dsl>
 <action_postfix>
 "  Starting Federal AGI: $" result.agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 0 local@ wi_retirement_subtraction &gt;


### PR DESCRIPTION
## Summary

Authors descriptive EL `_dsl` strings for the broken/empty entries in the East North Central state tax tables, per the inventory on #178. `_postfix` is intentionally left untouched.

Closes #459.

## Per-state breakdown

| State | Entries fixed | Skeleton-noted | Hard-to-translate |
|-------|--------------:|----------------|-------------------|
| IL    | 2 (`IL_Tax` actions 1 & 2)                                | — | — |
| IN    | 0                                                          | `IN_Tax` (added COMMENTS note flagging for human research follow-up; conditions/actions still empty) | — |
| MI    | 1 (`MI_Tax` action 2 — resident, flat 4.25%)              | — | — |
| OH    | 2 (`OH_Tax` actions 1 & 2 — progressive brackets)         | — | — |
| WI    | 3 (`WI_Tax` condition 1 + actions 1 & 2)                  | — | — |
| **Total** | **8** entries | 1 table | 0 |

The WI condition `_dsl` previously read `job.filing_status is equal to "married_joint"` — the corresponding postfix compares against an unresolved symbol `married_joint`, so the `_dsl` was misleading. Replaced with the standard descriptive form `Filing status is Married Filing Jointly`.

## Verification

- `./build/dtrules project diagnostics --project sampleprojects/TaxReturn` → `{"diagnostics": []}`
- `./build/dtrules verify sampleprojects/TaxReturn` → exit 0
- `make check` → passes
- `go test ./pkg/dtrules/ -run TestTaxReturn` → same single `TestTaxReturnResults` failure as `origin/main` baseline (unrelated `Filter_Taxpayer_Vehicle` execution issue)

## Test plan

- [x] Diagnostics clean
- [x] `verify` clean
- [x] `make check` passes
- [x] Tax tests at baseline parity

## Rules followed

- Only touched `states/{IL,IN,MI,OH,WI}_dt.xml`
- No `_postfix` modifications
- No new tables, no new entities
- IN_Tax skeleton left empty (no invented brackets/rates) per teammate guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)