### PR TITLE
feat(compiler/el): finish #803 — if/then, op-list tails, colon-LHS, et al (batch 12)

### DIFF
--- a/pkg/dtrules/compiler/el/issue_803_batch12_test.go
+++ b/pkg/dtrules/compiler/el/issue_803_batch12_test.go
@@ -1,0 +1,173 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #803 batch 12: leftovers — if/then, operatorlist entity tail,
+// left-array-colon LHS, and three forms with no runtime op
+// (entityFirst / entityFirstIn / dateEarliestAfter) that emit
+// elstmterror placeholders.
+
+func issue803Batch12Symbols() map[string]string {
+	return map[string]string{
+		"client.flag":   "boolean",
+		"client.tax":    "integer",
+		"client.code":   "string",
+		"client.kids":   "array",
+		"client.dates":  "array",
+		"client.due":    "date",
+		"family":        "entity",
+		"family.kids":   "array",
+		"family.parent": "entity",
+		"Client":        "entity",
+	}
+}
+
+// TestIssue803_IfThen: `if <b> then <stmts> endif` must emit
+// `<b> { <stmts> } if`. Pre-fix the entire conditional was dropped.
+func TestIssue803_IfThen(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch12Symbols())
+	got, err := c.CompileAction(`if client.flag then set client.tax = 5; endif`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	for _, tok := range []string{"client.flag", "{", "}", "if", "5"} {
+		if !strings.Contains(got, tok) {
+			t.Errorf("expected %q in postfix, got: %s", tok, got)
+		}
+	}
+}
+
+// TestIssue803_IfThenElse: `if/then/else` must emit `<b> { t } { e }
+// ifelse`. Pre-fix both branches were dropped.
+func TestIssue803_IfThenElse(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch12Symbols())
+	got, err := c.CompileAction(`if client.flag then set client.tax = 5; else set client.tax = 10; endif`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	for _, tok := range []string{"client.flag", "5", "10", "ifelse"} {
+		if !strings.Contains(got, tok) {
+			t.Errorf("expected %q in postfix, got: %s", tok, got)
+		}
+	}
+}
+
+// TestIssue803_OpListEntity: a non-terminal entity argument in an
+// operator call must be emitted. Pre-fix `op(<e1>, <s>, <e2>)` would
+// drop e1 silently.
+func TestIssue803_OpListEntity(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch12Symbols())
+	// Use a generic operator name; the type-check runs through
+	// operatorstatements which dispatches via the operatorlist tree.
+	got, err := c.CompileAction(`set client.code = string value of myop(family, "x")`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	// The entity arg must appear in the emitted postfix.
+	if !strings.Contains(got, "family") {
+		t.Errorf("expected entity arg `family` in postfix, got: %s", got)
+	}
+	if !strings.Contains(got, "myop") {
+		t.Errorf("expected op name in postfix, got: %s", got)
+	}
+}
+
+// TestIssue803_OpListEntitySingle: terminal single entity arg.
+func TestIssue803_OpListEntitySingle(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch12Symbols())
+	got, err := c.CompileAction(`set client.code = string value of myop(family)`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(got, "family") {
+		t.Errorf("expected entity arg `family` in postfix, got: %s", got)
+	}
+	if !strings.Contains(got, "myop") {
+		t.Errorf("expected op name in postfix, got: %s", got)
+	}
+}
+
+// TestIssue803_LeftArrayColon: `:Entity:<array-field>` on the LHS of
+// `set X = arrayExpr`. Mirrors the existing LeftXxxColon family
+// (visit colonRef → visit inner left-ref). The runtime xdef handles
+// the entity-aware store; no entitypush/pop wrapping is needed at the
+// emitter level (matches VisitLeftIexprColon behavior).
+//
+// Pre-fix the whole assignment was dropped because LeftArrayColon
+// collapsed to empty postfix.
+func TestIssue803_LeftArrayColon(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch12Symbols())
+	got, err := c.CompileAction(`set :Client:kids = family.kids`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	for _, tok := range []string{"Client", "/kids", "xdef", "family.kids"} {
+		if !strings.Contains(got, tok) {
+			t.Errorf("expected %q in postfix, got: %s", tok, got)
+		}
+	}
+}
+
+// TestIssue803_EntityFirst_ErrorsLoudly: `first <e> where ...` has
+// no runtime op. Must emit elstmterror.
+func TestIssue803_EntityFirst_ErrorsLoudly(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch12Symbols())
+	got, err := c.CompileAction(`set family.parent = first family where client.flag`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(got, "elstmterror") {
+		t.Errorf("expected elstmterror in postfix, got: %s", got)
+	}
+}
+
+// TestIssue803_EntityFirstIn_ErrorsLoudly: `first <e> in <arr>
+// where ...` likewise.
+func TestIssue803_EntityFirstIn_ErrorsLoudly(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch12Symbols())
+	got, err := c.CompileAction(`set family.parent = first family in family.kids where client.flag`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(got, "elstmterror") {
+		t.Errorf("expected elstmterror in postfix, got: %s", got)
+	}
+}
+
+// TestIssue803_DateEarliestAfter_ErrorsLoudly: `earliest of <arr>
+// after <d>` has no runtime op. Must emit elstmterror.
+func TestIssue803_DateEarliestAfter_ErrorsLoudly(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue803Batch12Symbols())
+	got, err := c.CompileAction(`set client.due = earliest of client.dates after client.due`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(got, "elstmterror") {
+		t.Errorf("expected elstmterror in postfix, got: %s", got)
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -6797,3 +6797,97 @@ func (e *PostfixEmitter) VisitDateNewYMDhmsInZoneWithDST(ctx *DateNewYMDhmsInZon
 	e.emit("newdateinzonewithdst")
 	return nil
 }
+
+// ============================================================================
+// #803 batch 12: leftovers (if/then, operatorlist tails, left-array-colon,
+// thereis/entity-first/date-earliest).
+// ============================================================================
+
+// VisitIfThen: `if <bexpr> then <block> endif` → `<bexpr> { <block> } if`.
+// Pre-fix the whole if-statement silently emitted nothing; conditional
+// action blocks were entirely lost.
+func (e *PostfixEmitter) VisitIfThen(ctx *IfThenContext) interface{} {
+	e.Visit(ctx.Bexpr())
+	e.emit("{")
+	e.Visit(ctx.Block())
+	e.emit("}")
+	e.emit("if")
+	return nil
+}
+
+// VisitIfThenElse: `if <bexpr> then <t> else <e> endif`
+// → `<bexpr> { <t> } { <e> } ifelse`. Pre-fix this silently emitted
+// nothing.
+func (e *PostfixEmitter) VisitIfThenElse(ctx *IfThenElseContext) interface{} {
+	e.Visit(ctx.Bexpr())
+	e.emit("{")
+	e.Visit(ctx.Block(0))
+	e.emit("}")
+	e.emit("{")
+	e.Visit(ctx.Block(1))
+	e.emit("}")
+	e.emit("ifelse")
+	return nil
+}
+
+// VisitOpListEntity: `<eexpr> , <operatorlist>` — non-terminal entity
+// argument in an operator call. Mirror the existing VisitOpListInt /
+// VisitOpListStr / VisitOpListFloat visitors: emit the eexpr first,
+// then recurse into the tail. Pre-fix this rule silently dropped any
+// entity-typed argument that wasn't last in the list.
+func (e *PostfixEmitter) VisitOpListEntity(ctx *OpListEntityContext) interface{} {
+	e.Visit(ctx.Eexpr())
+	e.Visit(ctx.Operatorlist())
+	return nil
+}
+
+// VisitOpListEntitySingle: terminal `<eexpr>` in an operator call.
+// Mirrors VisitOpListIntSingle / VisitOpListStrSingle. Pre-fix this
+// silently dropped a single entity argument.
+func (e *PostfixEmitter) VisitOpListEntitySingle(ctx *OpListEntitySingleContext) interface{} {
+	e.Visit(ctx.Eexpr())
+	return nil
+}
+
+// VisitLeftArrayColon: `:Entity:<array-field>` on the LHS of `set X =
+// Y`. Mirrors the existing VisitLeftIexprColon / VisitLeftFexprColon
+// / VisitLeftEexprColon family — visit the colonRef (which pushes
+// the entity and walks possessive-or-colon chain), then the inner
+// leftArrayRef which emits the field-store trailer. Pre-fix the rule
+// silently emitted nothing.
+func (e *PostfixEmitter) VisitLeftArrayColon(ctx *LeftArrayColonContext) interface{} {
+	e.Visit(ctx.ColonRef())
+	e.Visit(ctx.LeftArrayRef())
+	return nil
+}
+
+// VisitEntityFirst: `first <eexpr> where <bexpr>` — return the first
+// entity in the iterated set whose bexpr holds. No `firstwhere`-style
+// entity-returning runtime op exists yet. Emit an elstmterror
+// placeholder so this fails loudly at runtime instead of silently
+// emitting nothing. Tracked as a follow-up: needs a new runtime op
+// or a fold-with-capture postfix pattern via local vars.
+func (e *PostfixEmitter) VisitEntityFirst(ctx *EntityFirstContext) interface{} {
+	e.emit(`"first <e> where ... not yet implemented (needs firstwhere runtime op)"`)
+	e.emit("elstmterror")
+	return nil
+}
+
+// VisitEntityFirstIn: `first <eexpr> in <array> where <bexpr>` — same
+// as EntityFirst but with an explicit source array. Same
+// elstmterror-placeholder treatment until the runtime op lands.
+func (e *PostfixEmitter) VisitEntityFirstIn(ctx *EntityFirstInContext) interface{} {
+	e.emit(`"first <e> in <arr> where ... not yet implemented (needs firstwhere runtime op)"`)
+	e.emit("elstmterror")
+	return nil
+}
+
+// VisitDateEarliestAfter: `earliest of <array> after <date>` — return
+// the earliest date in the array that's strictly after the given
+// date. No `earliestafter` runtime op exists. Emit elstmterror;
+// tracked as a follow-up.
+func (e *PostfixEmitter) VisitDateEarliestAfter(ctx *DateEarliestAfterContext) interface{} {
+	e.emit(`"earliest of <arr> after <d> not yet implemented (needs earliestafter runtime op)"`)
+	e.emit("elstmterror")
+	return nil
+}

--- a/pkg/dtrules/compiler/el/visitor_pin_test.go
+++ b/pkg/dtrules/compiler/el/visitor_pin_test.go
@@ -79,9 +79,6 @@ var inheritedAllowlist = map[string]string{
 	"VisitBlistIcOr":                  "dead grammar; parent traverses via collectBlistStrexprs, never Visit",
 	"VisitBlistMulti":                 "dead grammar; parent traverses via collectBlistStrexprs, never Visit",
 	"VisitBlistOr":                    "dead grammar; parent traverses via collectBlistStrexprs, never Visit",
-	"VisitDateEarliestAfter":          "TODO(#803): triage; needs new `earliestafter` runtime op",
-	"VisitEntityFirst":                "TODO(#803): triage",
-	"VisitEntityFirstIn":              "TODO(#803): triage",
 	// AddTo/SubFrom — these alts live inside fexpr/iexpr but the
 	// action-statement form `add X to Y` / `subtract X from Y` parses
 	// as addtostatement (rule `addtostatement`), not via the fexpr
@@ -95,20 +92,15 @@ var inheritedAllowlist = map[string]string{
 	// shape because both IDENT-typed sides match more broadly. The
 	// actually-reached intUsingArray now has an override (#803 batch 6).
 	"VisitFloatUsing":                 "dead grammar; intUsingArray wins parser-side for IDENT inputs",
-	"VisitIfThen":                     "TODO(#803): triage; if/then in action statements has separate dispatch",
-	"VisitIfThenElse":                 "TODO(#803): triage; same",
 	"VisitIntAddTo":                   "dead grammar; addtostatement handles `add X to Y` (see VisitFloatAddTo)",
 	"VisitIntSubFrom":                 "dead grammar; addtostatement handles `subtract X from Y`",
 	"VisitIntUsing":                   "dead grammar; intUsingArray wins parser-side (see VisitFloatUsing)",
-	"VisitLeftArrayColon":             "TODO(#803): triage",
 	// leftTexpr alts are unreachable because the only SET form that
 	// targets a typedTable (setTable) now emits an elstmterror
 	// placeholder without visiting the leftTexpr (hash tables removed,
 	// #803 batch 6).
 	"VisitLeftTexprColon":             "dead grammar; setTable emits elstmterror without visiting leftTexpr",
 	"VisitLeftTexprSimple":            "dead grammar; setTable emits elstmterror without visiting leftTexpr",
-	"VisitOpListEntity":               "TODO(#803): triage",
-	"VisitOpListEntitySingle":         "TODO(#803): triage",
 	"VisitPerformName":                "dead grammar; ANTLR matches performDT/performDTExplicit first for any IDENT after PERFORM (verified by tree dump)",
 	// setArray<Type> are unreachable for non-array RHS: ANTLR picks
 	// setInt/setFloat/setString/setEntity/setDate first when the RHS
@@ -145,7 +137,11 @@ var inheritedAllowlist = map[string]string{
 	"VisitTableListMulti":             "dead grammar; helper rule under table-lookup which emits elstmterror",
 	"VisitTableListSingle":            "dead grammar; helper rule under table-lookup which emits elstmterror",
 	"VisitTableTyped":                 "dead grammar; helper rule under table-lookup which emits elstmterror",
-	"VisitThereis":                    "TODO(#803): triage",
+	// `thereis` is a purely structural rule (`THERE IS | IS THERE`) — just
+	// keyword matching. Every parent (boolThereIsWhere, boolMatchForall,
+	// etc.) emits its own postfix without visiting the thereis ctx (#803
+	// batch 12).
+	"VisitThereis":                    "dead grammar; parents emit logic without visiting the keyword-only rule",
 	// typedXxx and undefinedIdent are IDENT-classification rules. Every
 	// parent visitor that consumes them extracts the text via GetText()
 	// directly (e.g. VisitOperatorstatements at line 4906 reads


### PR DESCRIPTION
**Final batch.** All 135 `TODO(#803): triage` entries in the pin-test allowlist are now either real overrides, verified dead grammar, or documented `needs new runtime op` placeholders. **0 TODOs remain.**

## Real implementations

| Visitor | DSL | Postfix |
|---|---|---|
| `VisitIfThen` | `if <b> then <block> endif` | `<b> { <block> } if` |
| `VisitIfThenElse` | `if <b> then <t> else <e> endif` | `<b> { <t> } { <e> } ifelse` |
| `VisitOpListEntity` | `op(<e1>, <s>, <e2>)` non-terminal | `<e1>` then recurse |
| `VisitOpListEntitySingle` | `op(<e>)` terminal | `<e>` |
| `VisitLeftArrayColon` | `set :Entity:<arr-field> = ...` | colonRef → leftArrayRef trailer |

`VisitIfThen`/`VisitIfThenElse` are the most impactful — pre-fix every action-side `if` statement silently emitted nothing. The whole conditional was a no-op. Conditional logic in actions has been broken at the visitor level until now (likely masked by either always-`if/then` action tables routing through a different path, or by tests that don't exercise conditional actions).

## Loud-failure placeholders (deferred follow-ups)

| Visitor | Need |
|---|---|
| `VisitEntityFirst` | `firstwhere` or `forfirst`-with-capture runtime op |
| `VisitEntityFirstIn` | Same |
| `VisitDateEarliestAfter` | `earliestafter` runtime op |

All emit `<msg> elstmterror` so they fail loudly instead of silently.

## Allowlist

- `VisitThereis` → dead grammar (purely structural `THERE IS | IS THERE` keyword recognition; every parent emits its own logic).
- Drop 8 entries for the new overrides.

## Tests

`pkg/dtrules/compiler/el/issue_803_batch12_test.go` pins all behaviors plus the three loud-failure placeholders.

## #803 summary across all 12 batches

| | Count |
|---|---|
| Visitors triaged | 135 |
| TODOs remaining | 0 |
| Real overrides added | ~60 |
| Verified dead grammar | ~30 |
| Loud-failure placeholders | ~10 |
| Defensive overrides for unreachable alts | 2 |

Per-batch silent-failure findings (e.g. PR #831/832/833/834/836) are summarized in their commit messages.

`make check` passes.

## Closes

Closes #803.

🤖 Generated with [Claude Code](https://claude.com/claude-code)