### PR TITLE
chore(taxreturn): EL for South Atlantic state tables

### DIFF
--- a/sampleprojects/TaxReturn/xml/states/DC_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/DC_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Age 62 or older</condition_comment>
-<condition_dsl>Age 62 or older</condition_dsl>
+<condition_dsl>taxpayer.age &gt;= 62</condition_dsl>
 <condition_postfix>
 age &gt;= 62
 </condition_postfix>
@@ -28,7 +28,7 @@ age &gt;= 62
 <action_details>
 <action_number>2</action_number>
 <action_comment>No DC military retirement exemption (age &lt; 62)</action_comment>
-<action_dsl>No DC military retirement exemption (age &lt; 62)</action_dsl>
+<action_dsl>/* No DC military retirement exemption (age &lt; 62). */</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -36,7 +36,7 @@ age &gt;= 62
 <action_details>
 <action_number>3</action_number>
 <action_comment>No military retirement pay</action_comment>
-<action_dsl>No military retirement pay</action_dsl>
+<action_dsl>/* No military retirement pay. */</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -57,7 +57,7 @@ age &gt;= 62
 <contexts />
 <initial_actions>
 <initial_action>
-<action_dsl>Initialize DC tax calculation</action_dsl>
+<action_dsl>add "WASHINGTON DC FORM D-40 - State Income Tax Calculation" to job.audit_trail; set result.dc_agi = result.agi; set result.dc_bracket_1_tax = 0; set result.dc_bracket_2_tax = 0; set result.dc_bracket_3_tax = 0; set result.dc_bracket_4_tax = 0; set result.dc_bracket_5_tax = 0; set result.dc_bracket_6_tax = 0; set result.dc_bracket_7_tax = 0</action_dsl>
 <action_postfix>
 "WASHINGTON DC FORM D-40 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.dc_agi xdef
@@ -68,7 +68,7 @@ result.agi /result.dc_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Single or Married Filing Separately; job.filing_status is "Single" or "MFS"</condition_comment>
-<condition_dsl />
+<condition_dsl>job.filing_status is equal to "Single" or job.filing_status is equal to "MFS"</condition_dsl>
 <condition_postfix>
 job.filing_status Single streq job.filing_status MFS streq or
 </condition_postfix>
@@ -79,7 +79,7 @@ job.filing_status Single streq job.filing_status MFS streq or
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_dsl>job.filing_status is "HOH"</condition_dsl>
+<condition_dsl>job.filing_status is equal to "HOH"</condition_dsl>
 <condition_postfix>
 job.filing_status HOH streq
 </condition_postfix>
@@ -90,7 +90,7 @@ job.filing_status HOH streq
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Married Filing Jointly or Qualifying Widow(er); job.filing_status is "MFJ" or "QW"</condition_comment>
-<condition_dsl />
+<condition_dsl>job.filing_status is equal to "MFJ" or job.filing_status is equal to "QW"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq job.filing_status QW streq or
 </condition_postfix>
@@ -103,7 +103,7 @@ job.filing_status MFJ streq job.filing_status QW streq or
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate DC tax for Single/MFS; Apply DC standard deduction (Single/MFS) and calculate progressive tax</action_comment>
-<action_dsl />
+<action_dsl>add "  Starting Federal AGI: $" + result.dc_agi + " (Form 1040 Line 11)" to job.audit_trail; set result.dc_standard_deduction_amount = dc_standard_deduction_single; add "  Standard Deduction (Single/MFS): -$" + result.dc_standard_deduction_amount + " (Form D-40)" to job.audit_trail; set result.dc_taxable_income = the maximum of (result.dc_agi - result.dc_standard_deduction_amount) and 0.0; add "  DC Taxable Income: $" + result.dc_taxable_income + " (AGI - Standard Deduction)" to job.audit_trail; set result.dc_bracket_1_tax = (the minimum of result.dc_taxable_income and dc_bracket_1_limit) * dc_bracket_1_rate; set result.dc_bracket_2_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_2_limit) - dc_bracket_1_limit) and 0.0) * dc_bracket_2_rate; set result.dc_bracket_3_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_3_limit) - dc_bracket_2_limit) and 0.0) * dc_bracket_3_rate; set result.dc_bracket_4_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_4_limit) - dc_bracket_3_limit) and 0.0) * dc_bracket_4_rate; set result.dc_bracket_5_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_5_limit) - dc_bracket_4_limit) and 0.0) * dc_bracket_5_rate; set result.dc_bracket_6_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_6_limit) - dc_bracket_5_limit) and 0.0) * dc_bracket_6_rate; set result.dc_bracket_7_tax = (the maximum of (result.dc_taxable_income - dc_bracket_6_limit) and 0.0) * dc_bracket_7_rate; set result.dc_tax = result.dc_bracket_1_tax + result.dc_bracket_2_tax + result.dc_bracket_3_tax + result.dc_bracket_4_tax + result.dc_bracket_5_tax + result.dc_bracket_6_tax + result.dc_bracket_7_tax; add "  DC Tax (Progressive 4%-10.75%): $" + result.dc_tax + " (Form D-40)" to job.audit_trail</action_dsl>
 <action_postfix>
 "  Starting Federal AGI: $" result.dc_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 dc_standard_deduction_single /result.dc_standard_deduction_amount xdef
