### PR TITLE
feat(compiler/el): override sub-dest colon + boolFunction (#803 batch 7)

### DIFF
--- a/pkg/dtrules/compiler/el/issue_803_batch7_test.go
+++ b/pkg/dtrules/compiler/el/issue_803_batch7_test.go
@@ -1,0 +1,102 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #803 batch 7: SubDestColon + BoolFunction.
+//
+// Before this batch:
+//   - `subtract <n> from :Client:<field>` silently emitted empty
+//     postfix (no VisitSubDestColon; antlr's VisitChildren is a
+//     no-op).
+//   - `<func>(<args>)` where <func> is a TypedBoolFunction
+//     (`isstring`, `isnumber`, `isnull`, `isarray`) silently emitted
+//     empty postfix for the same reason.
+//
+// `VisitAddDestColon` already existed but only handled the
+// possessive form (`Client's <field>`) — the colon-chain form
+// (`:Client:<field>`) was missing. Both forms now share a
+// `colonRefEntityName` helper and produce matching postfix.
+
+func issue803Batch7Symbols() map[string]string {
+	return map[string]string{
+		"client.my_int":    "integer",
+		"client.my_double": "double",
+		"Client":           "entity",
+	}
+}
+
+// TestIssue803_AddSubDestColon: add/subtract destination via the
+// `:Entity:field` form must walk the entity stack just like the
+// `Entity's field` form. Both forms must emit identical postfix
+// shape (entitypush ... entitypop) so runtime semantics are stable
+// across spellings.
+func TestIssue803_AddSubDestColon(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch7Symbols())
+
+	cases := []struct {
+		dsl  string
+		want []string
+	}{
+		{`add 5 to :Client:my_int`, []string{"Client", "entitypush", "my_int", "entitypop"}},
+		{`add 5 to Client's my_int`, []string{"Client", "entitypush", "my_int", "entitypop"}},
+		{`subtract 5 from :Client:my_int`, []string{"Client", "entitypush", "my_int", "entitypop"}},
+		{`subtract 5 from Client's my_int`, []string{"Client", "entitypush", "my_int", "entitypop"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.dsl, func(t *testing.T) {
+			got, err := c.CompileAction(tc.dsl)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			for _, tok := range tc.want {
+				if !strings.Contains(got, tok) {
+					t.Errorf("expected %q in postfix, got: %s", tok, got)
+				}
+			}
+		})
+	}
+}
+
+// TestIssue803_BoolFunctionEmitsName: a bare TypedBoolFunction
+// reference (the grammar production is `typedBoolFunction : IDENT`,
+// no arg list) must emit the IDENT as the dispatch operator. Pre-fix
+// this produced empty postfix because there was no override for
+// VisitBoolFunction and antlr's VisitChildren is a no-op.
+func TestIssue803_BoolFunctionEmitsName(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch7Symbols())
+
+	// Niladic form: the IDENT alone resolves through bexpr's
+	// boolFunction alt; the resulting postfix must contain the IDENT
+	// so the runtime dispatches it.
+	cases := []string{"some_bool_fn", "another_bool_fn"}
+	for _, dsl := range cases {
+		t.Run(dsl, func(t *testing.T) {
+			got, err := c.CompileCondition(dsl)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			if !strings.Contains(got, dsl) {
+				t.Errorf("expected operator %q in postfix, got: %s", dsl, got)
+			}
+		})
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -5180,6 +5180,80 @@ func (e *PostfixEmitter) VisitIntUsingArray(ctx *IntUsingArrayContext) interface
 	return nil
 }
 
+// VisitBoolFunction: `<typedBoolFunction>` as a boolean expression —
+// a niladic boolean function call. Mirrors VisitOperatorstatements'
+// shape (emit the name as executable) but with no argument list.
+// Without this override, `bexpr: ... | typedBoolFunction # boolFunction`
+// silently emitted nothing.
+func (e *PostfixEmitter) VisitBoolFunction(ctx *BoolFunctionContext) interface{} {
+	e.emit(ctx.TypedBoolFunction().GetText())
+	return nil
+}
+
+// colonRefEntityName extracts the entity name from a colonRef AST node,
+// handling both the possessive-chain (`Client's`) and the colon-chain
+// (`:Client:`) forms. Returns "" if neither shape matches.
+func colonRefEntityName(colonRef IColonRefContext) string {
+	if colonRef == nil {
+		return ""
+	}
+	possRef := colonRef.PossessiveRef()
+	if possRef == nil {
+		return ""
+	}
+	switch n := possRef.(type) {
+	case *PossessiveChainContext:
+		tokens := n.AllPOSSESSIVE()
+		if len(tokens) > 0 {
+			text := tokens[0].GetText()
+			if strings.HasSuffix(text, "'s") {
+				return text[:len(text)-2]
+			}
+			return text
+		}
+	case *ColonChainContext:
+		if te := n.TypedEntity(); te != nil {
+			return te.GetText()
+		}
+	}
+	return ""
+}
+
+// VisitSubDestColon: `subtract <number> from <colonRef> <field>` —
+// mirrors VisitAddDestColon for subtraction. Pre-fix the entire
+// destination part was dropped (parent VisitSubtractNum emitted the
+// number but Visit(subtodest) hit BaseELVisitor's no-op). Matches
+// VisitSubDestPossessiveLong's `<field> - /<field> xdef` emission so
+// the runtime computes `value - field`.
+func (e *PostfixEmitter) VisitSubDestColon(ctx *SubDestColonContext) interface{} {
+	entityName := colonRefEntityName(ctx.ColonRef())
+	if entityName != "" {
+		if !e.emitLocalRef(entityName) {
+			e.emit(entityName)
+		}
+	}
+	e.emit("entitypush")
+
+	addDest2 := ctx.Addtodest2()
+	var fieldName string
+	switch d := addDest2.(type) {
+	case *AddDestLong2Context:
+		fieldName = d.TypedLong().GetText()
+	case *AddDestDouble2Context:
+		fieldName = d.TypedDouble().GetText()
+	case *AddDestArray2Context:
+		fieldName = d.ArrayExpr2().GetText()
+	}
+	if fieldName != "" {
+		e.emit(fieldName)
+		e.emit("-")
+		e.emit("/" + fieldName)
+		e.emit("xdef")
+	}
+	e.emit("entitypop")
+	return nil
+}
+
 // VisitBoolEntityIsOf: `<e1> is <type> of <e2>` — the findmatch/relationship
 // lookup op this used to call was removed alongside the hash-table ops. The
 // emit now produces an elstmterror so the form parses but errors at runtime
@@ -5445,31 +5519,15 @@ func (e *PostfixEmitter) VisitAddDestDouble(ctx *AddDestDoubleContext) interface
 
 func (e *PostfixEmitter) VisitAddDestColon(ctx *AddDestColonContext) interface{} {
 	// Pattern: <entity-ref> entitypush <field> + /<field> xdef entitypop
-	// The colonRef contains the possessive (e.g., "ThisClient's")
-	// The addtodest2 contains the field (e.g., "IncomeGroupCount")
-
-	// Get the possessive from colonRef
-	colonRef := ctx.ColonRef()
-	possRef := colonRef.PossessiveRef()
-
-	// Handle possessive chain
-	if possChain, ok := possRef.(*PossessiveChainContext); ok {
-		// Get all POSSESSIVE tokens
-		tokens := possChain.AllPOSSESSIVE()
-		if len(tokens) > 0 {
-			poss := tokens[0].GetText()
-			// Remove 's suffix to get entity name
-			entityName := poss[:len(poss)-2]
-
-			// Check if entity is a local variable
-			if e.emitLocalRef(entityName) {
-				// emitLocalRef already emitted "<index> local@"
-			} else {
-				e.emit(entityName)
-			}
+	// The colonRef contains either a possessive (`ThisClient's`) or a
+	// colon chain (`:ThisClient:`); both extract to an entity name.
+	// The addtodest2 contains the field (e.g., "IncomeGroupCount").
+	entityName := colonRefEntityName(ctx.ColonRef())
+	if entityName != "" {
+		if !e.emitLocalRef(entityName) {
+			e.emit(entityName)
 		}
 	}
-
 	e.emit("entitypush")
 
 	// Get the field from addtodest2

--- a/pkg/dtrules/compiler/el/visitor_pin_test.go
+++ b/pkg/dtrules/compiler/el/visitor_pin_test.go
@@ -65,9 +65,12 @@ var inheritedAllowlist = map[string]string{
 	// today; convert to explicit overrides or to a verified
 	// fall-through rationale in follow-up PRs.
 	// =========================================================
-	"VisitAddDestArray2":              "TODO(#803): triage",
-	"VisitAddDestDouble2":             "TODO(#803): triage",
-	"VisitAddDestLong2":               "TODO(#803): triage",
+	// addtodest2 alts are reached only from addDestColon/subDestColon,
+	// which type-switch and extract `GetText()` directly without calling
+	// Visit. Verified by inspection (#803 batch 7).
+	"VisitAddDestArray2":              "dead grammar; addDest/subDestColon extract via GetText, never Visit",
+	"VisitAddDestDouble2":             "dead grammar; addDest/subDestColon extract via GetText, never Visit",
+	"VisitAddDestLong2":               "dead grammar; addDest/subDestColon extract via GetText, never Visit",
 	"VisitArrayDeepCopy":              "TODO(#803): triage",
 	"VisitArrayDeepCopySimple":        "TODO(#803): triage",
 	"VisitArrayMap":                   "TODO(#803): triage",
@@ -77,7 +80,6 @@ var inheritedAllowlist = map[string]string{
 	"VisitBlistIcOr":                  "TODO(#803): triage",
 	"VisitBlistMulti":                 "TODO(#803): triage",
 	"VisitBlistOr":                    "TODO(#803): triage",
-	"VisitBoolFunction":               "TODO(#803): triage",
 	"VisitBoolStrEqIcList":            "TODO(#803): triage",
 	"VisitBoolStrEqList":              "TODO(#803): triage",
 	"VisitDateEarliestAfter":          "TODO(#803): triage; needs new `earliestafter` runtime op",
@@ -105,8 +107,12 @@ var inheritedAllowlist = map[string]string{
 	"VisitIntSumOf":                   "TODO(#803): triage",
 	"VisitIntUsing":                   "dead grammar; intUsingArray wins parser-side (see VisitFloatUsing)",
 	"VisitLeftArrayColon":             "TODO(#803): triage",
-	"VisitLeftTexprColon":             "TODO(#803): triage",
-	"VisitLeftTexprSimple":            "TODO(#803): triage",
+	// leftTexpr alts are unreachable because the only SET form that
+	// targets a typedTable (setTable) now emits an elstmterror
+	// placeholder without visiting the leftTexpr (hash tables removed,
+	// #803 batch 6).
+	"VisitLeftTexprColon":             "dead grammar; setTable emits elstmterror without visiting leftTexpr",
+	"VisitLeftTexprSimple":            "dead grammar; setTable emits elstmterror without visiting leftTexpr",
 	"VisitNameArrayAt":                "TODO(#803): triage",
 	"VisitNameFromStr":                "TODO(#803): triage",
 	"VisitOpListEntity":               "TODO(#803): triage",
@@ -145,7 +151,6 @@ var inheritedAllowlist = map[string]string{
 	"VisitStrTimestamp":               "TODO(#803): triage",
 	"VisitStrUsing":                   "dead grammar; intUsingArray wins parser-side (see VisitFloatUsing)",
 	"VisitStrXmlAttr":                 "TODO(#803): triage",
-	"VisitSubDestColon":               "TODO(#803): triage",
 	// tablelist / tableTyped are helper rules referenced from the
 	// table-lookup alts; with the table-lookup parent emitting
 	// elstmterror placeholders (#803 batch 6), the helpers are never
@@ -154,11 +159,17 @@ var inheritedAllowlist = map[string]string{
 	"VisitTableListSingle":            "dead grammar; helper rule under table-lookup which emits elstmterror",
 	"VisitTableTyped":                 "dead grammar; helper rule under table-lookup which emits elstmterror",
 	"VisitThereis":                    "TODO(#803): triage",
-	"VisitTypedBoolFunction":          "TODO(#803): triage",
-	"VisitTypedInvalid":               "TODO(#803): triage",
-	"VisitTypedNull":                  "TODO(#803): triage",
-	"VisitTypedOperator":              "TODO(#803): triage",
-	"VisitUndefinedIdent":             "TODO(#803): triage",
+	// typedXxx and undefinedIdent are IDENT-classification rules. Every
+	// parent visitor that consumes them extracts the text via GetText()
+	// directly (e.g. VisitOperatorstatements at line 4906 reads
+	// `ctx.TypedOperator().GetText()`; VisitLocalEntityInit reads
+	// `ctx.UndefinedIdent().GetText()`). The Visit() entry points are
+	// never invoked. Verified by source inspection (#803 batch 7).
+	"VisitTypedBoolFunction":          "dead grammar; consumers use TypedBoolFunction().GetText() directly",
+	"VisitTypedInvalid":               "dead grammar; only used by dead-grammar strConcatInvalid",
+	"VisitTypedNull":                  "dead grammar; only used by dead-grammar strConcatNull",
+	"VisitTypedOperator":              "dead grammar; VisitOperatorstatements extracts via GetText",
+	"VisitUndefinedIdent":             "dead grammar; CREATE/LOCAL parents extract via UndefinedIdent().GetText",
 	"VisitUsingstatement":             "dead grammar; the rule's only alt wraps usingblock which is visited via children elsewhere",
 	"VisitXmlvalues":                  "TODO(#803): triage",
 }


### PR DESCRIPTION
Two more silent-failure visitors get overrides; ten more inherited methods are verified dead grammar — 12 fewer TODO entries in the visitor pin-test.

## New visitors

- **VisitSubDestColon**: `subtract <n> from :Entity:<field>` and `subtract <n> from Entity's <field>` now walk the entity stack symmetric to `AddDestColon`: `<rhs> Entity entitypush <field> - /<field> xdef entitypop`. Pre-fix the colon form silently emitted nothing.
- **VisitBoolFunction**: a bare `typedBoolFunction` reference now emits the IDENT as the dispatch operator. Pre-fix the rule produced empty postfix.

## Helper

`colonRefEntityName` extracts the entity name from a `colonRef` AST node, handling both `PossessiveChainContext` (`Client's`) and `ColonChainContext` (`:Client:`). `VisitAddDestColon` was missing colon-chain handling; folding both visitors through the shared helper fixes that pre-existing bug too.

## Allowlist (visitor_pin_test.go)

Converted TODOs → dead-grammar rationale (verified by source inspection):

| Visitor | Why it's dead |
|---|---|
| `VisitAddDestArray2/Double2/Long2` | `addDestColon`/`subDestColon` type-switch and read `GetText()` directly; never call `Visit`. |
| `VisitTypedBoolFunction/TypedInvalid/TypedNull/TypedOperator` | Consumers read `TypedXxx().GetText()` directly. |
| `VisitUndefinedIdent` | CREATE/LOCAL parents read `UndefinedIdent().GetText()` directly. |
| `VisitLeftTexprColon/LeftTexprSimple` | `setTable` emits `elstmterror` without visiting `leftTexpr` (hash tables removed in batch 6). |

Dropped entries for `VisitBoolFunction`, `VisitSubDestColon` (now overridden).

## Tests

`pkg/dtrules/compiler/el/issue_803_batch7_test.go` pins:
- The colon and possessive forms emit identical postfix shape for both `add` and `subtract`.
- The bare `typedBoolFunction` case emits the IDENT.

`make check` passes.

## Issue

Progress on #803 (silent failures from inherited no-op visitors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)