### PR TITLE
fix(authoring): restore Excel-is-source-of-record contract; v1.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,88 @@
 # DTRules Changelog
 
+## v1.14.5 — 2026-05-28
+
+Restores the **"Excel is the system of record"** contract that
+v1.14.0–v1.14.4 had silently broken on every authoring surface.
+
+### The bug
+
+Six surfaces wrote XML without touching Excel:
+
+  - `dtrules table put` / `patch` → `Project.Save()` wrote XML only
+  - `dtrules edd put` / `patch` → `Project.SaveEDD()` wrote XML only
+  - MCP `table_put`, `table_patch`, `edd_put` → same as above
+  - `dtrules compile` → byte-level postfix surgery, no Excel awareness
+
+Result on staking: `pkg/dtrules/rules/staking_dt.xml` modified
+2026-05-27, `pkg/dtrules/source/staking.xlsx` last touched 2026-05-25.
+Three days of drift; AI-driven authoring edits never propagated to
+the spreadsheet anyone could open.
+
+### The fix
+
+Every XML-writing surface now runs two new gates around the write:
+
+1. **Pre-write Excel-mtime guard** (Phase 1). If a covered Excel file
+   has been touched since the sync manifest's last-export record (= a
+   human edited the spreadsheet outside DTRules), the write is
+   refused with `sync.ExcelModifiedError`. The operator either runs
+   `dtrules build --from-excel` first to merge those edits, or passes
+   `--force-overwrite-excel` (CLI) / sets `OverwriteExcel = true`
+   (Go API) to assert the XML version should win.
+
+2. **Lock-file detection**. `~$<name>.xlsx` (Microsoft Excel) and
+   `.~lock.<name>.xlsx#` (LibreOffice) sidecars block writes
+   unconditionally — writing through an open spreadsheet corrupts
+   in-app state. The override flag does not bypass this; the
+   operator must close the spreadsheet first.
+
+3. **Post-write Excel refresh** (Phase 2). After XML lands, the
+   covered Excel files are re-exported from the new in-memory state
+   so the two formats stay byte-paired on disk. Sync manifest's
+   `RecordExport` advances `LastExportTime` so the next guard starts
+   from a clean baseline.
+
+### What changes for callers
+
+- `dtrules table put` / `patch` / `dtrules edd put` / `patch` /
+  MCP `table_put` / `table_patch` / `edd_put` / `dtrules compile`:
+  all support `--force-overwrite-excel` and obey the new contract.
+- `authoring.Project` grows an `OverwriteExcel bool` field
+  (default false).
+- Two new package-level helpers in `pkg/dtrules/authoring`:
+  - `GuardExcelInDir(xmlDir, overwrite)` — runs Phase 1 + lock-file
+    check.
+  - `RefreshExcelInDir(xmlDir)` — runs Phase 2.
+  - `LoadSyncManifestForXMLDir(xmlDir)` — manifest discovery used by
+    both. Search order: `<xmlDir>/`, `<xmlDir>/../source/`,
+    `<xmlDir>/../excel/`, `<xmlDir>/../`. First match wins.
+- `Project.preWriteExcelGuard` and `refreshExcelFromXML` are now
+  thin facades over the package-level helpers.
+
+### Backward compatibility
+
+Projects without a `.sync-manifest.json` (legacy flat layouts, fresh
+test fixtures, the SyntaxTests sample project) are no-op'd on both
+guards — Save() / SaveEDD() / compile behave exactly as in v1.14.4
+for them. The new contract only kicks in for projects that have run
+`dtrules build` at least once and thus have a manifest beside their
+Excel files.
+
+### Tests
+
+Six new regression tests in
+`pkg/dtrules/authoring/excel_sync_test.go`:
+
+- `TestGuardExcelInDir_RefusesWhenExcelNewer` — core Phase 1.
+- `TestGuardExcelInDir_PassesWithOverwriteFlag` — override path.
+- `TestGuardExcelInDir_NoManifestIsNoOp` — backward-compatibility.
+- `TestGuardExcelInDir_RefusesWhenExcelLocked` — both ~$ and .~lock
+  conventions; override flag does not bypass.
+- `TestRefreshExcelInDir_NoOpOnNoManifest` — Phase 2 backward-compat.
+- `TestRefreshExcelInDir_UpdatesExcelMtime` — Phase 2 happy path:
+  xlsx mtime advances, manifest LastExportTime advances.
+
 ## v1.14.4 — 2026-05-25
 
 Two independent patches bundled. The advisory `decisiontable.Analyze`

--- a/cmd/dtrules/compile_cmd.go
+++ b/cmd/dtrules/compile_cmd.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
 	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
 	"github.com/DTRules/DTRules/pkg/dtrules/decisiontable"
 	"github.com/DTRules/DTRules/pkg/dtrules/excel"