@@ -144,7 +144,7 @@ dc_calculated_tax /result.dc_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate DC tax for HOH; Apply DC standard deduction (HOH) and calculate progressive tax</action_comment>
-<action_dsl />
+<action_dsl>add "  Starting Federal AGI: $" + result.dc_agi + " (Form 1040 Line 11)" to job.audit_trail; set result.dc_standard_deduction_amount = dc_standard_deduction_hoh; add "  Standard Deduction (HOH): -$" + result.dc_standard_deduction_amount + " (Form D-40)" to job.audit_trail; set result.dc_taxable_income = the maximum of (result.dc_agi - result.dc_standard_deduction_amount) and 0.0; add "  DC Taxable Income: $" + result.dc_taxable_income + " (AGI - Standard Deduction)" to job.audit_trail; set result.dc_bracket_1_tax = (the minimum of result.dc_taxable_income and dc_bracket_1_limit) * dc_bracket_1_rate; set result.dc_bracket_2_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_2_limit) - dc_bracket_1_limit) and 0.0) * dc_bracket_2_rate; set result.dc_bracket_3_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_3_limit) - dc_bracket_2_limit) and 0.0) * dc_bracket_3_rate; set result.dc_bracket_4_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_4_limit) - dc_bracket_3_limit) and 0.0) * dc_bracket_4_rate; set result.dc_bracket_5_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_5_limit) - dc_bracket_4_limit) and 0.0) * dc_bracket_5_rate; set result.dc_bracket_6_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_6_limit) - dc_bracket_5_limit) and 0.0) * dc_bracket_6_rate; set result.dc_bracket_7_tax = (the maximum of (result.dc_taxable_income - dc_bracket_6_limit) and 0.0) * dc_bracket_7_rate; set result.dc_tax = result.dc_bracket_1_tax + result.dc_bracket_2_tax + result.dc_bracket_3_tax + result.dc_bracket_4_tax + result.dc_bracket_5_tax + result.dc_bracket_6_tax + result.dc_bracket_7_tax; add "  DC Tax (Progressive 4%-10.75%): $" + result.dc_tax + " (Form D-40)" to job.audit_trail</action_dsl>
 <action_postfix>
 "  Starting Federal AGI: $" result.dc_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 dc_standard_deduction_hoh /result.dc_standard_deduction_amount xdef
@@ -185,7 +185,7 @@ dc_calculated_tax /result.dc_tax xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate DC tax for MFJ/QW; Apply DC standard deduction (MFJ/QW) and calculate progressive tax</action_comment>
-<action_dsl />
+<action_dsl>add "  Starting Federal AGI: $" + result.dc_agi + " (Form 1040 Line 11)" to job.audit_trail; set result.dc_standard_deduction_amount = dc_standard_deduction_joint; add "  Standard Deduction (MFJ/QW): -$" + result.dc_standard_deduction_amount + " (Form D-40)" to job.audit_trail; set result.dc_taxable_income = the maximum of (result.dc_agi - result.dc_standard_deduction_amount) and 0.0; add "  DC Taxable Income: $" + result.dc_taxable_income + " (AGI - Standard Deduction)" to job.audit_trail; set result.dc_bracket_1_tax = (the minimum of result.dc_taxable_income and dc_bracket_1_limit) * dc_bracket_1_rate; set result.dc_bracket_2_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_2_limit) - dc_bracket_1_limit) and 0.0) * dc_bracket_2_rate; set result.dc_bracket_3_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_3_limit) - dc_bracket_2_limit) and 0.0) * dc_bracket_3_rate; set result.dc_bracket_4_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_4_limit) - dc_bracket_3_limit) and 0.0) * dc_bracket_4_rate; set result.dc_bracket_5_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_5_limit) - dc_bracket_4_limit) and 0.0) * dc_bracket_5_rate; set result.dc_bracket_6_tax = (the maximum of ((the minimum of result.dc_taxable_income and dc_bracket_6_limit) - dc_bracket_5_limit) and 0.0) * dc_bracket_6_rate; set result.dc_bracket_7_tax = (the maximum of (result.dc_taxable_income - dc_bracket_6_limit) and 0.0) * dc_bracket_7_rate; set result.dc_tax = result.dc_bracket_1_tax + result.dc_bracket_2_tax + result.dc_bracket_3_tax + result.dc_bracket_4_tax + result.dc_bracket_5_tax + result.dc_bracket_6_tax + result.dc_bracket_7_tax; add "  DC Tax (Progressive 4%-10.75%): $" + result.dc_tax + " (Form D-40)" to job.audit_trail</action_dsl>
 <action_postfix>
 "  Starting Federal AGI: $" result.dc_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 dc_standard_deduction_mfj /result.dc_standard_deduction_amount xdef
@@ -251,7 +251,7 @@ dc_calculated_tax /result.dc_tax xdef
 <contexts />
 <initial_actions>
 <initial_action>
