### PR TITLE
feat(analysis): EDDWarning.Category split (#776 piece C)

### DIFF
--- a/pkg/dtrules/analysis/edd_unused.go
+++ b/pkg/dtrules/analysis/edd_unused.go
@@ -24,11 +24,37 @@ import (
 	"strings"
 )
 
+// EDDUsageCategory tags every EDDWarning with its finding class so
+// consumers can route on category rather than parsing the human-
+// readable Reason. The four categories follow the design in #776
+// phase 3 piece C.
+type EDDUsageCategory string
+
+const (
+	// EDDUsageUnused — declared in the EDD, never referenced in any
+	// reachable DSL fragment. Safe to remove modulo external
+	// mapping/JSON consumers.
+	EDDUsageUnused EDDUsageCategory = "unused"
+
+	// EDDUsageWriteOnly — set somewhere but never read anywhere.
+	// Almost always a bug: either the read got deleted, or the set
+	// is doing nothing.
+	EDDUsageWriteOnly EDDUsageCategory = "write_only"
+
+	// EDDUsagePossibly — referenced inside an unbound dynamic-
+	// dispatch target the analyzer can't enumerate. The reference
+	// might be reached at runtime; the analyzer can't prove it
+	// unreached. Reserved for #776 piece B (enumeration-bounded
+	// dispatch) — not emitted by the current pass.
+	EDDUsagePossibly EDDUsageCategory = "possibly_used"
+)
+
 // EDDWarning records an informational finding about EDD field usage.
 type EDDWarning struct {
-	Field   string // "entity.attribute"
-	EddFile string // source EDD file name
-	Reason  string
+	Field    string           // "entity.attribute"
+	EddFile  string           // source EDD file name
+	Reason   string           // human-readable explanation (legacy field, prefer Category for routing)
+	Category EDDUsageCategory // finding class (#776 piece C)
 }
 
 // String formats the warning in the canonical INFO form.
@@ -721,9 +747,10 @@ func diffEDDUsage(decls map[string]eddField, readRefs, writeRefs map[string]bool
 		if f.Access == "r" {
 			if !isRead {
 				warnings = append(warnings, EDDWarning{
-					Field:   key,
-					EddFile: f.EddFile,
-					Reason:  fmt.Sprintf("unused EDD field: %s (declared in %s, never referenced)", key, f.EddFile),
+					Field:    key,
+					EddFile:  f.EddFile,
+					Reason:   fmt.Sprintf("unused EDD field: %s (declared in %s, never referenced)", key, f.EddFile),
+					Category: EDDUsageUnused,
 				})
 			}
 			continue
@@ -731,15 +758,17 @@ func diffEDDUsage(decls map[string]eddField, readRefs, writeRefs map[string]bool
 
 		if !isRead && !isWritten {
 			warnings = append(warnings, EDDWarning{
-				Field:   key,
-				EddFile: f.EddFile,
-				Reason:  fmt.Sprintf("unused EDD field: %s (declared in %s, never referenced)", key, f.EddFile),
+				Field:    key,
+				EddFile:  f.EddFile,
+				Reason:   fmt.Sprintf("unused EDD field: %s (declared in %s, never referenced)", key, f.EddFile),
+				Category: EDDUsageUnused,
 			})
 		} else if isWritten && !isRead {
 			warnings = append(warnings, EDDWarning{
-				Field:   key,
-				EddFile: f.EddFile,
-				Reason:  fmt.Sprintf("write-only EDD field: %s (set but never read)", key),
+				Field:    key,
+				EddFile:  f.EddFile,
+				Reason:   fmt.Sprintf("write-only EDD field: %s (set but never read)", key),
+				Category: EDDUsageWriteOnly,
 			})
 		}
 	}

--- a/pkg/dtrules/analysis/edd_warning_category_test.go
+++ b/pkg/dtrules/analysis/edd_warning_category_test.go
@@ -1,0 +1,120 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Issue #776 piece C: EDDWarning gets a Category field so consumers
+// can route by finding class instead of parsing Reason text. This
+// test pins that the existing two emitters (unused, write-only) set
+// the right category, and that the Reason field stays populated for
+// back-compat.
+
+const writeOnlyEDD = `<?xml version="1.0" encoding="UTF-8"?>
+<entity_data_dictionary version="2">
+  <entity name="client" access="rw">
+    <field name="never_read" type="boolean" subtype="" access="rw" input="" default_value="false" comment=""/>
+    <field name="declared_but_never_seen" type="boolean" subtype="" access="rw" input="" default_value="false" comment=""/>
+  </entity>
+</entity_data_dictionary>
+`
+
+const writeOnlyDT = `<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+<decision_table>
+<table_name>WriteOnlyDemo</table_name>
+<xls_file>test.xlsx</xls_file>
+<attribute_fields><Type>FIRST</Type><COMMENTS></COMMENTS><TABLE_NUMBER>1</TABLE_NUMBER></attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
+<conditions></conditions>
+<actions>
+  <action_details>
+    <action_number>1</action_number>
+    <action_dsl>set client.never_read = true;</action_dsl>
+    <action_postfix></action_postfix>
+    <action_column column_number="1" column_value="X"/>
+  </action_details>
+</actions>
+</decision_table>
+</decision_tables>
+`
+
+// TestEDDWarningCategory_UnusedAndWriteOnly: each category is emitted
+// with the right tag, the Reason field stays human-readable, and the
+// EddFile / Field fields keep their existing meaning.
+func TestEDDWarningCategory_UnusedAndWriteOnly(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x_edd.xml"), []byte(writeOnlyEDD), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "x_dt.xml"), []byte(writeOnlyDT), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	warnings, err := AnalyzeEDDUsage(dir)
+	if err != nil {
+		t.Fatalf("AnalyzeEDDUsage: %v", err)
+	}
+
+	byField := map[string]EDDWarning{}
+	for _, w := range warnings {
+		byField[w.Field] = w
+	}
+
+	wo, ok := byField["client.never_read"]
+	if !ok {
+		t.Fatalf("expected write-only warning for client.never_read, got %v", warnings)
+	}
+	if wo.Category != EDDUsageWriteOnly {
+		t.Errorf("client.never_read category = %q, want %q", wo.Category, EDDUsageWriteOnly)
+	}
+	if wo.Reason == "" {
+		t.Errorf("Reason must remain populated for back-compat, got empty")
+	}
+
+	un, ok := byField["client.declared_but_never_seen"]
+	if !ok {
+		t.Fatalf("expected unused warning for client.declared_but_never_seen, got %v", warnings)
+	}
+	if un.Category != EDDUsageUnused {
+		t.Errorf("client.declared_but_never_seen category = %q, want %q", un.Category, EDDUsageUnused)
+	}
+	if un.Reason == "" {
+		t.Errorf("Reason must remain populated for back-compat, got empty")
+	}
+}
+
+// TestEDDWarningCategory_ConstantsAreStable: the public category
+// constants are part of the API surface — callers route on them.
+// Pin the literal string values so a rename has to be deliberate.
+func TestEDDWarningCategory_ConstantsAreStable(t *testing.T) {
+	cases := []struct {
+		got, want EDDUsageCategory
+	}{
+		{EDDUsageUnused, "unused"},
+		{EDDUsageWriteOnly, "write_only"},
+		{EDDUsagePossibly, "possibly_used"},
+	}
+	for _, c := range cases {
+		if string(c.got) != string(c.want) {
+			t.Errorf("category constant drift: got %q, want %q", c.got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Adds a typed `Category` field to `EDDWarning` so consumers can route on finding class instead of parsing the human-readable `Reason` string. Per #776 phase 3 piece C.

## New API

```go
type EDDUsageCategory string

const (
    EDDUsageUnused    EDDUsageCategory = "unused"
    EDDUsageWriteOnly EDDUsageCategory = "write_only"
    EDDUsagePossibly  EDDUsageCategory = "possibly_used"  // reserved for piece B
)

type EDDWarning struct {
    Field    string
    EddFile  string
    Reason   string              // legacy, kept populated for back-compat
    Category EDDUsageCategory    // NEW — route on this
}
```

`possibly_used` is **reserved** — not emitted by the current pass. It lights up once piece B (enumeration-bounded dynamic dispatch) lands.

## Tests

- `TestEDDWarningCategory_UnusedAndWriteOnly` — end-to-end against a fresh fixture with one unused and one write-only field. Verifies each warning gets the correct category and `Reason` stays populated for back-compat.
- `TestEDDWarningCategory_ConstantsAreStable` — pins the literal string values of the three constants so a rename has to be deliberate (they're public API).

## Compatibility

Additive: no existing callers break, the JSON output of `dtrules review` and the MCP surfaces gain a `category` field, and `Reason` stays as-is.

`make check` passes.

## Issue

Progress on #776 (piece C — category split for downstream routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)