### PR TITLE
fix(el): `set local.field = X` emits slot-store + correct cv* (closes #819)

### DIFF
--- a/pkg/dtrules/compiler/el/issue_819_test.go
+++ b/pkg/dtrules/compiler/el/issue_819_test.go
@@ -1,0 +1,169 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #819: writing to a local-entity field (`set r.field = X` where
+// r was declared as `local entity r = new T entity`) used to emit two
+// wrong pieces of postfix:
+//
+//  1. The store path: `/r.field xdef` — treating `r.field` as a global
+//     field path instead of slot-indexed access on the local entity.
+//  2. The type cast: `cvi` — defaulting to integer because the
+//     symbol-table lookup for `r.field` didn't resolve to anything
+//     (the local's specific entity type wasn't tracked).
+//
+// Both are fixed in the same PR:
+//
+//   - emitFieldStore now tries emitAliasFieldStore, which emits the
+//     entity-stack-mediated assignment sequence
+//     `<slot> local@ entitypush /<field> xdef entitypop pop`.
+//   - LocalVar tracks the entity type captured from
+//     `new T entity` declarations; mutationType uses it to look up
+//     `<T>.<field>` in the EDD for type-aware cv* dispatch.
+
+// issue819Symbols mirrors the staking-style fixture: a fresh
+// token_recipient entity gets stored in a local, with field types
+// covering string / fixed / integer / boolean (the four cv*
+// dispatches we need to verify).
+func issue819Symbols() map[string]string {
+	return map[string]string{
+		"token_recipient":         "entity",
+		"token_recipient.url":     "string",
+		"token_recipient.amount":  "fixed",
+		"token_recipient.count":   "integer",
+		"token_recipient.active":  "boolean",
+		"payout_url":              "string",
+		"net_reward":              "fixed",
+	}
+}
+
+// TestIssue819_SetLocalEntityFieldEmitsSlotStore confirms the
+// entity-stack-mediated store sequence replaces the old `/r.field xdef`
+// global-write that was the original bug.
+func TestIssue819_SetLocalEntityFieldEmitsSlotStore(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue819Symbols())
+	if _, err := c.CompileContext("local entity r = new token_recipient entity"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	cases := []struct {
+		dsl, mustContain, mustNotContain string
+	}{
+		{
+			dsl:            `set r.url = "literal"`,
+			mustContain:    "0 local@ entitypush /url xdef entitypop pop",
+			mustNotContain: "/r.url xdef",
+		},
+		{
+			dsl:            `set r.amount = 100fp`,
+			mustContain:    "0 local@ entitypush /amount xdef entitypop pop",
+			mustNotContain: "/r.amount xdef",
+		},
+		{
+			dsl:            `set r.count = 5`,
+			mustContain:    "0 local@ entitypush /count xdef entitypop pop",
+			mustNotContain: "/r.count xdef",
+		},
+		{
+			dsl:            `set r.active = true`,
+			mustContain:    "0 local@ entitypush /active xdef entitypop pop",
+			mustNotContain: "/r.active xdef",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.dsl, func(t *testing.T) {
+			got, err := c.CompileAction(tc.dsl)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			if !strings.Contains(got, tc.mustContain) {
+				t.Errorf("missing slot-based store sequence %q in postfix:\n  %s", tc.mustContain, got)
+			}
+			if strings.Contains(got, tc.mustNotContain) {
+				t.Errorf("postfix still contains pre-fix global-write %q:\n  %s", tc.mustNotContain, got)
+			}
+		})
+	}
+}
+
+// TestIssue819_LocalEntityFieldCvDispatch confirms the cv* cast on
+// the value matches the FIELD's declared type (looked up via the
+// local's tracked entity type), not the parser's default integer
+// fallback that fired pre-fix.
+func TestIssue819_LocalEntityFieldCvDispatch(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue819Symbols())
+	if _, err := c.CompileContext("local entity r = new token_recipient entity"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	cases := []struct {
+		dsl, wantCv string
+	}{
+		// String field — value comes from another string field; cv must
+		// be cvs (the type of the destination field), not cvi.
+		{`set r.url = payout_url`, "cvs"},
+		// Fixed field — pre-fix this got cvi because mutationType
+		// returned "" and the SET defaulted to integer.
+		{`set r.amount = net_reward`, "cvfp"},
+		// Integer field — happens to match the default but assert
+		// anyway so future changes can't drift it.
+		{`set r.count = 5`, "cvi"},
+		// Boolean field — distinct cv to catch any "default to int"
+		// regression.
+		{`set r.active = true`, "cvb"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.dsl, func(t *testing.T) {
+			got, err := c.CompileAction(tc.dsl)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			// The cv* must precede the slot-store sequence. Pad with
+			// spaces so " cv* " matches at boundaries.
+			padded := " " + got + " "
+			want := " " + tc.wantCv + " "
+			if !strings.Contains(padded, want) {
+				t.Errorf("expected cast op %q in postfix, got: %s", tc.wantCv, got)
+			}
+		})
+	}
+}
+
+// TestIssue819_ReadPathStillWorks is a regression guard: the existing
+// emitAliasFieldAccess (read-side) must continue to emit the slot-based
+// `<slot> local@ /<field> get` sequence and nothing about the
+// emitAliasFieldStore (write-side) addition should regress it.
+func TestIssue819_ReadPathStillWorks(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue819Symbols())
+	if _, err := c.CompileContext("local entity r = new token_recipient entity"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	got, err := c.CompileCondition(`r.url == "x"`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(got, "0 local@ /url get") {
+		t.Errorf("expected slot-based read sequence in postfix, got: %s", got)
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -23,9 +23,18 @@ import (
 )
 
 // LocalVar tracks a local variable's stack frame index and type.
+//
+// For TypeEntity locals declared via `local entity r = new T entity`,
+// the EntityType field captures `T` so mutations like
+// `set r.field = X` can look up `T.field` in the EDD symbol table for
+// correct type-aware dispatch (#819). Empty EntityType means the type
+// wasn't determinable at declaration time (e.g.
+// `local entity r = some_dynamic_eexpr`) — callers fall back to
+// default integer dispatch in that case.
 type LocalVar struct {
-	Index int
-	Type  string
+	Index      int
+	Type       string
+	EntityType string // for Type==TypeEntity locals from `new T entity`
 }
 
 // PostfixEmitter walks the EL parse tree and emits postfix notation.
@@ -63,9 +72,19 @@ func (e *PostfixEmitter) SetCollectionResolver(fn func(entityType string) (strin
 
 // declareLocal registers a local variable and returns its stack frame index.
 func (e *PostfixEmitter) declareLocal(name string, varType string) int {
+	return e.declareLocalEntity(name, varType, "")
+}
+
+// declareLocalEntity registers a local variable that is specifically a
+// TypeEntity local with a known entity type T. The third argument is
+// the entity-type name (e.g. "token_recipient"); pass "" if the type
+// isn't known. Stored on LocalVar so mutationType can resolve
+// `<local>.<field>` against `<T>.<field>` in the symbol table — without
+// this, SET dispatch falls back to default integer cv* (#819).
+func (e *PostfixEmitter) declareLocalEntity(name, varType, entityType string) int {
 	name = strings.ToLower(name)
 	idx := e.localCnt
-	e.locals[name] = LocalVar{Index: idx, Type: varType}
+	e.locals[name] = LocalVar{Index: idx, Type: varType, EntityType: entityType}
 	e.localCnt++
 	return idx
 }
@@ -350,6 +369,22 @@ func (e *PostfixEmitter) mutationType(name string) string {
 	if lv, ok := e.lookupLocal(name); ok {
 		return lv.Type
 	}
+	// #819: `<local-entity>.<field>` resolution. If `name` has the
+	// shape `head.tail` and `head` is a TypeEntity local with a known
+	// entity type, look up `<EntityType>.<tail>` in the EDD symbol
+	// table. Without this, SET dispatch on local-entity fields falls
+	// back to the default integer cv* cast.
+	if idx := strings.Index(name, "."); idx > 0 {
+		head := name[:idx]
+		tail := name[idx+1:]
+		if tail != "" && !strings.Contains(tail, ".") {
+			if lv, ok := e.lookupLocal(head); ok && lv.Type == TypeEntity && lv.EntityType != "" {
+				if t := e.lookupType(lv.EntityType + "." + tail); t != "" {
+					return t
+				}
+			}
+		}
+	}
 	return e.lookupType(name)
 }
 
@@ -364,13 +399,61 @@ func (e *PostfixEmitter) emitFieldPush(name string) {
 }
 
 // emitFieldStore stores the top-of-stack value back into a mutation
-// target. For declared locals it emits `<index> local!`; for entity
-// fields it emits `/<name> xdef`.
+// target. Tries each strategy in order until one matches:
+//
+//  1. The name is a declared local — emit `<index> local!`.
+//  2. The name has the shape `local.field` where `local` is a TypeEntity
+//     local — emit the entity-stack-mediated assignment sequence
+//     `<slot> local@ entitypush /<field> xdef entitypop pop` (#819).
+//     Symmetric to emitAliasFieldAccess on the read side.
+//  3. Plain entity field — emit `/<name> xdef`.
 func (e *PostfixEmitter) emitFieldStore(name string) {
-	if !e.emitLocalAssign(name) {
-		e.emit("/" + name)
-		e.emit("xdef")
+	if e.emitLocalAssign(name) {
+		return
 	}
+	if e.emitAliasFieldStore(name) {
+		return
+	}
+	e.emit("/" + name)
+	e.emit("xdef")
+}
+
+// emitAliasFieldStore handles `local.field = value` for a TypeEntity
+// local. Stack effect with value already on top:
+//
+//	[..., value]                  on entry
+//	 → <slot> local@              [..., value, entity]
+//	 → entitypush                 [..., value]            entity-stack: [..., entity]
+//	 → /<field>                   [..., value, /field]
+//	 → xdef                       [...]                   (entity.Put via stack lookup)
+//	 → entitypop                  [..., entity]
+//	 → pop                        [...]
+//
+// Returns false (no emission) if the name isn't shaped like
+// `head.tail` or the head isn't a TypeEntity local. Symmetric to
+// `emitAliasFieldAccess`.
+func (e *PostfixEmitter) emitAliasFieldStore(name string) bool {
+	idx := strings.Index(name, ".")
+	if idx <= 0 {
+		return false
+	}
+	head := name[:idx]
+	tail := name[idx+1:]
+	if tail == "" || strings.Contains(tail, ".") {
+		return false
+	}
+	lv, ok := e.lookupLocal(head)
+	if !ok || lv.Type != TypeEntity {
+		return false
+	}
+	e.emit(fmt.Sprintf("%d", lv.Index))
+	e.emit("local@")
+	e.emit("entitypush")
+	e.emit("/" + tail)
+	e.emit("xdef")
+	e.emit("entitypop")
+	e.emit("pop")
+	return true
 }
 
 // emitTypeAwareAddSub emits the store-back sequence for a field mutation
@@ -2996,7 +3079,11 @@ func (e *PostfixEmitter) VisitLocalEntityUndef(ctx *LocalEntityUndefContext) int
 
 func (e *PostfixEmitter) VisitLocalEntityInit(ctx *LocalEntityInitContext) interface{} {
 	name := ctx.UndefinedIdent().GetText()
-	e.declareLocal(name, TypeEntity)
+	// Capture the entity type when the RHS is `new <typedEntity> entity`
+	// (#819) so mutationType can resolve `<local>.<field>` against the
+	// EDD's `<typedEntity>.<field>` symbol — without this, SET on a
+	// local-entity field gets the default integer cv* cast.
+	e.declareLocalEntity(name, TypeEntity, entityTypeFromEexpr(ctx.Eexpr()))
 	e.Visit(ctx.Eexpr())
 	e.emit("cve")
 	e.emit("allocate")
@@ -3004,6 +3091,30 @@ func (e *PostfixEmitter) VisitLocalEntityInit(ctx *LocalEntityInitContext) inter
 	e.emit("deallocate")
 	e.emit("pop")
 	return nil
+}
+
+// entityTypeFromEexpr returns the entity-type name when an eexpr is a
+// `new T entity` constructor. Two grammar alts can match — ANTLR picks
+// `entityNewName` first because IDENT also matches nexpr, but
+// `entityNewTyped` is reachable in theory; handle both. Other eexpr
+// shapes — bare typedEntity references, function calls, table lookups
+// — don't expose a compile-time entity type, so we return "" and the
+// local declaration is type-unaware.
+func entityTypeFromEexpr(ee IEexprContext) string {
+	if ee == nil {
+		return ""
+	}
+	switch n := ee.(type) {
+	case *EntityNewNameContext:
+		if ne := n.Nexpr(); ne != nil {
+			return ne.GetText()
+		}
+	case *EntityNewTypedContext:
+		if te := n.TypedEntity(); te != nil {
+			return te.GetText()
+		}
+	}
+	return ""
 }
 
 func (e *PostfixEmitter) VisitLocalEntityDefined(ctx *LocalEntityDefinedContext) interface{} {


### PR DESCRIPTION
Closes #819. Two related write-side bugs for fields of a local-entity declaration (`local entity r = new T entity`):

1. **Store path was a global write.** `set r.url = X` emitted `X cv? /r.url xdef` — runtime xdef walks the entity stack looking for an attribute literally named "r.url"; not found.
2. **cv* defaulted to integer.** `r.amount` wasn't a known symbol so the SET dispatch fell back to int, emitting `cvi` on a fixed field.

Surfaced during #812 testing.

## Pre-fix vs post-fix

```
Before: set r.url = payout_url    →  "payout_url cvi /r.url xdef"   ← global write + wrong cv
After:  set r.url = payout_url    →
        "payout_url cvs 0 local@ entitypush /url xdef entitypop pop"

Before: set r.amount = net_reward →  "net_reward cvi /r.amount xdef"
After:  set r.amount = net_reward →
        "net_reward cvfp 0 local@ entitypush /amount xdef entitypop pop"
```

## Fix 1 — emitAliasFieldStore

Symmetric to the read-side `emitAliasFieldAccess`. `emitFieldStore` now tries this between the plain-local-assign check and the bare-field fallback. Emits the entity-stack-mediated sequence so xdef's `state.FindEntity` lookup finds the pushed local entity. No new runtime op needed.

## Fix 2 — LocalVar.EntityType + smarter mutationType

`LocalVar` gains an `EntityType` field. `VisitLocalEntityInit` captures it from `new T entity` (whether matched as `entityNewName` or `entityNewTyped`). `mutationType("local.field")` resolves through `<EntityType>.<field>` for type-aware dispatch.

## Tests

3 new tests in `issue_819_test.go`: the slot-store presence + pre-fix-signature absence; the cv* dispatch across string/fixed/int/bool; and a guard that the existing read path still works.

`make check` passes.

## Staking impact

This + #814 + #812 close the umbrella of issues blocking staking #276 slice 4's natural DSL pattern. The `Action.Postfix` override (closed in #817) is no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)