-<action_dsl>Initialize DC homebuyer credit</action_dsl>
+<action_dsl>set result.dc_homebuyer_credit = 0.0</action_dsl>
 <action_postfix>
 0.0 /result.dc_homebuyer_credit xdef
 </action_postfix>
@@ -261,7 +261,7 @@ dc_calculated_tax /result.dc_tax xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Purchased DC home as first-time buyer</condition_comment>
-<condition_dsl>job.purchased_dc_home_first_time equals true</condition_dsl>
+<condition_dsl>job.purchased_dc_home_first_time</condition_dsl>
 <condition_postfix>job.purchased_dc_home_first_time</condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="N" />
@@ -279,7 +279,7 @@ dc_calculated_tax /result.dc_tax xdef
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate DC homebuyer credit; Calculate DC credit (lesser of $5,000 or purchase price)</action_comment>
-<action_dsl />
+<action_dsl>add "Calculating DC First-Time Homebuyer Credit (Form 8859)" to job.audit_trail; set result.dc_homebuyer_credit = the minimum of 5000.0 and job.dc_home_purchase_price; add "  Purchase price: $" + job.dc_home_purchase_price to job.audit_trail; add "  DC Homebuyer Credit: $" + result.dc_homebuyer_credit to job.audit_trail</action_dsl>
 <action_postfix>
 "Calculating DC First-Time Homebuyer Credit (Form 8859)" job.audit_trail swap addto
 5000.0 job.dc_home_purchase_price fmin /result.dc_homebuyer_credit xdef
@@ -291,7 +291,7 @@ dc_calculated_tax /result.dc_tax xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>No DC homebuyer credit; DC homebuyer credit not applicable</action_comment>
-<action_dsl />
+<action_dsl>add "DC Homebuyer Credit not applicable" to job.audit_trail</action_dsl>
 <action_postfix>
 "DC Homebuyer Credit not applicable" job.audit_trail swap addto
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/DE_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/DE_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay</action_comment>
-<action_dsl>No military retirement pay</action_dsl>
+<action_dsl>/* No military retirement pay. */</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -40,7 +40,7 @@
 <contexts />
 <initial_actions>
 <initial_action>
-<action_dsl>Initialize DE tax calculation</action_dsl>
+<action_dsl>add "DELAWARE FORM 200-01 - State Income Tax Calculation" to job.audit_trail; set result.de_agi = result.agi; set result.de_bracket_1_tax = 0; set result.de_bracket_2_tax = 0; set result.de_bracket_3_tax = 0; set result.de_bracket_4_tax = 0; set result.de_bracket_5_tax = 0; set result.de_bracket_6_tax = 0; set result.de_bracket_7_tax = 0</action_dsl>
 <action_postfix>
 "DELAWARE FORM 200-01 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.de_agi xdef
@@ -70,7 +70,7 @@ job.filing_status married_filing_jointly streq
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate DE tax MFJ; Calculate DE tax with MFJ standard deduction and progressive brackets</action_comment>
-<action_dsl />
+<action_dsl>add "  Starting Federal AGI: $" + result.de_agi + " (Form 1040 Line 11)" to job.audit_trail; set result.de_standard_deduction = de_standard_deduction_joint; add "  Standard Deduction (MFJ): $" + result.de_standard_deduction to job.audit_trail; set result.de_taxable_income = the maximum of (result.de_agi - result.de_standard_deduction) and 0.0; add "  DE Taxable Income: $" + result.de_taxable_income + " (AGI - Std Deduction)" to job.audit_trail; set result.de_bracket_1_tax = (the minimum of result.de_taxable_income and de_bracket_1_limit) * de_bracket_1_rate; set result.de_bracket_2_tax = (the maximum of ((the minimum of result.de_taxable_income and de_bracket_2_limit) - de_bracket_1_limit) and 0.0) * de_bracket_2_rate; set result.de_bracket_3_tax = (the maximum of ((the minimum of result.de_taxable_income and de_bracket_3_limit) - de_bracket_2_limit) and 0.0) * de_bracket_3_rate; set result.de_bracket_4_tax = (the maximum of ((the minimum of result.de_taxable_income and de_bracket_4_limit) - de_bracket_3_limit) and 0.0) * de_bracket_4_rate; set result.de_bracket_5_tax = (the maximum of ((the minimum of result.de_taxable_income and de_bracket_5_limit) - de_bracket_4_limit) and 0.0) * de_bracket_5_rate; set result.de_bracket_6_tax = (the maximum of ((the minimum of result.de_taxable_income and de_bracket_6_limit) - de_bracket_5_limit) and 0.0) * de_bracket_6_rate; set result.de_bracket_7_tax = (the maximum of (result.de_taxable_income - de_bracket_6_limit) and 0.0) * de_bracket_7_rate; set result.de_tax = result.de_bracket_1_tax + result.de_bracket_2_tax + result.de_bracket_3_tax + result.de_bracket_4_tax + result.de_bracket_5_tax + result.de_bracket_6_tax + result.de_bracket_7_tax; add "  Total DE Tax: $" + result.de_tax + " (Form 200-01)" to job.audit_trail</action_dsl>
 <action_postfix>
 "  Starting Federal AGI: $" result.de_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 de_standard_deduction_mfj /result.de_standard_deduction xdef
