### PR TITLE
fix(SyntaxTests): remove dead `type='table'` fields (closes #760)

### DIFF
--- a/sampleprojects/SyntaxTests/xml/syntaxexample_dt.xml
+++ b/sampleprojects/SyntaxTests/xml/syntaxexample_dt.xml
@@ -367,14 +367,6 @@ mailingAddress cve /address xdef
 effectivedate cvd /currentdate xdef  
 </initial_action_postfix></initial_action_details>
 <initial_action_details>
-<intial_action_number>11</intial_action_number>
-<initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
-<initial_action_requirement />
-<initial_action_dsl>set translationTable = anotherTable</initial_action_dsl>
-<initial_action_postfix>
-anotherTable /translationTable xdef  
-</initial_action_postfix></initial_action_details>
-<initial_action_details>
 <intial_action_number>12</intial_action_number>
 <initial_action_comment />
 <initial_action_requirement />
@@ -2567,14 +2559,6 @@ mailingAddress cve /address xdef
 <initial_action_dsl>set currentdate = effectivedate</initial_action_dsl>
 <initial_action_postfix>
 effectivedate cvd /currentdate xdef  
-</initial_action_postfix></initial_action_details>
-<initial_action_details>
-<intial_action_number>11</intial_action_number>
-<initial_action_comment>Okay.... Statement was wrong</initial_action_comment>
-<initial_action_requirement />
-<initial_action_dsl>set translationTable = anotherTable</initial_action_dsl>
-<initial_action_postfix>
-anotherTable /translationTable xdef  
 </initial_action_postfix></initial_action_details>
 <initial_action_details>
 <intial_action_number>12</intial_action_number>

--- a/sampleprojects/SyntaxTests/xml/syntaxexample_edd.xml
+++ b/sampleprojects/SyntaxTests/xml/syntaxexample_edd.xml
@@ -51,8 +51,6 @@
 		<field name='validatedCitizenship' type='boolean' subtype='' access='r' input='main' default_value='' comment=''></field>
 	</entity>
 	<entity name='constants' access='rw' comment=''>
-		<field name='anotherTable' type='table' subtype='' access='rw' input='' default_value='{ { &quot;bob&quot; &quot;bobby&quot; }
-  { &quot;james&quot; &quot;jim&quot; } }' comment=''></field>
 		<field name='AtCostCoverage' type='string' subtype='' access='r' input='' default_value='At Cost Coverage' comment='Coverage Level for the Program'></field>
 		<field name='child' type='string' subtype='' access='r' input='' default_value='child' comment='Relationship Type'></field>
 		<field name='ChildSupport' type='string' subtype='' access='r' input='' default_value='CS' comment='Income Type'></field>
@@ -75,8 +73,6 @@
 		<field name='SocialSecurity' type='string' subtype='' access='r' input='' default_value='SS' comment='Income Type'></field>
 		<field name='SSI' type='string' subtype='' access='r' input='' default_value='SSI' comment='Income Type'></field>
 		<field name='Tips' type='string' subtype='' access='r' input='' default_value='TIP' comment='Income Type'></field>
-		<field name='translationTable' type='table' subtype='' access='rw' input='' default_value='{ { &quot;first&quot; &quot;1st&quot; }
-  { &quot;second&quot; &quot;2nd&quot; } }' comment=''></field>
 		<field name='Wages' type='string' subtype='' access='r' input='' default_value='WA' comment='Income Type'></field>
 	</entity>
 	<entity name='ErrorDetails' access='rw' comment=''>


### PR DESCRIPTION
Closes #760. Hash tables were removed from the runtime; the SyntaxTests EDD still had two `type='table'` fields the loader rejects with `unknown type 'table'` — the stale build-failure error for 11+ runs.

## Diff

```
EDD:  4 lines removed (2 field declarations)
DT:  16 lines removed (2 identical 8-line init_action blocks)
```

## Removed

- EDD fields `constants.anotherTable`, `constants.translationTable` (both `type='table'`)
- The two `set translationTable = anotherTable` init_action #11 blocks in Syntax_Examples and Syntax_Examples_2

## Verified

`rs.LoadEDD` succeeds cleanly; `make check` passes.

## Out of scope

SyntaxTests still has separate "DSL without compiled postfix" issues at DT-load time (#783) — those are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)