### PR TITLE
fix(compile): ResetLocals per-table, not per-file (closes #814)

### DIFF
--- a/cmd/dtrules/compile_cmd.go
+++ b/cmd/dtrules/compile_cmd.go
@@ -432,27 +432,68 @@ var dslPostfixPairs = []kindPair{
 // #790 SetSymbols repair) to refresh stored postfix that was produced
 // by an earlier buggy version. Default behavior only fills empty
 // postfix; existing content is preserved as the authoritative form.
+// decisionTableRe finds each `<decision_table>...</decision_table>`
+// block. Per #814, each block needs an isolated local-variable scope —
+// `ResetLocals` is called at every table boundary so slot indices and
+// name maps don't bleed across tables. The (?s) flag lets `.` match
+// newlines so the body content is captured.
+var decisionTableRe = regexp.MustCompile(`(?s)<decision_table>.*?</decision_table>`)
+
 func compileFile(cmp *el.Compiler, f string, dryRun, strict, force bool) (int, int, []string) {
 	data, err := os.ReadFile(f)
 	if err != nil {
 		return 0, 0, []string{fmt.Sprintf("read failed: %v", err)}
 	}
 
-	cmp.ResetLocals()
-
 	var compileErrs []string
 	filled := 0
 	skipped := 0
 
-	// Run one pass per kind. Each pass walks the (already-rewritten) byte
-	// buffer end-to-end. Order matters for diagnostic numbering only: we
-	// process kinds in the same order they appear in dslPostfixPairs so
-	// `condition N` in an error message lines up with the loader's view.
+	// #814: process each <decision_table> block in isolation. The EL
+	// compiler's `ResetLocals` docstring literally says "Call this
+	// between tables to prevent slot indices from bleeding across
+	// independent compilation scopes" — this is the caller that
+	// honors it. Bytes outside any <decision_table> tag (the XML
+	// preamble, the <decision_tables> wrapper) pass through unchanged.
+	newData := decisionTableRe.ReplaceAllFunc(data, func(tableBytes []byte) []byte {
+		cmp.ResetLocals()
+		rewritten, f, s, errs := compileOneTable(cmp, tableBytes, force)
+		filled += f
+		skipped += s
+		compileErrs = append(compileErrs, errs...)
+		return rewritten
+	})
+
+	// Strict mode: any error blocks the write so the file stays in a
+	// fully-known state. Non-strict (default): write the successful
+	// fills and report the errors — the file is no worse than before
+	// for the failing elements, and the successful ones land.
+	if strict && len(compileErrs) > 0 {
+		return filled, skipped, compileErrs
+	}
+	if filled > 0 && !dryRun {
+		if err := os.WriteFile(f, newData, 0o644); err != nil {
+			return filled, skipped, append(compileErrs, fmt.Sprintf("write failed: %v", err))
+		}
+	}
+	return filled, skipped, compileErrs
+}
+
+// compileOneTable runs the four-kind compile pass (context →
+// initial_action → action → condition) within the bytes of one
+// `<decision_table>` block. Order matters for diagnostic numbering
+// only — `condition N` in an error message lines up with the loader's
+// per-table view. Locals declared in this table's context are visible
+// to its conditions and actions; nothing about that scope leaks back
+// out because the caller called `ResetLocals` before invoking us.
+func compileOneTable(cmp *el.Compiler, data []byte, force bool) ([]byte, int, int, []string) {
+	var compileErrs []string
+	filled := 0
+	skipped := 0
 	newData := data
+
 	for _, kp := range dslPostfixPairs {
 		kind := kp.kind
-		// Pick the regex that matches the operating mode: --force rewrites
-		// any existing postfix; default only fills empty slots.
 		re := kp.reEmpty
 		if force {
 			re = kp.reAny
@@ -480,9 +521,6 @@ func compileFile(cmp *el.Compiler, f string, dryRun, strict, force bool) (int, i
 			}
 
 			filled++
-			// Reconstruct the pair with the postfix slot populated.
-			// Preserve the original DSL bytes verbatim by indexing the
-			// match: everything up to the postfix open tag stays as-is.
 			postfixOpen := []byte(fmt.Sprintf("<%s_postfix>", kind))
 			openIdx := indexOfLast(match, postfixOpen)
 			if openIdx < 0 {
@@ -496,20 +534,7 @@ func compileFile(cmp *el.Compiler, f string, dryRun, strict, force bool) (int, i
 			return out
 		})
 	}
-
-	// Strict mode: any error blocks the write so the file stays in a
-	// fully-known state. Non-strict (default): write the successful
-	// fills and report the errors — the file is no worse than before
-	// for the failing elements, and the successful ones land.
-	if strict && len(compileErrs) > 0 {
-		return filled, skipped, compileErrs
-	}
-	if filled > 0 && !dryRun {
-		if err := os.WriteFile(f, newData, 0o644); err != nil {
-			return filled, skipped, append(compileErrs, fmt.Sprintf("write failed: %v", err))
-		}
-	}
-	return filled, skipped, compileErrs
+	return newData, filled, skipped, compileErrs
 }
 
 // compileKind dispatches to the right EL compiler entry point for each

--- a/cmd/dtrules/compile_cmd_test.go
+++ b/cmd/dtrules/compile_cmd_test.go
@@ -131,3 +131,170 @@ func TestCompile_FixedOperandsEmitFixedOps(t *testing.T) {
 		}
 	}
 }
+
+// TestCompile_LocalsResetPerTable_Issue814 is the #814 regression.
+// Before the fix, `compileFile` called `cmp.ResetLocals()` once per
+// FILE rather than per TABLE. With two tables in one file that each
+// declared a local with the same name, the slot counter and name map
+// leaked across them — Table A's actions ended up referencing Table
+// B's slot index (last write wins on the map). At runtime, Table A's
+// frame had only its own slot 0 → `OutOfBounds` on GetFrameValue.
+//
+// The fix processes each `<decision_table>` block in isolation and
+// calls ResetLocals at every boundary. This test pins that behavior
+// by compiling two tables with a same-named local and asserting both
+// tables' postfix references slot 0 — the canonical-isolated index.
+//
+// Reproducer (pre-fix output, with the bug):
+//
+//	TableA condition postfix: "1 local@ /value get 0 >"   ← wrong: slot 1 doesn't exist in A's frame
+//	TableB condition postfix: "1 local@ /value get 0 >"
+//
+// Post-fix output:
+//
+//	TableA condition postfix: "0 local@ /value get 0 >"
+//	TableB condition postfix: "0 local@ /value get 0 >"
+func TestCompile_LocalsResetPerTable_Issue814(t *testing.T) {
+	dir := t.TempDir()
+
+	// EDD: two entity types (one per table) plus a job entity for the
+	// action's RHS to assign into.
+	const eddXML = `<?xml version="1.0" encoding="UTF-8"?>
+<entity_data_dictionary version="2">
+  <entity name="result_a" access="rw">
+    <field name="value" type="integer" subtype="" access="rw" input="" default_value="0" comment=""/>
+  </entity>
+  <entity name="result_b" access="rw">
+    <field name="value" type="integer" subtype="" access="rw" input="" default_value="0" comment=""/>
+  </entity>
+  <entity name="job" access="rw">
+    <field name="summary" type="integer" subtype="" access="rw" input="" default_value="0" comment=""/>
+  </entity>
+</entity_data_dictionary>
+`
+
+	// Two tables, each declaring a local entity `r` in their context.
+	// Both reference `r.value` in conditions and actions. Pre-fix,
+	// each table would compile against the WRONG slot because the
+	// slot map leaked across tables.
+	const dtXML = `<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+<decision_table>
+<table_name>TableA</table_name>
+<xls_file>x.xlsx</xls_file>
+<attribute_fields><Type>FIRST</Type><COMMENTS></COMMENTS><TABLE_NUMBER>1</TABLE_NUMBER></attribute_fields>
+<contexts>
+  <context_details>
+    <context_number>1</context_number>
+    <context_comment></context_comment>
+    <context_dsl>local entity r = new result_a entity</context_dsl>
+    <context_postfix></context_postfix>
+  </context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+  <condition_details>
+    <condition_number>1</condition_number>
+    <condition_comment>always</condition_comment>
+    <condition_dsl>r.value &gt; 0</condition_dsl>
+    <condition_postfix></condition_postfix>
+    <condition_column column_number="1" column_value="Y"/>
+  </condition_details>
+</conditions>
+<actions>
+  <action_details>
+    <action_number>1</action_number>
+    <action_comment></action_comment>
+    <action_dsl>set summary = r.value</action_dsl>
+    <action_postfix></action_postfix>
+    <action_column column_number="1" column_value="X"/>
+  </action_details>
+</actions>
+</decision_table>
+<decision_table>
+<table_name>TableB</table_name>
+<xls_file>x.xlsx</xls_file>
+<attribute_fields><Type>FIRST</Type><COMMENTS></COMMENTS><TABLE_NUMBER>2</TABLE_NUMBER></attribute_fields>
+<contexts>
+  <context_details>
+    <context_number>1</context_number>
+    <context_comment></context_comment>
+    <context_dsl>local entity r = new result_b entity</context_dsl>
+    <context_postfix></context_postfix>
+  </context_details>
+</contexts>
+<initial_actions></initial_actions>
+<conditions>
+  <condition_details>
+    <condition_number>1</condition_number>
+    <condition_comment>always</condition_comment>
+    <condition_dsl>r.value &gt; 0</condition_dsl>
+    <condition_postfix></condition_postfix>
+    <condition_column column_number="1" column_value="Y"/>
+  </condition_details>
+</conditions>
+<actions>
+  <action_details>
+    <action_number>1</action_number>
+    <action_comment></action_comment>
+    <action_dsl>set summary = r.value</action_dsl>
+    <action_postfix></action_postfix>
+    <action_column column_number="1" column_value="X"/>
+  </action_details>
+</actions>
+</decision_table>
+</decision_tables>
+`
+
+	if err := os.WriteFile(filepath.Join(dir, "fixture_edd.xml"), []byte(eddXML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	dtPath := filepath.Join(dir, "fixture_dt.xml")
+	if err := os.WriteFile(dtPath, []byte(dtXML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cli := NewCLI()
+	if code := cli.runCompile([]string{dir}); code != 0 {
+		t.Fatalf("runCompile exit=%d; want 0", code)
+	}
+
+	out, err := os.ReadFile(dtPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+
+	// Split the output by table so we can assert each table's slot
+	// references independently.
+	splitAt := strings.Index(got, "<table_name>TableB</table_name>")
+	if splitAt < 0 {
+		t.Fatalf("TableB section not found in compiled output")
+	}
+	tableA := got[:splitAt]
+	tableB := got[splitAt:]
+
+	// Each table's locals reset cleanly: the only `r` in scope is the
+	// one declared in *its own* context, which always lands at slot 0.
+	// Pre-fix, TableA's postfix contained "1 local@" because TableB's
+	// declaration had bumped the counter.
+	for _, sec := range []struct{ name, body string }{
+		{"TableA", tableA},
+		{"TableB", tableB},
+	} {
+		// Positive: the canonical slot-0 access must appear in both
+		// the condition (read) and the action (read).
+		want := "0 local@ /value get"
+		if !strings.Contains(sec.body, want) {
+			t.Errorf("%s missing canonical slot-0 access %q; got:\n%s",
+				sec.name, want, sec.body)
+		}
+		// Negative: the leaked slot-1 access from the pre-fix bug must
+		// NOT appear. (Other slot numbers ≥ 1 would be equally wrong
+		// here — only one local is declared per table.)
+		if strings.Contains(sec.body, "1 local@") {
+			t.Errorf("%s still contains `1 local@` — locals leaked across tables (#814); body:\n%s",
+				sec.name, sec.body)
+		}
+	}
+}


### PR DESCRIPTION
Closes #814. Per the user's framing — "the scoping of stack frames for Local variables is perhaps the most significant failing".

## The bug

`cmd/dtrules/compile_cmd.go::compileFile` called `cmp.ResetLocals()` once at file load. A multi-table file with two tables that each declared a local with the same name caused the slot counter and name map to leak across tables. The EL compiler's `ResetLocals` docstring literally says "Call this between tables" — the caller didn't.

## Reproducer

Two tables, each declaring `local entity r = new <type> entity` in their context. Conditions and actions read `r.value`:

```
Pre-fix:
  TableA condition_postfix:  "1 local@ /value get 0 >"   ← TableA's frame only has slot 0 → OutOfBounds at runtime
  TableB condition_postfix:  "1 local@ /value get 0 >"

Post-fix:
  TableA condition_postfix:  "0 local@ /value get 0 >"
  TableB condition_postfix:  "0 local@ /value get 0 >"
```

## Fix

Restructure `compileFile` to walk `<decision_table>...</decision_table>` blocks and call `ResetLocals` at every boundary. New helper `compileOneTable` runs the four-kind pass (context → initial_action → action → condition) within one block's bytes. Bytes outside tables pass through unchanged. Diagnostic numbering (`condition N`) becomes per-table, which matches the loader's view.

## Test

`TestCompile_LocalsResetPerTable_Issue814` constructs the two-table fixture, runs `dtrules compile`, splits at the TableB boundary, and asserts:
- both tables emit `0 local@ /value get` (canonical isolated-scope slot)
- neither contains `1 local@` (the leaked-slot signature)

## Staking impact

The upstream half of staking #276 slice 4. The workaround there used the `Action.Postfix` v1.14.7 override to bypass the buggy local slot allocation; with this fix that workaround is no longer required.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)