@@ -159,7 +159,7 @@ result.de_bracket_1_tax result.de_bracket_2_tax f+ result.de_bracket_3_tax f+ re
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate DE tax Single/other; Calculate DE tax with Single standard deduction and progressive brackets</action_comment>
-<action_dsl />
+<action_dsl>add "  Starting Federal AGI: $" + result.de_agi + " (Form 1040 Line 11)" to job.audit_trail; set result.de_standard_deduction = de_standard_deduction_single; add "  Standard Deduction (Single): $" + result.de_standard_deduction to job.audit_trail; set result.de_taxable_income = the maximum of (result.de_agi - result.de_standard_deduction) and 0.0; add "  DE Taxable Income: $" + result.de_taxable_income + " (AGI - Std Deduction)" to job.audit_trail; set result.de_bracket_1_tax = (the minimum of result.de_taxable_income and de_bracket_1_limit) * de_bracket_1_rate; set result.de_bracket_2_tax = (the maximum of ((the minimum of result.de_taxable_income and de_bracket_2_limit) - de_bracket_1_limit) and 0.0) * de_bracket_2_rate; set result.de_bracket_3_tax = (the maximum of ((the minimum of result.de_taxable_income and de_bracket_3_limit) - de_bracket_2_limit) and 0.0) * de_bracket_3_rate; set result.de_bracket_4_tax = (the maximum of ((the minimum of result.de_taxable_income and de_bracket_4_limit) - de_bracket_3_limit) and 0.0) * de_bracket_4_rate; set result.de_bracket_5_tax = (the maximum of ((the minimum of result.de_taxable_income and de_bracket_5_limit) - de_bracket_4_limit) and 0.0) * de_bracket_5_rate; set result.de_bracket_6_tax = (the maximum of ((the minimum of result.de_taxable_income and de_bracket_6_limit) - de_bracket_5_limit) and 0.0) * de_bracket_6_rate; set result.de_bracket_7_tax = (the maximum of (result.de_taxable_income - de_bracket_6_limit) and 0.0) * de_bracket_7_rate; set result.de_tax = result.de_bracket_1_tax + result.de_bracket_2_tax + result.de_bracket_3_tax + result.de_bracket_4_tax + result.de_bracket_5_tax + result.de_bracket_6_tax + result.de_bracket_7_tax; add "  Total DE Tax: $" + result.de_tax + " (Form 200-01)" to job.audit_trail</action_dsl>
 <action_postfix>
 "  Starting Federal AGI: $" result.de_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 de_standard_deduction_single /result.de_standard_deduction xdef

--- a/sampleprojects/TaxReturn/xml/states/GA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/GA_dt.xml
@@ -57,7 +57,7 @@ Age 65 or older
 <contexts />
 <initial_actions>
 <initial_action>
-<action_dsl>Initialize GA tax calculation</action_dsl>
+<action_dsl>add "GEORGIA FORM 500 - State Income Tax Calculation" to job.audit_trail; set result.ga_agi = result.agi</action_dsl>
 <action_postfix>
 "GEORGIA FORM 500 - State Income Tax Calculation" job.audit_trail swap addto
 result.agi /result.ga_agi xdef
@@ -68,7 +68,7 @@ result.agi /result.ga_agi xdef
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Married Filing Jointly</condition_comment>
-<condition_dsl>Filing status is MFJ</condition_dsl>
+<condition_dsl>job.filing_status is equal to "MFJ"</condition_dsl>
 <condition_postfix>
 job.filing_status MFJ streq
 </condition_postfix>
@@ -79,8 +79,8 @@ job.filing_status MFJ streq
 <actions>
 <action_details>
 <action_number>1</action_number>
-<action_comment>Calculate GA tax for MFJ; Apply MFJ standard deduction ($24,000) and calculate tax at 5.19%</action_comment>
-<action_dsl />
+<action_comment>Calculate GA tax for MFJ; Apply MFJ standard deduction ($24,000) and calculate tax at 5.19%. NOTE: GA_edd lacks ga_standard_deduction_{mfj,single} and ga_tax_rate constants (only military exemption fields are defined); EL uses the postfix-named symbols.</action_comment>
+<action_dsl>add "  Starting Federal AGI: $" + result.ga_agi + " (Form 1040 Line 11)" to job.audit_trail; set result.ga_standard_deduction = ga_standard_deduction_mfj; add "  Standard Deduction (MFJ): $" + result.ga_standard_deduction + " (Form 500 Line 9)" to job.audit_trail; set result.ga_taxable_income = the maximum of (result.ga_agi - result.ga_standard_deduction) and 0.0; add "  Georgia Taxable Income: $" + result.ga_taxable_income + " (AGI - Standard Deduction)" to job.audit_trail; set result.ga_tax = result.ga_taxable_income * ga_tax_rate; add "  Georgia Tax (5.19%): $" + result.ga_tax + " (Form 500 Line 16)" to job.audit_trail</action_dsl>
 <action_postfix>
 "  Starting Federal AGI: $" result.ga_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 ga_standard_deduction_mfj /result.ga_standard_deduction xdef
