### PR TITLE
fix(compile): pass EDD symbols so fixed operands emit fp ops (#790); v1.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # DTRules Changelog
 
+## v1.14.2 — 2026-05-24
+
+Patch: `dtrules compile` now passes a symbol table to the EL compiler so
+fixed-point operands compile to fixed-point operators. v1.14.x's
+standalone compile path was emitting integer ops on `fixed`-typed
+operands; the strict loader then rejected those at runtime
+(`[Conversion Error] IntValue: No Integer value exists for this type`).
+This blocked staking and any other consumer whose tables use `fixed`
+operands from migrating off v1.12.0.
+
+- **`dtrules compile` discovers `*_edd.xml` near the target, parses out
+  field → type symbols, and calls `el.Compiler.SetSymbols` before the
+  compile loop (#790).** Mirrors what `session.RuleSet.buildSymbolTable`
+  used to do for the in-loader compiler in v1.12.0 (removed in v1.14.0)
+  and what the workbook importer does for the build pipeline. With
+  symbols in play, the EL compiler picks `fp-` / `fpmin` / `cvfp` for
+  fixed operands instead of `-` / `min` / `cvi`.
+
+- **New `--force` flag.** Rewrites existing postfix from a fresh
+  compile (default only fills empty postfix). Use after a compiler
+  fix like this one to refresh stored postfix produced by an earlier
+  buggy version.
+
+- Regression test `TestCompile_FixedOperandsEmitFixedOps` pins the
+  fixed → `fp-` / `fpmin` / `cvfp` behavior end-to-end through the
+  CLI dispatch.
+
+### Known limitation (not in scope for this patch)
+
+The EL compiler's `double` dispatch is less reliable than its `fixed`
+dispatch — `double` operands can still emit integer ops in some
+patterns (notably `the minimum of A and (B * C)`). Affects DTRules'
+own TaxReturn sample project, which still passes its test suite. No
+downstream consumer reported this in #790; tracking separately.
+
+### Migration
+
+Consumers who ran `dtrules compile` against their rules under v1.14.0
+or v1.14.1 should re-run with `--force` to overwrite stale postfix:
+
+```bash
+go get github.com/DTRules/DTRules@v1.14.2
+dtrules compile --force <rules-dir>
+git diff
+git commit -am 'refresh postfix per v1.14.2 #790 fix'
+```
+
 ## v1.14.1 — 2026-05-24
 
 Single-flag follow-up to v1.14.0: `dtrules compile` now runs the

--- a/cmd/dtrules/compile_cmd.go
+++ b/cmd/dtrules/compile_cmd.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"encoding/xml"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -51,6 +52,7 @@ func (c *CLI) runCompile(args []string) int {
 	verbose := false
 	strict := false
 	noAnalyze := false
+	force := false
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--dry-run":
@@ -59,6 +61,8 @@ func (c *CLI) runCompile(args []string) int {
 			strict = true
 		case "--no-analyze":
 			noAnalyze = true
+		case "--force":
+			force = true
 		case "-v", "--verbose":
 			verbose = true
 		case "-h", "--help":
@@ -114,13 +118,37 @@ func (c *CLI) runCompile(args []string) int {
 	}
 
 	cmp := el.NewCompiler()
+
+	// Wire up the EDD-derived symbol table so the EL compiler picks the
+	// right arithmetic dispatch (fp- / fpmin for fixed operands, f- / fmin
+	// for double, - / min for integer). Without this, every operand
+	// defaults to integer and the emitted postfix uses int ops + `cvi`
+	// conversions that crash at runtime when the actual value is RFixed or
+	// RDouble (#790). The build pipeline's workbook importer already does
+	// this; v1.12.0's in-loader compiler did this; the standalone compile
+	// path needs to do it too.
+	//
+	// EDDs are discovered next to (and recursively under) the target. If
+	// none are found, the compiler proceeds with no symbol table — fine
+	// for projects with no typed operands, but a heads-up is printed so
+	// the user knows type-aware dispatch was skipped.
+	symbols := loadEDDSymbols(target)
+	if len(symbols) > 0 {
+		cmp.SetSymbols(symbols)
+		if verbose {
+			fmt.Printf("loaded %d symbols from EDD\n", len(symbols))
+		}
+	} else if verbose {
+		fmt.Println("no EDD found near target — compile will assume integer-typed operands")
+	}
+
 	totalCompiled := 0
 	totalSkipped := 0
 	totalErrors := 0
 	var errLines []string
 
 	for _, f := range files {
-		filled, skipped, errs := compileFile(cmp, f, dryRun, strict)
+		filled, skipped, errs := compileFile(cmp, f, dryRun, strict, force)
 		totalCompiled += filled
 		totalSkipped += skipped
 		totalErrors += len(errs)
@@ -169,6 +197,71 @@ func (c *CLI) runCompile(args []string) int {
 	return 0
 }
 
+// loadEDDSymbols discovers every *_edd.xml file under root (or alongside
+// root if root is a file) and parses out a flat map of field → type that
+// the EL compiler's SetSymbols expects. Both `<field>` and
+// `<entity>.<field>` keys are emitted so bare-name references and
+// qualified references resolve identically — matching what
+// session.RuleSet.buildSymbolTable used to produce before v1.14.0 made
+// that method unused.
+//
+// Schema is the minimal subset the EL compiler cares about: entity name
+// and the field's `type` attribute. Anything else in the EDD is ignored.
+// Parse errors on individual files are silently skipped — a malformed EDD
+// is the project's problem, not the compile pass's, and the compile will
+// surface it through a downstream parse failure if the DT depends on it.
+func loadEDDSymbols(root string) map[string]string {
+	type eddField struct {
+		Name string `xml:"name,attr"`
+		Type string `xml:"type,attr"`
+	}
+	type eddEntity struct {
+		Name   string     `xml:"name,attr"`
+		Fields []eddField `xml:"field"`
+	}
+	type eddFile struct {
+		Entities []eddEntity `xml:"entity"`
+	}
+
+	// Decide which directory tree to walk. If root is a *_dt.xml file we
+	// look in its containing directory; otherwise we walk root itself.
+	walkDir := root
+	if info, err := os.Stat(root); err == nil && !info.IsDir() {
+		walkDir = filepath.Dir(root)
+	}
+
+	symbols := make(map[string]string)
+	_ = filepath.WalkDir(walkDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), "_edd.xml") {
+			return nil
+		}
+		data, readErr := os.ReadFile(p)
+		if readErr != nil {
+			return nil
+		}
+		var f eddFile
+		if xml.Unmarshal(data, &f) != nil {
+			return nil
+		}
+		for _, ent := range f.Entities {
+			for _, fld := range ent.Fields {
+				if fld.Name == "" || fld.Type == "" {
+					continue
+				}
+				symbols[fld.Name] = fld.Type
+				if ent.Name != "" {
+					symbols[ent.Name+"."+fld.Name] = fld.Type
+				}
+			}
+		}
+		return nil
+	})
+	return symbols
+}
+
 // analyzeFile parses a *_dt.xml file and runs the advisory pass on every
 // table within it. Returns the aggregated warning slice. Errors during
 // parse short-circuit to an empty slice — the compile step already
@@ -206,6 +299,10 @@ Options:
   --strict      Refuse to write any file that has at least one compile
                 error (atomic-or-nothing per file). Default writes the
                 successful fills and reports the errors.
+  --force       Overwrite existing postfix with a fresh compile. Use
+                after a compiler bug fix (e.g. v1.14.2 #790) to refresh
+                postfix produced by an earlier buggy version. Default
+                only fills empty postfix.
   --no-analyze  Skip the advisory pass after compile. Default runs it.
   -v, --verbose Per-file compiled/skipped/error/warning counts.
 
@@ -238,19 +335,40 @@ advisory pass), use 'dtrules build'.`)
 // avoids any cross-element backtracking. Newlines pass through fine
 // because the character class only excludes `<`.
 type kindPair struct {
-	kind string
-	re   *regexp.Regexp
+	kind    string
+	reEmpty *regexp.Regexp // matches only empty <X_postfix> (default mode)
+	reAny   *regexp.Regexp // matches any <X_postfix> body (--force mode, for refreshing stale postfix)
 }
 
+// Each regex is anchored to a single element kind. `[^<]` inside both DSL
+// and postfix captures keeps us inside the text node — `<` is always
+// entity-encoded inside body content, so this avoids cross-element
+// backtracking.
 var dslPostfixPairs = []kindPair{
-	{"context", regexp.MustCompile(`<context_dsl>([^<]*)</context_dsl>\s*<context_postfix>\s*</context_postfix>`)},
-	{"initial_action", regexp.MustCompile(`<initial_action_dsl>([^<]*)</initial_action_dsl>\s*<initial_action_postfix>\s*</initial_action_postfix>`)},
-	{"action", regexp.MustCompile(`<action_dsl>([^<]*)</action_dsl>\s*<action_postfix>\s*</action_postfix>`)},
-	{"condition", regexp.MustCompile(`<condition_dsl>([^<]*)</condition_dsl>\s*<condition_postfix>\s*</condition_postfix>`)},
+	{
+		"context",
+		regexp.MustCompile(`<context_dsl>([^<]*)</context_dsl>\s*<context_postfix>\s*</context_postfix>`),
+		regexp.MustCompile(`<context_dsl>([^<]*)</context_dsl>\s*<context_postfix>[^<]*</context_postfix>`),
+	},
+	{
+		"initial_action",
+		regexp.MustCompile(`<initial_action_dsl>([^<]*)</initial_action_dsl>\s*<initial_action_postfix>\s*</initial_action_postfix>`),
+		regexp.MustCompile(`<initial_action_dsl>([^<]*)</initial_action_dsl>\s*<initial_action_postfix>[^<]*</initial_action_postfix>`),
+	},
+	{
+		"action",
+		regexp.MustCompile(`<action_dsl>([^<]*)</action_dsl>\s*<action_postfix>\s*</action_postfix>`),
+		regexp.MustCompile(`<action_dsl>([^<]*)</action_dsl>\s*<action_postfix>[^<]*</action_postfix>`),
+	},
+	{
+		"condition",
+		regexp.MustCompile(`<condition_dsl>([^<]*)</condition_dsl>\s*<condition_postfix>\s*</condition_postfix>`),
+		regexp.MustCompile(`<condition_dsl>([^<]*)</condition_dsl>\s*<condition_postfix>[^<]*</condition_postfix>`),
+	},
 }
 
-// compileFile reads f, compiles each DSL→postfix pair with an empty
-// postfix slot, and writes f back. Returns (filled, skipped, errors).
+// compileFile reads f, compiles each DSL→postfix pair, and writes f
+// back. Returns (filled, skipped, errors).
 //
 // In the default mode any successful fills are written even when other
 // elements in the same file failed to compile — the file is improved
@@ -259,7 +377,13 @@ var dslPostfixPairs = []kindPair{
 // With strict=true the file is written only if every non-comment DSL
 // element compiles. Use --strict when you need an atomic guarantee
 // that every element in the file is build-clean (CI gate behavior).
-func compileFile(cmp *el.Compiler, f string, dryRun, strict bool) (int, int, []string) {
+//
+// With force=true any existing postfix is overwritten with a fresh
+// compile result. Use --force after a compiler fix (e.g. v1.14.2's
+// #790 SetSymbols repair) to refresh stored postfix that was produced
+// by an earlier buggy version. Default behavior only fills empty
+// postfix; existing content is preserved as the authoritative form.
+func compileFile(cmp *el.Compiler, f string, dryRun, strict, force bool) (int, int, []string) {
 	data, err := os.ReadFile(f)
 	if err != nil {
 		return 0, 0, []string{fmt.Sprintf("read failed: %v", err)}
@@ -278,10 +402,16 @@ func compileFile(cmp *el.Compiler, f string, dryRun, strict bool) (int, int, []s
 	newData := data
 	for _, kp := range dslPostfixPairs {
 		kind := kp.kind
+		// Pick the regex that matches the operating mode: --force rewrites
+		// any existing postfix; default only fills empty slots.
+		re := kp.reEmpty
+		if force {
+			re = kp.reAny
+		}
 		n := 0
-		newData = kp.re.ReplaceAllFunc(newData, func(match []byte) []byte {
+		newData = re.ReplaceAllFunc(newData, func(match []byte) []byte {
 			n++
-			m := kp.re.FindSubmatch(match)
+			m := re.FindSubmatch(match)
 			if len(m) < 2 {
 				return match
 			}

--- a/cmd/dtrules/compile_cmd_test.go
+++ b/cmd/dtrules/compile_cmd_test.go
@@ -1,0 +1,133 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCompile_FixedOperandsEmitFixedOps is the #790 regression. Before
+// v1.14.2 the standalone `dtrules compile` did not pass a symbol table
+// to the EL compiler, so operations on `fixed`-typed operands compiled
+// to integer operators (`-`, `min`, `cvi`) — postfix that the strict
+// runtime then rejected at execution time with
+// "[Conversion Error] IntValue: No Integer value exists for this type"
+// because the actual operands were `*RFixed`.
+//
+// The fix: discover and load *_edd.xml beside the target, build a
+// symbol table, call `cmp.SetSymbols(symbols)` before the compile
+// loop. With that in place, the EL compiler picks `fp-` / `fpmin` /
+// `cvfp` for fixed operands.
+//
+// This test pins that behavior end-to-end through the compile-file
+// pipeline: write a small project (EDD + DT) to a temp dir, run
+// `dtrules compile`, and assert the emitted postfix contains the
+// fixed-point operators. A regression here would mean SetSymbols was
+// dropped from the call site again or stopped being passed the EDD
+// type info.
+func TestCompile_FixedOperandsEmitFixedOps(t *testing.T) {
+	dir := t.TempDir()
+
+	// Minimal EDD: a single `job` entity with three `fixed`-typed
+	// fields that mirror staking's withholding-table operands. These
+	// are the operands the EL compiler must see as `fixed` for the
+	// dispatcher to pick fp- and fpmin instead of integer ops.
+	const eddXML = `<?xml version="1.0" encoding="UTF-8"?>
+<entity_data_dictionary version="2">
+  <entity name="job" access="rw">
+    <field name="effective_withholding" type="fixed" subtype="" access="rw" input="" default_value="0fp" comment=""/>
+    <field name="withholding_cap"       type="fixed" subtype="" access="r"  input="" default_value="0fp" comment=""/>
+    <field name="withholding_paid"      type="fixed" subtype="" access="r"  input="" default_value="0fp" comment=""/>
+  </entity>
+</entity_data_dictionary>
+`
+
+	// DT with the smoking-gun DSL: `set fixed = the minimum of fixed and (fixed - fixed)`.
+	// Postfix is left empty so compile must produce it from the DSL.
+	const dtXML = `<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+<decision_table>
+<table_name>Calculate_Withholding</table_name>
+<xls_file>calc.xlsx</xls_file>
+<attribute_fields><Type>FIRST</Type><COMMENTS></COMMENTS><TABLE_NUMBER>1</TABLE_NUMBER></attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
+<conditions>
+  <condition_details>
+    <condition_number>1</condition_number>
+    <condition_comment>always</condition_comment>
+    <condition_dsl>withholding_cap &gt; 0fp</condition_dsl>
+    <condition_postfix>withholding_cap 0fp fp&gt;</condition_postfix>
+    <condition_column column_number="1" column_value="Y"/>
+  </condition_details>
+</conditions>
+<actions>
+  <action_details>
+    <action_number>1</action_number>
+    <action_comment>cap withholding</action_comment>
+    <action_dsl>set effective_withholding = the minimum of effective_withholding and (withholding_cap - withholding_paid)</action_dsl>
+    <action_postfix></action_postfix>
+    <action_column column_number="1" column_value="X"/>
+  </action_details>
+</actions>
+</decision_table>
+</decision_tables>
+`
+
+	if err := os.WriteFile(filepath.Join(dir, "fixture_edd.xml"), []byte(eddXML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	dtPath := filepath.Join(dir, "fixture_dt.xml")
+	if err := os.WriteFile(dtPath, []byte(dtXML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the same code path `dtrules compile <dir>` runs. We exercise
+	// the CLI dispatch (not just compileFile directly) so the EDD
+	// discovery + SetSymbols wiring is also covered.
+	cli := NewCLI()
+	if code := cli.runCompile([]string{dir}); code != 0 {
+		t.Fatalf("runCompile exit=%d; want 0", code)
+	}
+
+	out, err := os.ReadFile(dtPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	postfix := string(out)
+
+	// Positive: the compiled postfix must use the fixed-point operators.
+	// `fp-` is the diagnostic the issue specifically calls out; pinning
+	// it is the regression catch. `fpmin` confirms `the minimum of` also
+	// dispatches correctly. `cvfp` is the assignment-conversion op for
+	// fixed (vs `cvi` for integer).
+	for _, want := range []string{"fp-", "fpmin", "cvfp"} {
+		if !strings.Contains(postfix, want) {
+			t.Errorf("compiled postfix missing %q; got:\n%s", want, postfix)
+		}
+	}
+
+	// Negative: the integer-op pattern from the bug must NOT appear.
+	// Spaces around the operators rule out accidental substring hits
+	// (e.g. matching `fpmin` instead of bare `min`).
+	for _, banned := range []string{" - cvi ", " - min ", " min cvi "} {
+		if strings.Contains(postfix, banned) {
+			t.Errorf("compiled postfix still contains banned int-op pattern %q; got:\n%s", banned, postfix)
+		}
+	}
+}


### PR DESCRIPTION
## Why — closes #790

v1.14.x's standalone `dtrules compile` skipped the `SetSymbols` step that v1.12.0's in-loader compiler and the workbook importer both perform. Result: operations on `fixed`-typed operands compiled to integer ops (`-`, `min`, `cvi`); the strict loader then rejected them at runtime:

```
[Conversion Error] IntValue: No Integer value exists for this type
PostFix: effective_withholding withholding_cap withholding_paid -  ERROR==> min  <== cvi /effective_withholding xdef
```

Staking and any other consumer on `fixed` operands had to pin at v1.12.0 to stay functional. Blocker.

## Fix

- `dtrules compile` walks the target tree for `*_edd.xml`, parses a lightweight subset (entity name + field name + type), builds a flat `field → type` map (both bare and entity-qualified keys), and calls `cmp.SetSymbols(symbols)` once before the compile loop. Mirrors `session.RuleSet.buildSymbolTable` (removed in v1.14.0) and the workbook importer's behavior.

- New `--force` flag rewrites existing postfix from a fresh compile (default only fills empty postfix). Needed because v1.14.0 / v1.14.1 may have written stale int-op postfix that's already on disk — `--force` lets consumers refresh it.

## Verification

- Standalone EL test: same DSL through `compiler/el` with `SetSymbols({"fixed"})` emits `fp- fpmin cvfp` instead of `- min cvi`.
- Regression test `TestCompile_FixedOperandsEmitFixedOps` pins this behavior end-to-end through the CLI dispatch.
- Staking smoke (`pkg/dtrules/rules/`): all 104 elements compile with `fp-` / `fpmin` / `cvfp` for fixed operands — no `- cvi` / `min cvi` patterns left on staking-side fixed operands.
- `make check` passes.

## Known limitation (out of scope)

The EL compiler's `double` dispatch is less reliable than the `fixed` dispatch. Patterns like `the minimum of A and (B * C)` with double assignment target can still emit integer ops. Affects DTRules' own TaxReturn sample (test suite still green) but no consumer reported it in #790. Tracking separately.

## Migration

```bash
go get github.com/DTRules/DTRules@v1.14.2
dtrules compile --force <rules-dir>
git diff
git commit -am 'refresh postfix per v1.14.2 #790 fix'
```

## Out of scope (still open from the same session)

- **#787** — warnings don't surface from `dtrules build` (partial v1.14.1 fix for `compile`)
- **#788** — `dtrules review <path>` ignores positional arg
- **#791** — `dtrules table list/warnings` discovery inconsistent with `dtrules compile`

Will address in follow-up PRs.

## Test plan

- [x] `make check` passes (full module + vet + scoped tests + hand-coded-postfix gate).
- [x] `TestCompile_FixedOperandsEmitFixedOps` passes; reverting `SetSymbols` makes it fail with the int-op assertions.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)