@@ -53,6 +54,7 @@ func (c *CLI) runCompile(args []string) int {
 	strict := false
 	noAnalyze := false
 	force := false
+	forceOverwriteExcel := false
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--dry-run":
@@ -63,6 +65,8 @@ func (c *CLI) runCompile(args []string) int {
 			noAnalyze = true
 		case "--force":
 			force = true
+		case "--force-overwrite-excel":
+			forceOverwriteExcel = true
 		case "-v", "--verbose":
 			verbose = true
 		case "-h", "--help":
@@ -117,6 +121,29 @@ func (c *CLI) runCompile(args []string) int {
 		return 1
 	}
 
+	// Excel-sync guard (v1.14.5): refuse the write if a covered Excel
+	// file has been touched since the last export. `dtrules compile`
+	// writes XML in place; without this guard an AI's compile could
+	// silently override a human's open Excel edits. --dry-run skips
+	// the guard since nothing is actually written.
+	if !dryRun {
+		// Decide the directory the guard searches in. For dir targets
+		// it's the target itself; for single-file targets it's the
+		// file's parent directory (where any sibling `.sync-manifest.json`
+		// would live).
+		guardDir := target
+		if info, err := os.Stat(target); err == nil && !info.IsDir() {
+			guardDir = filepath.Dir(target)
+		}
+		if err := authoring.GuardExcelInDir(guardDir, forceOverwriteExcel); err != nil {
+			fmt.Fprintf(os.Stderr, "compile: %v\n", err)
+			fmt.Fprintln(os.Stderr, "\nTo proceed, either:")
+			fmt.Fprintln(os.Stderr, "  1) Run `dtrules build --from-excel` to import the Excel changes first, OR")
+			fmt.Fprintln(os.Stderr, "  2) Re-run with --force-overwrite-excel to overwrite the human Excel edits.")
+			return 1
+		}
+	}
+
 	cmp := el.NewCompiler()
 
 	// Wire up the EDD-derived symbol table so the EL compiler picks the
@@ -164,6 +191,23 @@ func (c *CLI) runCompile(args []string) int {
 		len(files), totalCompiled, totalSkipped, totalErrors)
 	if dryRun {
 		fmt.Println("(dry run — no files modified)")
+	}
+
+	// Excel refresh (v1.14.5): now that XML postfix has been written,
+	// re-export Excel from the new state so the two formats stay
+	// paired on disk. No-op on projects without a `.sync-manifest.json`
+	// (legacy / flat layouts). Skipped on --dry-run.
+	if !dryRun && totalCompiled > 0 {
+		refreshDir := target
+		if info, err := os.Stat(target); err == nil && !info.IsDir() {
+			refreshDir = filepath.Dir(target)
+		}
+		if err := authoring.RefreshExcelInDir(refreshDir); err != nil {
+			fmt.Fprintf(os.Stderr, "compile: Excel refresh failed: %v\n", err)
+			fmt.Fprintln(os.Stderr, "  XML was written; Excel may be stale. Run `dtrules build` to recover.")
+			// Don't fail the command — XML write succeeded. Exit code
+			// reflects compile success/failure only.
+		}
 	}
 
 	// Advisory pass: run decisiontable.Analyze on every table in every file.
@@ -303,6 +347,11 @@ Options:
                 after a compiler bug fix (e.g. v1.14.2 #790) to refresh
                 postfix produced by an earlier buggy version. Default
                 only fills empty postfix.
+  --force-overwrite-excel
+                Bypass the Excel-mtime guard. By default 'compile'
+                refuses to run when a covered Excel file is newer than
+                its last export (would clobber human edits). Pass this
+                flag only after deciding the XML version should win.
   --no-analyze  Skip the advisory pass after compile. Default runs it.
   -v, --verbose Per-file compiled/skipped/error/warning counts.
 

--- a/cmd/dtrules/project_cmd.go
+++ b/cmd/dtrules/project_cmd.go
@@ -36,7 +36,7 @@ func (c *CLI) runProject(args []string) int {
 	}
 	sub := args[0]
 	rest := args[1:]
-	ctx.projectPath, rest = parseProjectFlag(rest)
+	ctx.projectPath, ctx.forceOverwriteExcel, rest = parseProjectFlag(rest)
 
 	switch sub {
 	case "diagnostics":

--- a/cmd/dtrules/table_cmd.go
+++ b/cmd/dtrules/table_cmd.go
@@ -44,6 +44,11 @@ type tableCmdCtx struct {
 	stdout      io.Writer
 	stderr      io.Writer
 	projectPath string
+	// forceOverwriteExcel, when true, bypasses Project.Save's
+	// "Excel newer than last export" guard for this command. Set by
+	// the `--force-overwrite-excel` CLI flag; the default is false,
+	// which preserves human Excel edits by refusing the XML write.
+	forceOverwriteExcel bool
 }
 
 // emitErr writes a JSON error record to stderr and returns the exit code.
@@ -62,9 +67,11 @@ func writeJSON(w io.Writer, v interface{}) error {
 	return enc.Encode(v)
 }
 
-// parseProjectFlag pulls --project out of a flag slice, returning the value
-// and a copy of args with that flag removed. Defaults to ".".
-func parseProjectFlag(args []string) (projectPath string, rest []string) {
+// parseProjectFlag pulls --project / -p and --force-overwrite-excel
+// out of a flag slice, returning the parsed values and a copy of args
+// with those flags removed. Defaults: projectPath=".",
+// forceOverwriteExcel=false.
+func parseProjectFlag(args []string) (projectPath string, forceOverwriteExcel bool, rest []string) {
 	projectPath = "."
 	out := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
@@ -75,9 +82,13 @@ func parseProjectFlag(args []string) (projectPath string, rest []string) {
 				continue
 			}
 		}
+		if args[i] == "--force-overwrite-excel" {
+			forceOverwriteExcel = true
+			continue
+		}
 		out = append(out, args[i])
 	}
-	return projectPath, out
+	return projectPath, forceOverwriteExcel, out
 }
 
 // runTable dispatches `dtrules table ...`.
@@ -89,7 +100,7 @@ func (c *CLI) runTable(args []string) int {
 	}
 	sub := args[0]
 	rest := args[1:]
-	ctx.projectPath, rest = parseProjectFlag(rest)
+	ctx.projectPath, ctx.forceOverwriteExcel, rest = parseProjectFlag(rest)
 
 	switch sub {
 	case "list":
@@ -122,7 +133,7 @@ func (c *CLI) runEDD(args []string) int {
 	}
 	sub := args[0]
 	rest := args[1:]
-	ctx.projectPath, rest = parseProjectFlag(rest)
+	ctx.projectPath, ctx.forceOverwriteExcel, rest = parseProjectFlag(rest)
 
 	switch sub {
 	case "get":
@@ -149,6 +160,9 @@ func (ctx *tableCmdCtx) openProject() (*authoring.Project, int) {
 	if err != nil {
 		return nil, emitErr(ctx.stderr, 1, "io_error", "", "project must contain an xml/ subdirectory or *_dt.xml files directly", err.Error())
 	}
+	// Thread the --force-overwrite-excel flag through so Save / SaveEDD
+	// know whether to bypass the Excel-mtime guard for this command.
+	p.OverwriteExcel = ctx.forceOverwriteExcel
 	return p, 0
 }
 

--- a/pkg/dtrules/authoring/edd.go
+++ b/pkg/dtrules/authoring/edd.go
@@ -92,8 +92,31 @@ func (p *Project) EDD() *EDD {
 	return p.edd
 }
 
-// SaveEDD writes the EDD back to its file.
+// SaveEDD writes the project's EDD XML AND refreshes any covered Excel
+// workbook. Same guard + auto-refresh contract as Project.Save: the
+// pre-write check refuses if a covered Excel has been touched since
+// the last export (set OverwriteExcel = true to bypass), and a
+// successful write triggers a fresh Excel export so the two formats
+// stay paired on disk.
+//
+// Save() bypasses this wrapper internally — it runs its own guard
+// once and then calls saveEDDXMLOnly directly so we don't double-
+// guard or double-refresh.
 func (p *Project) SaveEDD() error {
+	if err := p.preWriteExcelGuard(); err != nil {
+		return err
+	}
+	if err := p.saveEDDXMLOnly(); err != nil {
+		return err
+	}
+	return p.refreshExcelFromXML()
+}
+
+// saveEDDXMLOnly is the legacy EDD-XML-only writer. Callers that want
+// the Excel-sync contract use the public SaveEDD wrapper above; only
+// internal Save() (which guards once for the whole project) calls
+// this directly.
+func (p *Project) saveEDDXMLOnly() error {
 	if p.edd == nil {
 		return nil
 	}

--- a/pkg/dtrules/authoring/excel_sync.go
+++ b/pkg/dtrules/authoring/excel_sync.go
@@ -1,0 +1,209 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/excel"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+	"github.com/DTRules/DTRules/pkg/dtrules/sync"
+)
+
+// Package-level helpers that implement the "Excel is system of record"
+// contract for any caller working with a DTRules project on disk.
+// Project.Save / SaveEDD wrap them; dtrules compile (which does
+// byte-level XML rewriting outside the Project model) calls them
+// directly around its compile loop.
+//
+// Both helpers are no-ops on projects with no `.sync-manifest.json`
+// reachable from the XML directory — that's the legacy / flat layout
+// where Excel isn't in play, and the legacy Save behavior must stay
+// preserved.
+
+// GuardExcelInDir runs the manifest-driven Excel-mtime guard against
+// the project rooted at xmlDir. If `overwrite` is false (the default)
+// and any covered Excel file has been touched since the last export,
+// the guard returns a `*sync.ExcelModifiedError` naming the file. Pass
+// true to bypass the mtime guard while still running the lock-file
+// detection — lock files always block writes because writing through
+// an open spreadsheet corrupts the on-disk state from the other app's
+// perspective.
+//
+// Returns nil on no-manifest projects.
+func GuardExcelInDir(xmlDir string, overwrite bool) error {
+	m, manifestDir := LoadSyncManifestForXMLDir(xmlDir)
+	if m == nil {
+		return nil
+	}
+	for excelRel := range m.Files {
+		excelPath := filepath.Join(manifestDir, excelRel)
+		if err := excelLockError(excelPath); err != nil {
+			return err
+		}
+		if overwrite {
+			continue
+		}
+		if err := m.ExportGuard(excelPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RefreshExcelInDir re-exports every Excel file the project's sync
+// manifest covers from the current on-disk XML state. Loads a
+// tolerant RuleSet so the export works even when the operator is
+// mid-edit (DSL added but not yet compiled to postfix).
+//
+// Idempotent: a second call right after the first writes the same
+// bytes. Called by Save / SaveEDD / dtrules compile after their
+// respective XML writes; the manifest's RecordExport refreshes
+// LastExportTime so the next GuardExcelInDir starts from a clean
+// baseline.
+//
+// Returns nil on no-manifest projects.
+func RefreshExcelInDir(xmlDir string) error {
+	m, manifestDir := LoadSyncManifestForXMLDir(xmlDir)
+	if m == nil {
+		return nil
+	}
+	rs, err := loadRuleSetForExportInDir(xmlDir)
+	if err != nil {
+		return fmt.Errorf("excel refresh: load ruleset: %w", err)
+	}
+	exporter := excel.NewExporter(rs)
+	for excelRel, entry := range m.Files {
+		excelPath := filepath.Join(manifestDir, excelRel)
+		if err := exporter.ExportDecisionTables(excelPath); err != nil {
+			return fmt.Errorf("excel refresh: export %s: %w", excelPath, err)
+		}
+		if err := m.RecordExport(excelPath, entry.XMLFiles); err != nil {
+			return fmt.Errorf("excel refresh: record manifest for %s: %w", excelPath, err)
+		}
+	}
+	return nil
+}
+
+// LoadSyncManifestForXMLDir searches the conventional layouts for the
+// `.sync-manifest.json` that pairs Excel files with their XML exports.
+// Returns the manifest plus the directory it lives in (manifest paths
+// are relative to that directory), or (nil, "") if no manifest is
+// reachable.
+//
+// Search order:
+//  1. `<xmlDir>/.sync-manifest.json` — canonical xml/+excel/-as-siblings layout.
+//  2. `<xmlDir>/../source/.sync-manifest.json` — staking's convention
+//     (rules/ and source/ as siblings under pkg/dtrules).
+//  3. `<xmlDir>/../excel/.sync-manifest.json` — TaxReturn-style layout.
+//  4. `<xmlDir>/../.sync-manifest.json` — flat catch-all.
+//
+// First match wins. Exported so callers in cmd/dtrules can probe
+// before deciding whether to enforce the Excel contract.
+func LoadSyncManifestForXMLDir(xmlDir string) (*sync.Manifest, string) {
+	parent := filepath.Dir(xmlDir)
+	candidates := []string{
+		xmlDir,
+		filepath.Join(parent, "source"),
+		filepath.Join(parent, "excel"),
+		parent,
+	}
+	for _, dir := range candidates {
+		manifestPath := filepath.Join(dir, ".sync-manifest.json")
+		if _, err := os.Stat(manifestPath); err != nil {
+			continue
+		}
+		m, err := sync.LoadManifest(manifestPath)
+		if err != nil {
+			continue
+		}
+		return m, dir
+	}
+	return nil, ""
+}
+
+// excelLockError returns a non-nil error when an Excel file appears
+// to be open in another process. Two conventions are recognized:
+//   - `~$<name>.xlsx`        Microsoft Excel (Windows / macOS)
+//   - `.~lock.<name>.xlsx#`  LibreOffice
+//
+// Writing to a workbook that's open in either application from outside
+// the app corrupts it from the app's point of view. Refusing the
+// write here is friendlier than the post-hoc cleanup users would
+// otherwise face.
+func excelLockError(excelPath string) error {
+	dir := filepath.Dir(excelPath)
+	base := filepath.Base(excelPath)
+	candidates := []string{
+		filepath.Join(dir, "~$"+base),
+		filepath.Join(dir, ".~lock."+base+"#"),
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return fmt.Errorf("Excel file %q appears to be open (lock file %q present); close the spreadsheet app and retry, or remove the lock file if stale",
+				excelPath, c)
+		}
+	}
+	return nil
+}
+
+// loadRuleSetForExportInDir is the file-system-driven function used
+// by RefreshExcelInDir. It globs EDD and DT files directly
+// under xmlDir (the same set Project.loadDTFiles + Project.loadEDD
+// would have produced) and loads them into a tolerant RuleSet. Used
+// by callers that don't already have a Project in memory — chiefly
+// dtrules compile, which does byte-level XML rewriting outside the
+// Project model.
+func loadRuleSetForExportInDir(xmlDir string) (*session.RuleSet, error) {
+	rs := session.NewRuleSet("authoring-export")
+	if rs == nil {
+		return nil, fmt.Errorf("failed to create ruleset")
+	}
+	eddMatches, _ := filepath.Glob(filepath.Join(xmlDir, "*_edd.xml"))
+	for _, eddPath := range eddMatches {
+		if err := rs.LoadEDDFile(eddPath); err != nil {
+			return nil, fmt.Errorf("load edd %s: %w", eddPath, err)
+		}
+	}
+	// DT files are loaded recursively so nested layouts (e.g.
+	// states/CA_dt.xml under xml/) get picked up the way the loader
+	// would discover them at runtime.
+	var dtPaths []string
+	_ = filepath.WalkDir(xmlDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if filepath.Ext(name) != ".xml" {
+			return nil
+		}
+		if filepath.Base(name) == "" {
+			return nil
+		}
+		// _dt.xml only; skip _edd.xml (already loaded) and _map.xml.
+		if len(name) >= 7 && name[len(name)-7:] == "_dt.xml" {
+			dtPaths = append(dtPaths, p)
+		}
+		return nil
+	})
+	for _, dtPath := range dtPaths {
+		if err := rs.LoadDecisionTablesTolerantFile(dtPath); err != nil {
+			return nil, fmt.Errorf("load dt %s: %w", dtPath, err)
+		}
+	}
+	return rs, nil
+}

--- a/pkg/dtrules/authoring/excel_sync_test.go
+++ b/pkg/dtrules/authoring/excel_sync_test.go
@@ -1,0 +1,285 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+	"github.com/DTRules/DTRules/pkg/dtrules/sync"
+)
+
+// Minimal DT XML used across the Excel-sync tests below. One table,
+// one condition, one action, postfix populated — the loader's strict
+// path won't reject it during the auto-export refresh.
+const excelSyncDTFixture = `<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+<decision_table>
+<table_name>ExcelSyncFixture</table_name>
+<xls_file>fixture.xlsx</xls_file>
+<attribute_fields><Type>FIRST</Type><COMMENTS></COMMENTS><TABLE_NUMBER>1</TABLE_NUMBER></attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
+<conditions>
+  <condition_details>
+    <condition_number>1</condition_number>
+    <condition_comment>flag</condition_comment>
+    <condition_dsl>job.flag</condition_dsl>
+    <condition_postfix>job.flag</condition_postfix>
+    <condition_column column_number="1" column_value="Y"/>
+  </condition_details>
+</conditions>
+<actions>
+  <action_details>
+    <action_number>1</action_number>
+    <action_comment>noop</action_comment>
+    <action_dsl></action_dsl>
+    <action_postfix></action_postfix>
+    <action_column column_number="1" column_value="X"/>
+  </action_details>
+</actions>
+</decision_table>
+</decision_tables>
+`
+
+const excelSyncEDDFixture = `<?xml version="1.0" encoding="UTF-8"?>
+<entity_data_dictionary version="2">
+  <entity name="job" access="rw">
+    <field name="flag" type="boolean" subtype="" access="rw" input="" default_value="false" comment=""/>
+  </entity>
+</entity_data_dictionary>
+`
+
+// setupExcelSyncProject lays out the staking-style flat project that
+// the Excel-sync helpers are meant to support: a `.sync-manifest.json`
+// next to a fake xlsx, in a sibling directory to the xml. Returns the
+// xml dir, the manifest dir, and the fake xlsx path. The xlsx is just
+// an empty placeholder file — the helpers care about its mtime, not
+// its bytes.
+func setupExcelSyncProject(t *testing.T) (xmlDir, manifestDir, xlsxPath string) {
+	t.Helper()
+	root := t.TempDir()
+	xmlDir = filepath.Join(root, "rules")
+	manifestDir = filepath.Join(root, "source")
+	if err := os.MkdirAll(xmlDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a placeholder Excel file. The exporter will overwrite it
+	// during refresh; for guard tests we only need it to exist.
+	xlsxPath = filepath.Join(manifestDir, "fixture.xlsx")
+	if err := os.WriteFile(xlsxPath, []byte("placeholder"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a manifest that records the xlsx as last-exported a long
+	// time ago (well before any subsequent file touches in the test).
+	pastTime := time.Now().Add(-24 * time.Hour)
+	manifest := map[string]interface{}{
+		"version":     1,
+		"lastUpdated": pastTime.Format(time.RFC3339Nano),
+		"files": map[string]interface{}{
+			"fixture.xlsx": map[string]interface{}{
+				"lastExportTime":       pastTime.Format(time.RFC3339Nano),
+				"excelModTimeAtExport": pastTime.Format(time.RFC3339Nano),
+				"xmlFiles":             []string{"../rules/fixture_dt.xml", "../rules/fixture_edd.xml"},
+			},
+		},
+	}
+	manifestBytes, _ := json.MarshalIndent(manifest, "", "  ")
+	if err := os.WriteFile(filepath.Join(manifestDir, ".sync-manifest.json"), manifestBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write the DT + EDD XML.
+	if err := os.WriteFile(filepath.Join(xmlDir, "fixture_dt.xml"), []byte(excelSyncDTFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(xmlDir, "fixture_edd.xml"), []byte(excelSyncEDDFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the xlsx older than the manifest's last-export time so the
+	// guard sees "Excel not modified since export" by default.
+	veryPast := pastTime.Add(-time.Hour)
+	if err := os.Chtimes(xlsxPath, veryPast, veryPast); err != nil {
+		t.Fatal(err)
+	}
+	return xmlDir, manifestDir, xlsxPath
+}
+
+// TestGuardExcelInDir_RefusesWhenExcelNewer is the core Phase 1
+// contract: AI/CLI writes that would clobber human Excel edits get
+// refused. The guard returns sync.ExcelModifiedError naming the file
+// so the operator can investigate.
+func TestGuardExcelInDir_RefusesWhenExcelNewer(t *testing.T) {
+	xmlDir, _, xlsxPath := setupExcelSyncProject(t)
+
+	// Touch the xlsx to make it "newer than last export" — the
+	// exact condition that flags it as "user edited Excel since the
+	// last build."
+	now := time.Now()
+	if err := os.Chtimes(xlsxPath, now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	err := authoring.GuardExcelInDir(xmlDir, false)
+	if err == nil {
+		t.Fatal("expected guard to refuse (Excel newer than last export); got nil")
+	}
+	if !sync.IsExcelModifiedError(err) {
+		t.Errorf("expected sync.ExcelModifiedError, got %T: %v", err, err)
+	}
+}
+
+// TestGuardExcelInDir_PassesWithOverwriteFlag verifies the
+// --force-overwrite-excel CLI flag's underlying behavior: when the
+// caller asserts the XML version should win, the mtime guard yields.
+// The lock-file check still runs (an open Excel still blocks the
+// write — the override is for human edits, not for live conflicts).
+func TestGuardExcelInDir_PassesWithOverwriteFlag(t *testing.T) {
+	xmlDir, _, xlsxPath := setupExcelSyncProject(t)
+	now := time.Now()
+	if err := os.Chtimes(xlsxPath, now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := authoring.GuardExcelInDir(xmlDir, true); err != nil {
+		t.Errorf("guard should yield with overwrite=true; got %v", err)
+	}
+}
+
+// TestGuardExcelInDir_NoManifestIsNoOp pins the backward-compatibility
+// promise: projects that don't have a `.sync-manifest.json` (legacy
+// XML-only or fresh fixtures with no Excel side) skip the guard
+// entirely. Without this every test in the codebase would break.
+func TestGuardExcelInDir_NoManifestIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	if err := authoring.GuardExcelInDir(dir, false); err != nil {
+		t.Errorf("guard on no-manifest dir should be no-op; got %v", err)
+	}
+}
+
+// TestGuardExcelInDir_RefusesWhenExcelLocked is the lock-file path.
+// Microsoft Excel's `~$<name>.xlsx` sidecar and LibreOffice's
+// `.~lock.<name>.xlsx#` sidecar both indicate an open spreadsheet;
+// writing through either corrupts the in-app state. The guard
+// refuses regardless of the OverwriteExcel flag — overrides apply
+// to human-edits-vs-AI, not to live-conflicts.
+func TestGuardExcelInDir_RefusesWhenExcelLocked(t *testing.T) {
+	xmlDir, manifestDir, xlsxPath := setupExcelSyncProject(t)
+
+	// LibreOffice convention.
+	lockPath := filepath.Join(manifestDir, ".~lock.fixture.xlsx#")
+	if err := os.WriteFile(lockPath, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Even with overwrite=true the lock blocks.
+	err := authoring.GuardExcelInDir(xmlDir, true)
+	if err == nil {
+		t.Fatal("expected guard to refuse on lock file; got nil")
+	}
+	if !strings.Contains(err.Error(), "appears to be open") {
+		t.Errorf("expected lock-file message; got: %v", err)
+	}
+	os.Remove(lockPath)
+
+	// Microsoft Excel convention.
+	excelLockPath := filepath.Join(manifestDir, "~$fixture.xlsx")
+	if err := os.WriteFile(excelLockPath, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err = authoring.GuardExcelInDir(xmlDir, true)
+	if err == nil {
+		t.Fatal("expected guard to refuse on MS Excel lock file; got nil")
+	}
+	if !strings.Contains(err.Error(), "appears to be open") {
+		t.Errorf("expected lock-file message; got: %v", err)
+	}
+
+	// Keep xlsxPath referenced so the linter doesn't flag the helper
+	// return value as unused on this branch.
+	_ = xlsxPath
+}
+
+// TestRefreshExcelInDir_NoOpOnNoManifest is the symmetric backward-
+// compatibility check for Phase 2. Fresh fixtures without a manifest
+// must not trigger any RuleSet load or Excel write — Save / compile
+// against them stay XML-only as in v1.14.4.
+func TestRefreshExcelInDir_NoOpOnNoManifest(t *testing.T) {
+	dir := t.TempDir()
+	if err := authoring.RefreshExcelInDir(dir); err != nil {
+		t.Errorf("refresh on no-manifest dir should be no-op; got %v", err)
+	}
+}
+
+// TestRefreshExcelInDir_UpdatesExcelMtime is the Phase 2 happy path:
+// after the refresh runs, the xlsx file's mtime has moved forward
+// (proof that the exporter wrote bytes) AND the manifest's
+// LastExportTime has advanced (proof that RecordExport ran).
+//
+// We don't assert on the xlsx contents — the existing
+// pkg/dtrules/excel tests cover that — only that the refresh
+// happens at all.
+func TestRefreshExcelInDir_UpdatesExcelMtime(t *testing.T) {
+	xmlDir, manifestDir, xlsxPath := setupExcelSyncProject(t)
+
+	beforeMtime := mtimeOf(t, xlsxPath)
+	manifestPathBefore := filepath.Join(manifestDir, ".sync-manifest.json")
+	manifestBefore, err := os.ReadFile(manifestPathBefore)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sleep briefly so an mtime change is observable; some filesystems
+	// have second-resolution mtime.
+	time.Sleep(1100 * time.Millisecond)
+
+	if err := authoring.RefreshExcelInDir(xmlDir); err != nil {
+		t.Fatalf("RefreshExcelInDir: %v", err)
+	}
+
+	afterMtime := mtimeOf(t, xlsxPath)
+	if !afterMtime.After(beforeMtime) {
+		t.Errorf("xlsx mtime did not advance after refresh: before=%v after=%v",
+			beforeMtime, afterMtime)
+	}
+
+	manifestAfter, err := os.ReadFile(manifestPathBefore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(manifestBefore) == string(manifestAfter) {
+		t.Error("manifest unchanged after refresh — RecordExport should have advanced LastExportTime")
+	}
+}
+
+func mtimeOf(t *testing.T, path string) time.Time {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return info.ModTime()
+}

--- a/pkg/dtrules/authoring/project.go
+++ b/pkg/dtrules/authoring/project.go
@@ -33,6 +33,16 @@ type Project struct {
 	edd         *EDD         // lazily loaded
 	execSt      *execState   // lazily-created execution state; nil until first use
 	diagnostics []Diagnostic // authoring-time diagnostics (duplicate renames, etc.)
+
+	// OverwriteExcel, when true, suppresses the "Excel newer than last
+	// export" guard in Save() / SaveEDD(). Default false: a downstream
+	// Excel that's newer than what the sync manifest recorded means a
+	// human edited the spreadsheet outside DTRules; silently
+	// overwriting it with the XML-derived render would lose work. The
+	// guard refuses with sync.ExcelModifiedError and the operator
+	// either runs `dtrules build --from-excel` first to merge those
+	// changes, or sets this flag to force-overwrite.
+	OverwriteExcel bool
 }
 
 // dtFileEntry tracks a single decision-table XML file and its in-memory model.
@@ -224,16 +234,90 @@ func (p *Project) loadDTFiles(xmlDir string) error {
 	return nil
 }
 
-// Save writes all pending mutations back to disk as canonical XML files.
-// The output uses the same format as the DTImporter.WriteXML pipeline.
+// Save writes all pending mutations back to disk as canonical XML files
+// AND refreshes any Excel workbook the project's sync manifest points at,
+// keeping the "Excel is system of record" contract honored on every
+// authoring write.
+//
+// The flow:
+//
+//  1. Locate the sync manifest (the `.sync-manifest.json` that
+//     `dtrules build` maintains beside the project's Excel files).
+//     If no manifest exists, the project is treated as XML-only and
+//     Save behaves like the pre-v1.14.5 version — XML write only.
+//
+//  2. For each Excel file the manifest covers, run ExportGuard to
+//     refuse the write if the user has touched Excel since the last
+//     export (mtime-based). The error type is
+//     `sync.ExcelModifiedError`; set `OverwriteExcel = true` on the
+//     project to bypass this guard.
+//
+//  3. Refuse the write if any covered Excel file is locked by another
+//     process (`~$<name>.xlsx` or `.~lock.<name>.xlsx#` siblings).
+//     Writing through a lock corrupts the file from the other app's
+//     point of view.
+//
+//  4. Write XML (as before).
+//
+//  5. Re-export every covered Excel from the in-memory project so
+//     XML and Excel stay byte-paired on disk. Update the manifest's
+//     last-export record afterward so the next Save's guard sees a
+//     fresh baseline.
+//
+// XML is always written if the guards pass. If the Excel refresh
+// fails (e.g. mid-write disk error), the XML write has already
+// happened; Save returns a wrapped error naming the failed Excel
+// path so the operator can recover.
 func (p *Project) Save() error {
+	if err := p.preWriteExcelGuard(); err != nil {
+		return err
+	}
+
 	imp := excel.NewDTImporter()
 	for _, entry := range p.dtFiles {
 		if err := imp.WriteXML(entry.tables, entry.path); err != nil {
 			return fmt.Errorf("failed to write %s: %w", entry.path, err)
 		}
 	}
-	return p.SaveEDD()
+	if err := p.saveEDDXMLOnly(); err != nil {
+		return err
+	}
+	return p.refreshExcelFromXML()
+}
+
+// preWriteExcelGuard is the Project-method facade over GuardExcelInDir.
+// It threads the project's OverwriteExcel flag through and otherwise
+// delegates straight to the package-level helper, so the same code
+// path runs whether the caller is Project.Save or a non-Project
+// surface like dtrules compile.
+func (p *Project) preWriteExcelGuard() error {
+	return GuardExcelInDir(p.xmlDir, p.OverwriteExcel)
+}
+
+// refreshExcelFromXML re-exports every Excel file the sync manifest
+// covers from the project's freshly-written XML state. Called after
+// the XML write so XML and Excel are byte-paired on disk by the time
+// Save returns.
+//
+// The export goes through `excel.NewExporter(rs)` which requires a
+// `*session.RuleSet`. Loading the RuleSet here pays a one-time cost
+// per Save — modest for a single-workbook project (staking), more
+// noticeable on TaxReturn-scale corpora. Tolerant load so DSL-only
+// elements (no postfix) don't error out; Save is an authoring
+// surface and the operator may be in the middle of an edit.
+//
+// Manifest is updated via RecordExport after each successful Excel
+// write so the next Save's ExportGuard sees the fresh baseline.
+//
+// No-manifest projects skip this whole step (same logic as the
+// preWriteExcelGuard) — Save behaves as the legacy XML-only writer
+// for them.
+// refreshExcelFromXML is the Project-method facade over
+// RefreshExcelInDir. Same pattern as preWriteExcelGuard: delegate to
+// the package-level helper so the same code path runs from any caller
+// (Save, SaveEDD, dtrules compile).
+func (p *Project) refreshExcelFromXML() error {
+	return RefreshExcelInDir(p.xmlDir)
 }
 
 // Tables lists the names of every decision table in the project.


### PR DESCRIPTION
## Bug

Six XML-writing surfaces had been silently breaking the documented "Excel is the system of record" contract since v1.14.0:

| Surface | What it called | Excel touched? |
|---|---|---|
| `dtrules table put` / `patch` | `Project.Save()` | **No** |
| `dtrules edd put` / `patch` | `Project.SaveEDD()` | **No** |
| MCP `table_put` / `table_patch` / `edd_put` | same `Save()` paths | **No** |
| `dtrules compile` | direct byte-level XML write | **No** (was an explicit v1.14.0 non-goal) |

CLAUDE.md says "Excel is the source of truth" and "run `dtrules build` after every edit", but the authoring tools didn't enforce it — and an AI agent calling `table_put` via MCP would never run build at all. Easy to skip; impossible to detect after the fact.

### Concrete drift, today

On the staking project:

```
pkg/dtrules/rules/staking_dt.xml   2026-05-27 16:51   ← AI edited
pkg/dtrules/source/staking.xlsx    2026-05-25 01:15   ← stale
sync-manifest.json lastExportTime: 2026-05-18
```

Three days of authoring went past with the spreadsheet anyone could open frozen at an earlier state.

## Fix — three pieces

1. **Pre-write Excel-mtime guard (Phase 1).** Before any XML write, check the sync manifest's last-export record against every covered Excel file's mtime. If a human has touched Excel since the last export, refuse the write with `sync.ExcelModifiedError`. Override: `--force-overwrite-excel` (CLI) / `Project.OverwriteExcel = true` (Go API).

2. **Lock-file detection.** `~$<name>.xlsx` (MS Excel) and `.~lock.<name>.xlsx#` (LibreOffice) sidecars block writes unconditionally — writing through an open spreadsheet corrupts in-app state. The override flag does **not** bypass this; the operator must close the spreadsheet first.

3. **Post-write Excel refresh (Phase 2).** After XML lands, covered Excel files are re-exported via `excel.NewExporter` from the new in-memory state. Sync manifest's `RecordExport` advances `LastExportTime` so the next guard starts from a clean baseline.

## API

Two new package-level helpers in `pkg/dtrules/authoring`:

- `GuardExcelInDir(xmlDir, overwrite)` — runs Phase 1 + lock-file check.
- `RefreshExcelInDir(xmlDir)` — runs Phase 2.
- `LoadSyncManifestForXMLDir(xmlDir)` — manifest discovery. Search order: `<xmlDir>/`, `<xmlDir>/../source/`, `<xmlDir>/../excel/`, `<xmlDir>/../`. First match wins. Covers staking's flat `pkg/dtrules/{rules,source}/` layout AND the canonical TaxReturn `<project>/{xml,excel}/` layout.

`Project.Save` / `SaveEDD` / `dtrules compile` all route through these. `Project.OverwriteExcel bool` field threads the override.

## Backward compatibility

Projects without `.sync-manifest.json` (legacy XML-only fixtures, fresh `dtrules init` projects that haven't been built yet, SyntaxTests sample) skip both guards entirely. Behavior is bit-for-bit identical to v1.14.4 for them.

The new contract only activates for projects that have run `dtrules build` at least once and thus have a manifest beside their Excel files.

## Tests

Six new regression tests in `pkg/dtrules/authoring/excel_sync_test.go`:

- `TestGuardExcelInDir_RefusesWhenExcelNewer` — Phase 1 core contract.
- `TestGuardExcelInDir_PassesWithOverwriteFlag` — override path.
- `TestGuardExcelInDir_NoManifestIsNoOp` — backward compat.
- `TestGuardExcelInDir_RefusesWhenExcelLocked` — both lock-file conventions; override doesn't bypass.
- `TestRefreshExcelInDir_NoOpOnNoManifest` — Phase 2 backward compat.
- `TestRefreshExcelInDir_UpdatesExcelMtime` — Phase 2 happy path; mtime + manifest both advance.

`make check` passes.

## Behavior change worth knowing

Any caller of `dtrules table put` / `compile` / MCP against a project with a manifest AND an open Excel file (lock file present) will now fail loudly where it used to silently succeed. Staking's `.~lock.staking_dt.xlsx#` was present when I diagnosed this — first call after the bump will refuse until they close the spreadsheet, which is the contract working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)