### PR TITLE
docs: narratives for EDD analyzer, redundant-column advisory, first pass, for-all-type-entities (#807)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,25 @@ for day-to-day use:
 
 ---
 
+## Feature Narratives
+
+Long-form companions to the embedded `dtrules docs` topics, focused on
+*why* and *when* rather than syntax. The embedded topics remain the
+authoritative usage walkthrough.
+
+| Document | Feature | First shipped |
+|----------|---------|---------------|
+| [EDD Usage Analyzer](edd-usage-analyzer.md) | Entity-stack-aware `unused` / `write-only` detection | v1.13.0 |
+| [Redundant Action-Set Column Advisory](advisory-redundant-action-set.md) | Column-level redundancy check on the compiled decision tree | v1.14.6 |
+| [`first pass` Predicate](first-pass-predicate.md) | EL predicate for the first iteration of the innermost active loop | v1.12.0 |
+| [`for all <type> entities` Loop](for-all-type-entities.md) | Type-driven iteration via the EDD `owns` declaration | [#703](https://github.com/DTRules/DTRules/issues/703) |
+
+For features without a narrative companion, see the embedded `dtrules
+docs` topics (`dtrules docs operators` covers `fphalfup/` and
+`fpdivr/`; `dtrules docs el` covers `create T as alias`).
+
+---
+
 ## Java Implementation
 
 | Document | Description |

--- a/docs/advisory-redundant-action-set.md
+++ b/docs/advisory-redundant-action-set.md
@@ -1,0 +1,62 @@
+# Redundant Action-Set Column Advisory
+
+> Status: as of v1.14.6 (issue [#797](https://github.com/DTRules/DTRules/issues/797)).
+
+A decision-table column is **redundant** when it reaches the same action set as an earlier column. The runtime would produce the same output if that column were removed and its inputs fell through, or if it were collapsed into the earlier column with all conditions set to `*`.
+
+This is a **stronger check** than the cell-level redundant-condition advisory ([#762](https://github.com/DTRules/DTRules/issues/762), [#794](https://github.com/DTRules/DTRules/issues/794)): the cell-level check flags individual `Y`/`N` entries that are forced by other rows; this check flags entire **columns** whose behavior is already covered.
+
+## The check, in one paragraph
+
+After the table is compiled into its decision tree, walk the tree and group columns by the **ordered tuple** of action numbers they reach. For each group, keep the smallest column number ("first to introduce this action set") and flag every other column as redundant ("same action set already covered by column N").
+
+## Why "ordered tuple"
+
+The runtime executes actions in the order they're listed, and that order is observable: audit-trail line ordering, sequence dependencies between sets and reads, side effects between `set` and a read of the same field. So:
+
+- Columns reaching `[3, 5, 7]` and `[3, 5, 7]` → same action set.
+- Columns reaching `[3, 5, 7]` and `[7, 5, 3]` → **different** action sets, no warning.
+
+This is conservative — sometimes order doesn't matter and the columns really are equivalent, but the analyzer can't prove that without modeling each action's read/write effects, so it errs on the side of "you said order matters, I'll take you at your word."
+
+## What gets reported
+
+```
+WARN <table>: column 4 reaches the same action set as column 2 — consider
+collapsing into a single column (all conditions = '-') or removing if the
+inputs should fall through downstream
+```
+
+The output points at the **later** column (the redundant one) and names the **earlier** column (the one already covering this behavior).
+
+## What it doesn't catch
+
+- **Unreachable columns**: columns that no tree leaf maps to. These are caught by a separate `unreachable column` warning — they're skipped here because "doesn't reach this action set" doesn't apply when they don't reach anything at all.
+- **Columns with empty action sets**: a column with no action numbers is the table's no-op column, covered by the `no-op column` warning.
+- **Cross-table redundancy**: two different tables having redundant columns relative to each other isn't part of this check; the analyzer is per-table.
+
+## Suggested remediation
+
+Two reasonable fixes:
+
+**Collapse into a catch-all.** If columns 2 and 4 are both producing action set `[3, 5, 7]`, the table is implicitly saying "any input matching either column 2 or column 4 should run these actions." Often the cleaner expression is a single column with all conditions = `-` (always matches), or columns 2 and 4 merged with their conditions OR'd via the cell-level entries.
+
+**Remove and let it fall through.** If the redundant column was a defensive belt-and-braces ("just in case the earlier column doesn't catch this"), removing it and trusting the earlier column tends to make the table clearer. The advisory is a prompt to decide which intent the column was serving.
+
+## Running it
+
+The check runs as part of `decisiontable.Analyze`, which is invoked by:
+
+```bash
+dtrules build <project>            # advisory pass on every build
+dtrules review <project>           # full review including this check
+```
+
+It also surfaces in the cmd/dtrules MCP advisory tool surfaces.
+
+## Related
+
+- `pkg/dtrules/decisiontable/tree_analysis.go:checkRedundantActionSetColumns` — implementation
+- [#762](https://github.com/DTRules/DTRules/issues/762) — cell-level redundant-condition check
+- [#794](https://github.com/DTRules/DTRules/issues/794) — leave-one rule capping the cell-level check at K-1
+- `dtrules docs decision-tables` — embedded decision-table reference

--- a/docs/edd-usage-analyzer.md
+++ b/docs/edd-usage-analyzer.md
@@ -1,0 +1,112 @@
+# EDD Usage Analyzer
+
+> Status: as of v1.13.0 (entity-stack-aware) — phases 1 and 2 shipped; phase 3 (cross-table + enumeration-bounded dynamic strings) tracked in [#776](https://github.com/DTRules/DTRules/issues/776).
+
+The EDD usage analyzer answers two questions about a DTRules project:
+
+1. Which declared EDD fields are **never read** by any rule? (candidate for removal)
+2. Which fields are **only written**, never read? (probable bug — the rule sets the field but nothing downstream consumes it)
+
+Surfaced through `dtrules review` as `INFO` advisories.
+
+## Why a separate analyzer
+
+Before v1.13.0, EDD usage was a single regex pass over DSL text:
+
+```go
+var identifierPattern = regexp.MustCompile(`\b([a-z_][a-z0-9_]*)\.([a-z_][a-z0-9_]*)\b`)
+```
+
+This catches dotted references like `taxpayer.income`, but misses the case that drove the rewrite: **bare identifiers resolved against the entity stack at runtime**.
+
+A rule like:
+
+```
+for all taxpayers
+  taxpayer.is_self_employed and earned_income > 0
+```
+
+references `taxpayer.earned_income` indirectly. The `for all taxpayers` pushes `taxpayer` onto the entity stack; the bare `earned_income` resolves against the top of that stack at evaluation time. To the regex pass, only `taxpayer.is_self_employed` is visible, and `earned_income` looks unreferenced anywhere — so the EDD declaration for `taxpayer.earned_income` is flagged as **unused** even though it's the most-read field in the table.
+
+The downstream staking project surfaced ~97 such false-positive `unused` warnings before the rewrite landed. After the rewrite: ~5 genuine.
+
+## What it tracks
+
+The analyzer walks every `*_dt.xml` under the project's `xml/` directory. For each DSL fragment it threads an **entity stack** mirroring what the runtime does:
+
+| Construct | Push effect (duration) |
+|---|---|
+| `for all <field>` block | type of the iterated entity, for the duration of the block |
+| `for all <field> where <pred>` | same, plus the `where` clause is in scope of the iterated entity |
+| `for first of <field> where <pred>` | same |
+| `for first in <field> where <pred>` | same |
+| `using <entity> { ... }` block | named entity, for the duration of the block |
+| `for each <entity> in <array>` block | iterated entity, for the duration of the block |
+| `for all <type> entities [where ...]` | iterated entity type (resolved via the EDD's `owns` declaration) |
+
+At each reference site, bare identifiers resolve against the topmost entity. Dotted identifiers (`owner.field`) bypass the stack and resolve directly.
+
+References are split into **read** and **write** kinds:
+
+- `set <target> = <expr>` and `set <target> = ...` flavors record `<target>` as a **write**, every identifier in `<expr>` as a **read**.
+- Plain identifier references in conditions and non-set actions are all **reads**.
+- `for all <field>` records `<field>` as a **read** (the iterator must read the collection to iterate it).
+
+## Output categories
+
+| Category | Meaning |
+|---|---|
+| `INFO unused EDD field` | Declared in EDD, no read or write reference. Safe to remove, modulo external mapping/JSON consumers. |
+| `INFO write-only EDD field` | Set somewhere, never read anywhere. Likely a bug — either the read got deleted, or the set is doing nothing. |
+
+Both surface through `dtrules review` and the build pipeline's advisory channel.
+
+## What it still misses (phase 3 backlog)
+
+- **Cross-table references**: a `perform <Table>` call descends into the called table's context. The current pass treats each `*_dt.xml` independently. A field read only inside a table called via `perform` from another table is currently visible at the file granularity, but the **caller's** entity-stack push doesn't carry into the callee's reference resolution.
+- **Dynamic dispatch**: `perform table named (<string-expression>)` (shipped v1.12.0) computes the target table name at runtime. The analyzer sees the string expression but cannot enumerate possible values. [#776](https://github.com/DTRules/DTRules/issues/776) proposes EDD-declared enumeration bounds so authors can give the analyzer the bounded set.
+- **Postfix-only blocks**: the strict hand-coded-postfix gate (v1.11.0) means new code can't introduce hand-edited postfix anyway, but legacy fixtures with raw postfix and no EL DSL fall outside the analyzer's view.
+
+When phase 3 lands, the categories grow to:
+
+| Category | Meaning |
+|---|---|
+| `Used` | Reference visible somewhere reachable. |
+| `Unused` | No reference anywhere. |
+| `Possibly used` | Referenced inside an unbound-string dispatch target — the analyzer can't prove unreached. |
+| `Write-only` | Set, never read. |
+
+Unbound dynamic dispatch (no enumeration declared) escalates from a warning to an error in `dtrules build --require-review`.
+
+## Running it
+
+```bash
+dtrules review <project>           # invokes the analyzer alongside every other check
+dtrules build <project>            # surfaces the same warnings on the advisory channel
+```
+
+The analyzer is also accessible programmatically:
+
+```go
+import "github.com/DTRules/DTRules/pkg/dtrules/analysis"
+
+warnings, err := analysis.AnalyzeEDDUsage("/path/to/project/xml")
+```
+
+Each `EDDWarning` carries:
+
+```go
+type EDDWarning struct {
+    Field   string // "entity.attribute"
+    EddFile string // source EDD file name
+    Reason  string // human-readable explanation
+}
+```
+
+## Related
+
+- [#776](https://github.com/DTRules/DTRules/issues/776) — full design including phase 3 (cross-table + enumeration bounds)
+- [#778](https://github.com/DTRules/DTRules/pull/778) — phase 2 rollout
+- [#777](https://github.com/DTRules/DTRules/pull/777) — phase 1 rollout
+- `pkg/dtrules/analysis/edd_unused.go` — implementation
+- `dtrules docs edd` — embedded EDD reference (entity/field declaration syntax)

--- a/docs/first-pass-predicate.md
+++ b/docs/first-pass-predicate.md
@@ -1,0 +1,119 @@
+# `first pass` Predicate
+
+> Status: as of v1.12.0 (issue [#764](https://github.com/DTRules/DTRules/issues/764)).
+
+The EL predicate `first pass` returns `true` exactly when the **innermost active loop** is on its first iteration, `false` otherwise. It's the canonical way to emit a one-time setup action or skip a separator before the first iteration of a `for all` / `for first of` / `foreach` block.
+
+## Shape
+
+```
+for all customers
+  if first pass then
+    set total = 0;
+  endif
+  set total = total + customer.balance;
+```
+
+The `if first pass` guards `set total = 0` — it runs only on the first iteration; subsequent iterations see the accumulated `total` carried forward.
+
+## What "innermost active loop" means
+
+Every loop the runtime enters (`for`, `forr`, `forall`, `forallr`) pushes a fresh iteration counter onto an internal stack:
+
+- The counter starts at 0 before the body's first execution.
+- The runtime increments it after each successful body run.
+- The counter pops when the loop exits.
+
+`first pass` reads the topmost counter. So:
+
+- Outside any loop: stack is empty → `first pass` is `false`. ("First pass of nothing" doesn't have a defensible meaning, and the alternative — `true` — would surprise rules that read `first pass` outside an obviously-looping context.)
+- Inside one loop, first iteration: `true`.
+- Inside nested loops, first iteration of the inner one: `true` regardless of outer state. The outer loop's iteration count is on the stack below but `first pass` reads the **top**.
+- Inside nested loops, second iteration of the inner one (within the outer's first iteration): `false`.
+
+## Common patterns
+
+### Per-iteration accumulator initialization
+
+```
+for all line_items
+  if first pass then
+    set running_total = 0;
+  endif
+  set running_total = running_total + line_item.amount;
+```
+
+Idiomatic. The `if first pass` is the explicit "do this once before the loop body proper" hook.
+
+### Skipping a separator before the first emitted value
+
+```
+for all states
+  if first pass then
+    set output = "";
+  else
+    set output = output + ", ";
+  endif
+  set output = output + state.abbr;
+```
+
+Produces `CA, NY, TX` rather than `, CA, NY, TX`.
+
+### Nested loops
+
+```
+for all parents
+  if first pass then
+    set summary = "Parents:";
+  endif
+  for all parent.children
+    if first pass then
+      set summary = summary + " (";  // ← fires per parent
+    endif
+    set summary = summary + child.name;
+  endfor
+endfor
+```
+
+The inner `if first pass` fires once per parent (the inner loop's first iteration), not once for the whole nested walk. The outer `if first pass` fires once total, before the first parent.
+
+## Postfix lowering
+
+`first pass` compiles to the niladic `firstpass` operator. Source:
+
+```
+if first pass then
+  set total = 0;
+endif
+```
+
+Postfix:
+
+```
+firstpass { 0 cvi /total xdef } if
+```
+
+The runtime's `opFirstPass` pushes `true` or `false` based on `state.IsFirstLoopPass()`, which is itself just a peek at the iteration stack.
+
+## Edge cases
+
+- **Empty loop body**: if the loop has no iterations at all (`for all <empty-collection>`), the body never executes and `first pass` is never evaluated. There's no "you skipped me on iteration 0" surprise.
+- **Conditional bodies**: `first pass` measures **loop iterations**, not body execution count. A loop body wrapped in `if some_condition then ... endif` still has `first pass` true only on the first iteration of the loop, regardless of whether `some_condition` was true that pass.
+- **Recursive `perform` calls**: a `perform <Table>` from inside a loop body does not push a new iteration counter — `first pass` inside the called table reads the **caller's** topmost loop counter. This is usually what authors want; if you need a "first time entering this table" predicate, that's a separate concept (and not what `first pass` provides).
+
+## When to reach for it
+
+Whenever the alternative would be a sentinel field (`if not initialized then ... set initialized = true`). The sentinel approach requires:
+
+- A field in the EDD for the flag
+- A reset somewhere outside the loop
+- Discipline that nothing else flips the flag
+
+`first pass` is local to the loop and resets automatically when the loop exits.
+
+## Related
+
+- `pkg/dtrules/operators/control.go:opFirstPass` — runtime op
+- `pkg/dtrules/compiler/el/postfix_emitter.go:VisitBoolFirstPass` — EL → postfix
+- `dtrules docs el` — embedded EL reference
+- `pkg/dtrules/operators/firstpass_test.go` — exhaustive regression suite covering nested loops and edge cases

--- a/docs/for-all-type-entities.md
+++ b/docs/for-all-type-entities.md
@@ -1,0 +1,97 @@
+# `for all <type> entities` Loop
+
+> Status: as of [#703](https://github.com/DTRules/DTRules/issues/703).
+
+The EL action `for all <type> entities` iterates over **all instances of an entity type**, resolved through the EDD's ownership declaration rather than by walking a named array. It's the right form when you want "every customer" or "every account" without having to find the right `<owner>.<field>` to point at.
+
+## Shape
+
+```
+for all customer entities
+  set customer.flagged = false;
+```
+
+vs the array-walking form:
+
+```
+for all client.customers
+  set customer.flagged = false;
+```
+
+Both iterate `customer` entities. The difference: the type form discovers the source collection via the EDD; the array form names it explicitly.
+
+## With a `where` filter
+
+```
+for all customer entities where customer.balance > 0
+  set customer.dunning_eligible = true;
+```
+
+Same semantics as `for all <field> where`, with the source collection resolved by type.
+
+## How the EDD resolution works
+
+Every entity type in the EDD declares its owner via an `owns` relationship:
+
+```xml
+<entity name="client">
+  <field name="customers" type="array" subtype="customer" owns="true"/>
+</entity>
+
+<entity name="customer">
+  <field name="balance" type="double"/>
+  <!-- ... -->
+</entity>
+```
+
+`client.customers` is declared with `owns="true"`. When the compiler sees `for all customer entities`, it asks the EDD: "which field owns `customer`?" and finds `client.customers`. The DSL gets rewritten to that path before postfix emission.
+
+## Postfix lowering
+
+`for all customer entities` lowers to the same shape as `for all client.customers`:
+
+```
+dup client.customers forall pop
+```
+
+For the `where` form, the body is wrapped in the standard predicate-execute pattern that `forallWhere` uses, with the resolved owner-field substituted for the array.
+
+This means the runtime cost is identical — the type form is pure syntactic sugar over the resolved EDD path.
+
+## When the resolution fails
+
+If the EDD has no `owns="true"` field for the named type, the visitor emits nothing and the surrounding statement collapses. In a strict-loader build, this surfaces upstream as a compile error from the advisory pass; in non-strict modes it would be a silent no-op (one of the silent-failure classes [#803](https://github.com/DTRules/DTRules/issues/803) hardened against).
+
+Typical fix: add the `owns="true"` declaration to the field that holds the collection. The compiler's error message names the type that couldn't be resolved.
+
+## Why use it
+
+The array-walking form (`for all client.customers`) requires the author to know:
+
+- Which entity holds the collection
+- What the collection field is called
+
+The type form requires only the entity type. For tables that operate at the "for every X in the system" level, that's the clearer expression — readers don't have to chase the owner field, and the rule keeps working if the EDD owner gets restructured (renamed field, moved to a different owner) as long as the new owner declares `owns="true"`.
+
+For tables that are scoped to a specific subset (`for all client.preferred_customers`), the array-walking form remains the right choice — it makes the scope explicit.
+
+## Interaction with the entity stack
+
+`for all customer entities` pushes `customer` onto the entity stack for the duration of the body, the same way `for all client.customers` does. Bare identifiers inside the body resolve against the iterated `customer`:
+
+```
+for all customer entities
+  if balance > 1000 then          // balance → customer.balance
+    set tier = "premium";          // tier    → customer.tier
+  endif
+```
+
+The [EDD usage analyzer](edd-usage-analyzer.md) tracks this push so the bare-name references count as `customer.*` for usage purposes.
+
+## Related
+
+- `pkg/dtrules/compiler/el/postfix_emitter.go:VisitForallTypeEntities` and `:VisitForallTypeEntitiesWhere` — the EL → postfix lowering
+- `pkg/dtrules/compiler/el/postfix_emitter.go:resolveEntitiesCollection` — the EDD-ownership lookup
+- [`edd-usage-analyzer.md`](edd-usage-analyzer.md) — entity-stack tracking
+- `dtrules docs edd` — embedded EDD reference (entity/field declaration syntax)
+- `dtrules docs el` — embedded EL reference


### PR DESCRIPTION
Four feature narratives — the four `(a)` rows from [#807's decision matrix](https://github.com/DTRules/DTRules/issues/807). Each is a long-form companion to the embedded `dtrules docs` topics, focused on **why** and **when** rather than syntax. The embedded topics remain the authoritative usage walkthrough.

## Added

| File | Feature | First shipped |
|---|---|---|
| `docs/edd-usage-analyzer.md` | Entity-stack-aware EDD usage analysis | v1.13.0 (#776 phases 1+2) |
| `docs/advisory-redundant-action-set.md` | Column-level redundancy check | v1.14.6 (#797) |
| `docs/first-pass-predicate.md` | EL `first pass` predicate | v1.12.0 (#764) |
| `docs/for-all-type-entities.md` | EDD-driven type iteration | (#703) |

## Per-feature notes

- **EDD analyzer**: the rationale for replacing the regex pass with entity-stack-aware analysis; the full list of constructs that push (`for all`, `using`, `for each`, `for all <type> entities`); the Used/Unused/Possibly-used/Write-only categorization that phase 3 will add; what's still missing.
- **Redundant action-set**: how the check groups columns by action-set signature; why action order matters (audit-trail / sequence dependencies); what it doesn't catch; suggested remediation patterns.
- **`first pass`**: semantics of "innermost active loop"; nested-loop behavior; postfix lowering; when to reach for it vs a sentinel field.
- **`for all <type> entities`**: EDD-driven iteration via the `owns="true"` declaration; how the type form is sugar over array-walking; what happens when resolution fails; interaction with the entity stack.

## docs/README.md

New **Feature Narratives** section links all four with first-shipped versions. One-line pointer to the embedded docs for the `(b)` features (`fphalfup/`, `fpdivr/`, `create T as alias`) which were judged covered by the embedded reference.

## Per #807's decision matrix

| Feature | Decision | Status |
|---|---|---|
| EDD analyzer | (a) | ✅ |
| redundant-action-set | (a) | ✅ |
| `first pass` | (a) | ✅ |
| `for all <type> entities` | (a) | ✅ |
| `fphalfup/`, `fpdivr/` | (b) | embedded sufficient (linked) |
| `create T as alias` | (b) | embedded sufficient (linked) |

Closes #807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)