@@ -94,8 +94,8 @@ result.ga_taxable_income ga_tax_rate f* /result.ga_tax xdef
 </action_details>
 <action_details>
 <action_number>2</action_number>
-<action_comment>Calculate GA tax for Single/HOH; Apply Single/HOH standard deduction ($12,000) and calculate tax at 5.19%</action_comment>
-<action_dsl />
+<action_comment>Calculate GA tax for Single/HOH; Apply Single/HOH standard deduction ($12,000) and calculate tax at 5.19%. NOTE: GA_edd lacks ga_standard_deduction_{mfj,single} and ga_tax_rate constants; EL uses postfix-named symbols.</action_comment>
+<action_dsl>add "  Starting Federal AGI: $" + result.ga_agi + " (Form 1040 Line 11)" to job.audit_trail; set result.ga_standard_deduction = ga_standard_deduction_single; add "  Standard Deduction (Single/HOH): $" + result.ga_standard_deduction + " (Form 500 Line 9)" to job.audit_trail; set result.ga_taxable_income = the maximum of (result.ga_agi - result.ga_standard_deduction) and 0.0; add "  Georgia Taxable Income: $" + result.ga_taxable_income + " (AGI - Standard Deduction)" to job.audit_trail; set result.ga_tax = result.ga_taxable_income * ga_tax_rate; add "  Georgia Tax (5.19%): $" + result.ga_tax + " (Form 500 Line 16)" to job.audit_trail</action_dsl>
 <action_postfix>
 "  Starting Federal AGI: $" result.ga_agi cvs strconcat " (Form 1040 Line 11)" strconcat job.audit_trail swap addto
 ga_standard_deduction_single /result.ga_standard_deduction xdef

--- a/sampleprojects/TaxReturn/xml/states/MD_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MD_dt.xml
@@ -17,7 +17,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Age 55 or older</condition_comment>
-<condition_dsl>Age 55 or older</condition_dsl>
+<condition_dsl>taxpayer.age &gt;= 55</condition_dsl>
 <condition_postfix>
 age &gt;= 55
 </condition_postfix>
@@ -28,7 +28,7 @@ age &gt;= 55
 <action_details>
 <action_number>2</action_number>
 <action_comment>Apply MD $12,500 military retirement exemption (under age 55)</action_comment>
-<action_dsl>Apply MD $12,500 military retirement exemption (under age 55)</action_dsl>
+<action_dsl>/* Apply MD $12,500 military retirement exemption (under age 55). Per-iteration; no-op at table level. */</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -36,7 +36,7 @@ age &gt;= 55
 <action_details>
 <action_number>3</action_number>
 <action_comment>No military retirement pay - no exemption</action_comment>
-<action_dsl>No military retirement pay - no exemption</action_dsl>
+<action_dsl>/* No military retirement pay - no exemption. */</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -52,7 +52,7 @@ age &gt;= 55
 <xls_file>MD.xlsx</xls_file>
 <attribute_fields>
 <Type>FIRST</Type>
-<COMMENTS>Maryland state income tax calculation. Implements progressive 8-bracket tax structure per MD tax code (2025).</COMMENTS>
+<COMMENTS>Maryland state income tax calculation. Implements progressive 8-bracket tax structure per MD tax code (2025). Skeleton table — needs authorship (no conditions or actions defined yet).</COMMENTS>
 <TABLE_NUMBER>42050</TABLE_NUMBER>
 </attribute_fields>
 <contexts></contexts>

--- a/sampleprojects/TaxReturn/xml/states/NC_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NC_dt.xml
@@ -29,7 +29,7 @@ Filing status is Head of Household
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Default case (Married Filing Separately, etc.)</condition_comment>
-<condition_dsl>otherwise</condition_dsl>
+<condition_dsl>job.filing_status is not equal to "MFJ" and job.filing_status is not equal to "Single" and job.filing_status is not equal to "HOH"</condition_dsl>
 <condition_postfix>
 Default case (Married Filing Separately, etc.)
 </condition_postfix>
@@ -51,7 +51,7 @@ Calculate NC AGI (Federal AGI minus subtractions)
 <action_details>
 <action_number>5</action_number>
 <action_comment>Calculate NC taxable income (NC AGI - standard deduction, minimum 0)</action_comment>
-<action_dsl>set result.nc_taxable_income = (result.nc_agi - result.nc_total_deduction) max 0</action_dsl>
+<action_dsl>set result.nc_taxable_income = the maximum of (result.nc_agi - result.nc_total_deduction) and 0</action_dsl>
 <action_postfix>
 Calculate NC taxable income (NC AGI - standard deduction, minimum 0)
 </action_postfix>
@@ -75,7 +75,7 @@ Calculate NC tax: taxable income × 4.25%
 <xls_file>NC.xlsx</xls_file>
 <attribute_fields>
 <Type>FIRST</Type>
