### PR TITLE
feat(loader): strict — no runtime EL compile, error on missing postfix

### DIFF
--- a/pkg/dtrules/excel/workbook_exporter.go
+++ b/pkg/dtrules/excel/workbook_exporter.go
@@ -90,8 +90,12 @@ func (w *WorkbookExporter) ExportDecisionTable(xmlPath, excelPath string) error 
 		}
 	}
 
-	// Load the decision table
-	if err := rs.LoadDecisionTablesFile(xmlPath); err != nil {
+	// Load the decision table in tolerant mode — the XML-authored build's
+	// export step reads partially-compiled XML to write Excel before the
+	// import step runs the compile. Strict loading would refuse this
+	// mid-pipeline state. The compile drop check that follows on the
+	// import side is what fails the build when EL doesn't parse.
+	if err := rs.LoadDecisionTablesTolerantFile(xmlPath); err != nil {
 		return fmt.Errorf("failed to load decision table: %w", err)
 	}
 
@@ -187,10 +191,12 @@ func (w *WorkbookExporter) ExportCombined(dtPath, eddPath, excelPath string) err
 		}
 	}
 
-	// Load DT (if exists)
+	// Load DT (if exists). Tolerant: see the comment on the matching
+	// load above — export reads XML mid-pipeline, before the build's
+	// compile step has filled in postfix.
 	if dtPath != "" {
 		if _, err := os.Stat(dtPath); err == nil {
-			if err := rs.LoadDecisionTablesFile(dtPath); err != nil {
+			if err := rs.LoadDecisionTablesTolerantFile(dtPath); err != nil {
 				return fmt.Errorf("failed to load decision table: %w", err)
 			}
 		}

--- a/pkg/dtrules/loader/dt.go
+++ b/pkg/dtrules/loader/dt.go
@@ -25,49 +25,69 @@ import (
 
 	"github.com/DTRules/DTRules/pkg/dtrules"
 	"github.com/DTRules/DTRules/pkg/dtrules/compiler"
-	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
 	"github.com/DTRules/DTRules/pkg/dtrules/decisiontable"
 	"github.com/DTRules/DTRules/pkg/dtrules/entity"
 )
 
 // DTLoader loads Decision Table files (XML or JSON).
+//
+// The loader is strictly a *consumer* of pre-compiled postfix. EL DSL is
+// authoritative source text and is the authoring contract; postfix is the
+// compiled artifact and is what the loader executes. Compilation lives in
+// `dtrules build` and `dtrules compile` — never in the load path.
+//
+// When a table element has non-empty, non-comment EL DSL but its
+// `<*_postfix>` is empty or comment-only, the loader returns an error
+// directing the operator to run `dtrules build` (or `dtrules compile`)
+// before embedding the XML. This refusal prevents silent stale-build
+// drift and removes the EL compiler dependency from every consumer's
+// runtime binary.
+//
+// Build-time tooling (the export step of `dtrules build --from-xml`,
+// which loads partially-built XML so it can write Excel) sets
+// `Tolerant=true` to disable the postfix-presence check. Runtime
+// consumers should never use tolerant mode — it accepts XML that will
+// crash at execution time.
 type DTLoader struct {
-	session    dtrules.Session
-	factory    *entity.Factory
-	compiler   *compiler.Compiler
-	elCompiler *el.Compiler
-	errors     []error
+	session  dtrules.Session
+	factory  *entity.Factory
+	compiler *compiler.Compiler
+	errors   []error
+
+	// Tolerant disables the "DSL with no compiled postfix" load error.
+	// Used by build-time tooling that consumes XML mid-compile (export
+	// → re-import pipeline). Default false; runtime consumers stay
+	// strict.
+	Tolerant bool
 }
 
-// NewDTLoader creates a new Decision Table loader.
+// NewDTLoader creates a new Decision Table loader in the default strict mode.
 func NewDTLoader(session dtrules.Session, factory *entity.Factory) *DTLoader {
 	return &DTLoader{
-		session:    session,
-		factory:    factory,
-		compiler:   compiler.NewCompiler(session, factory),
-		elCompiler: el.NewCompiler(),
-		errors:     make([]error, 0),
+		session:  session,
+		factory:  factory,
+		compiler: compiler.NewCompiler(session, factory),
+		errors:   make([]error, 0),
 	}
 }
 
-// SetSymbols wires an EDD-derived symbol table (map of field name → type)
-// into the EL compiler so arithmetic type promotion (bigint × int → bigint,
-// etc.) can fire during runtime DSL compilation. Without this, the loader
-// compiles every EL expression as if all operands were integers and loses
-// access to the bigint / double / bytes promotion paths.
-//
-// Call this after `rs.LoadEDD(...)` and before `rs.LoadDecisionTables(...)`
-// so the symbol table is populated when tables are compiled.
-func (l *DTLoader) SetSymbols(symbols map[string]string) {
-	l.elCompiler.SetSymbols(symbols)
-}
+// SetSymbols is retained as a no-op for source compatibility with callers
+// (notably `session.RuleSet.LoadDecisionTables`). The loader no longer
+// compiles EL — DSL must be pre-compiled to postfix by the build pipeline
+// — so a symbol table here would have nothing to do. Symbol resolution
+// belongs to `dtrules build` / `dtrules compile`, which already build
+// the symbol map from the EDD they load alongside the tables.
+func (l *DTLoader) SetSymbols(_ map[string]string) {}
 
-// SetCollectionResolver wires an EDD-backed resolver for the
-// `for all <type> entities` DSL form, turning a bare entity-type name into
-// the `<owner>.<field>` path of the array that owns entities of that type.
-func (l *DTLoader) SetCollectionResolver(fn el.CollectionResolver) {
-	l.elCompiler.SetCollectionResolver(fn)
-}
+// SetCollectionResolver is retained as a no-op for the same reason as
+// SetSymbols. The `for all <type> entities` DSL form is resolved at
+// authoring time by the EL compiler; at load time we only see the
+// already-resolved postfix.
+//
+// The parameter is typed as `any` so the loader no longer needs to
+// import `compiler/el`. Callers that were passing an
+// `el.CollectionResolver` continue to compile unchanged.
+func (l *DTLoader) SetCollectionResolver(_ any) {}
 
 // Structures matching the DTRules decision table format (XML and JSON)
 
@@ -329,7 +349,14 @@ func (l *DTLoader) Load(r io.Reader) error {
 		for i, err := range l.errors {
 			log.Printf("DT Load Error %d: %v", i+1, err)
 		}
-		return fmt.Errorf("decision table loading completed with %d errors", len(l.errors))
+		// Embed the first error's text in the returned aggregate so
+		// callers and tests see the actionable detail (which table,
+		// which row, "run `dtrules build`") instead of just a count.
+		// Multi-error case keeps the count too.
+		if len(l.errors) == 1 {
+			return fmt.Errorf("decision table loading failed: %w", l.errors[0])
+		}
+		return fmt.Errorf("decision table loading failed with %d errors; first: %w", len(l.errors), l.errors[0])
 	}
 	return nil
 }
@@ -354,13 +381,6 @@ func (l *DTLoader) processTable(table *DTTable) error {
 	// Create the decision table using the builder
 	builder := decisiontable.NewBuilder(name.StringValue(), l.session)
 
-	// Each table has its own local-variable namespace. Clear any locals left
-	// over from the previous table so slot indices start at 0 — within this
-	// table, the context, conditions, and actions share the same emitter
-	// state so `<alias>.<field>` declared in the context resolves in the
-	// condition/action passes.
-	l.elCompiler.ResetLocals()
-
 	// Set table type
 	builder.SetTypeFromString(table.AttributeFields.GetType())
 
@@ -374,11 +394,11 @@ func (l *DTLoader) processTable(table *DTTable) error {
 		builder.SetFilePath(table.AttributeFields.FilePath)
 	}
 
-	// Process contexts. Prefer a fresh compile from DSL so compiler bug
-	// fixes (e.g. #626 / #632 / v1.7.0) propagate without requiring a
-	// manual `dtrules build` step. If DSL is present but doesn't compile
-	// as valid EL (prose descriptions, legacy hand-authored postfix-only
-	// tables, comment-only DSL), fall back to the stored postfix.
+	// Process contexts. The loader consumes pre-compiled postfix; EL DSL
+	// is informational source text only. If DSL is present (non-comment)
+	// but stored postfix is empty, that's a stale build — refuse to load
+	// rather than silently no-op. Comment-only DSL is allowed with empty
+	// postfix (the runtime treats it as a no-op context).
 	contexts := make([]string, len(table.Contexts.Contexts))
 	contextsPostfix := make([]string, len(table.Contexts.Contexts))
 	contextsComment := make([]string, len(table.Contexts.Contexts))
@@ -388,29 +408,18 @@ func (l *DTLoader) processTable(table *DTTable) error {
 		stored := strings.TrimSpace(ctx.Postfix)
 		dslTrimmed := strings.TrimSpace(dsl)
 
-		if dslTrimmed != "" && !isCommentLine(dslTrimmed) {
-			compiled, err := l.elCompiler.CompileContext(dsl)
-			switch {
-			case err == nil:
-				if stored != "" && stored != strings.TrimSpace(compiled) {
-					log.Printf("loader: context %d ('%s') — recompiled postfix differs from stored; using fresh compile. Run `dtrules build` to refresh the XML.", i+1, dsl)
-				}
-				contextsPostfix[i] = compiled
-			case stored != "":
-				log.Printf("loader: context %d ('%s') is not valid EL, using existing postfix: %v", i+1, dsl, err)
-				contextsPostfix[i] = stored
-			default:
-				return fmt.Errorf("failed to compile EL context %d ('%s'): %w", i+1, dsl, err)
-			}
-		} else {
-			contextsPostfix[i] = stored
+		if !l.Tolerant && dslTrimmed != "" && !isCommentLine(dslTrimmed) && stored == "" {
+			return fmt.Errorf("context %d ('%s') has DSL but no compiled postfix in table %s — run `dtrules build` or `dtrules compile` before loading",
+				i+1, dsl, name.StringValue())
 		}
+		contextsPostfix[i] = stored
 		contextsComment[i] = ctx.Comment
 	}
 
 	builder.SetContexts(contexts)
 
-	// Process initial actions
+	// Process initial actions. Same strict policy as contexts: non-comment
+	// DSL paired with an empty postfix is a stale build — refuse to load.
 	initialActions := make([]string, len(table.InitialActions.Actions))
 	initialActionsPostfix := make([]string, len(table.InitialActions.Actions))
 	for i, action := range table.InitialActions.Actions {
@@ -418,27 +427,12 @@ func (l *DTLoader) processTable(table *DTTable) error {
 		initialActions[i] = dsl
 		postfix := strings.TrimSpace(action.GetPostfix())
 
-		// Auto-compile EL DSL to postfix if postfix is empty or only comments
 		dslTrimmed := strings.TrimSpace(dsl)
 		commentTrimmed := strings.TrimSpace(action.Comment)
-		if isEmptyOrCommentOnly(postfix) && dslTrimmed != "" && !isCommentLine(dslTrimmed) && dslTrimmed != commentTrimmed {
-			compiled, err := l.elCompiler.CompileAction(dsl)
-			if err != nil {
-				// DSL is not valid EL - preserve existing postfix if present, otherwise use no-op
-				if postfix != "" {
-					// Keep existing postfix (even if comment-only) - it may contain documentation
-					log.Printf("Warning: Initial action %d ('%s') is not valid EL, using existing postfix: %v",
-						i+1, dsl, err)
-				} else {
-					log.Printf("Warning: Initial action %d ('%s') is not valid EL, using no-op: %v",
-						i+1, dsl, err)
-					// postfix is already "" (no-op)
-				}
-			} else {
-				postfix = compiled
-			}
+		if !l.Tolerant && isEmptyOrCommentOnly(postfix) && dslTrimmed != "" && !isCommentLine(dslTrimmed) && dslTrimmed != commentTrimmed {
+			return fmt.Errorf("initial action %d ('%s') has DSL but no compiled postfix in table %s — run `dtrules build` or `dtrules compile` before loading",
+				i+1, dsl, name.StringValue())
 		}
-		// If DSL is a comment, postfix stays as-is (could be empty, which is no-op)
 		initialActionsPostfix[i] = postfix
 	}
 	builder.SetInitialActions(initialActions)
@@ -459,30 +453,18 @@ func (l *DTLoader) processTable(table *DTTable) error {
 		conditions[i] = dsl
 		postfix := strings.TrimSpace(cond.Postfix)
 
-		// Auto-compile EL DSL to postfix if postfix is empty or only comments
 		dslTrimmed := strings.TrimSpace(dsl)
 		commentTrimmed := strings.TrimSpace(cond.Comment)
-		if isEmptyOrCommentOnly(postfix) && dslTrimmed != "" && !isCommentLine(dslTrimmed) && dslTrimmed != commentTrimmed {
-			compiled, err := l.elCompiler.CompileCondition(dsl)
-			if err != nil {
-				// DSL is not valid EL - preserve existing postfix if present, otherwise use fallback
-				if postfix != "" {
-					// Keep existing postfix (even if comment-only) - it may contain documentation
-					log.Printf("Warning: Condition %d ('%s') is not valid EL, using existing postfix: %v",
-						i+1, dsl, err)
-				} else {
-					log.Printf("Warning: Condition %d ('%s') is not valid EL, using 'always true': %v",
-						i+1, dsl, err)
-					postfix = "true always"
-				}
-			} else {
-				postfix = compiled
-			}
-		} else if isEmptyOrCommentOnly(postfix) && isCommentLine(dslTrimmed) {
-			// DSL is a comment - use "true always" as fallback only if no existing postfix
-			if postfix == "" {
-				postfix = "true always"
-			}
+		if !l.Tolerant && isEmptyOrCommentOnly(postfix) && dslTrimmed != "" && !isCommentLine(dslTrimmed) && dslTrimmed != commentTrimmed {
+			return fmt.Errorf("condition %d ('%s') has DSL but no compiled postfix in table %s — run `dtrules build` or `dtrules compile` before loading",
+				i+1, dsl, name.StringValue())
+		}
+		// Comment-only DSL with no stored postfix → "true always" so the
+		// table builder still has a parseable condition expression to
+		// emit. This preserves the editor convenience of leaving
+		// documentation rows without postfix.
+		if isEmptyOrCommentOnly(postfix) && isCommentLine(dslTrimmed) && postfix == "" {
+			postfix = "true always"
 		}
 		conditionsPostfix[i] = postfix
 		conditionsComment[i] = cond.Comment
@@ -516,27 +498,12 @@ func (l *DTLoader) processTable(table *DTTable) error {
 		actions[i] = dsl
 		postfix := strings.TrimSpace(action.Postfix)
 
-		// Auto-compile EL DSL to postfix if postfix is empty or only comments
 		dslTrimmed := strings.TrimSpace(dsl)
 		commentTrimmed := strings.TrimSpace(action.Comment)
-		if isEmptyOrCommentOnly(postfix) && dslTrimmed != "" && !isCommentLine(dslTrimmed) && dslTrimmed != commentTrimmed {
-			compiled, err := l.elCompiler.CompileAction(dsl)
-			if err != nil {
-				// DSL is not valid EL - preserve existing postfix if present, otherwise use no-op
-				if postfix != "" {
-					// Keep existing postfix (even if comment-only) - it may contain documentation
-					log.Printf("Warning: Action %d ('%s') is not valid EL, using existing postfix: %v",
-						i+1, dsl, err)
-				} else {
-					log.Printf("Warning: Action %d ('%s') is not valid EL, using no-op: %v",
-						i+1, dsl, err)
-					// postfix is already "" (no-op)
-				}
-			} else {
-				postfix = compiled
-			}
+		if !l.Tolerant && isEmptyOrCommentOnly(postfix) && dslTrimmed != "" && !isCommentLine(dslTrimmed) && dslTrimmed != commentTrimmed {
+			return fmt.Errorf("action %d ('%s') has DSL but no compiled postfix in table %s — run `dtrules build` or `dtrules compile` before loading",
+				i+1, dsl, name.StringValue())
 		}
-		// If DSL is a comment, postfix stays as-is (could be empty, which is no-op)
 		actionsPostfix[i] = postfix
 		actionsComment[i] = action.Comment
 

--- a/pkg/dtrules/loader/dt_test.go
+++ b/pkg/dtrules/loader/dt_test.go
@@ -260,18 +260,20 @@ func TestDTTableGetTableNumber(t *testing.T) {
 	}
 }
 
-// TestDTLoaderELAutoCompile tests that EL descriptions are automatically compiled
-// to postfix when the postfix element is empty or missing.
-func TestDTLoaderELAutoCompile(t *testing.T) {
+// TestDTLoaderRejectsDSLWithoutPostfix is the strict-loader contract: EL
+// DSL with no compiled postfix is a stale build and must fail to load.
+// Pre-PR-B the loader silently auto-compiled the DSL at load time; now
+// it refuses, directing the operator to `dtrules build`.
+func TestDTLoaderRejectsDSLWithoutPostfix(t *testing.T) {
 	factory := entity.NewFactory(nil)
 	session := &mockSession{factory: factory}
 	loader := NewDTLoader(session, factory)
 
-	// XML with EL descriptions but no postfix - should auto-compile
+	// XML with EL descriptions but no postfix — must fail.
 	xml := `<?xml version="1.0" encoding="UTF-8"?>
 <decision_tables>
     <decision_table>
-        <table_name>Test_EL_AutoCompile</table_name>
+        <table_name>Test_StrictNoPostfix</table_name>
         <attribute_fields>
             <Type>First</Type>
         </attribute_fields>
@@ -298,10 +300,15 @@ func TestDTLoaderELAutoCompile(t *testing.T) {
 </decision_tables>`
 
 	err := loader.Load(strings.NewReader(xml))
-	if err != nil {
-		t.Fatalf("Failed to load DT with EL auto-compile: %v", err)
+	if err == nil {
+		t.Fatal("expected load to fail (DSL present, no postfix), got success")
 	}
-	t.Log("Table Test_EL_AutoCompile loaded successfully with auto-compiled EL")
+	if !strings.Contains(err.Error(), "no compiled postfix") {
+		t.Errorf("expected error to mention missing postfix, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "dtrules build") {
+		t.Errorf("expected error to direct caller to `dtrules build`, got: %v", err)
+	}
 }
 
 // TestDTLoaderELAutoCompileWithExistingPostfix tests that existing postfix is preserved
@@ -348,18 +355,21 @@ func TestDTLoaderELAutoCompileWithExistingPostfix(t *testing.T) {
 	t.Log("Table loaded successfully with existing postfix preserved")
 }
 
-// TestDTLoaderELAutoCompileFallback tests that invalid EL expressions use a fallback.
-// Invalid EL descriptions now log a warning and use a fallback ("true always" for conditions).
-func TestDTLoaderELAutoCompileFallback(t *testing.T) {
+// TestDTLoaderRejectsInvalidDSLWithoutPostfix is the second-tier strict
+// contract: even if the DSL is unparseable (so a previous build would
+// have failed), the strict loader doesn't need to know — it sees the
+// postfix slot is empty and refuses. The error message and direction
+// to the operator stays the same.
+func TestDTLoaderRejectsInvalidDSLWithoutPostfix(t *testing.T) {
 	factory := entity.NewFactory(nil)
 	session := &mockSession{factory: factory}
 	loader := NewDTLoader(session, factory)
 
-	// XML with invalid EL expression - should succeed with fallback
+	// Invalid EL in condition_dsl, no condition_postfix.
 	xml := `<?xml version="1.0" encoding="UTF-8"?>
 <decision_tables>
     <decision_table>
-        <table_name>Test_EL_Fallback</table_name>
+        <table_name>Test_StrictInvalidDSL</table_name>
         <attribute_fields>
             <Type>First</Type>
         </attribute_fields>
@@ -385,27 +395,25 @@ func TestDTLoaderELAutoCompileFallback(t *testing.T) {
 </decision_tables>`
 
 	err := loader.Load(strings.NewReader(xml))
-	// Should succeed now - invalid EL uses fallback with warning
-	if err != nil {
-		t.Fatalf("Unexpected error (invalid EL should use fallback): %v", err)
+	if err == nil {
+		t.Fatal("expected load to fail (invalid DSL, no postfix), got success")
 	}
-	t.Log("Invalid EL description correctly used fallback")
 }
 
-// TestDTLoaderPreservePostfixComments tests that when EL compilation fails but there's
-// existing postfix (even if comment-only), the original postfix is preserved.
-// This is issue #438 - non-EL descriptions should not overwrite existing postfix.
-func TestDTLoaderPreservePostfixComments(t *testing.T) {
+// TestDTLoaderRejectsCommentOnlyPostfix verifies that a comment-only
+// postfix is still treated as "no postfix" — comments are documentation,
+// not executable code. Pre-PR-B the loader preserved them silently
+// alongside whatever the EL fallback produced; the strict loader rejects
+// the row so the operator authors real EL (or removes the dead DSL).
+func TestDTLoaderRejectsCommentOnlyPostfix(t *testing.T) {
 	factory := entity.NewFactory(nil)
 	session := &mockSession{factory: factory}
 	loader := NewDTLoader(session, factory)
 
-	// XML with invalid EL in action_dsl but comment-only postfix
-	// The postfix comments should be preserved, not replaced with no-op
 	xml := `<?xml version="1.0" encoding="UTF-8"?>
 <decision_tables>
     <decision_table>
-        <table_name>Test_Preserve_Comments</table_name>
+        <table_name>Test_StrictCommentOnlyPostfix</table_name>
         <attribute_fields>
             <Type>First</Type>
         </attribute_fields>
@@ -417,7 +425,7 @@ func TestDTLoaderPreservePostfixComments(t *testing.T) {
                 <condition_dsl>Check some condition</condition_dsl>
                 <condition_postfix>
 // This is a documentation comment
-// It should be preserved even if DSL is invalid
+// It should NOT count as real postfix
 </condition_postfix>
                 <condition_column column_number="1" column_value="y"/>
             </condition_details>
@@ -428,7 +436,6 @@ func TestDTLoaderPreservePostfixComments(t *testing.T) {
                 <action_dsl>Apportionment will be calculated by tables 7000-7500</action_dsl>
                 <action_postfix>
 // Physical nexus established - filing required
-// Apportionment documentation
 </action_postfix>
                 <action_column column_number="1" column_value="x"/>
             </action_details>
@@ -438,10 +445,9 @@ func TestDTLoaderPreservePostfixComments(t *testing.T) {
 </decision_tables>`
 
 	err := loader.Load(strings.NewReader(xml))
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected load to fail (DSL with comment-only postfix), got success")
 	}
-	t.Log("Postfix comments preserved when EL compilation fails")
 }
 
 // TestFilePathLoading tests that FILE_PATH is loaded and stored on the decision table.

--- a/pkg/dtrules/session/ruleset.go
+++ b/pkg/dtrules/session/ruleset.go
@@ -91,44 +91,37 @@ func (rs *RuleSet) LoadEDDJSON(r io.Reader) error {
 	return jsonLoader.Load(r)
 }
 
-// LoadDecisionTables loads decision tables from a reader.
+// LoadDecisionTables loads decision tables from a reader using the
+// loader's strict policy: every non-comment DSL element must have a
+// compiled postfix or the load fails. Runtime consumers should use
+// this entry point — it guarantees the embedded XML was built before
+// it was shipped.
 func (rs *RuleSet) LoadDecisionTables(r io.Reader) error {
-	// Create a temporary session for loading
+	return rs.loadDecisionTables(r, false)
+}
+
+// LoadDecisionTablesTolerant is for build-time tooling that consumes
+// XML mid-compile (e.g. the export step of `dtrules build --from-xml`,
+// which reads partially-built XML to write Excel). It skips the
+// "DSL with no compiled postfix" load error.
+//
+// Do NOT use this from runtime code — it accepts XML that will crash
+// at execution time when a DSL-described action has no postfix to
+// run. Confined to the build pipeline and the small set of internal
+// tools that pre-process XML before compile.
+func (rs *RuleSet) LoadDecisionTablesTolerant(r io.Reader) error {
+	return rs.loadDecisionTables(r, true)
+}
+
+func (rs *RuleSet) loadDecisionTables(r io.Reader, tolerant bool) error {
 	tempSession := &loadSession{
 		factory:    rs.entityFactory,
 		dateParser: NewDateParser(),
 	}
 
 	dtLoader := loader.NewDTLoader(tempSession, rs.entityFactory)
-	// Build the symbol table from the EDD so the EL compiler can pick the
-	// right arithmetic dispatch (bigint × int → bigint, etc.) when the DSL
-	// references typed fields. Without this the compiler defaults to integer
-	// arithmetic for every iexpr × iexpr multiply and loses type promotion.
-	dtLoader.SetSymbols(rs.buildSymbolTable())
-	// Build a subtype → owner.field index so `for all <type> entities`
-	// can resolve to the EDD-declared collection at compile time.
-	dtLoader.SetCollectionResolver(loader.MakeCollectionResolver(loader.BuildCollectionIndex(rs.entityFactory)))
+	dtLoader.Tolerant = tolerant
 	return dtLoader.Load(r)
-}
-
-// buildSymbolTable walks the entity factory's registered reference entities
-// and returns a flat map of "entity.field" and "field" → type-name suitable
-// for the EL compiler's SetSymbols.
-func (rs *RuleSet) buildSymbolTable() map[string]string {
-	symbols := map[string]string{}
-	for _, ent := range rs.entityFactory.GetRefEntities() {
-		entityName := ent.GetName().StringValue()
-		for _, entry := range ent.GetEntries() {
-			if entry.Type == nil {
-				continue
-			}
-			fieldName := entry.Attribute.StringValue()
-			typeName := entry.Type.GetName().StringValue()
-			symbols[fieldName] = typeName
-			symbols[entityName+"."+fieldName] = typeName
-		}
-	}
-	return symbols
 }
 
 // LoadFromDirectory loads all XML files from a directory.
@@ -168,7 +161,7 @@ func (rs *RuleSet) LoadEDDFile(filePath string) error {
 	return rs.LoadEDD(f)
 }
 
-// LoadDecisionTablesFile loads decision tables from a file path.
+// LoadDecisionTablesFile loads decision tables from a file path (strict).
 func (rs *RuleSet) LoadDecisionTablesFile(filePath string) error {
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -176,6 +169,19 @@ func (rs *RuleSet) LoadDecisionTablesFile(filePath string) error {
 	}
 	defer f.Close()
 	return rs.LoadDecisionTables(f)
+}
+
+// LoadDecisionTablesTolerantFile is the tolerant-mode counterpart for
+// build-time tooling that reads partially-compiled XML. See
+// LoadDecisionTablesTolerant for the contract — do not use this from
+// runtime code paths.
+func (rs *RuleSet) LoadDecisionTablesTolerantFile(filePath string) error {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open DT file %s: %w", filePath, err)
+	}
+	defer f.Close()
+	return rs.LoadDecisionTablesTolerant(f)
 }
 
 // LoadFromPath loads rules from a path (either a directory or individual files).


### PR DESCRIPTION
## Why

The loader was importing `compiler/el` and recompiling every DSL element at load time, then preferring the fresh compile over stored postfix. Three consequences:

1. Every library consumer's runtime binary shipped the entire EL compiler (grammar + parser + emitter + symbol table). For an embedded use case like staking, that's a non-trivial dependency they didn't ask for.
2. Pre-built postfix in XML was decorative — the loader recompiled it anyway. The "compile pipeline produces canonical artifacts" contract wasn't enforced at the load boundary.
3. The `loader: context N (...) — recompiled postfix differs from stored; using fresh compile` warnings spammed every load for any project where stored postfix didn't byte-match a fresh compile. This noise was actively blocking staking's table cleanup ("warnings prevent cleanup of the tables").

## What lands

- **`pkg/dtrules/loader/dt.go`** drops the `compiler/el` import. The `DTLoader.elCompiler` field is gone. `SetSymbols` and `SetCollectionResolver` survive as no-ops for source compatibility with `session.RuleSet`.
- Every authoring element (`context`, `initial_action`, `condition`, `action`) checks: non-comment DSL with empty-or-comment-only postfix → error. The error names the table, the element kind and number, the DSL snippet, and directs the operator to `dtrules build` or `dtrules compile`.
- The Load aggregator embeds the first inner error in the returned message so callers see the actionable detail, not just an error count.

## Tolerant mode for build-time tooling

The XML-authored build's export step legitimately reads partially-compiled XML — it loads source XML to write Excel, then re-imports to compile EL on the way back. A strict loader would refuse that mid-pipeline state.

`DTLoader.Tolerant` (default `false`) disables the postfix-presence check. `RuleSet.LoadDecisionTablesTolerant` / `LoadDecisionTablesTolerantFile` expose it. The workbook exporter opts in at both call sites; **nothing else does**. Runtime consumers stay strict by default.

## Tests updated

`TestDTLoaderELAutoCompile`, `TestDTLoaderELAutoCompileFallback`, and `TestDTLoaderPreservePostfixComments` asserted the OLD behavior (auto-compile, fallback, comment-only preservation). Replaced with:

- `TestDTLoaderRejectsDSLWithoutPostfix` — DSL + no postfix → error mentioning "no compiled postfix" and `dtrules build`.
- `TestDTLoaderRejectsInvalidDSLWithoutPostfix` — same contract; the loader doesn't need to parse DSL to know postfix is missing.
- `TestDTLoaderRejectsCommentOnlyPostfix` — comment-only postfix counts as no postfix.

`TestDTLoaderELAutoCompileWithExistingPostfix` keeps passing — it's the positive test of the new contract (DSL + real postfix → load OK).

## Migration for library consumers

Bump to this release, then:

```bash
dtrules compile pkg/dtrules/rules   # fills postfix from DSL
git diff                            # review the change
git commit -am 'compile DSL → postfix'
```

After that, `session.LoadDecisionTables` is silent on load. The runtime no longer pulls `compiler/el` into the binary.

## Sample-project status — out of scope

Per the directive that sample projects don't block infrastructure:

- TaxReturn has 6 prose-DSL elements with hand-coded postfix in legacy `<action_postfix>` aliases — filed as **#781**.
- SyntaxTests has 2 DSL-without-postfix elements — filed as **#783**.
- A few `cmd/dtrules` and `pkg/dtrules` test fixtures still use the auto-compile pattern — filed as **#784**.

None of these are on the runtime path that staking and other library consumers exercise.

## Test plan

- [x] `make check` passes (full module + vet + scoped tests + hand-coded-postfix gate).
- [x] Three new tests assert the strict contract directly.
- [x] `TestBuildFromXML_ImportStepReportsCompileDrop` keeps passing via the new tolerant-mode loader on the export step.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)