### PR TITLE
feat(compiler/el): override string membership tests (#803 batch 10)

### DIFF
--- a/pkg/dtrules/compiler/el/issue_803_batch10_test.go
+++ b/pkg/dtrules/compiler/el/issue_803_batch10_test.go
@@ -1,0 +1,88 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #803 batch 10: string-membership tests against an inline
+// list. Both rules previously emitted empty postfix.
+
+func issue803Batch10Symbols() map[string]string {
+	return map[string]string{
+		"client.state": "string",
+		"client.code":  "string",
+	}
+}
+
+// TestIssue803_BoolStrEqList: `<str> = "a", "b" or "c"` is a
+// membership check. Verify each literal appears in the postfix, the
+// equality op is `s==`, and the chain ends with `or`s to combine the
+// results.
+func TestIssue803_BoolStrEqList(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch10Symbols())
+	got, err := c.CompileCondition(`client.state == "CA", "NY", or "TX"`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	for _, tok := range []string{`"CA"`, `"NY"`, `"TX"`, "s==", "or"} {
+		if !strings.Contains(got, tok) {
+			t.Errorf("expected %q in postfix, got: %s", tok, got)
+		}
+	}
+	// Three values → two `or` operators total. Cheap arity check.
+	if strings.Count(got, "or") < 2 {
+		t.Errorf("expected at least two `or` operators for a 3-value list, got: %s", got)
+	}
+}
+
+// TestIssue803_BoolStrEqIcList: case-insensitive variant. Same shape
+// but `s==i` for each comparison.
+func TestIssue803_BoolStrEqIcList(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch10Symbols())
+	got, err := c.CompileCondition(`client.state is equal to ignore case "ca", "ny", or "tx"`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	for _, tok := range []string{`"ca"`, `"ny"`, `"tx"`, "s==i", "or"} {
+		if !strings.Contains(got, tok) {
+			t.Errorf("expected %q in postfix, got: %s", tok, got)
+		}
+	}
+}
+
+// TestIssue803_BoolStrEqList_TwoValues: minimum non-trivial list is
+// two values. Confirms the visitor doesn't emit a leading `or` and
+// produces exactly one combining op.
+func TestIssue803_BoolStrEqList_TwoValues(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch10Symbols())
+	got, err := c.CompileCondition(`client.state == "CA", or "NY"`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if strings.Count(got, "or") != 1 {
+		t.Errorf("expected exactly one `or` for a 2-value list, got %d occurrences: %s",
+			strings.Count(got, "or"), got)
+	}
+	if strings.Count(got, "s==") != 2 {
+		t.Errorf("expected exactly two `s==` ops for a 2-value list, got %d: %s",
+			strings.Count(got, "s=="), got)
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -835,6 +835,80 @@ func (e *PostfixEmitter) VisitBoolStrEqIc(ctx *BoolStrEqIcContext) interface{} {
 	return nil
 }
 
+// collectBlistStrexprs walks a blist / blistIc tree (left-leaning,
+// terminating in an OR alt) and returns the flat list of comparison
+// values in source order. blistMulti has shape `strexpr COMMA blist`
+// and blistOr has shape `OR strexpr`. Same shape for blistIc.
+//
+// Pulling the walk out of the antlr Visit dispatch lets the parent
+// visitor emit the membership-test postfix in one pass without
+// relying on individual Blist* overrides (which never fire because
+// VisitChildren is a no-op).
+func collectBlistStrexprs(node antlr.Tree) []IStrexprContext {
+	var out []IStrexprContext
+	var walk func(antlr.Tree)
+	walk = func(n antlr.Tree) {
+		switch c := n.(type) {
+		case *BlistMultiContext:
+			out = append(out, c.Strexpr())
+			if tail := c.Blist(); tail != nil {
+				walk(tail)
+			}
+		case *BlistOrContext:
+			out = append(out, c.Strexpr())
+		case *BlistIcMultiContext:
+			out = append(out, c.Strexpr())
+			if tail := c.Blist(); tail != nil {
+				walk(tail)
+			}
+		case *BlistIcOrContext:
+			out = append(out, c.Strexpr())
+		}
+	}
+	walk(node)
+	return out
+}
+
+// emitStrEqList emits `<lhs> v0 <op>  <lhs> v1 <op> or  <lhs> v2 <op>
+// or  ...` — the lhs is re-visited per element rather than dup'd so
+// any side effects in <lhs> evaluation match the singleton boolStrEq
+// path. Used by both boolStrEqList (op=s==) and boolStrEqIcList
+// (op=s==i).
+func (e *PostfixEmitter) emitStrEqList(lhs IStrexprContext, values []IStrexprContext, eqOp string) {
+	if len(values) == 0 {
+		// Defensive: empty list shouldn't be reachable through the grammar
+		// (blist always terminates in an OR strexpr), but emit a literal
+		// false so a malformed tree fails closed rather than silently.
+		e.emit("false")
+		return
+	}
+	for i, v := range values {
+		e.Visit(lhs)
+		e.Visit(v)
+		e.emit(eqOp)
+		if i > 0 {
+			e.emit("or")
+		}
+	}
+}
+
+// VisitBoolStrEqList: `<strexpr> = "a", "b" or "c"` — membership
+// against a comma-separated list ending in OR. Emit a chain of
+// `s==` comparisons OR'd together. Pre-fix this rule silently
+// emitted nothing.
+func (e *PostfixEmitter) VisitBoolStrEqList(ctx *BoolStrEqListContext) interface{} {
+	e.emitStrEqList(ctx.Strexpr(), collectBlistStrexprs(ctx.Blist()), "s==")
+	return nil
+}
+
+// VisitBoolStrEqIcList: `<strexpr> equals "a", "b" or "c"` —
+// case-insensitive variant. Same shape as boolStrEqList but using
+// the s==i op. Pre-fix this rule silently emitted nothing.
+func (e *PostfixEmitter) VisitBoolStrEqIcList(ctx *BoolStrEqIcListContext) interface{} {
+	e.emitStrEqList(ctx.Strexpr(), collectBlistStrexprs(ctx.BlistIc()), "s==i")
+	return nil
+}
+
 func (e *PostfixEmitter) VisitBoolStrNeqIc(ctx *BoolStrNeqIcContext) interface{} {
 	e.Visit(ctx.Strexpr(0))
 	e.Visit(ctx.Strexpr(1))

--- a/pkg/dtrules/compiler/el/visitor_pin_test.go
+++ b/pkg/dtrules/compiler/el/visitor_pin_test.go
@@ -71,12 +71,14 @@ var inheritedAllowlist = map[string]string{
 	"VisitAddDestArray2":              "dead grammar; addDest/subDestColon extract via GetText, never Visit",
 	"VisitAddDestDouble2":             "dead grammar; addDest/subDestColon extract via GetText, never Visit",
 	"VisitAddDestLong2":               "dead grammar; addDest/subDestColon extract via GetText, never Visit",
-	"VisitBlistIcMulti":               "TODO(#803): triage",
-	"VisitBlistIcOr":                  "TODO(#803): triage",
-	"VisitBlistMulti":                 "TODO(#803): triage",
-	"VisitBlistOr":                    "TODO(#803): triage",
-	"VisitBoolStrEqIcList":            "TODO(#803): triage",
-	"VisitBoolStrEqList":              "TODO(#803): triage",
+	// blist / blistIc alts are traversed directly by the parent
+	// visitors (VisitBoolStrEqList / VisitBoolStrEqIcList via
+	// collectBlistStrexprs), not via the antlr Visit dispatch — so
+	// these Visit* methods are never reached (#803 batch 10).
+	"VisitBlistIcMulti":               "dead grammar; parent traverses via collectBlistStrexprs, never Visit",
+	"VisitBlistIcOr":                  "dead grammar; parent traverses via collectBlistStrexprs, never Visit",
+	"VisitBlistMulti":                 "dead grammar; parent traverses via collectBlistStrexprs, never Visit",
+	"VisitBlistOr":                    "dead grammar; parent traverses via collectBlistStrexprs, never Visit",
 	"VisitDateEarliestAfter":          "TODO(#803): triage; needs new `earliestafter` runtime op",
 	"VisitEntityFirst":                "TODO(#803): triage",
 	"VisitEntityFirstIn":              "TODO(#803): triage",


### PR DESCRIPTION
Two new visitor overrides plus four verified dead-grammar entries. 15 TODOs remaining in the pin-test (down from 135).

## Implementations

| Visitor | DSL | Postfix |
|---|---|---|
| `VisitBoolStrEqList` | `<str> == "a", "b", or "c"` | `<lhs> "a" s== <lhs> "b" s== or <lhs> "c" s== or` |
| `VisitBoolStrEqIcList` | `<str> is equal to ignore case "a", "b", or "c"` | Same shape with `s==i` |

The lhs is re-visited per element rather than dup'd so any side effects in lhs evaluation match the singleton `boolStrEq` path.

## Helpers

- `collectBlistStrexprs` walks the recursive `blist` / `blistIc` tree (left-leaning, terminating in `blistOr` / `blistIcOr`) and returns the flat list of comparison values in source order.
- `emitStrEqList` emits the comparison-OR chain. Empty list emits `false` defensively — the grammar guarantees at least one element via the terminating OR alt.

## Allowlist

Convert TODO → dead grammar (parent traverses, never Visit):
- `VisitBlistMulti`, `VisitBlistOr`, `VisitBlistIcMulti`, `VisitBlistIcOr`

Drop entries for `VisitBoolStrEqList`, `VisitBoolStrEqIcList` — now overridden.

## Side discovery

While reviewing the existing `VisitBoolStrEqIc`, found it emits `sic==` and `VisitBoolStrNeq` / `VisitBoolStrIsNot` emit `strneq` — **neither is a registered runtime op**. The current visitors look correct but their emitted operators never dispatch. Will file as a separate issue (out of scope for this batch — narrow patch principle).

## Tests

`pkg/dtrules/compiler/el/issue_803_batch10_test.go` pins both visitors with 3- and 2-value lists and confirms the IC variant emits `s==i`.

`make check` passes.

## Issue

Progress on #803 (silent failures from inherited no-op visitors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)