### PR TITLE
fix: remove unused translationTable field with unsupported type (#783)

### DIFF
--- a/pkg/dtrules/syntaxtests_integration_test.go
+++ b/pkg/dtrules/syntaxtests_integration_test.go
@@ -347,8 +347,10 @@ func TestSyntaxTestsLoadEDD(t *testing.T) {
 
 	expectedConstantsAttrs := []string{
 		"FPL_Base", "FPL_PerAdditionalPerson", "coveredCounties",
-		"ExcludedIncomeTypes", "diagCodes", "translationTable",
+		"ExcludedIncomeTypes", "diagCodes",
 	}
+	// `translationTable` was declared with the unsupported `type='table'`
+	// and used nowhere in the project; removed in #783's narrow cleanup.
 	for _, attr := range expectedConstantsAttrs {
 		if !constantsRef.ContainsAttribute(dtrules.GetRName(attr)) {
 			t.Errorf("Constants entity missing attribute: %s", attr)

--- a/sampleprojects/SyntaxTests/repository/xml/syntaxexample_edd.xml
+++ b/sampleprojects/SyntaxTests/repository/xml/syntaxexample_edd.xml
@@ -72,7 +72,6 @@
 		<field name='SocialSecurity' type='string' subtype='' access='r' input='' default_value='SS' comment='Income Type'></field>
 		<field name='SSI' type='string' subtype='' access='r' input='' default_value='SSI' comment='Income Type'></field>
 		<field name='Tips' type='string' subtype='' access='r' input='' default_value='TIP' comment='Income Type'></field>
-		<field name='translationTable' type='table' subtype='' access='rw' input='' default_value='' comment=''></field>
 		<field name='Wages' type='string' subtype='' access='r' input='' default_value='WA' comment='Income Type'></field>
 	</entity>
 	<entity name='ErrorDetails' access='rw' comment=''>


### PR DESCRIPTION
Narrow cleanup. `constants.translationTable` was declared with `type='table'` (rejected by the EDD type system) and used nowhere in the SyntaxTests project. Removed.

## Before

```
EDD loading error: entity constants: unknown type 'table' for field translationTable
```

That single error blocked 5 SyntaxTests subtests.

## After

| Test | Before | After |
|---|---|---|
| `TestSyntaxTestsCompile` | FAIL | ✅ PASS |
| `TestSyntaxTestsLoadEDD` | FAIL | ✅ PASS |
| `TestSyntaxTestsMapping` | FAIL | ✅ PASS |
| `TestSyntaxTestsIntegration` | FAIL | ⚠️ Still fails (different reason) |
| `TestSyntaxTestsExecuteEachTable` | FAIL | ⚠️ Still fails (different reason) |

The remaining two fail on a separate, deeper issue: `Syntax_Examples_3` and `Syntax_Examples_4` contain actions with hand-coded postfix and no EL DSL, which the strict-loader gate rejects. Fixing that requires either authoring the missing DSL or removing the affected actions — out of scope for this narrow patch.

## Changes

- `sampleprojects/SyntaxTests/repository/xml/syntaxexample_edd.xml`: drop the broken field
- `pkg/dtrules/syntaxtests_integration_test.go`: drop `translationTable` from `TestSyntaxTestsLoadEDD`'s expected-attribute list (it was tracking the broken state)

## Verification

`grep -rn translationTable sampleprojects/SyntaxTests/` confirms zero remaining references after the fix.

`make check` passes.

## Issues

Partial progress on #783; #520 also benefits (its SyntaxTests subtree drops 3 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)