### PR TITLE
feat(build): route static analysis through decisiontable.Analyze

### DIFF
--- a/cmd/dtrules/build.go
+++ b/cmd/dtrules/build.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/DTRules/DTRules/pkg/dtrules/analysis"
 	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+	"github.com/DTRules/DTRules/pkg/dtrules/decisiontable"
 	"github.com/DTRules/DTRules/pkg/dtrules/excel"
 	dtrsync "github.com/DTRules/DTRules/pkg/dtrules/sync"
 )
@@ -563,8 +564,23 @@ func (c *CLI) syncMAPFiles(xmlDir, excelDir, direction string, verbose bool) err
 	})
 }
 
-// runStaticAnalysis walks xmlDir, runs per-table and EDD usage checks, and
-// appends warnings to step. Errors are non-fatal and printed to stderr.
+// runStaticAnalysis walks xmlDir, runs the matrix-driven advisory pass on
+// every decision table, runs the EDD usage analyzer, and appends
+// warnings to step. Errors are non-fatal and printed to stderr.
+//
+// Every *_dt.xml file is parsed and each table is run through the same
+// decisiontable.Analyze entry point used by `dtrules table warnings`
+// and `dtrules review`. Covers no-op columns, subsumption, DSL-negation
+// unreachability, FIRST-policy redundant conditions (#762), and
+// assignment-only tables (#763) — everything that is provable from the
+// Y/N matrix and DSL strings without a compiled tree.
+//
+// Tree-based checks (#765 unreachable column, #766 dead condition row)
+// need the compiled decision tree, not just the matrix. They aren't
+// wired here because building a full RuleSet on every `dtrules build`
+// is too expensive on large projects (TaxReturn-scale load + optimize
+// takes minutes). A future `--full` flag, or wiring that piggybacks on
+// a compile the build already pays for, can re-introduce them.
 func runStaticAnalysis(xmlDir string, step *dtrsync.StepSummary) {
 	if err := filepath.WalkDir(xmlDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
@@ -583,10 +599,9 @@ func runStaticAnalysis(xmlDir string, step *dtrsync.StepSummary) {
 		}
 		for i := range dt.Tables {
 			table := &dt.Tables[i]
-			conds, acts, maxCol := buildAnalysisInputs(table)
-			warns := analyzeTableStructure(table.TableName, conds, acts, maxCol)
-			for _, w := range warns {
-				step.AddWarning(w.table, w.column, w.kind, w.reason)
+			in := buildAnalysisInputs(table)
+			for _, w := range decisiontable.Analyze(in) {
+				step.AddWarning(w.Table, w.Column, w.Kind, formatWarningReason(w))
 			}
 		}
 		return nil
@@ -604,55 +619,20 @@ func runStaticAnalysis(xmlDir string, step *dtrsync.StepSummary) {
 	}
 }
 
-type analysisWarn struct {
-	table  string
-	column int
-	kind   string
-	reason string
-}
-
-type analysisCondRow struct {
-	dsl  string
-	cols []string
-}
-
-type analysisActRow struct {
-	dsl  string
-	cols []string
-}
-
-var analysisNegationPairs = [][2]string{
-	{" is equal to ", " is not equal to "},
-	{" is not equal to ", " is equal to "},
-	{" > ", " <= "},
-	{" <= ", " > "},
-	{" < ", " >= "},
-	{" >= ", " < "},
-}
-
-func analysisDSLNegation(a, b string) bool {
-	a = strings.TrimSpace(a)
-	b = strings.TrimSpace(b)
-	for _, pair := range analysisNegationPairs {
-		if strings.Contains(a, pair[0]) && strings.Contains(b, pair[1]) {
-			aBase := strings.Replace(a, pair[0], "\x00", 1)
-			bBase := strings.Replace(b, pair[1], "\x00", 1)
-			if aBase == bBase {
-				return true
-			}
-		}
+// formatWarningReason renders a decisiontable.Warning's reason text for the
+// build summary. Row scope is folded into the reason because StepSummary
+// only has (table, column, item, reason) slots — there's no row slot.
+func formatWarningReason(w decisiontable.Warning) string {
+	if w.ConditionRow >= 0 {
+		return fmt.Sprintf("condition row %d %s", w.ConditionRow+1, w.Reason)
 	}
-	if strings.HasPrefix(b, "not ") && strings.TrimPrefix(b, "not ") == a {
-		return true
-	}
-	if strings.HasPrefix(a, "not ") && strings.TrimPrefix(a, "not ") == b {
-		return true
-	}
-	return false
+	return w.Reason
 }
 
-// buildAnalysisInputs converts a DecisionTableXML into column arrays for analysis.
-func buildAnalysisInputs(table *excel.DecisionTableXML) ([]analysisCondRow, []analysisActRow, int) {
+// buildAnalysisInputs converts a DecisionTableXML into the Inputs the
+// advisory pass consumes. Policy comes from <Type> on the table so the
+// FIRST-policy redundancy check (#762) fires when applicable.
+func buildAnalysisInputs(table *excel.DecisionTableXML) decisiontable.Inputs {
 	maxCol := 0
 	for _, c := range table.Conditions {
 		for _, cv := range c.Columns {
@@ -669,155 +649,38 @@ func buildAnalysisInputs(table *excel.DecisionTableXML) ([]analysisCondRow, []an
 		}
 	}
 
-	conditions := make([]analysisCondRow, len(table.Conditions))
+	conditions := make([]decisiontable.ConditionRow, len(table.Conditions))
 	for i, c := range table.Conditions {
-		row := analysisCondRow{dsl: c.DSL, cols: make([]string, maxCol)}
-		for j := range row.cols {
-			row.cols[j] = "-"
+		row := decisiontable.ConditionRow{DSL: c.DSL, Columns: make([]string, maxCol)}
+		for j := range row.Columns {
+			row.Columns[j] = "-"
 		}
 		for _, cv := range c.Columns {
 			if cv.Number >= 1 && cv.Number <= maxCol {
-				row.cols[cv.Number-1] = cv.Value
+				row.Columns[cv.Number-1] = cv.Value
 			}
 		}
 		conditions[i] = row
 	}
 
-	actions := make([]analysisActRow, len(table.Actions))
+	actions := make([]decisiontable.ActionRow, len(table.Actions))
 	for i, a := range table.Actions {
-		row := analysisActRow{dsl: a.DSL, cols: make([]string, maxCol)}
+		row := decisiontable.ActionRow{DSL: a.DSL, Columns: make([]string, maxCol)}
 		for _, cv := range a.Columns {
 			if cv.Number >= 1 && cv.Number <= maxCol {
-				row.cols[cv.Number-1] = cv.Value
+				row.Columns[cv.Number-1] = cv.Value
 			}
 		}
 		actions[i] = row
 	}
 
-	return conditions, actions, maxCol
-}
-
-// analyzeTableStructure runs Parts 1+2 of static analysis on a single table.
-func analyzeTableStructure(tableName string, conditions []analysisCondRow, actions []analysisActRow, maxCol int) []analysisWarn {
-	if maxCol == 0 {
-		return nil
+	return decisiontable.Inputs{
+		Name:       table.TableName,
+		Policy:     table.AttributeFields.Type,
+		Conditions: conditions,
+		Actions:    actions,
+		MaxCol:     maxCol,
 	}
-
-	var warnings []analysisWarn
-
-	// Part 1a: no-action columns
-	for col := 0; col < maxCol; col++ {
-		hasAction := false
-		for _, a := range actions {
-			if col < len(a.cols) && strings.ToUpper(strings.TrimSpace(a.cols[col])) == "X" {
-				hasAction = true
-				break
-			}
-		}
-		if !hasAction {
-			warnings = append(warnings, analysisWarn{
-				table:  tableName,
-				column: col + 1,
-				kind:   "no-op column",
-				reason: fmt.Sprintf("column %d is redundant (no actions)", col+1),
-			})
-		}
-	}
-
-	// Build per-column constraint and action profiles for subsumption check.
-	type profile struct {
-		constraints map[int]string
-		actionSet   map[int]bool
-	}
-	profiles := make([]profile, maxCol)
-	for col := 0; col < maxCol; col++ {
-		p := profile{
-			constraints: make(map[int]string),
-			actionSet:   make(map[int]bool),
-		}
-		for row, c := range conditions {
-			v := ""
-			if col < len(c.cols) {
-				v = strings.ToUpper(strings.TrimSpace(c.cols[col]))
-			}
-			if v == "Y" || v == "N" {
-				p.constraints[row] = v
-			}
-		}
-		for row, a := range actions {
-			if col < len(a.cols) && strings.ToUpper(strings.TrimSpace(a.cols[col])) == "X" {
-				p.actionSet[row] = true
-			}
-		}
-		profiles[col] = p
-	}
-
-	// Part 1b: subsumed columns
-	for a := 0; a < maxCol; a++ {
-		if len(profiles[a].actionSet) == 0 {
-			continue
-		}
-		for b := 0; b < maxCol; b++ {
-			if a == b {
-				continue
-			}
-			bSubsumesA := true
-			for row, bVal := range profiles[b].constraints {
-				aVal, ok := profiles[a].constraints[row]
-				if !ok || aVal != bVal {
-					bSubsumesA = false
-					break
-				}
-			}
-			if bSubsumesA {
-				for row := range profiles[a].actionSet {
-					if !profiles[b].actionSet[row] {
-						bSubsumesA = false
-						break
-					}
-				}
-			}
-			if bSubsumesA && len(profiles[b].constraints) < len(profiles[a].constraints) {
-				warnings = append(warnings, analysisWarn{
-					table:  tableName,
-					column: a + 1,
-					kind:   "no-op column",
-					reason: fmt.Sprintf("column %d is redundant (subsumed by column %d)", a+1, b+1),
-				})
-				break
-			}
-		}
-	}
-
-	// Part 2: unreachable columns — mutually exclusive Y conditions
-	for col := 0; col < maxCol; col++ {
-		var yRows []int
-		for row, c := range conditions {
-			v := ""
-			if col < len(c.cols) {
-				v = strings.ToUpper(strings.TrimSpace(c.cols[col]))
-			}
-			if v == "Y" {
-				yRows = append(yRows, row)
-			}
-		}
-		found := false
-		for i := 0; i < len(yRows) && !found; i++ {
-			for j := i + 1; j < len(yRows) && !found; j++ {
-				if analysisDSLNegation(conditions[yRows[i]].dsl, conditions[yRows[j]].dsl) {
-					warnings = append(warnings, analysisWarn{
-						table:  tableName,
-						column: col + 1,
-						kind:   "unreachable column",
-						reason: fmt.Sprintf("column %d can never match (conditions %d and %d are mutually exclusive)", col+1, yRows[i]+1, yRows[j]+1),
-					})
-					found = true
-				}
-			}
-		}
-	}
-
-	return warnings
 }
 
 func (c *CLI) printBuildUsage() {

--- a/cmd/dtrules/build_test.go
+++ b/cmd/dtrules/build_test.go
@@ -455,6 +455,86 @@ func TestStaticAnalysis_NoActionColumn(t *testing.T) {
 	}
 }
 
+// staticAnalysisFirstRedundantDT exercises the FIRST-policy redundancy
+// check (#762): two conditions, three columns, FIRST policy. Reaching
+// column 3 implies column 2 failed; column 2's only Y/N is row 1 = N, so
+// row 1 = Y in column 3 must hold — the explicit Y is redundant. Used by
+// TestStaticAnalysis_FirstPolicyRedundancy to confirm `dtrules build`
+// runs the Inputs-keyed Analyze (the legacy AnalyzeTable shim drops
+// Policy and silently disables this check).
+const staticAnalysisFirstRedundantDT = `<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+<decision_table>
+<table_name>FirstRedundantFixture</table_name>
+<xls_file>fixture.xlsx</xls_file>
+<attribute_fields><Type>FIRST</Type><COMMENTS></COMMENTS><TABLE_NUMBER>2</TABLE_NUMBER></attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
+<conditions>
+  <condition_details>
+    <condition_number>1</condition_number>
+    <condition_comment>enabled flag</condition_comment>
+    <condition_dsl>job.status is equal to "active"</condition_dsl>
+    <condition_postfix></condition_postfix>
+    <condition_column column_number="1" column_value="Y"></condition_column>
+    <condition_column column_number="2" column_value="N"></condition_column>
+    <condition_column column_number="3" column_value="Y"></condition_column>
+  </condition_details>
+  <condition_details>
+    <condition_number>2</condition_number>
+    <condition_comment>past threshold</condition_comment>
+    <condition_dsl>job.result > 0</condition_dsl>
+    <condition_postfix></condition_postfix>
+    <condition_column column_number="1" column_value="Y"></condition_column>
+    <condition_column column_number="3" column_value="N"></condition_column>
+  </condition_details>
+</conditions>
+<actions>
+  <action_details>
+    <action_number>1</action_number>
+    <action_comment>set result</action_comment>
+    <action_dsl>set job.result to 1</action_dsl>
+    <action_postfix></action_postfix>
+    <action_column column_number="1" column_value="X"></action_column>
+    <action_column column_number="2" column_value="X"></action_column>
+    <action_column column_number="3" column_value="X"></action_column>
+  </action_details>
+</actions>
+</decision_table>
+</decision_tables>
+`
+
+// TestStaticAnalysis_FirstPolicyRedundancy confirms that runStaticAnalysis
+// surfaces the FIRST-policy redundancy warning (#762). Before #781 the
+// build path ran an inlined analyzer that omitted the policy-gated check;
+// it now routes through decisiontable.Analyze, which honors Policy. A
+// regression here would mean we've slipped back to the inlined path or
+// dropped Policy from buildAnalysisInputs.
+func TestStaticAnalysis_FirstPolicyRedundancy(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "fixture_edd.xml"), []byte(staticAnalysisFixtureEDD), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "fixture_dt.xml"), []byte(staticAnalysisFirstRedundantDT), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	step := &dtrsync.StepSummary{}
+	runStaticAnalysis(dir, step)
+
+	found := false
+	for _, w := range step.Warnings {
+		if w.Item == "redundant condition" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a redundant condition warning (FIRST-policy #762), got %v", step.Warnings)
+	}
+}
+
 // TestStaticAnalysis_UnusedEDDField verifies that an EDD field never
 // referenced in any DT produces an unused warning.
 func TestStaticAnalysis_UnusedEDDField(t *testing.T) {

--- a/cmd/dtrules/review.go
+++ b/cmd/dtrules/review.go
@@ -183,7 +183,11 @@ func runFullReview(projectPath string) (*reviewReport, error) {
 		}
 	}
 
-	// 4. Per-table optimizer pass.
+	// 4. Per-table optimizer pass — matrix-driven (#761/#762/#763) on
+	// every authoring table. The tree-driven checks (#765/#766) need a
+	// compiled RuleSet and currently pay too high a cost on large
+	// projects; reintroducing them awaits an opt-in flag or shared
+	// compiled state that makes paying that cost practical.
 	for _, name := range p.Tables() {
 		t := p.Table(name)
 		if t == nil {

--- a/cmd/dtrules/table_analysis.go
+++ b/cmd/dtrules/table_analysis.go
@@ -30,6 +30,10 @@ import (
 // This is the authoring half of the advisory split (#761): structural
 // checks only, fast, XML-driven. Tree-based checks (#765, #766) and
 // cross-table analysis run from the Full Review (#768).
+//
+// Goes through decisiontable.Analyze with the Inputs struct so the
+// policy-gated checks (#762 FIRST-redundancy) fire; the legacy
+// AnalyzeTable shim drops Policy and would silently disable those.
 func analyzeAuthoringTable(t *authoring.Table) []decisiontable.Warning {
 	if t == nil {
 		return nil
@@ -58,7 +62,13 @@ func analyzeAuthoringTable(t *authoring.Table) []decisiontable.Warning {
 		}
 		acts[i] = decisiontable.ActionRow{DSL: a.DSL, Columns: cols}
 	}
-	return decisiontable.AnalyzeTable(t.Name, conds, acts, maxCol)
+	return decisiontable.Analyze(decisiontable.Inputs{
+		Name:       t.Name,
+		Policy:     t.Policy,
+		Conditions: conds,
+		Actions:    acts,
+		MaxCol:     maxCol,
+	})
 }
 
 // warningsForJSON marshals a warning slice into a stable shape for the


### PR DESCRIPTION
## Summary

`dtrules build`, `dtrules table warnings`, and `dtrules review` all ran a static-analysis pass, but only build had ever surfaced warnings about no-op columns, subsumption, and DSL-negation unreachability. The FIRST-policy redundancy check (#762) and the assignment-only-table check (#763) lived in `decisiontable.Analyze` (the Inputs-keyed entry point), which had **zero production callers** — every surface went through the legacy `AnalyzeTable` shim, which drops `Policy` and silently disables both checks.

User-visible symptom: a FIRST-policy table with obvious "implied by prior column failure" Y entries produced no warnings on build, on `table warnings`, or on review.

## What lands

- **`cmd/dtrules/table_analysis.go`** — `analyzeAuthoringTable` swaps the `AnalyzeTable` shim for `decisiontable.Analyze(Inputs{Policy: t.Policy, …})`. Restores #762 / #763 firing from `dtrules table warnings`, `dtrules table get`, the `project_full_review` MCP tool, and `dtrules review`'s per-table optimizer pass.

- **`cmd/dtrules/build.go`** — removes the inlined `analyzeTableStructure` (≈200 lines of duplicated check logic + DSL-negation table) and routes `runStaticAnalysis` through the same `decisiontable.Analyze` call. Policy is carried from `<Type>`; `ConditionRow` is folded into the `StepSummary` reason text since `StepSummary.AddWarning` has no row slot. One source of truth across build / review / table-warnings.

- **`cmd/dtrules/review.go`** — documents why the tree-based checks (#765, #766) still aren't wired anywhere: the `LoadFromDirectory` + compile + optimize cost is in the minutes on TaxReturn-scale projects (a 10-minute test timeout reproduced this empirically). Those checks remain reachable from `decisiontable.AnalyzeCompiledTable` but need an opt-in path before they can run on every build.

## What now fires on every `dtrules build`

| Warning kind | Issue |
|---|---|
| `no-op column` | — |
| `unreachable column` (DSL negation) | — |
| `redundant condition` | **#762 — new on build** |
| `assignment-only table` | **#763 — new on build** |

## Test plan

- [x] `make check` passes (full module build, `go vet`, scoped test suite, hand-coded-postfix gate).
- [x] New `TestStaticAnalysis_FirstPolicyRedundancy` regression: a 2-condition, 3-column FIRST table where reaching col 3 implies row 1 = Y; the explicit Y must surface as `redundant condition`. A revert to `AnalyzeTable` (or any `Policy` drop) makes it fail.
- [x] Existing `TestStaticAnalysis_NoActionColumn` and `TestStaticAnalysis_UnusedEDDField` still pass.
- [x] Previously-failing-mid-iteration `TestBuildFromXML_ImportStepReportsNonZeroCounts` recovers (was 10m+ timeout when tree-based was wired in; now ~2m).

## Caveat for library consumers

Library consumers that load XML via `session.LoadDecisionTables` (e.g. the staking project's `engine.NewEngine`) do **not** see these warnings just by loading rules — the loader consumes pre-compiled postfix and does no compilation, which is the correct place for *runtime* loading but means the advisory pass intentionally doesn't fire there. To see warnings, run `dtrules build` against the rules dir as part of the authoring/CI flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)