### PR TITLE
fix(el): 7 colon-ref visitors + 4 AddTo/SubFrom verified (#803 batch 4)

### DIFF
--- a/pkg/dtrules/compiler/el/issue_803_batch4_test.go
+++ b/pkg/dtrules/compiler/el/issue_803_batch4_test.go
@@ -1,0 +1,113 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #803 batch 4: colon-ref field access + AddTo/SubFrom dead-grammar
+// verification.
+
+func issue803Batch4Symbols() map[string]string {
+	return map[string]string{
+		"Client":         "entity",
+		"client.fee":     "bigint",
+		"client.count":   "integer",
+		"client.balance": "double",
+		"client.active":  "boolean",
+		"client.dob":     "date",
+	}
+}
+
+// TestIssue803_ColonRefEmitsField confirms `:Client:<field>` produces
+// non-empty postfix. Pre-fix the LHS was dropped entirely — for
+// instance `:Client:fee > 0` compiled to "0 >" with the field gone.
+//
+// Reachable alts (per parse-tree inspection): intColonRef (numeric
+// IDENT) and boolColonRef (after `is true/false`). The other 5 alts
+// are defensive overrides; the parser doesn't reach them for normal
+// IDENT-prefixed forms but the visitors handle the case symmetrically
+// if the grammar ever shifts.
+func TestIssue803_ColonRefEmitsField(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch4Symbols())
+
+	cases := []struct {
+		dsl, mustContain string
+	}{
+		// intColonRef: typedLong wins parser-side for any IDENT
+		// matching a numeric type.
+		{`:Client:fee > 0`, "fee"},
+		{`:Client:count > 0`, "count"},
+		{`:Client:balance > 0.0`, "balance"},
+		{`:Client:dob > today`, "dob"},
+		// boolColonRef: `is true/false` forces the boolean path.
+		{`:Client:active is true`, "active"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.dsl, func(t *testing.T) {
+			got, err := c.CompileCondition(tc.dsl)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			if !strings.Contains(got, tc.mustContain) {
+				t.Errorf("expected field %q in postfix, got: %s", tc.mustContain, got)
+			}
+			// Client (the colon-ref entity name) must also appear —
+			// pre-fix the entire colonRef walk was a no-op too.
+			if !strings.Contains(got, "Client") {
+				t.Errorf("expected entity `Client` in postfix, got: %s", got)
+			}
+		})
+	}
+}
+
+// TestIssue803_AddToSubFromUseAddtostatement confirms the action forms
+// `add X to Y` and `subtract X from Y` route through the
+// addtostatement rule, not the fexpr/iexpr AddTo/SubFrom alts. The
+// fexpr alts are dead grammar; this test pins the actually-firing
+// path so a future grammar reorder that flips dispatch lands here.
+func TestIssue803_AddToSubFromUseAddtostatement(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{
+		"a.x": "double", "a.y": "integer", "a.f": "fixed",
+	})
+	cases := []struct {
+		dsl, mustContain string
+	}{
+		// double field: cvd promotes int operand; f+ does the work.
+		{"add 2 to a.x", "f+"},
+		{"subtract 2 from a.x", "f-"},
+		// integer field: plain + / -.
+		{"add 2 to a.y", " + "},
+		{"subtract 2 from a.y", " - "},
+		// fixed field: cvfp promotes int; fp+ does the work.
+		{"add 2 to a.f", "fp+"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.dsl, func(t *testing.T) {
+			got, err := c.CompileAction(tc.dsl)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			padded := " " + got + " "
+			if !strings.Contains(padded, tc.mustContain) {
+				t.Errorf("expected %q in postfix, got: %s", tc.mustContain, got)
+			}
+		})
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -5693,6 +5693,70 @@ func (e *PostfixEmitter) VisitBigColonRef(ctx *BigColonRefContext) interface{} {
 	return nil
 }
 
+// =============================================================================
+// #803 batch 4: colon-ref field access. Mirrors the existing
+// VisitBigColonRef / VisitBytesColonRef pattern across all typed
+// variants. Pre-fix, `:Client:fee > 0` and `:Client:active is true`
+// produced empty LHS in postfix because the matching XxxColonRef alt
+// had no override and antlr's VisitChildren is a no-op.
+//
+// Confirmed reachable by parse-tree inspection:
+//   - intColonRef:  `:Client:<numeric-field>` (the most common case;
+//                   typedLong wins because IDENT matches across types)
+//   - boolColonRef: `:Client:<bool-field> is true`
+//
+// Likely dead grammar for the others (Float/Date/Str/Name/Array/Name
+// don't appear as the parser's first-match for IDENT-prefixed forms).
+// Adding all 7 anyway as defensive overrides; the visitors share the
+// same simple emission shape so the cost is small.
+// =============================================================================
+
+func (e *PostfixEmitter) VisitIntColonRef(ctx *IntColonRefContext) interface{} {
+	e.Visit(ctx.ColonRef())
+	e.Visit(ctx.TypedLong())
+	return nil
+}
+
+func (e *PostfixEmitter) VisitFloatColonRef(ctx *FloatColonRefContext) interface{} {
+	e.Visit(ctx.ColonRef())
+	e.Visit(ctx.TypedDouble())
+	return nil
+}
+
+func (e *PostfixEmitter) VisitBoolColonRef(ctx *BoolColonRefContext) interface{} {
+	e.Visit(ctx.ColonRef())
+	e.Visit(ctx.TypedBoolean())
+	return nil
+}
+
+func (e *PostfixEmitter) VisitDateColonRef(ctx *DateColonRefContext) interface{} {
+	e.Visit(ctx.ColonRef())
+	e.Visit(ctx.TypedDate())
+	return nil
+}
+
+// VisitStrColonRef: `colonRef strexpr` — note this takes a full strexpr,
+// not a typed-IDENT like the others. In practice the parser doesn't
+// reach this alt because the simpler typed forms win first; included
+// for grammar completeness and defensive depth.
+func (e *PostfixEmitter) VisitStrColonRef(ctx *StrColonRefContext) interface{} {
+	e.Visit(ctx.ColonRef())
+	e.Visit(ctx.Strexpr())
+	return nil
+}
+
+func (e *PostfixEmitter) VisitNameColonRef(ctx *NameColonRefContext) interface{} {
+	e.Visit(ctx.ColonRef())
+	e.Visit(ctx.TypedName())
+	return nil
+}
+
+func (e *PostfixEmitter) VisitArrayColonRef(ctx *ArrayColonRefContext) interface{} {
+	e.Visit(ctx.ColonRef())
+	e.Visit(ctx.TypedArray())
+	return nil
+}
+
 func (e *PostfixEmitter) VisitBigFromStr(ctx *BigFromStrContext) interface{} {
 	e.Visit(ctx.Strexpr())
 	e.emit("cvbi")

--- a/pkg/dtrules/compiler/el/visitor_pin_test.go
+++ b/pkg/dtrules/compiler/el/visitor_pin_test.go
@@ -68,7 +68,6 @@ var inheritedAllowlist = map[string]string{
 	"VisitAddDestArray2":              "TODO(#803): triage",
 	"VisitAddDestDouble2":             "TODO(#803): triage",
 	"VisitAddDestLong2":               "TODO(#803): triage",
-	"VisitArrayColonRef":              "TODO(#803): triage",
 	"VisitArrayDeepCopy":              "TODO(#803): triage",
 	"VisitArrayDeepCopySimple":        "TODO(#803): triage",
 	"VisitArrayMap":                   "TODO(#803): triage",
@@ -78,11 +77,9 @@ var inheritedAllowlist = map[string]string{
 	"VisitBlistIcOr":                  "TODO(#803): triage",
 	"VisitBlistMulti":                 "TODO(#803): triage",
 	"VisitBlistOr":                    "TODO(#803): triage",
-	"VisitBoolColonRef":               "TODO(#803): triage",
 	"VisitBoolFunction":               "TODO(#803): triage",
 	"VisitBoolStrEqIcList":            "TODO(#803): triage",
 	"VisitBoolStrEqList":              "TODO(#803): triage",
-	"VisitDateColonRef":               "TODO(#803): triage",
 	"VisitDateEarliestAfter":          "TODO(#803): triage",
 	"VisitDateFromArrayAt":            "TODO(#803): triage",
 	"VisitDateFromIndex":              "TODO(#803): triage",
@@ -93,18 +90,22 @@ var inheritedAllowlist = map[string]string{
 	"VisitEntityFirst":                "TODO(#803): triage",
 	"VisitEntityFirstIn":              "TODO(#803): triage",
 	"VisitEntityTableLookup":          "TODO(#803): triage",
-	"VisitFloatAddTo":                 "TODO(#803): triage; in practice action statement `add X to Y` uses a different dispatch and emits correctly",
-	"VisitFloatColonRef":              "TODO(#803): triage",
-	"VisitFloatSubFrom":               "TODO(#803): triage; same caveat as VisitFloatAddTo",
+	// AddTo/SubFrom — these alts live inside fexpr/iexpr but the
+	// action-statement form `add X to Y` / `subtract X from Y` parses
+	// as addtostatement (rule `addtostatement`), not via the fexpr
+	// path. Confirmed by tree-dump probe; `add 2 to a.x` matches
+	// addNumToDest and emits the correct postfix through that path
+	// (#803 batch 4).
+	"VisitFloatAddTo":                 "dead grammar; addtostatement handles `add X to Y` as a statement",
+	"VisitFloatSubFrom":               "dead grammar; addtostatement handles `subtract X from Y`",
 	"VisitFloatSumOf":                 "TODO(#803): triage",
 	"VisitFloatTableLookup":           "TODO(#803): triage",
 	"VisitFloatUsing":                 "TODO(#803): triage",
 	"VisitIfThen":                     "TODO(#803): triage; if/then in action statements has separate dispatch",
 	"VisitIfThenElse":                 "TODO(#803): triage; same",
-	"VisitIntAddTo":                   "TODO(#803): triage; same caveat as VisitFloatAddTo",
-	"VisitIntColonRef":                "TODO(#803): triage",
+	"VisitIntAddTo":                   "dead grammar; addtostatement handles `add X to Y` (see VisitFloatAddTo)",
 	"VisitIntIndexOf":                 "TODO(#803): triage",
-	"VisitIntSubFrom":                 "TODO(#803): triage",
+	"VisitIntSubFrom":                 "dead grammar; addtostatement handles `subtract X from Y`",
 	"VisitIntSumOf":                   "TODO(#803): triage",
 	"VisitIntTableLookup":             "TODO(#803): triage",
 	"VisitIntUsing":                   "TODO(#803): triage",
@@ -113,7 +114,6 @@ var inheritedAllowlist = map[string]string{
 	"VisitLeftTexprColon":             "TODO(#803): triage",
 	"VisitLeftTexprSimple":            "TODO(#803): triage",
 	"VisitNameArrayAt":                "TODO(#803): triage",
-	"VisitNameColonRef":               "TODO(#803): triage",
 	"VisitNameFromStr":                "TODO(#803): triage",
 	"VisitOpListEntity":               "TODO(#803): triage",
 	"VisitOpListEntitySingle":         "TODO(#803): triage",
@@ -135,7 +135,6 @@ var inheritedAllowlist = map[string]string{
 	"VisitSetStringFromTable":         "dead grammar; ANTLR picks setTable for texpr RHS",
 	"VisitSetTable":                   "TODO(#803): triage",
 	"VisitStrAttrOf":                  "TODO(#803): triage",
-	"VisitStrColonRef":                "TODO(#803): triage",
 	// strConcat<Type> are all unreachable: ANTLR always picks the base
 	// `strexpr PLUS strexpr` # strConcat first because the RHS IDENT
 	// matches typedXmlValue inside strexpr. Confirmed by parse-tree


### PR DESCRIPTION
Continuation of #803. 11 entries cleared (7 fixed + 4 dead-grammar verified).

## Silent failure fixed

```
Before: :Client:fee > 0  →  "0 >"             (LHS dropped)
After:  :Client:fee > 0  →  "Client fee 0 >"
```

The parser matched `intColonRef` for `:Client:fee` (typedLong wins because every typed-IDENT alt has the same shape) but the visitor was inherited from BaseELVisitor → no-op.

## Fixed (7)

Match the existing `VisitBigColonRef` / `VisitBytesColonRef` pattern:

```go
e.Visit(ctx.ColonRef())
e.Visit(ctx.TypedXxx())
```

- **Reachable**: `VisitIntColonRef` (handles all numeric forms), `VisitBoolColonRef` (`:X:bool is true`)
- **Defensive**: 5 more (Float, Date, Str, Name, Array) — dead in practice but included for symmetry and future-proofing if grammar order changes

## Verified dead-grammar (4)

`add X to Y` / `subtract X from Y` match `addtostatement` (statement-level rule), not the fexpr alts. Confirmed by parse-tree probe. The fexpr alts are silent-bug-shaped but never reached by real input:

- `VisitFloatAddTo`, `VisitFloatSubFrom`, `VisitIntAddTo`, `VisitIntSubFrom`

## Tests

- `TestIssue803_ColonRefEmitsField` covers 5 reachable forms across types
- `TestIssue803_AddToSubFromUseAddtostatement` pins the actually-firing dispatch (catches a grammar-reorder regression)

`make check` passes.

Total #803: 47 fixed + 19 verified = 66/135 entries cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)