-<COMMENTS>North Carolina military retirement pay exclusion. Full exemption for 20+ years of service or medical retirement (Group B). Changed from partial to full exemption in 2021. MSRRA compliant. SCRA compliant. SBP payments fully exempt.</COMMENTS>
+<COMMENTS>North Carolina military retirement pay exclusion. Full exemption for 20+ years of service or medical retirement (Group B). Changed from partial to full exemption in 2021. MSRRA compliant. SCRA compliant. SBP payments fully exempt. Skeleton table — needs authorship (no conditions or actions defined yet).</COMMENTS>
 <TABLE_NUMBER>43050</TABLE_NUMBER>
 </attribute_fields>
 <contexts></contexts>

--- a/sampleprojects/TaxReturn/xml/states/SC_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/SC_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_dsl>No military retirement pay - no exclusion</action_dsl>
+<action_dsl>/* No military retirement pay - no exclusion. */</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -40,8 +40,8 @@
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_comment>Calculate SC taxable income with standard deduction</context_comment>
-<context_dsl>local double sc_std_deduction = SC standard deduction based on filing status</context_dsl>
+<context_comment>Calculate SC taxable income with standard deduction. Hard: EL context grammar lacks inline if/else for branching on filing_status; postfix uses ifelse with allocate/execute/deallocate stack manipulation. Postfix retained as source of truth.</context_comment>
+<context_dsl />
 <context_postfix>
 { sc_standard_deduction_mfj }
 { sc_standard_deduction_single }
@@ -59,7 +59,7 @@ deallocate pop
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>In bracket 1 only (0%); sc_taxable_income at or below sc_bracket_1</condition_comment>
-<condition_dsl />
+<condition_dsl>result.sc_taxable_income &lt;= sc_bracket_1_limit</condition_dsl>
 <condition_postfix>
 result.sc_taxable_income sc_bracket_1 &lt;=
 </condition_postfix>
@@ -71,7 +71,7 @@ result.sc_taxable_income sc_bracket_1 &lt;=
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>In bracket 2 (3%); sc_taxable_income at or below sc_bracket_2</condition_comment>
-<condition_dsl />
+<condition_dsl>result.sc_taxable_income &lt;= sc_bracket_2_limit</condition_dsl>
 <condition_postfix>
 result.sc_taxable_income sc_bracket_2 &lt;=
 </condition_postfix>
@@ -83,7 +83,7 @@ result.sc_taxable_income sc_bracket_2 &lt;=
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>In bracket 3 (6%)</condition_comment>
-<condition_dsl>sc_taxable_income above sc_bracket_2</condition_dsl>
+<condition_dsl>result.sc_taxable_income &gt; sc_bracket_2_limit</condition_dsl>
 <condition_postfix>
 result.sc_taxable_income sc_bracket_2 &gt;
 </condition_postfix>
@@ -95,7 +95,7 @@ result.sc_taxable_income sc_bracket_2 &gt;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Zero or negative taxable income; sc_taxable_income at or below 0</condition_comment>
-<condition_dsl />
+<condition_dsl>result.sc_taxable_income &lt;= 0</condition_dsl>
 <condition_postfix>
 result.sc_taxable_income 0 &lt;=
 </condition_postfix>
@@ -109,7 +109,7 @@ result.sc_taxable_income 0 &lt;=
 <action_details>
 <action_number>1</action_number>
 <action_comment>Bracket 1 tax (0%); set result.sc_state_tax = 0 (below $3,560)</action_comment>
-<action_dsl />
+<action_dsl>set result.sc_state_tax = 0</action_dsl>
 <action_postfix>
 0 /result.sc_state_tax xdef
 </action_postfix>
@@ -118,7 +118,7 @@ result.sc_taxable_income 0 &lt;=
 <action_details>
 <action_number>2</action_number>
 <action_comment>Bracket 2 tax (3%); set result.sc_state_tax = (income - $3,560) * 3%</action_comment>
-<action_dsl />
+<action_dsl>set result.sc_state_tax = (result.sc_taxable_income - sc_bracket_1_limit) * sc_bracket_2_rate</action_dsl>
 <action_postfix>
 result.sc_taxable_income sc_bracket_1 f- sc_rate_2 f* /result.sc_state_tax xdef
 </action_postfix>
@@ -127,7 +127,7 @@ result.sc_taxable_income sc_bracket_1 f- sc_rate_2 f* /result.sc_state_tax xdef
 <action_details>
 <action_number>3</action_number>
 <action_comment>Bracket 3 tax (6%); set result.sc_state_tax = $428.10 + (income - $17,830) * 6%</action_comment>
-<action_dsl />
+<action_dsl>set result.sc_state_tax = (sc_bracket_2_limit - sc_bracket_1_limit) * sc_bracket_2_rate + (result.sc_taxable_income - sc_bracket_2_limit) * sc_bracket_3_rate</action_dsl>
 <action_postfix>
 sc_bracket_2 sc_bracket_1 f- sc_rate_2 f*
 result.sc_taxable_income sc_bracket_2 f- sc_rate_3 f* f+

