### PR TITLE
fix: postfix is a compiled artifact, not authored (closes #817)

### DIFF
--- a/cmd/dtrules/compile_cmd.go
+++ b/cmd/dtrules/compile_cmd.go
@@ -53,7 +53,6 @@ func (c *CLI) runCompile(args []string) int {
 	verbose := false
 	strict := false
 	noAnalyze := false
-	force := false
 	forceOverwriteExcel := false
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -64,7 +63,9 @@ func (c *CLI) runCompile(args []string) int {
 		case "--no-analyze":
 			noAnalyze = true
 		case "--force":
-			force = true
+			// Deprecated in #817 — compile always rewrites postfix from
+			// DSL, so --force is now the only behavior. Accept the flag
+			// silently for backward compatibility with existing scripts.
 		case "--force-overwrite-excel":
 			forceOverwriteExcel = true
 		case "-v", "--verbose":
@@ -175,7 +176,7 @@ func (c *CLI) runCompile(args []string) int {
 	var errLines []string
 
 	for _, f := range files {
-		filled, skipped, errs := compileFile(cmp, f, dryRun, strict, force)
+		filled, skipped, errs := compileFile(cmp, f, dryRun, strict)
 		totalCompiled += filled
 		totalSkipped += skipped
 		totalErrors += len(errs)
@@ -384,9 +385,8 @@ advisory pass), use 'dtrules build'.`)
 // avoids any cross-element backtracking. Newlines pass through fine
 // because the character class only excludes `<`.
 type kindPair struct {
-	kind    string
-	reEmpty *regexp.Regexp // matches only empty <X_postfix> (default mode)
-	reAny   *regexp.Regexp // matches any <X_postfix> body (--force mode, for refreshing stale postfix)
+	kind string
+	re   *regexp.Regexp // matches any <X_postfix> body; postfix is always regenerated from DSL
 }
 
 // Each regex is anchored to a single element kind. `[^<]` inside both DSL
@@ -396,22 +396,18 @@ type kindPair struct {
 var dslPostfixPairs = []kindPair{
 	{
 		"context",
-		regexp.MustCompile(`<context_dsl>([^<]*)</context_dsl>\s*<context_postfix>\s*</context_postfix>`),
 		regexp.MustCompile(`<context_dsl>([^<]*)</context_dsl>\s*<context_postfix>[^<]*</context_postfix>`),
 	},
 	{
 		"initial_action",
-		regexp.MustCompile(`<initial_action_dsl>([^<]*)</initial_action_dsl>\s*<initial_action_postfix>\s*</initial_action_postfix>`),
 		regexp.MustCompile(`<initial_action_dsl>([^<]*)</initial_action_dsl>\s*<initial_action_postfix>[^<]*</initial_action_postfix>`),
 	},
 	{
 		"action",
-		regexp.MustCompile(`<action_dsl>([^<]*)</action_dsl>\s*<action_postfix>\s*</action_postfix>`),
 		regexp.MustCompile(`<action_dsl>([^<]*)</action_dsl>\s*<action_postfix>[^<]*</action_postfix>`),
 	},
 	{
 		"condition",
-		regexp.MustCompile(`<condition_dsl>([^<]*)</condition_dsl>\s*<condition_postfix>\s*</condition_postfix>`),
 		regexp.MustCompile(`<condition_dsl>([^<]*)</condition_dsl>\s*<condition_postfix>[^<]*</condition_postfix>`),
 	},
 }
@@ -439,7 +435,7 @@ var dslPostfixPairs = []kindPair{
 // newlines so the body content is captured.
 var decisionTableRe = regexp.MustCompile(`(?s)<decision_table>.*?</decision_table>`)
 
-func compileFile(cmp *el.Compiler, f string, dryRun, strict, force bool) (int, int, []string) {
+func compileFile(cmp *el.Compiler, f string, dryRun, strict bool) (int, int, []string) {
 	data, err := os.ReadFile(f)
 	if err != nil {
 		return 0, 0, []string{fmt.Sprintf("read failed: %v", err)}
@@ -457,7 +453,7 @@ func compileFile(cmp *el.Compiler, f string, dryRun, strict, force bool) (int, i
 	// preamble, the <decision_tables> wrapper) pass through unchanged.
 	newData := decisionTableRe.ReplaceAllFunc(data, func(tableBytes []byte) []byte {
 		cmp.ResetLocals()
-		rewritten, f, s, errs := compileOneTable(cmp, tableBytes, force)
+		rewritten, f, s, errs := compileOneTable(cmp, tableBytes)
 		filled += f
 		skipped += s
 		compileErrs = append(compileErrs, errs...)
@@ -486,7 +482,7 @@ func compileFile(cmp *el.Compiler, f string, dryRun, strict, force bool) (int, i
 // per-table view. Locals declared in this table's context are visible
 // to its conditions and actions; nothing about that scope leaks back
 // out because the caller called `ResetLocals` before invoking us.
-func compileOneTable(cmp *el.Compiler, data []byte, force bool) ([]byte, int, int, []string) {
+func compileOneTable(cmp *el.Compiler, data []byte) ([]byte, int, int, []string) {
 	var compileErrs []string
 	filled := 0
 	skipped := 0
@@ -494,10 +490,7 @@ func compileOneTable(cmp *el.Compiler, data []byte, force bool) ([]byte, int, in
 
 	for _, kp := range dslPostfixPairs {
 		kind := kp.kind
-		re := kp.reEmpty
-		if force {
-			re = kp.reAny
-		}
+		re := kp.re
 		n := 0
 		newData = re.ReplaceAllFunc(newData, func(match []byte) []byte {
 			n++
@@ -509,8 +502,22 @@ func compileOneTable(cmp *el.Compiler, data []byte, force bool) ([]byte, int, in
 			dslTrimmed := strings.TrimSpace(dsl)
 
 			if dslTrimmed == "" || isCommentOnly(dslTrimmed) {
+				// Empty / comment-only DSL → empty postfix. Per #817
+				// postfix is a derived artifact; an empty source must
+				// produce an empty postfix, wiping any prior hand-coded
+				// content. The element is still counted as touched.
+				postfixOpen := []byte(fmt.Sprintf("<%s_postfix>", kind))
+				openIdx := indexOfLast(match, postfixOpen)
+				if openIdx < 0 {
+					skipped++
+					return match
+				}
+				out := make([]byte, 0, len(match))
+				out = append(out, match[:openIdx]...)
+				out = append(out, postfixOpen...)
+				out = append(out, []byte(fmt.Sprintf("</%s_postfix>", kind))...)
 				skipped++
-				return match
+				return out
 			}
 
 			compiled, err := compileKind(cmp, kind, dsl)

--- a/pkg/dtrules/authoring/hardening_test.go
+++ b/pkg/dtrules/authoring/hardening_test.go
@@ -732,74 +732,64 @@ func TestUpdateAction_InvalidEL(t *testing.T) {
 // TestUpdateAction_ExplicitPostfixOverride pins the escape hatch for the
 // rare case where the EL DSL can't express the desired postfix (e.g. an
 // operator the EL grammar doesn't have a syntax for yet). Setting
-// Action.Postfix to a non-empty string writes that postfix verbatim into
-// the XML, overriding the carry-from-prior. Empty Postfix preserves the
-// prior postfix as before.
-func TestUpdateAction_ExplicitPostfixOverride(t *testing.T) {
-	p := openMutableProject(t)
-	tbl := p.Table("Check_Eligibility")
-	if tbl == nil {
-		t.Fatal("Check_Eligibility not found")
+// TestUpdateAction_PostfixRegeneratedFromDSL_Issue817 pins the new
+// contract: postfix is a compiled artifact of the EL DSL, not an
+// author-supplied override. After UpdateAction, the on-disk
+// <action_postfix> reflects the EL compile of the new DSL — there is
+// no path through the authoring API to write a non-DSL-derived
+// postfix. Replaces the deleted TestUpdateAction_ExplicitPostfixOverride
+// and TestUpdateAction_EmptyPostfixPreservesPrior, both of which
+// pinned the now-removed override behavior.
+func TestUpdateAction_PostfixRegeneratedFromDSL_Issue817(t *testing.T) {
+	// Inline setup so we can read the saved XML by path. The
+	// openMutableProject helper hides tmp; we need it for the on-disk
+	// inspection.
+	tmp := t.TempDir()
+	xmlTmp := filepath.Join(tmp, "xml")
+	if err := os.MkdirAll(xmlTmp, 0755); err != nil {
+		t.Fatal(err)
 	}
-	num := tbl.Actions[0].Number
-	customPostfix := "applicant.eligible /eligible_flag xdef"
-	err := tbl.UpdateAction(num, authoring.Action{
-		DSL:     `set applicant.eligible = true`,
-		Postfix: customPostfix,
-	})
+	copyFixtureToTmp(t, "testdata/minimal/xml", xmlTmp)
+	p, err := authoring.OpenProject(tmp)
 	if err != nil {
-		t.Fatalf("UpdateAction: %v", err)
+		t.Fatalf("OpenProject: %v", err)
 	}
-	// Reload through the typed view (which reads from XML) and check.
-	for _, a := range tbl.Actions {
-		if a.Number == num {
-			if a.Postfix != customPostfix {
-				t.Errorf("Postfix override not honored: got %q, want %q", a.Postfix, customPostfix)
-			}
-			return
-		}
-	}
-	t.Fatalf("action %d not found after update", num)
-}
 
-// TestUpdateAction_EmptyPostfixPreservesPrior pins that the override is
-// opt-in: an empty Postfix field leaves the existing (prior-compile)
-// postfix intact, matching the pre-feature behavior.
-func TestUpdateAction_EmptyPostfixPreservesPrior(t *testing.T) {
-	p := openMutableProject(t)
 	tbl := p.Table("Check_Eligibility")
 	if tbl == nil {
 		t.Fatal("Check_Eligibility not found")
 	}
 	num := tbl.Actions[0].Number
 
-	// Capture the existing postfix from the typed view (populated by
-	// syncFromXML).
-	var prior string
-	for _, a := range tbl.Actions {
-		if a.Number == num {
-			prior = a.Postfix
-			break
-		}
-	}
-
-	// Update DSL only; leave Postfix empty.
-	err := tbl.UpdateAction(num, authoring.Action{
+	// Update the DSL to something distinctive whose compile output we
+	// can identify in the XML.
+	if err := tbl.UpdateAction(num, authoring.Action{
 		DSL: `set applicant.eligible = false`,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("UpdateAction: %v", err)
 	}
-	for _, a := range tbl.Actions {
-		if a.Number == num {
-			if a.Postfix != prior {
-				t.Errorf("empty Postfix didn't preserve prior: got %q, want %q",
-					a.Postfix, prior)
-			}
-			return
-		}
+	if err := p.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
 	}
-	t.Fatalf("action %d not found after update", num)
+
+	// Read the saved XML and confirm the postfix for this action
+	// matches the EL compile of the new DSL.
+	dtPath := filepath.Join(xmlTmp, "minimal_dt.xml")
+	bytes, err := os.ReadFile(dtPath)
+	if err != nil {
+		t.Fatalf("read saved file: %v", err)
+	}
+	saved := string(bytes)
+	want := "false cvb /applicant.eligible xdef"
+	if !strings.Contains(saved, want) {
+		t.Errorf("saved XML missing expected postfix %q from new DSL\nsaved:\n%s", want, saved)
+	}
+	// And the OLD postfix (for `eligible = true`) must NOT survive the
+	// round-trip — postfix is derived from current DSL only.
+	stale := "applicant.eligible true beq"
+	if strings.Contains(saved, stale) {
+		t.Errorf("saved XML still contains stale postfix %q from previous DSL", stale)
+	}
 }
 
 func TestUpdateColumn_ReplacesValues(t *testing.T) {

--- a/pkg/dtrules/authoring/table.go
+++ b/pkg/dtrules/authoring/table.go
@@ -57,19 +57,16 @@ type Condition struct {
 
 // Action holds one action row of a decision table.
 //
-// `Postfix` is an optional explicit postfix override. The compiler's
-// default mode (no --force) preserves existing postfix, so an override
-// set once stays until a --force compile rewrites it. Use this for the
-// rare case where the EL DSL can't express the desired postfix — e.g.
-// an operator the EL grammar doesn't have a syntax for yet — and write
-// the DSL as the human-readable description of intent. Empty string
-// means "leave the prior postfix in place" (the typical case for plain
-// DSL edits).
+// Postfix is intentionally NOT a field on this struct. Per #817,
+// postfix is a compiled artifact of the EL DSL — the authoring view
+// only models authoring inputs. On write-out, syncToXML runs the EL
+// compiler over `DSL` and the result becomes the `<action_postfix>`
+// bytes; whatever postfix was on disk before is overwritten. If the
+// DSL is empty, the postfix is also empty.
 type Action struct {
 	Number  int
 	Comment string
 	DSL     string
-	Postfix string       // optional explicit postfix; empty = preserve prior
 	Columns map[int]bool // col -> executes on that column?
 }
 
@@ -141,33 +138,33 @@ func (t *Table) syncFromXML() {
 			Number:  num,
 			Comment: a.Comment,
 			DSL:     a.DSL,
-			Postfix: a.Postfix,
 			Columns: cols,
 		})
 	}
 }
 
 // syncToXML writes the typed view back into the underlying XML model,
-// preserving every field the typed view doesn't expose (postfix, legacy
-// alternate tag content, context_entity directives, context number/comment/
+// preserving every field the typed view doesn't expose (legacy alternate
+// tag content, context_entity directives, context number/comment/
 // description, …) by matching against the original XML records.
 //
-// Matching rules:
-//   - Conditions / Actions: by `Number`. The typed view rebuilds the slice;
-//     when a typed entry's Number matches an existing XML record the
-//     unmodeled fields from the original are carried through.
-//   - InitialActions: by position. The typed view doesn't expose Number, so
-//     we map index → index. Extra typed entries beyond the original list get
-//     bare records (no postfix); deletions drop the extra originals.
-//   - Contexts: position-by-position over the Details slice. Entities and
-//     all other Detail fields (Number, Comment, Name, Description, Postfix)
-//     are preserved from the original.
+// Postfix is NOT preserved from the original XML — it is regenerated
+// from each typed entry's current DSL via the EL compiler (#817).
+// An empty DSL produces an empty postfix; a malformed DSL produces an
+// empty postfix too (mutations already validated through CheckXxx, so
+// in practice this is unreachable from authoring callers).
+//
+// Matching rules for non-postfix carry-through:
+//   - Conditions / Actions: by `Number`. Carries Number, Comment from
+//     original when present.
+//   - InitialActions: by position. Carries Comment, ActionDSL from
+//     original. ActionPostfix is regenerated from the carried ActionDSL.
+//   - Contexts: position-by-position over the Details slice.
 func (t *Table) syncToXML() {
 	t.xml.TableName = t.Name
 	t.xml.AttributeFields.Type = t.Policy
 
-	// Contexts: preserve Entities entirely and per-detail unmodeled fields by
-	// position-matching. New typed entries append fresh details.
+	// Contexts.
 	origDetails := t.xml.Contexts.Details
 	newDetails := make([]excel.ContextDetailXML, 0, len(t.Contexts))
 	for i, c := range t.Contexts {
@@ -180,30 +177,28 @@ func (t *Table) syncToXML() {
 			entry.Comment = origDetails[i].Comment
 			entry.Name = origDetails[i].Name
 			entry.Description = origDetails[i].Description
-			entry.Postfix = origDetails[i].Postfix
 		}
+		entry.Postfix = compileDSLOrEmpty(c.DSL, t.symbols, "context")
 		newDetails = append(newDetails, entry)
 	}
 	t.xml.Contexts.Details = newDetails
-	// (t.xml.Contexts.Entities is left untouched — the typed view doesn't
-	// model legacy <context_entity> directives, so they round-trip as-is.)
 
-	// Initial actions: match by position to preserve postfix + comment.
+	// Initial actions.
 	origInits := t.xml.InitialActions
 	newInits := make([]excel.InitialActionXML, 0, len(t.InitialActions))
 	for i, ia := range t.InitialActions {
 		entry := excel.InitialActionXML{DSL: ia.DSL}
 		if i < len(origInits) {
 			entry.Comment = origInits[i].Comment
-			entry.Postfix = origInits[i].Postfix
 			entry.ActionDSL = origInits[i].ActionDSL
-			entry.ActionPostfix = origInits[i].ActionPostfix
+			entry.ActionPostfix = compileDSLOrEmpty(origInits[i].ActionDSL, t.symbols, "action")
 		}
+		entry.Postfix = compileDSLOrEmpty(ia.DSL, t.symbols, "action")
 		newInits = append(newInits, entry)
 	}
 	t.xml.InitialActions = newInits
 
-	// Conditions: match by Number to preserve postfix.
+	// Conditions.
 	origConds := map[int]excel.ConditionXML{}
 	for _, c := range t.xml.Conditions {
 		n, _ := strconv.Atoi(c.Number)
@@ -212,9 +207,6 @@ func (t *Table) syncToXML() {
 	t.xml.Conditions = nil
 	for _, c := range t.Conditions {
 		var cols []excel.ColumnValueXML
-		// Emit explicit Y / N / - values; only skip truly absent (empty)
-		// entries. The dash "-" is a meaningful "don't care" signal and
-		// must be preserved on round-trip.
 		for n, v := range c.Columns {
 			if v != "" {
 				cols = append(cols, excel.ColumnValueXML{Number: n, Value: v})
@@ -226,18 +218,11 @@ func (t *Table) syncToXML() {
 			DSL:     c.DSL,
 			Columns: cols,
 		}
-		if orig, ok := origConds[c.Number]; ok {
-			entry.Postfix = orig.Postfix
-		}
+		entry.Postfix = compileDSLOrEmpty(c.DSL, t.symbols, "condition")
 		t.xml.Conditions = append(t.xml.Conditions, entry)
 	}
 
-	// Actions: match by Number to preserve postfix.
-	origActs := map[int]excel.ActionXML{}
-	for _, a := range t.xml.Actions {
-		n, _ := strconv.Atoi(a.Number)
-		origActs[n] = a
-	}
+	// Actions.
 	t.xml.Actions = nil
 	for _, a := range t.Actions {
 		var cols []excel.ColumnValueXML
@@ -252,16 +237,42 @@ func (t *Table) syncToXML() {
 			DSL:     a.DSL,
 			Columns: cols,
 		}
-		if orig, ok := origActs[a.Number]; ok {
-			entry.Postfix = orig.Postfix
-		}
-		// An explicit Postfix on the typed view overrides the carry-from-XML
-		// (rare; used when the EL DSL can't express the desired postfix).
-		if a.Postfix != "" {
-			entry.Postfix = a.Postfix
-		}
+		entry.Postfix = compileDSLOrEmpty(a.DSL, t.symbols, "action")
 		t.xml.Actions = append(t.xml.Actions, entry)
 	}
+}
+
+// compileDSLOrEmpty compiles a single element's DSL via the EL compiler
+// and returns the postfix. Empty DSL returns empty postfix. A compile
+// failure also returns empty — the mutation entry points all validate
+// via CheckXxx before storing, so a compile failure here means the
+// underlying XML was loaded with broken DSL; surfacing it as empty
+// postfix lets the loader's hand-coded-postfix check flag the table
+// rather than silently preserving a stale prior compile.
+//
+// Per #817, this is the ONLY path that writes <*_postfix> bytes in
+// the authoring round-trip. There is no carry-through from the
+// original XML's postfix content.
+func compileDSLOrEmpty(dsl string, symbols map[string]string, kind string) string {
+	if strings.TrimSpace(dsl) == "" {
+		return ""
+	}
+	var (
+		postfix string
+		err     error
+	)
+	switch kind {
+	case "context":
+		postfix, err = CheckContext(dsl, symbols)
+	case "condition":
+		postfix, err = CheckCondition(dsl, symbols)
+	case "action":
+		postfix, err = CheckAction(dsl, symbols)
+	}
+	if err != nil {
+		return ""
+	}
+	return postfix
 }
 
 // Columns returns the number of rule columns in this table.
@@ -375,9 +386,8 @@ func (t *Table) AddAction(a Action) error {
 
 // UpdateAction replaces the action with the given number.
 //
-// If a.Postfix is empty, the prior postfix is preserved (carried from
-// the XML model) — both in the underlying XML and on the refreshed
-// typed view. Set a.Postfix to override.
+// Postfix is regenerated from DSL on every syncToXML — there is no
+// way to carry a non-DSL-derived postfix through this path (#817).
 func (t *Table) UpdateAction(num int, a Action) error {
 	if _, err := CheckAction(a.DSL, t.symbols); err != nil {
 		return err
@@ -387,12 +397,6 @@ func (t *Table) UpdateAction(num int, a Action) error {
 			a.Number = num
 			if a.Columns == nil {
 				a.Columns = existing.Columns
-			}
-			if a.Postfix == "" {
-				// Carry prior from typed view (matches what syncToXML
-				// will preserve on the XML side, keeping the typed
-				// view's Postfix field consistent with the written XML).
-				a.Postfix = existing.Postfix
 			}
 			t.Actions[i] = a
 			t.syncToXML()


### PR DESCRIPTION
Closes #817. Per the user's framing — "The workaround should be impossible. Compiling XML should wipe out hand coded postfix. And authorship should have no path to update postfix."

## What was broken

1. **`dtrules compile` preserved hand-coded postfix by default.** The compile pass had two regex modes (`reEmpty` and `reAny`); only `--force` rewrote existing postfix. A hand-edit survived a default compile.

2. **`pkg/dtrules/authoring.Action.Postfix`** was a settable field. The docstring called it "an optional explicit postfix override … for the rare case where the EL DSL can't express the desired postfix." CLI `table put`/`patch`, MCP `table_put`/`table_patch` — any authoring caller could write directly to `<action_postfix>` without going through the EL compiler.

The second is the loophole that made #814's workaround possible. With both #814 (yesterday) and #817 (this PR) closed, that workaround is no longer possible.

## What changes

### `dtrules compile`

- Always rewrites postfix from DSL. No more `reEmpty` vs `reAny` distinction.
- Empty/comment-only DSL → empty postfix; hand-coded content is wiped.
- `--force` is now a deprecated no-op (kept for backward compat).
- `compileFile` / `compileOneTable` lose their `force` parameter.

### `pkg/dtrules/authoring.Action`

- `Postfix` field removed. The struct models authoring inputs only.
- `syncFromXML` no longer reads postfix into the typed view.
- `syncToXML` regenerates postfix for every element kind by calling `CheckContext` / `CheckCondition` / `CheckAction` over the current DSL. The original XML's postfix is discarded; what gets written is the EL compile of the current DSL.
- New helper `compileDSLOrEmpty` centralizes the transformation.
- `UpdateAction` no longer carries prior postfix (no field to carry to).

## Probe-verified

Hand-coded garbage in `<condition_postfix>` and `<action_postfix>`:
```
<condition_postfix>HAND CODED GARBAGE THAT SHOULD GET WIPED</condition_postfix>
<action_postfix>MORE HAND CODED CRUFT</action_postfix>
```
After one `dtrules compile` pass:
```
<condition_postfix>withholding_cap 0 &gt;</condition_postfix>
<action_postfix>42 cvi /withholding_cap xdef</action_postfix>
```

## Tests

- Replaces two hardening tests that pinned the old override behavior with one (`TestUpdateAction_PostfixRegeneratedFromDSL_Issue817`) that opens a project, updates an action's DSL, saves to disk, reads back, and asserts both: the new postfix matches the EL compile of the new DSL, AND the stale postfix from the previous DSL is gone.

`make check` passes (the long-broken forall / EvalAction authoring fixtures stay excluded per the existing Makefile note; those failures predate this change).

## Staking impact

The `Action.Postfix` escape valve is gone. Anyone who needs behavior the EL grammar can't express has to file a grammar issue (#812 is one example of that proper path). The DSL is the authoring source of truth, full stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)