### PR TITLE
fix(authoring): resolve xml symlinks before WalkDir (closes #791)

### DIFF
--- a/pkg/dtrules/authoring/project.go
+++ b/pkg/dtrules/authoring/project.go
@@ -99,14 +99,25 @@ func OpenProject(path string) (*Project, error) {
 // `*_dt.xml` lives there. Either way the returned directory is
 // guaranteed to contain DT files at load time — callers can treat it
 // as the project's effective XML root.
+//
+// Any symlinks in the returned path are resolved (#791): callers walk
+// the directory with `filepath.WalkDir`, which treats a symlink root
+// as a single non-directory entry rather than descending into it.
+// Returning the post-EvalSymlinks path so the walk descends correctly.
 func resolveProjectXMLDir(path string) (string, error) {
 	canonical := filepath.Join(path, "xml")
 	if info, err := os.Stat(canonical); err == nil && info.IsDir() {
+		if resolved, err := filepath.EvalSymlinks(canonical); err == nil {
+			return resolved, nil
+		}
 		return canonical, nil
 	}
 	// Flat layout: accept `path` itself when it contains *_dt.xml.
 	matches, _ := filepath.Glob(filepath.Join(path, "*_dt.xml"))
 	if len(matches) > 0 {
+		if resolved, err := filepath.EvalSymlinks(path); err == nil {
+			return resolved, nil
+		}
 		return path, nil
 	}
 	return "", fmt.Errorf("no xml/ subdirectory and no *_dt.xml files found in %s", path)

--- a/pkg/dtrules/authoring/project_layout_test.go
+++ b/pkg/dtrules/authoring/project_layout_test.go
@@ -154,3 +154,40 @@ func TestOpenProject_NeitherLayoutErrorsClearly(t *testing.T) {
 		t.Errorf("error should mention flat *_dt.xml fallback, got: %v", err)
 	}
 }
+
+// TestOpenProject_XmlSymlinkLayout_Issue791 is the #791 regression.
+// The staking project ships a layout where `<root>/xml` is a symlink
+// to `<root>/rules` (the symlink lets `go:embed` find the files
+// under `xml/...` paths). Pre-fix, `resolveProjectXMLDir` returned
+// the symlink path and `filepath.WalkDir` treated the symlink root
+// as a single non-directory entry (per Go's spec), so the walk never
+// descended and the project loaded with zero tables. `dtrules table
+// list --project <root>` returned `{"tables": []}` silently.
+//
+// The fix resolves the symlink via `filepath.EvalSymlinks` so the
+// walker sees a real directory root.
+func TestOpenProject_XmlSymlinkLayout_Issue791(t *testing.T) {
+	root := t.TempDir()
+	// Put the actual files under `rules/`, then create `xml -> rules`.
+	rules := filepath.Join(root, "rules")
+	if err := os.MkdirAll(rules, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rules, "flat_dt.xml"), []byte(flatLayoutDT), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rules, "flat_edd.xml"), []byte(flatLayoutEDD), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("rules", filepath.Join(root, "xml")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	p, err := authoring.OpenProject(root)
+	if err != nil {
+		t.Fatalf("OpenProject on symlinked xml/ layout failed: %v", err)
+	}
+	if p.Table("Test_Flat") == nil {
+		t.Errorf("expected Test_Flat to be discovered through xml -> rules symlink, got %v", p.Tables())
+	}
+}


### PR DESCRIPTION
Closes #791. `dtrules table list --project <root>` silently returned `{"tables": []}` when `<root>/xml` was a symlink — `filepath.WalkDir` on a symlink-rooted path treats the symlink as a non-directory entry per Go's spec and never descends.

## Probe

Setup: `<root>/rules/{x_dt.xml,x_edd.xml}` with `<root>/xml -> rules` symlink.

```
Pre-fix:  dtrules table list --project <root>  →  {"tables": []}
Post-fix: dtrules table list --project <root>  →  {"tables": ["Test_Flat", ...]}
```

## Fix

`resolveProjectXMLDir` now calls `filepath.EvalSymlinks` on the resolved path before returning. Applied to both discovery branches (canonical `xml/` and flat fallback) so other authoring surfaces (`Save`, refresh) get the fix for free.

## Test

`TestOpenProject_XmlSymlinkLayout_Issue791` creates the exact failing layout from the issue body (real files in `rules/`, symlink at `xml/`) and asserts that the table is discovered.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)