### PR TITLE
feat(compiler/el): override str/xml family (#803 batch 11)

### DIFF
--- a/pkg/dtrules/compiler/el/issue_803_batch11_test.go
+++ b/pkg/dtrules/compiler/el/issue_803_batch11_test.go
@@ -1,0 +1,131 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #803 batch 11: str-family and xmlvalues container.
+// All six rules previously emitted empty postfix.
+
+func issue803Batch11Symbols() map[string]string {
+	return map[string]string{
+		"client.code": "string",
+		"client.ts":   "string",
+		"family":      "entity",
+		"family.head": "entity",
+	}
+}
+
+// TestIssue803_StrTimestamp: `get current_timestamp` is a niladic
+// runtime op call. The op is registered as `gettimestamp`.
+func TestIssue803_StrTimestamp(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch11Symbols())
+	got, err := c.CompileAction(`set client.ts = get current timestamp`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(got, "gettimestamp") {
+		t.Errorf("expected gettimestamp in postfix, got: %s", got)
+	}
+}
+
+// TestIssue803_StrAttrOf_ErrorsLoudly: `attribute <name> of <entity>`
+// has no runtime op; the visitor must emit elstmterror so the rule
+// fails loudly instead of silently dropping the access.
+func TestIssue803_StrAttrOf_ErrorsLoudly(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch11Symbols())
+	got, err := c.CompileAction(`set client.code = attribute "name" of family`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(got, "elstmterror") {
+		t.Errorf("expected elstmterror in postfix, got: %s", got)
+	}
+}
+
+// TestIssue803_StrMappingKey_ErrorsLoudly: bare `mappingkey` keyword
+// has no runtime op in the Go engine. Must emit elstmterror.
+func TestIssue803_StrMappingKey_ErrorsLoudly(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch11Symbols())
+	got, err := c.CompileAction(`set client.code = mapping key`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(got, "elstmterror") {
+		t.Errorf("expected elstmterror in postfix, got: %s", got)
+	}
+}
+
+// TestIssue803_StrRelationship_ErrorsLoudly: `relationship between
+// <e1> and <e2>` has no runtime op. Must emit elstmterror.
+func TestIssue803_StrRelationship_ErrorsLoudly(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch11Symbols())
+	got, err := c.CompileAction(`set client.code = relationship between family and family.head`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(got, "elstmterror") {
+		t.Errorf("expected elstmterror in postfix, got: %s", got)
+	}
+}
+
+// TestIssue803_StrXmlAttr_ErrorsLoudly: `<xmlval> : get attribute
+// <name>` has no XML runtime op. Must emit elstmterror.
+func TestIssue803_StrXmlAttr_ErrorsLoudly(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{
+		"client.code": "string",
+		"client.xml":  "xmlvalue",
+	})
+	got, err := c.CompileAction(`set client.code = client.xml: get attribute "id"`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(got, "elstmterror") {
+		t.Errorf("expected elstmterror in postfix, got: %s", got)
+	}
+}
+
+// TestIssue803_Xmlvalues_UnreachableViaXmlMutation pins the
+// finding that VisitXmlvalues' override is defensive — every
+// xmlvaluestatements alt emits an elstmterror without visiting the
+// RHS xmlvalues. The whole mutation collapses to a placeholder. If
+// the XML runtime is ever wired up and the parents stop short-
+// circuiting, this test will fail loudly and the body should be
+// replaced with a positive assertion on the dispatched child.
+func TestIssue803_Xmlvalues_UnreachableViaXmlMutation(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{
+		"client.xml":  "xmlvalue",
+		"client.code": "string",
+	})
+	got, err := c.CompileAction(`client.xml: set attribute "id" = client.code`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(got, "elstmterror") {
+		t.Errorf("expected xml mutation to short-circuit to elstmterror, got: %s", got)
+	}
+	if strings.Contains(got, "client.code") {
+		t.Errorf("xmlvalues now reachable; replace this test with a positive child-dispatch assertion. got: %s", got)
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -2303,6 +2303,85 @@ func (e *PostfixEmitter) VisitStrToLower(ctx *StrToLowerContext) interface{} {
 	return nil
 }
 
+// VisitStrTimestamp: `get current_timestamp` → `gettimestamp`. The
+// runtime op is niladic and pushes the current wall-clock timestamp
+// (RFC 3339 string). Pre-fix this rule silently emitted nothing.
+func (e *PostfixEmitter) VisitStrTimestamp(ctx *StrTimestampContext) interface{} {
+	e.emit("gettimestamp")
+	return nil
+}
+
+// VisitStrAttrOf: `attribute <strexpr> of <eexpr>` — generic
+// attribute lookup by string name on an entity. No dedicated runtime
+// op exists (the standard field-access path goes through
+// possessive/colon refs with a known typed field). Emit an
+// elstmterror placeholder so this fails loudly at runtime instead of
+// silently dropping the access. Pre-fix the rule silently emitted
+// nothing.
+func (e *PostfixEmitter) VisitStrAttrOf(ctx *StrAttrOfContext) interface{} {
+	e.emit(`"attribute <name> of <entity> not yet implemented"`)
+	e.emit("elstmterror")
+	return nil
+}
+
+// VisitStrMappingKey: `mappingkey` — niladic keyword that yields the
+// current decision-table key inside a mapping operation. The runtime
+// has no `mappingkey` op registered (the legacy Java engine had one
+// tied to its mapping-table machinery; the Go runtime doesn't ship
+// equivalent yet). Emit an elstmterror placeholder; pre-fix this
+// rule silently emitted nothing.
+func (e *PostfixEmitter) VisitStrMappingKey(ctx *StrMappingKeyContext) interface{} {
+	e.emit(`"mappingkey not yet implemented"`)
+	e.emit("elstmterror")
+	return nil
+}
+
+// VisitStrRelationship: `relationship between <e1> and <e2>` — name
+// of the relationship that links two entities, used by audit/policy
+// rendering. No dedicated runtime op. Emit elstmterror; pre-fix this
+// rule silently emitted nothing.
+func (e *PostfixEmitter) VisitStrRelationship(ctx *StrRelationshipContext) interface{} {
+	e.emit(`"relationship between ... not yet implemented"`)
+	e.emit("elstmterror")
+	return nil
+}
+
+// VisitStrXmlAttr: `<typedXmlValue> : get attribute <strexpr>` —
+// read an attribute from an XML-valued field. No XML runtime ops
+// registered. Emit elstmterror; pre-fix this rule silently emitted
+// nothing.
+func (e *PostfixEmitter) VisitStrXmlAttr(ctx *StrXmlAttrContext) interface{} {
+	e.emit(`"xml get attribute not yet implemented"`)
+	e.emit("elstmterror")
+	return nil
+}
+
+// VisitXmlvalues: container rule whose body is one of
+// strexpr/iexpr/fexpr/dexpr/nexpr. Dispatch to the present child so
+// the parent xmlSetAttr/xmlAddAttr rule sees the value on the data
+// stack.
+//
+// Currently unreachable: every xmlvaluestatements alt
+// (xmlSetAttr/xmlSetAttrEntity/xmlAddAttr/xmlAddAttrEntity) emits an
+// elstmterror placeholder for the whole mutation without visiting
+// the RHS xmlvalues — the Go runtime has no XML mutation ops. This
+// override is kept defensively for when the XML runtime is wired up.
+func (e *PostfixEmitter) VisitXmlvalues(ctx *XmlvaluesContext) interface{} {
+	switch {
+	case ctx.Strexpr() != nil:
+		e.Visit(ctx.Strexpr())
+	case ctx.Iexpr() != nil:
+		e.Visit(ctx.Iexpr())
+	case ctx.Fexpr() != nil:
+		e.Visit(ctx.Fexpr())
+	case ctx.Dexpr() != nil:
+		e.Visit(ctx.Dexpr())
+	case ctx.Nexpr() != nil:
+		e.Visit(ctx.Nexpr())
+	}
+	return nil
+}
+
 func (e *PostfixEmitter) VisitStrToUpper(ctx *StrToUpperContext) interface{} {
 	e.Visit(ctx.Strexpr())
 	e.emit("toupper")

--- a/pkg/dtrules/compiler/el/visitor_pin_test.go
+++ b/pkg/dtrules/compiler/el/visitor_pin_test.go
@@ -125,7 +125,6 @@ var inheritedAllowlist = map[string]string{
 	// IDENT-prefixed RHS. Confirmed by parse-tree inspection (#803 batch 2).
 	"VisitSetStringFromNumber":        "dead grammar; ANTLR picks setInt/setFloat for IDENT/number RHS",
 	"VisitSetStringFromTable":         "dead grammar; ANTLR picks setTable for texpr RHS",
-	"VisitStrAttrOf":                  "TODO(#803): triage",
 	// strConcat<Type> are all unreachable: ANTLR always picks the base
 	// `strexpr PLUS strexpr` # strConcat first because the RHS IDENT
 	// matches typedXmlValue inside strexpr. Confirmed by parse-tree
@@ -138,11 +137,7 @@ var inheritedAllowlist = map[string]string{
 	"VisitStrConcatInt":               "dead grammar; base strConcat wins parser-side",
 	"VisitStrConcatInvalid":           "dead grammar; base strConcat wins parser-side",
 	"VisitStrConcatNull":              "dead grammar; base strConcat wins parser-side",
-	"VisitStrMappingKey":              "TODO(#803): triage",
-	"VisitStrRelationship":            "TODO(#803): triage",
-	"VisitStrTimestamp":               "TODO(#803): triage",
 	"VisitStrUsing":                   "dead grammar; intUsingArray wins parser-side (see VisitFloatUsing)",
-	"VisitStrXmlAttr":                 "TODO(#803): triage",
 	// tablelist / tableTyped are helper rules referenced from the
 	// table-lookup alts; with the table-lookup parent emitting
 	// elstmterror placeholders (#803 batch 6), the helpers are never
@@ -163,7 +158,6 @@ var inheritedAllowlist = map[string]string{
 	"VisitTypedOperator":              "dead grammar; VisitOperatorstatements extracts via GetText",
 	"VisitUndefinedIdent":             "dead grammar; CREATE/LOCAL parents extract via UndefinedIdent().GetText",
 	"VisitUsingstatement":             "dead grammar; the rule's only alt wraps usingblock which is visited via children elsewhere",
-	"VisitXmlvalues":                  "TODO(#803): triage",
 }
 
 // TestPostfixEmitterVisitorCoverage asserts that the inherited


### PR DESCRIPTION
Six new visitor overrides — 9 TODOs remaining in the pin-test (135 → 9 across batches 1–11).

## Implementations

### Real
| Visitor | DSL | Postfix |
|---|---|---|
| `VisitStrTimestamp` | `get current timestamp` | `gettimestamp` |

### Loud-failure placeholders (no runtime op)

| Visitor | DSL | Postfix |
|---|---|---|
| `VisitStrAttrOf` | `attribute "name" of <entity>` | `<msg> elstmterror` |
| `VisitStrMappingKey` | `mapping key` | `<msg> elstmterror` |
| `VisitStrRelationship` | `relationship between <e1> and <e2>` | `<msg> elstmterror` |
| `VisitStrXmlAttr` | `<xmlval> : get attribute <name>` | `<msg> elstmterror` |

These rules previously silently emitted nothing — now they fail loudly at runtime with a clear message.

### Defensive (currently unreachable)

`VisitXmlvalues` dispatches to its present child (strexpr/iexpr/fexpr/dexpr/nexpr). However, every `xmlvaluestatements` parent (`xmlSetAttr`/`xmlSetAttrEntity`/`xmlAddAttr`/`xmlAddAttrEntity`) emits an `elstmterror` short-circuit without visiting the RHS — so this override is dead today. Kept defensively for when the XML runtime is wired.

## Tests

`pkg/dtrules/compiler/el/issue_803_batch11_test.go` pins all six. `TestIssue803_Xmlvalues_UnreachableViaXmlMutation` documents the short-circuit finding — when XML mutation is ever implemented, the test fails loudly and the body should be replaced with a positive child-dispatch assertion.

## Allowlist

Drop six entries: `VisitStrTimestamp`, `VisitStrAttrOf`, `VisitStrMappingKey`, `VisitStrRelationship`, `VisitStrXmlAttr`, `VisitXmlvalues`.

`make check` passes.

## Issue

Progress on #803 (silent failures from inherited no-op visitors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)