### PR TITLE
fix(CorporateTax): NV condition_dsl uses == not = (closes #751)

### DIFF
--- a/sampleprojects/CorporateTax/xml/states/NV_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NV_corp_dt.xml
@@ -458,7 +458,7 @@ result.apportionment_percentage 0 gt and
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Has nexus but no apportionment percentage</condition_comment>
-<condition_dsl>has_nexus AND apportionment_percentage = 0</condition_dsl>
+<condition_dsl>has_nexus AND apportionment_percentage == 0</condition_dsl>
 <condition_postfix>
 result.has_physical_presence_nv result.nv_gross_receipts result.nv_economic_nexus_threshold ge or
 result.apportionment_percentage 0 eq and


### PR DESCRIPTION
Closes #751. Single bare `=` in `<condition_dsl>` at `sampleprojects/CorporateTax/xml/states/NV_corp_dt.xml:461`. Runtime currently correct only because the postfix was hand-authored with `eq`; #817's always-regenerate-postfix pipeline would replace that with the broken DSL output on the next compile pass.

Fix: `= 0` → `== 0` on the one offending line. Project-wide scan for other bare `=` in condition_dsl came back empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)