### PR TITLE
feat(review): orphan-call detection from table call graph (#776 piece A integration)

### DIFF
--- a/cmd/dtrules/mcp_tools.go
+++ b/cmd/dtrules/mcp_tools.go
@@ -107,7 +107,7 @@ func buildToolDefs() []mcpToolDef {
 		},
 		{
 			Name:        "project_full_review",
-			Description: "Run the project-wide Full Review (structure + EL compliance + load diagnostics + per-table optimizer + EDD-unused). Persists the report to .dtrules/last-review.json and returns it. The deployment gate (dtrules build --require-review) reads this file. Errors gate deployment; warnings do not.",
+			Description: "Run the project-wide Full Review (structure + EL compliance + load diagnostics + per-table optimizer + EDD-unused + table call graph orphan-call detection). Persists the report to .dtrules/last-review.json and returns it. The deployment gate (dtrules build --require-review) reads this file. Errors gate deployment; warnings do not.",
 			InputSchema: schemaProjectOnly(),
 		},
 	}

--- a/cmd/dtrules/review.go
+++ b/cmd/dtrules/review.go
@@ -67,6 +67,7 @@ const (
 	reviewCategoryELCompliance = "el_compliance"
 	reviewCategoryDiagnostic   = "diagnostic"
 	reviewCategoryLoad         = "load"
+	reviewCategoryCallGraph    = "call_graph"
 )
 
 // runFullReview is the entry point used by both `dtrules review` and the
