### PR TITLE
feat(compiler/el): override sum/index/name aggregations (#803 batch 8)

### DIFF
--- a/pkg/dtrules/compiler/el/issue_803_batch8_test.go
+++ b/pkg/dtrules/compiler/el/issue_803_batch8_test.go
@@ -1,0 +1,140 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #803 batch 8: aggregation + name-coercion family.
+// All five rules below previously emitted empty postfix (no override;
+// antlr's VisitChildren is a no-op).
+
+func issue803Batch8Symbols() map[string]string {
+	return map[string]string{
+		"client.income":  "double",
+		"client.tax":     "integer",
+		"client.code":    "string",
+		"client.taxname": "name",
+		"client.kids":    "array",
+		"client.names":   "array",
+		"family.kids":    "array",
+		// Bare IDENTs for typedDouble/typedLong resolution inside fold
+		// bodies — the floatSumOf alt requires a typedDouble (IDENT),
+		// not a possessive/colon attr ref.
+		"income":         "double",
+		"tax":            "integer",
+	}
+}
+
+// TestIssue803_IntSumOf: integer fold across an array. Element
+// entity is auto-pushed by forall, so `client.tax` resolves against
+// each element.
+func TestIssue803_IntSumOf(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch8Symbols())
+	got, err := c.CompileAction(`set client.tax = sum of client.tax in family.kids`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	for _, tok := range []string{"0", "forall", "+"} {
+		if !strings.Contains(got, tok) {
+			t.Errorf("expected %q in postfix, got: %s", tok, got)
+		}
+	}
+}
+
+// TestIssue803_FloatSumOf_Unreachable documents that floatSumOf is
+// currently a grammar zombie: ANTLR's LL(*) prediction picks
+// intSumOf at every fexpr-allowing context because `typedLong` and
+// `typedDouble` both lex as bare IDENT, and `number : iexpr | fexpr`
+// lists iexpr first. The VisitFloatSumOf override is still defined
+// (right shape for when the grammar is disambiguated by a future
+// token-classification pass), but the parser never reaches it. This
+// test pins that finding so a future grammar fix breaks here loudly
+// instead of silently — at which point the body should be replaced
+// with the positive assertion (`f+`, `0.0` present).
+func TestIssue803_FloatSumOf_Unreachable(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch8Symbols())
+	got, err := c.CompileAction(`print sum of income in family.kids`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	// Today the parse goes through intSumOf — `+` and a bare `0` seed.
+	// If this ever flips to `f+`/`0.0`, replace this test body.
+	if strings.Contains(got, "f+") {
+		t.Errorf("floatSumOf is now reachable; replace this test with positive assertions. got: %s", got)
+	}
+	if !strings.Contains(got, "+") || !strings.Contains(got, "forall") {
+		t.Errorf("expected intSumOf fallback postfix (+, forall), got: %s", got)
+	}
+}
+
+// TestIssue803_IntIndexOf: emits the haystack and needle, then
+// `indexof`. opIndexOf signature is ( string substring -- index ),
+// so the haystack must be pushed first.
+func TestIssue803_IntIndexOf(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch8Symbols())
+	got, err := c.CompileAction(`set client.tax = index of "AB" in client.code`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(got, "indexof") {
+		t.Errorf("expected indexof in postfix, got: %s", got)
+	}
+	// Both operands must appear; the haystack must precede the needle
+	// in the emitted token stream so the op pops needle first.
+	hayIdx := strings.Index(got, "client.code")
+	needleIdx := strings.Index(got, `"AB"`)
+	if hayIdx < 0 || needleIdx < 0 {
+		t.Fatalf("expected both operands in postfix, got: %s", got)
+	}
+	if !(hayIdx < needleIdx) {
+		t.Errorf("expected haystack to precede needle, got: %s", got)
+	}
+}
+
+// TestIssue803_NameFromStr: `(name) <strexpr>` must coerce via
+// `cvn` — same as `the name <strexpr>`.
+func TestIssue803_NameFromStr(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch8Symbols())
+	got, err := c.CompileAction(`set client.taxname = (name) client.code`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(got, "cvn") {
+		t.Errorf("expected cvn in postfix, got: %s", got)
+	}
+}
+
+// TestIssue803_NameArrayAt: `name <typedArray>[<iexpr>]` must emit
+// the array name, the index, and a `getat` dispatch.
+func TestIssue803_NameArrayAt(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch8Symbols())
+	got, err := c.CompileAction(`set client.taxname = name client.names[2]`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	for _, tok := range []string{"client.names", "2", "getat"} {
+		if !strings.Contains(got, tok) {
+			t.Errorf("expected %q in postfix, got: %s", tok, got)
+		}
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -1360,6 +1360,35 @@ func (e *PostfixEmitter) VisitIntNumberOfWhere(ctx *IntNumberOfWhereContext) int
 	return nil
 }
 
+// VisitIntSumOf: `sum of <iexpr> in <arrayExpr>` — fold the array
+// accumulating <iexpr> per element. Element entity is auto-pushed by
+// forall, so <iexpr> may reference the element's fields directly.
+// Pre-fix this rule silently emitted nothing.
+func (e *PostfixEmitter) VisitIntSumOf(ctx *IntSumOfContext) interface{} {
+	e.emit("0")
+	e.Visit(ctx.ArrayExpr())
+	e.emit("{")
+	e.Visit(ctx.Iexpr())
+	e.emit("+")
+	e.emit("}")
+	e.emit("forall")
+	return nil
+}
+
+// VisitIntIndexOf: `index of <needle> in <haystack>` — emit
+// `<haystack> <needle> indexof`. opIndexOf pops substring then
+// string. Pre-fix the rule silently emitted nothing.
+func (e *PostfixEmitter) VisitIntIndexOf(ctx *IntIndexOfContext) interface{} {
+	all := ctx.AllStrexpr()
+	if len(all) != 2 {
+		return nil
+	}
+	e.Visit(all[1]) // haystack
+	e.Visit(all[0]) // needle
+	e.emit("indexof")
+	return nil
+}
+
 func (e *PostfixEmitter) VisitIntLengthArray(ctx *IntLengthArrayContext) interface{} {
 	// If the arrayExpr is actually a bytes-typed identifier, emit byteslen.
 	if e.arrayExprIsBytes(ctx.ArrayExpr()) {
@@ -2031,6 +2060,28 @@ func (e *PostfixEmitter) VisitFloatRoundedBoundry(ctx *FloatRoundedBoundryContex
 	e.Visit(ctx.Iexpr())
 	e.Visit(ctx.Fexpr(1))
 	e.emit("roundto")
+	return nil
+}
+
+// VisitFloatSumOf: `sum of <typedDouble> in <arrayExpr>` — fold the
+// array summing the named double field. forall auto-pushes each
+// element entity onto the entity stack, so the typedDouble resolves
+// against the element via the standard field-access path.
+//
+// Currently unreachable due to a grammar prediction issue: ANTLR's
+// LL(*) picks intSumOf over floatSumOf for `sum of <ident> in
+// <array>` because typedLong/typedDouble both lex as bare IDENT, and
+// `number : iexpr | fexpr` lists iexpr first. The override is kept
+// defensively for when a future token-classification pass makes
+// floatSumOf reachable. See TestIssue803_FloatSumOf_Unreachable.
+func (e *PostfixEmitter) VisitFloatSumOf(ctx *FloatSumOfContext) interface{} {
+	e.emit("0.0")
+	e.Visit(ctx.ArrayExpr())
+	e.emit("{")
+	e.Visit(ctx.TypedDouble())
+	e.emit("f+")
+	e.emit("}")
+	e.emit("forall")
 	return nil
 }
 
@@ -4252,6 +4303,26 @@ func (e *PostfixEmitter) VisitForctl(ctx *ForctlContext) interface{} {
 func (e *PostfixEmitter) VisitNameTheName(ctx *NameTheNameContext) interface{} {
 	e.Visit(ctx.Strexpr())
 	e.emit("cvn")
+	return nil
+}
+
+// VisitNameFromStr: `(name) <strexpr>` → `<strexpr> cvn`. Same
+// coercion as `the name <strexpr>`; just a parenthesized cast form.
+// Pre-fix the rule silently emitted nothing.
+func (e *PostfixEmitter) VisitNameFromStr(ctx *NameFromStrContext) interface{} {
+	e.Visit(ctx.Strexpr())
+	e.emit("cvn")
+	return nil
+}
+
+// VisitNameArrayAt: `name <typedArray>[<iexpr>]` → `<typedArray>
+// <iexpr> getat`. Index into a name-typed array. Parallels
+// VisitBoolArrayAt / VisitDateFromArrayAt. Pre-fix the rule silently
+// emitted nothing.
+func (e *PostfixEmitter) VisitNameArrayAt(ctx *NameArrayAtContext) interface{} {
+	e.emit(ctx.TypedArray().GetText())
+	e.Visit(ctx.Iexpr())
+	e.emit("getat")
 	return nil
 }
 

--- a/pkg/dtrules/compiler/el/visitor_pin_test.go
+++ b/pkg/dtrules/compiler/el/visitor_pin_test.go
@@ -93,7 +93,6 @@ var inheritedAllowlist = map[string]string{
 	// (#803 batch 4).
 	"VisitFloatAddTo":                 "dead grammar; addtostatement handles `add X to Y` as a statement",
 	"VisitFloatSubFrom":               "dead grammar; addtostatement handles `subtract X from Y`",
-	"VisitFloatSumOf":                 "TODO(#803): triage",
 	// Float/Int/Str Using are unreachable: ANTLR adaptive prediction
 	// picks intUsingArray (in iexpr) first for the `using <ident>(<expr>)`
 	// shape because both IDENT-typed sides match more broadly. The
@@ -102,9 +101,7 @@ var inheritedAllowlist = map[string]string{
 	"VisitIfThen":                     "TODO(#803): triage; if/then in action statements has separate dispatch",
 	"VisitIfThenElse":                 "TODO(#803): triage; same",
 	"VisitIntAddTo":                   "dead grammar; addtostatement handles `add X to Y` (see VisitFloatAddTo)",
-	"VisitIntIndexOf":                 "TODO(#803): triage",
 	"VisitIntSubFrom":                 "dead grammar; addtostatement handles `subtract X from Y`",
-	"VisitIntSumOf":                   "TODO(#803): triage",
 	"VisitIntUsing":                   "dead grammar; intUsingArray wins parser-side (see VisitFloatUsing)",
 	"VisitLeftArrayColon":             "TODO(#803): triage",
 	// leftTexpr alts are unreachable because the only SET form that
@@ -113,8 +110,6 @@ var inheritedAllowlist = map[string]string{
 	// #803 batch 6).
 	"VisitLeftTexprColon":             "dead grammar; setTable emits elstmterror without visiting leftTexpr",
 	"VisitLeftTexprSimple":            "dead grammar; setTable emits elstmterror without visiting leftTexpr",
-	"VisitNameArrayAt":                "TODO(#803): triage",
-	"VisitNameFromStr":                "TODO(#803): triage",
 	"VisitOpListEntity":               "TODO(#803): triage",
 	"VisitOpListEntitySingle":         "TODO(#803): triage",
 	"VisitPerformName":                "dead grammar; ANTLR matches performDT/performDTExplicit first for any IDENT after PERFORM (verified by tree dump)",


### PR DESCRIPTION
Four new visitor overrides plus one defensive override for an unreachable grammar alt. Five fewer TODOs in the pin-test allowlist (135 → 26 across batches 1–8).

## New visitors

| Visitor | DSL | Postfix |
|---|---|---|
| `VisitIntSumOf` | `sum of <iexpr> in <array>` | `0 <array> { <iexpr> + } forall` |
| `VisitIntIndexOf` | `index of <needle> in <haystack>` | `<haystack> <needle> indexof` |
| `VisitNameFromStr` | `(name) <strexpr>` | `<strexpr> cvn` |
| `VisitNameArrayAt` | `name <typedArray>[<iexpr>]` | `<typedArray> <iexpr> getat` |

`opIndexOf` pops substring then string, so the haystack must be pushed first. `cvn` is the existing name-coercion op already used by `VisitNameTheName`.

## Defensive override: `VisitFloatSumOf`

Identical shape to `VisitIntSumOf` but with `0.0` seed and `f+` op. **Currently unreachable** due to ANTLR LL(*) prediction:
- `typedLong` and `typedDouble` both lex as bare IDENT
- `number : iexpr | fexpr` lists iexpr first
- Every `sum of <ident> in <array>` lands in `intSumOf` first (the postfix gets a trailing `cvd` to coerce when the LHS is double)

Override is kept defensively for when a future token-classification pass disambiguates `typedLong`/`typedDouble`. The visitor comment and `TestIssue803_FloatSumOf_Unreachable` document this finding.

## Tests

`pkg/dtrules/compiler/el/issue_803_batch8_test.go` pins all five overrides. The unreachability test fails **loudly** when the grammar is ever fixed — at that point, replace the body with positive assertions.

## Allowlist

Drop entries for `VisitIntSumOf`, `VisitIntIndexOf`, `VisitNameFromStr`, `VisitNameArrayAt`, `VisitFloatSumOf` (now overridden).

`make check` passes.

## Issue

Progress on #803 (silent failures from inherited no-op visitors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)