### PR TITLE
fix(authoring): accept `fixed` type in EDD SDK

### DIFF
--- a/pkg/dtrules/authoring/edd.go
+++ b/pkg/dtrules/authoring/edd.go
@@ -22,10 +22,19 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/DTRules/DTRules/pkg/dtrules"
 	"github.com/DTRules/DTRules/pkg/dtrules/excel"
 )
 
-// validTypes is the set of DTRules primitive types.
+// validTypes is the set of DTRules primitive types accepted by the
+// authoring SDK. Must stay in sync with what the EDD loader and runtime
+// accept on the read path — projects in the wild use `fixed`
+// (10⁻⁸-scaled bigint mantissa, see pkg/dtrules/fixed.go::RFixed) on
+// existing EDD entities; omitting it here means a project loaded from
+// an XML that has `type="fixed"` reads fine but any SDK
+// AddAttribute/UpdateAttribute with `Type: "fixed"` is rejected as
+// "unknown type". The authoring surface is meant to be a strict
+// superset of what the loader accepts, never a stricter subset.
 var validTypes = map[string]bool{
 	"string":  true,
 	"integer": true,
@@ -34,6 +43,7 @@ var validTypes = map[string]bool{
 	"boolean": true,
 	"date":    true,
 	"bigint":  true,
+	"fixed":   true, // 10^-8 fp; see RFixed in pkg/dtrules/fixed.go
 	"array":   true,
 	"entity":  true,
 }
@@ -336,6 +346,17 @@ func validateDefault(typ, def string) error {
 		lower := strings.ToLower(def)
 		if lower != "true" && lower != "false" {
 			return fmt.Errorf("default %q is not a valid boolean", def)
+		}
+	case "fixed":
+		// Accept the same surface forms as GetRFixedFromString: bare
+		// integers, decimals, optional sign, optional "fp" suffix.
+		// "0" and "0.00000000" are both valid; empty is allowed too
+		// (treated as 0 by the loader).
+		if def == "" {
+			return nil
+		}
+		if _, err := dtrules.GetRFixedFromString(def); err != nil {
+			return fmt.Errorf("default %q is not a valid fixed: %v", def, err)
 		}
 	}
 	// string, date, array, entity: any value is syntactically acceptable

--- a/pkg/dtrules/authoring/edd_test.go
+++ b/pkg/dtrules/authoring/edd_test.go
@@ -88,6 +88,18 @@ func TestAddAttribute_ValidType(t *testing.T) {
 	}); err == nil {
 		t.Fatal("expected error for unknown type, got nil")
 	}
+
+	// `fixed` (10⁻⁸ fp) is a first-class type — projects in the wild
+	// declare e.g. `weekly_budget type="fixed"`, and any new attribute
+	// authored via the SDK must be allowed to use it too. Regression
+	// guard: prior to this commit, validTypes omitted "fixed" and an
+	// SDK AddAttribute with Type:"fixed" was rejected as "unknown type"
+	// even though the loader accepted the same value on the read path.
+	if err := ent.AddAttribute(authoring.Attribute{
+		Name: "weekly_budget", Type: "fixed", Access: "rw",
+	}); err != nil {
+		t.Fatalf("`fixed` type rejected by SDK: %v", err)
+	}
 }
 
 func TestAddAttribute_DefaultMatchesType(t *testing.T) {


### PR DESCRIPTION
`validTypes` was missing `"fixed"` — the loader and runtime accept it (existing EDD projects use it everywhere: `weekly_budget`, `total_staked`, balance fields, etc.), but any authoring-SDK `AddAttribute`/`UpdateAttribute` with `Type:"fixed"` was rejected as "unknown type". The authoring surface should be a strict superset of what the loader accepts, never a subset.

Also extends `validateDefault` so `Type:"fixed"` defaults are parsed via `GetRFixedFromString` — same surface the runtime accepts (decimals, optional `fp` suffix, optional sign). Empty is treated as 0 by the loader and accepted as default here.

Discovered by the Accumulate staking project while adding a `distribution_drift` fixed attribute via the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)