--- a/sampleprojects/TaxReturn/xml/states/VA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/VA_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exemption</action_comment>
-<action_dsl>No military retirement pay - no exemption</action_dsl>
+<action_dsl>/* No military retirement pay - no exemption. */</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -45,7 +45,7 @@
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Single</condition_comment>
-<condition_dsl>Single</condition_dsl>
+<condition_dsl>job.filing_status is equal to "Single"</condition_dsl>
 <condition_postfix>
 filing_status == &quot;Single&quot;
 </condition_postfix>
@@ -53,7 +53,7 @@ filing_status == &quot;Single&quot;
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Head of Household</condition_comment>
-<condition_dsl>Head of Household</condition_dsl>
+<condition_dsl>job.filing_status is equal to "HOH"</condition_dsl>
 <condition_postfix>
 filing_status == &quot;HOH&quot;
 </condition_postfix>
@@ -61,7 +61,7 @@ filing_status == &quot;HOH&quot;
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Married Filing Separately</condition_comment>
-<condition_dsl>Married Filing Separately</condition_dsl>
+<condition_dsl>job.filing_status is equal to "MFS"</condition_dsl>
 <condition_postfix>
 filing_status == &quot;MFS&quot;
 </condition_postfix>
@@ -71,7 +71,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>2</action_number>
 <action_comment>Calculate Virginia progressive tax - Single</action_comment>
-<action_dsl>Calculate Virginia progressive tax - Single</action_dsl>
+<action_dsl>add "VIRGINIA FORM 760 - State Income Tax Calculation (Single)" to job.audit_trail; set result.va_agi = result.agi; set result.va_standard_deduction = va_standard_deduction_single; set result.va_taxable_income = the maximum of (result.va_agi - result.va_standard_deduction) and 0.0; set result.va_bracket_1_tax = (the minimum of result.va_taxable_income and va_bracket_1_limit) * va_bracket_1_rate; set result.va_bracket_2_tax = (the maximum of ((the minimum of result.va_taxable_income and va_bracket_2_limit) - va_bracket_1_limit) and 0.0) * va_bracket_2_rate; set result.va_bracket_3_tax = (the maximum of ((the minimum of result.va_taxable_income and va_bracket_3_limit) - va_bracket_2_limit) and 0.0) * va_bracket_3_rate; set result.va_bracket_4_tax = (the maximum of (result.va_taxable_income - va_bracket_3_limit) and 0.0) * va_bracket_4_rate; set result.va_tax = result.va_bracket_1_tax + result.va_bracket_2_tax + result.va_bracket_3_tax + result.va_bracket_4_tax; add "  VA Tax (Progressive 2%-5.75%): $" + result.va_tax to job.audit_trail</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -79,7 +79,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>3</action_number>
 <action_comment>Calculate Virginia progressive tax - HOH</action_comment>
-<action_dsl>Calculate Virginia progressive tax - HOH</action_dsl>
+<action_dsl>add "VIRGINIA FORM 760 - State Income Tax Calculation (HOH)" to job.audit_trail; set result.va_agi = result.agi; set result.va_standard_deduction = va_standard_deduction_hoh; set result.va_taxable_income = the maximum of (result.va_agi - result.va_standard_deduction) and 0.0; set result.va_bracket_1_tax = (the minimum of result.va_taxable_income and va_bracket_1_limit) * va_bracket_1_rate; set result.va_bracket_2_tax = (the maximum of ((the minimum of result.va_taxable_income and va_bracket_2_limit) - va_bracket_1_limit) and 0.0) * va_bracket_2_rate; set result.va_bracket_3_tax = (the maximum of ((the minimum of result.va_taxable_income and va_bracket_3_limit) - va_bracket_2_limit) and 0.0) * va_bracket_3_rate; set result.va_bracket_4_tax = (the maximum of (result.va_taxable_income - va_bracket_3_limit) and 0.0) * va_bracket_4_rate; set result.va_tax = result.va_bracket_1_tax + result.va_bracket_2_tax + result.va_bracket_3_tax + result.va_bracket_4_tax; add "  VA Tax (Progressive 2%-5.75%): $" + result.va_tax to job.audit_trail</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -87,7 +87,7 @@ filing_status == &quot;MFS&quot;
 <action_details>
 <action_number>4</action_number>
 <action_comment>Calculate Virginia progressive tax - MFS</action_comment>
-<action_dsl>Calculate Virginia progressive tax - MFS</action_dsl>
+<action_dsl>add "VIRGINIA FORM 760 - State Income Tax Calculation (MFS)" to job.audit_trail; set result.va_agi = result.agi; set result.va_standard_deduction = va_standard_deduction_mfs; set result.va_taxable_income = the maximum of (result.va_agi - result.va_standard_deduction) and 0.0; set result.va_bracket_1_tax = (the minimum of result.va_taxable_income and va_bracket_1_limit) * va_bracket_1_rate; set result.va_bracket_2_tax = (the maximum of ((the minimum of result.va_taxable_income and va_bracket_2_limit) - va_bracket_1_limit) and 0.0) * va_bracket_2_rate; set result.va_bracket_3_tax = (the maximum of ((the minimum of result.va_taxable_income and va_bracket_3_limit) - va_bracket_2_limit) and 0.0) * va_bracket_3_rate; set result.va_bracket_4_tax = (the maximum of (result.va_taxable_income - va_bracket_3_limit) and 0.0) * va_bracket_4_rate; set result.va_tax = result.va_bracket_1_tax + result.va_bracket_2_tax + result.va_bracket_3_tax + result.va_bracket_4_tax; add "  VA Tax (Progressive 2%-5.75%): $" + result.va_tax to job.audit_trail</action_dsl>
 <action_postfix>
 
 </action_postfix>

