### PR TITLE
feat(analyze): flag columns that don't introduce a new action set (#797); v1.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 # DTRules Changelog
 
+## v1.14.6 — 2026-05-28
+
+New analyzer check: **redundant action-set column** (#797).
+
+A column is redundant if it doesn't introduce a new action-set
+combination into the decision tree. The existing redundancy checks
+operate at the cell level (`redundant condition` flags individual
+Y/N entries; `subsumed column` requires another column to already be
+more permissive). Neither catches the common shape where a "catch-all"
+fallback is split across N condition combinations all firing the same
+actions.
+
+### Algorithm
+
+`AnalyzeCompiledTable` walks the compiled tree, groups columns by the
+ordered tuple of action numbers their path reaches, and for each
+group keeps the lowest column number ("useful — first to reach this
+action set"). Every other column in the group is flagged. Action-set
+identity is the *ordered* tuple — `[A, B]` and `[B, A]` are NOT the
+same set because the runtime executes them in order and order
+matters for audit trails, sequence between sets and reads, etc.
+
+### Concrete impact: staking's Calculate_Withholding
+
+Four-column table, FIRST policy. Two action sets:
+- A = `{Raw 45%, Cap, Staker=weekly-withhold, Track deposits}` — col 1
+- B = `{Zero, Full budget, Track deposits}` — cols 2, 3, 4
+
+Pre-fix the operator saw two `redundant condition` warnings on col 4
+(after #794's leave-one cap) plus three on col 3. Post-fix they
+additionally see:
+
+```
+WARN Calculate_Withholding: column 3 reaches the same action set as
+  column 2 — consider collapsing into a single column (all conditions
+  = '-') or removing if the inputs should fall through downstream
+WARN Calculate_Withholding: column 4 reaches the same action set as
+  column 2 — ...
+```
+
+Direct column-level recommendation instead of cell-by-cell hints.
+
+### Coverage
+
+Three new regression tests in `pkg/dtrules/decisiontable/tree_analysis_test.go`:
+
+- `TestCheckRedundantActionSetColumns_TwoActionSets` —
+  Calculate_Withholding shape; cols 3 and 4 flagged, col 2 not.
+- `TestCheckRedundantActionSetColumns_DistinctActionSets` — silent
+  when every column has a unique action set.
+- `TestCheckRedundantActionSetColumns_OrderMatters` — `[A, B]` vs
+  `[B, A]` are treated as distinct action sets.
+
+`dtrules docs warnings` catalogue extended with the new "9. redundant
+action-set column" entry. `TestDocumentation_WarningsTopic` pins the
+new term so future doc refactors can't silently drop it.
+
+### Where the check fires
+
+`AnalyzeCompiledTable` only — runs from `dtrules review` and the
+`project_full_review` MCP tool. The matrix-only `decisiontable.Analyze`
+path (used by `dtrules build`, `dtrules compile`, `dtrules table
+warnings`) doesn't have access to the compiled tree, so this check
+is invisible there. Consistent with the existing tree-only checks
+(`unreachable column` via tree, `dead condition row`).
+
 ## v1.14.5 — 2026-05-28
 
 Restores the **"Excel is the system of record"** contract that

--- a/cmd/dtrules/doc_warnings.go
+++ b/cmd/dtrules/doc_warnings.go
@@ -161,6 +161,30 @@ some other path the matrix-driven kind 4 above couldn't see.
 
   Action: delete the column.
 
+9. redundant action-set column (#797; tree-based, from review only)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Column N reaches the same ordered action set as an earlier column;
+its conditions are decorative — under FIRST policy any input that
+reaches column N would land on identical behavior had column N not
+existed. The warning identifies the earlier column.
+
+Most common shape: a final "catch-all" set of columns split across
+N condition combinations that all execute the same fallback
+actions. They can collapse into one column with all conditions
+= '-' (dash, "don't care").
+
+  Repro: Calculate_Withholding in the staking project has cols
+  2/3/4 all executing {Zero withholding, Full budget, Track
+  deposits} but with three different N-pattern condition matrices.
+  Flagged: col 3, col 4 (col 2 introduces the action set).
+
+  Action: collapse into one '-'-only column with that action set,
+  OR delete and let inputs fall through to a downstream column
+  with the intended fallback behavior. Order matters — '[A, B]'
+  and '[B, A]' are NOT the same action set because the runtime
+  executes them in order.
+
 Severity and exit codes
 -----------------------
 

--- a/cmd/dtrules/docs_test.go
+++ b/cmd/dtrules/docs_test.go
@@ -255,6 +255,7 @@ func TestDocumentation_WarningsTopic(t *testing.T) {
 		"assignment-only table",
 		"hand-coded postfix",
 		"dead condition row",
+		"redundant action-set column",
 		"decisiontable.Analyze",
 		"dtrules table warnings",
 		"dtrules review",

--- a/pkg/dtrules/decisiontable/tree_analysis.go
+++ b/pkg/dtrules/decisiontable/tree_analysis.go
@@ -14,6 +14,11 @@
 
 package decisiontable
 
+import (
+	"fmt"
+	"strings"
+)
+
 // AnalyzeCompiledTable runs the post-compile advisory checks on a
 // decision table whose tree has already been built (Build / Compile).
 // These checks need the compiled tree because they answer
@@ -43,6 +48,7 @@ func AnalyzeCompiledTable(dt *RDecisionTable) []Warning {
 	var warnings []Warning
 	warnings = append(warnings, checkUnreachableColumnsByTree(dt, root)...)
 	warnings = append(warnings, checkDeadConditionsByTree(dt, root)...)
+	warnings = append(warnings, checkRedundantActionSetColumns(dt, root)...)
 	return warnings
 }
 
@@ -117,6 +123,102 @@ func checkDeadConditionsByTree(dt *RDecisionTable, root DTNode) []Warning {
 		warnings = append(warnings, w)
 	}
 	return warnings
+}
+
+// checkRedundantActionSetColumns is the #797 check: a column is
+// redundant if it doesn't introduce a new action-set combination
+// into the table's reachable leaves. Walk the compiled tree, group
+// columns by the ordered tuple of action numbers they reach, and
+// for each group keep the smallest column number ("useful — first
+// to reach this action set") while flagging every other column in
+// the group ("redundant — same action set already covered by an
+// earlier column").
+//
+// Stronger than the cell-level redundant-condition check (#762,
+// capped at K-1 by #794's leave-one rule): that check operates on
+// Y/N entries one cell at a time and tells the operator
+// individual cells are forced; this one tells them entire columns
+// are doing nothing new and points at the earlier column already
+// covering the same behavior. Recommended remediation is to
+// collapse the redundant columns into a single catch-all (`*` in
+// every condition row) or remove them and let their inputs fall
+// through to a downstream column.
+//
+// Action-set identity is the ordered tuple of action numbers
+// reached at the leaf — same actions in a different order is NOT
+// considered the same action set because the runtime executes
+// them in order and a different order can have observably
+// different effects (audit-trail line ordering, sequence
+// dependencies between sets and reads).
+//
+// Pre-existing dead/unreachable columns from checkUnreachableColumnsByTree
+// are skipped: a column with no ANode leaf wasn't compiled into
+// the tree at all, so the "introduces this action set" question
+// doesn't apply.
+func checkRedundantActionSetColumns(dt *RDecisionTable, root DTNode) []Warning {
+	maxCol := dt.GetMaxCol()
+	if maxCol < 2 {
+		return nil
+	}
+
+	// columnLeaf[col] = action-set signature reached by `col`. Built
+	// by walking the tree once and recording every (col → ANode)
+	// mapping. A column with no entry here is unreachable; the
+	// caller already gets a separate warning for those.
+	columnLeaf := make(map[int]string, maxCol)
+	walkTree(root, func(a *ANode, _ *CNode) {
+		if a == nil {
+			return
+		}
+		sig := actionSetSignature(a.actionNumbers)
+		for _, col := range a.columns {
+			columnLeaf[col] = sig
+		}
+	})
+
+	// firstColForActionSet[sig] = lowest column number reaching
+	// this action set. Iterate columns in order so the lowest
+	// number wins.
+	firstColForActionSet := make(map[string]int, maxCol)
+	var warnings []Warning
+	for col := 1; col <= maxCol; col++ {
+		sig, ok := columnLeaf[col]
+		if !ok {
+			continue // unreachable column — separate warning
+		}
+		earlier, seen := firstColForActionSet[sig]
+		if !seen {
+			firstColForActionSet[sig] = col
+			continue
+		}
+		w := newWarning(dt.GetName(), "redundant action-set column",
+			fmt.Sprintf("column %d reaches the same action set as column %d — consider collapsing into a single column (all conditions = '-') or removing if the inputs should fall through downstream",
+				col, earlier))
+		w.Column = col
+		warnings = append(warnings, w)
+	}
+	return warnings
+}
+
+// actionSetSignature returns a stable string key for an ordered list
+// of action numbers. Used to group columns by action-set identity in
+// checkRedundantActionSetColumns. The exact format isn't observable
+// — only the property that two equal sigs imply equal ordered
+// tuples and vice versa.
+func actionSetSignature(actionNumbers []int) string {
+	if len(actionNumbers) == 0 {
+		return "[]"
+	}
+	var b strings.Builder
+	b.WriteByte('[')
+	for i, n := range actionNumbers {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, "%d", n)
+	}
+	b.WriteByte(']')
+	return b.String()
 }
 
 // walkTree does a depth-first walk over the compiled decision tree,

--- a/pkg/dtrules/decisiontable/tree_analysis_test.go
+++ b/pkg/dtrules/decisiontable/tree_analysis_test.go
@@ -15,6 +15,7 @@
 package decisiontable
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/DTRules/DTRules/pkg/dtrules"
@@ -142,5 +143,112 @@ func TestCheckDeadConditionsByTree_RowSkipped(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected dead-row warning for row 1, got %v", ws)
+	}
+}
+
+// TestCheckRedundantActionSetColumns_TwoActionSets is the #797 happy
+// path: two action sets in the table, the second set is reached by
+// three columns, and only one of those three is the "first" (useful)
+// one. Cols 3 and 4 must be flagged as redundant action-set columns
+// pointing at col 2 as the earlier column that already covers their
+// action set.
+//
+// This reproduces the staking Calculate_Withholding shape: col 1
+// fires action set A (full withholding actions), cols 2/3/4 all fire
+// action set B (zero-withholding fallback) under different
+// condition combinations.
+func TestCheckRedundantActionSetColumns_TwoActionSets(t *testing.T) {
+	// Tree shape: condition row 0 splits col 1 (Y) from "the rest".
+	// Then row 1 splits col 2 vs col 3 vs col 4 — but we collapse to
+	// the same action-set ANode (separate node instances; same
+	// actionNumbers tuple) so the check sees three distinct ANodes
+	// sharing an action-set signature.
+	leafA := &ANode{actionNumbers: []int{0, 1, 2}, columns: []int{1}}
+	leafB2 := &ANode{actionNumbers: []int{3, 4, 5}, columns: []int{2}}
+	leafB3 := &ANode{actionNumbers: []int{3, 4, 5}, columns: []int{3}}
+	leafB4 := &ANode{actionNumbers: []int{3, 4, 5}, columns: []int{4}}
+
+	tree := &CNode{
+		conditionNumber: 0,
+		IfTrue:          leafA,
+		IfFalse: &CNode{
+			conditionNumber: 1,
+			IfTrue:          leafB2,
+			IfFalse: &CNode{
+				conditionNumber: 2,
+				IfTrue:          leafB3,
+				IfFalse:         leafB4,
+			},
+		},
+	}
+	dt := newTreeTestTable("Calculate_Withholding_Shape", 4,
+		[]string{`enabled`, `past_start`, `cap_not_reached`}, tree)
+
+	ws := AnalyzeCompiledTable(dt)
+	gotCols := map[int]string{}
+	for _, w := range ws {
+		if w.Kind == "redundant action-set column" {
+			gotCols[w.Column] = w.Reason
+		}
+	}
+	if len(gotCols) != 2 {
+		t.Fatalf("expected exactly 2 redundant action-set warnings (cols 3, 4), got %d: %v", len(gotCols), gotCols)
+	}
+	for _, col := range []int{3, 4} {
+		reason, ok := gotCols[col]
+		if !ok {
+			t.Errorf("expected warning for column %d, got %v", col, gotCols)
+			continue
+		}
+		// The earlier column reported should be col 2, not col 3.
+		if !strings.Contains(reason, "column 2") {
+			t.Errorf("col %d warning should point at col 2 as earlier; got %q", col, reason)
+		}
+	}
+	if _, gotCol1 := gotCols[1]; gotCol1 {
+		t.Error("col 1 introduces its action set; must not be flagged")
+	}
+	if _, gotCol2 := gotCols[2]; gotCol2 {
+		t.Error("col 2 is the first to reach action set B; must not be flagged")
+	}
+}
+
+// TestCheckRedundantActionSetColumns_DistinctActionSets confirms the
+// check is silent when every column has a distinct action set — the
+// table genuinely needs each column to express different behavior.
+func TestCheckRedundantActionSetColumns_DistinctActionSets(t *testing.T) {
+	tree := &CNode{
+		conditionNumber: 0,
+		IfTrue:          &ANode{actionNumbers: []int{0}, columns: []int{1}},
+		IfFalse: &CNode{
+			conditionNumber: 1,
+			IfTrue:          &ANode{actionNumbers: []int{1}, columns: []int{2}},
+			IfFalse:         &ANode{actionNumbers: []int{2}, columns: []int{3}},
+		},
+	}
+	dt := newTreeTestTable("DistinctActions", 3, []string{`a`, `b`}, tree)
+	for _, w := range AnalyzeCompiledTable(dt) {
+		if w.Kind == "redundant action-set column" {
+			t.Errorf("did not expect redundant action-set warning, got %v", w)
+		}
+	}
+}
+
+// TestCheckRedundantActionSetColumns_OrderMatters confirms the check
+// treats different action orders as different action sets — the
+// runtime executes actions in order and order affects observable
+// behavior (audit-trail line ordering, sequence between sets and
+// reads). [0,1] and [1,0] are distinct.
+func TestCheckRedundantActionSetColumns_OrderMatters(t *testing.T) {
+	tree := &CNode{
+		conditionNumber: 0,
+		IfTrue:          &ANode{actionNumbers: []int{0, 1}, columns: []int{1}},
+		IfFalse:         &ANode{actionNumbers: []int{1, 0}, columns: []int{2}},
+	}
+	dt := newTreeTestTable("OrderMatters", 2, []string{`a`}, tree)
+	for _, w := range AnalyzeCompiledTable(dt) {
+		if w.Kind == "redundant action-set column" {
+			t.Errorf("different action orders must not be flagged as same set, got %v", w)
+		}
 	}
 }


### PR DESCRIPTION
## Closes #797

New tree-based analyzer check: a column is redundant if it doesn't introduce a new action-set combination into the decision tree. Stronger than the existing cell-level `redundant condition` check (#762 + #794's leave-one) — it flags entire columns and points at the earlier column already covering the same behavior.

## Algorithm

From the issue:

> As we add each column to a decision tree, if it does not create at least one new branch with a new combination of actions, the column is redundant.

`AnalyzeCompiledTable` walks the compiled tree, groups columns by the ordered tuple of action numbers they reach, and for each group keeps the lowest column number ("useful — first to reach this action set"). Every other column in the group is flagged with the earlier column named in the warning.

Action-set identity is the **ordered** tuple. `[A, B]` and `[B, A]` are distinct because the runtime executes actions in order and order matters (audit-trail lines, sequence between sets and reads).

## Concrete catch: staking's Calculate_Withholding

Four columns, two distinct action sets:

| col | actions |
|---|---|
| 1 | `Raw 45%, Cap, Staker = weekly − withholding, Track deposits` |
| 2 | `Zero withholding, Full budget, Track deposits` |
| 3 | same as col 2 |
| 4 | same as col 2 |

Post-fix warnings:

```
WARN Calculate_Withholding: column 3 reaches the same action set as column 2 — consider collapsing into a single column (all conditions = '-') or removing if the inputs should fall through downstream
WARN Calculate_Withholding: column 4 reaches the same action set as column 2 — ...
```

The cell-level `redundant condition` check still emits its cap-by-#794 set of warnings; the new check gives the operator the direct column-level recommendation.

## Coverage

`pkg/dtrules/decisiontable/tree_analysis_test.go` gets three new tests:

- `TestCheckRedundantActionSetColumns_TwoActionSets` — `Calculate_Withholding` shape; cols 3 and 4 flagged with col 2 named as the earlier reference. Col 1 (introduces action set A) and col 2 (first to reach action set B) are not flagged.
- `TestCheckRedundantActionSetColumns_DistinctActionSets` — silent when every column has a unique action set.
- `TestCheckRedundantActionSetColumns_OrderMatters` — `[A, B]` and `[B, A]` treated as distinct sets.

## Docs

`dtrules docs warnings` catalogue extended with "9. redundant action-set column". `TestDocumentation_WarningsTopic` pins the new term so doc refactors can't silently drop it.

## Where it fires

`AnalyzeCompiledTable` only — runs from `dtrules review` and the `project_full_review` MCP tool. The matrix-only `Analyze` path (used by `dtrules build`, `dtrules compile`, `dtrules table warnings`) doesn't have the compiled tree, so this check is silent there. Consistent with the existing tree-only checks (`unreachable column` via tree, `dead condition row`).

## Test plan

- [x] `make check` passes (full module + vet + scoped tests + hand-coded-postfix gate).
- [x] Three new regression tests + the doc-term assertion.
- [x] All existing redundancy + tree-analysis tests still pass.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)