@@ -81,6 +82,10 @@ const (
 //  4. Per-table optimizer pass (#762/#763 via Analyze, #765/#766 via
 //     AnalyzeCompiledTable) → warnings.
 //  5. EDD-unused (analysis.AnalyzeEDDUsage) → warnings.
+//  6. Table call graph (analysis.AnalyzeTableCallGraph) → errors when
+//     `perform <Name>` references a table that isn't defined (the
+//     runtime would fail with "table not found" the moment the rule
+//     fires; better to catch at review time).
 //
 // `passed = (len(errors) == 0)`. Warnings never affect passed. The
 // caller decides whether to surface the report as a CLI output or an
@@ -201,6 +206,22 @@ func runFullReview(projectPath string) (*reviewReport, error) {
 	eddWarns, eddErr := analysis.AnalyzeEDDUsage(xmlDir)
 	if eddErr == nil {
 		rep.EDDWarnings = append(rep.EDDWarnings, eddWarns...)
+	}
+
+	// 6. Table call graph — orphan `perform <Name>` calls become hard
+	// errors because the runtime would fail with "table not found" the
+	// moment those rules execute. Filing these at review time means
+	// they're caught before deploy rather than at runtime.
+	graph, graphErr := analysis.AnalyzeTableCallGraph(xmlDir)
+	if graphErr == nil && graph != nil {
+		for _, o := range graph.OrphanCalls {
+			rep.Errors = append(rep.Errors, reviewError{
+				Category: reviewCategoryCallGraph,
+				File:     o.DTFile,
+				Table:    o.Caller,
+				Message:  fmt.Sprintf("calls undefined table %q — runtime would fail with table-not-found", o.Callee),
+			})
+		}
 	}
 
 	rep.ProjectHash = hashProject(xmlDir)

--- a/cmd/dtrules/review_test.go
+++ b/cmd/dtrules/review_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -248,5 +249,86 @@ func TestEnforceReviewGate_Passes(t *testing.T) {
 	code := enforceReviewGate(dir, filepath.Join(dir, "xml"), 24*time.Hour)
 	if code != 0 {
 		t.Errorf("expected exit 0 on fresh passing review, got %d", code)
+	}
+}
+
+// TestRunFullReview_OrphanCallIsError pins the #776 piece-A integration:
+// a `perform <X>` referencing a table that isn't defined must surface as
+// a hard error in the review report. The runtime would fail with
+// "table not found" the moment that rule fired; static review must
+// catch it.
+func TestRunFullReview_OrphanCallIsError(t *testing.T) {
+	dir := t.TempDir()
+	xmlDir := filepath.Join(dir, "xml")
+	if err := os.MkdirAll(xmlDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	const eddXML = `<?xml version="1.0" encoding="UTF-8"?>
+<entity_data_dictionary version="2">
+  <entity name="client" access="rw">
+    <field name="flag" type="boolean" subtype="" access="rw" input="" default_value="false" comment=""/>
+  </entity>
+</entity_data_dictionary>
+`
+	const dtXML = `<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+<decision_table>
+<table_name>Caller_Table</table_name>
+<xls_file>test.xlsx</xls_file>
+<attribute_fields><Type>FIRST</Type><COMMENTS></COMMENTS><TABLE_NUMBER>1</TABLE_NUMBER></attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
+<conditions>
+  <condition_details>
+    <condition_number>1</condition_number>
+    <condition_comment>always</condition_comment>
+    <condition_dsl>client.flag</condition_dsl>
+    <condition_postfix>client.flag</condition_postfix>
+    <condition_column column_number="1" column_value="Y"/>
+  </condition_details>
+</conditions>
+<actions>
+  <action_details>
+    <action_number>1</action_number>
+    <action_comment>call missing</action_comment>
+    <action_dsl>perform Definitely_Missing_Table;</action_dsl>
+    <action_postfix>/Definitely_Missing_Table</action_postfix>
+    <action_column column_number="1" column_value="X"/>
+  </action_details>
+</actions>
+</decision_table>
+</decision_tables>
+`
+	if err := os.WriteFile(filepath.Join(xmlDir, "tiny_dt.xml"), []byte(dtXML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(xmlDir, "tiny_edd.xml"), []byte(eddXML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rep, err := runFullReview(dir)
+	if err != nil {
+		t.Fatalf("runFullReview: %v", err)
+	}
+	if rep == nil {
+		t.Fatal("expected report, got nil")
+	}
+
+	// Find the call-graph error.
+	var found bool
+	for _, e := range rep.Errors {
+		if e.Category == reviewCategoryCallGraph &&
+			e.Table == "Caller_Table" &&
+			strings.Contains(e.Message, "Definitely_Missing_Table") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected call_graph error pointing at Definitely_Missing_Table, got errors: %+v", rep.Errors)
+	}
+	if rep.Passed {
+		t.Errorf("expected passed=false with orphan call error, got passed=true")
 	}
 }


### PR DESCRIPTION
Wires the call graph from #841 into `runFullReview`. Each `perform <X>` whose target isn't a declared table becomes a **hard error** in the report — the runtime would fail with "table not found" the moment that rule fires, and catching it at review time avoids the runtime surprise.

## Changes

| File | Change |
|---|---|
| `cmd/dtrules/review.go` | New step 6 in the Full Review pipeline. New `reviewCategoryCallGraph` constant. Each `OrphanCall` lands in `rep.Errors` with `File` / `Table` / `Message` populated for UI routing. |
| `cmd/dtrules/mcp_tools.go` | `project_full_review` tool description now mentions orphan-call detection. |
| `cmd/dtrules/review_test.go` | `TestRunFullReview_OrphanCallIsError` builds a fresh tiny project whose only fixture is a `Caller_Table → Definitely_Missing_Table` perform reference; verifies the report has the right error category, table, and message and that `passed=false`. |

## Impact

- **CHIP** review: unchanged (0 orphans). All existing review tests still pass.
- **TaxReturn**: its 4 known orphans (`Calculate_Capital_Gains_Tax_HOH/MFJ/Single`, `DC_Homebuyer_Credit`) will now surface as errors when reviewed — but TaxReturn's existing test infrastructure doesn't gate on review-report errors, so this doesn't break any test.

## Follow-ups (still under #776)

- Piece A continued: entity-stack propagation across call edges.
- Piece B: enumeration-bounded dynamic dispatch.
- Piece C: `Used` / `Unused` / `Possibly used` / `Write-only` category split.

`make check` passes.

## Issue

Progress on #776 (piece A integration; piece A foundation landed in #841).

🤖 Generated with [Claude Code](https://claude.com/claude-code)