--- a/sampleprojects/TaxReturn/xml/states/WV_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/WV_dt.xml
@@ -19,7 +19,7 @@
 <action_details>
 <action_number>2</action_number>
 <action_comment>No military retirement pay - no exclusion</action_comment>
-<action_dsl>No military retirement pay - no exclusion</action_dsl>
+<action_dsl>/* No military retirement pay - no exclusion. */</action_dsl>
 <action_postfix>
 
 </action_postfix>
@@ -35,7 +35,7 @@
 <xls_file>WV.xlsx</xls_file>
 <attribute_fields>
 <Type>FIRST</Type>
-<COMMENTS>West Virginia state income tax calculation. Implements progressive tax structure with 5 brackets per WV Tax Division (2025).</COMMENTS>
+<COMMENTS>West Virginia state income tax calculation. Implements progressive tax structure with 5 brackets per WV Tax Division (2025). Skeleton table — needs authorship (no conditions or actions defined yet).</COMMENTS>
 <TABLE_NUMBER>44850</TABLE_NUMBER>
 </attribute_fields>
 <contexts></contexts>


### PR DESCRIPTION
## Summary

Authors real (compilable) EL DSL for the broken/empty entries in the South Atlantic state tax tables (DC, DE, GA, MD, NC, SC, VA, WV). All authored EL strings parse via `authoring.CheckCondition` / `authoring.CheckAction`.

Closes #457.

## Per-state breakdown

| State | Real EL entries | Hard | Skeleton-noted |
|-------|----------------:|-----:|----------------|
| DC    | 12 (init + 3 cond + 3 act 7-tier; military-retirement exemption + homebuyer credit no-ops) | — | — |
| DE    | 4 (init + act1+act2 7-tier MFJ/Single; mil-retirement no-op) | — | — |
| GA    | 4 (init + cond1 + act1+act2 flat-rate; EDD-gap noted in action_comment) | — | — |
| MD    | 3 (cond, mil-retirement act2+act3 no-ops) | — | `MD_Tax` (no conditions/actions) |
| NC    | 2 (cond3 fixed, act5 `max` syntax fixed) | — | `NC_Military_Retirement_Exclusion` |
| SC    | 8 (cond1-cond4 + act1-act3 + mil-retirement no-op) | 1 (`SC_Tax_Brackets` context_dsl: ifelse stack manipulation) | — |
| VA    | 7 (cond2-cond4 + act2+act3+act4 4-tier per filing status; mil-retirement no-op) | — | — |
| WV    | 1 (mil-retirement no-op) | — | `WV_Tax` (no conditions/actions) |
| **Total** | **41** entries authored | **1** Hard-noted | 3 skeletons noted |

## Idiom

Progressive brackets via slice-per-bracket (per PR #740): each bracket independently computes its slice as
```
set result.xx_bracket_N_tax = (the maximum of ((the minimum of TI and limit_N) - limit_{N-1}) and 0.0) * rate_N
```
with first/last brackets simplified, then summed into `result.xx_tax`.

## EDD gap surfaced

`GA_edd.xml` lacks `ga_standard_deduction_{mfj,single}` and `ga_tax_rate` constants (only military exemption fields are defined). GA EL uses the postfix-named symbols and surfaces this in each affected `<action_comment>` for follow-up authoring.

## Hard-noted entry

`SC_Tax_Brackets` `context_dsl` — postfix uses `ifelse` with `allocate`/`execute`/`deallocate` stack manipulation to choose a filing-status-specific standard deduction; EL context grammar lacks inline `if`/`else` for branching. Postfix retained as source of truth; `<context_comment>` carries a NOTE.

## Skeleton tables

`MD_Tax`, `NC_Military_Retirement_Exclusion`, `WV_Tax` are left untouched (no conditions/actions defined upstream); each has a "Skeleton table — needs authorship" note added to its `<COMMENTS>` per the bar.

## Postfix policy

`<*_postfix>` is left untouched. EL strings target behavioral equivalence, not byte-identical postfix.

## Test plan

- [x] All authored EL strings parse via `authoring.CheckAction` / `authoring.CheckCondition`
- [x] `dtrules project diagnostics --project sampleprojects/TaxReturn` -> `{"diagnostics": []}`
- [x] `dtrules verify sampleprojects/TaxReturn` -> exit 0
- [x] `go test ./pkg/dtrules/ -run TestTaxReturn -count=1` -> baseline `TestTaxReturnResults` failure (Filter_Taxpayer_Vehicle, present on origin/main) unchanged
- [x] `make check` -> pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)