### PR TITLE
fix(review): demote orphan-call findings from error to warning

### DIFF
--- a/cmd/dtrules/mcp_tools.go
+++ b/cmd/dtrules/mcp_tools.go
@@ -107,7 +107,7 @@ func buildToolDefs() []mcpToolDef {
 		},
 		{
 			Name:        "project_full_review",
-			Description: "Run the project-wide Full Review (structure + EL compliance + load diagnostics + per-table optimizer + EDD-unused + table call graph orphan-call detection). Persists the report to .dtrules/last-review.json and returns it. The deployment gate (dtrules build --require-review) reads this file. Errors gate deployment; warnings do not.",
+			Description: "Run the project-wide Full Review (structure + EL compliance + load diagnostics + per-table optimizer + EDD-unused + table call graph orphan-call detection — surfaced as warnings). Persists the report to .dtrules/last-review.json and returns it. The deployment gate (dtrules build --require-review) reads this file. Errors gate deployment; warnings do not.",
 			InputSchema: schemaProjectOnly(),
 		},
 	}

--- a/cmd/dtrules/review.go
+++ b/cmd/dtrules/review.go
@@ -67,7 +67,6 @@ const (
 	reviewCategoryELCompliance = "el_compliance"
 	reviewCategoryDiagnostic   = "diagnostic"
 	reviewCategoryLoad         = "load"
-	reviewCategoryCallGraph    = "call_graph"
 )
 
 // runFullReview is the entry point used by both `dtrules review` and the
@@ -82,10 +81,12 @@ const (
 //  4. Per-table optimizer pass (#762/#763 via Analyze, #765/#766 via
 //     AnalyzeCompiledTable) → warnings.
 //  5. EDD-unused (analysis.AnalyzeEDDUsage) → warnings.
-//  6. Table call graph (analysis.AnalyzeTableCallGraph) → errors when
-//     `perform <Name>` references a table that isn't defined (the
-//     runtime would fail with "table not found" the moment the rule
-//     fires; better to catch at review time).
+//  6. Table call graph (analysis.AnalyzeTableCallGraph) → warnings
+//     when `perform <Name>` references a table that isn't defined.
+//     The runtime would fail with "table not found" if the offending
+//     rule fires, but the reference may sit on an unreachable branch;
+//     warning-not-error keeps the finding visible without gating
+//     deployment.
 //
 // `passed = (len(errors) == 0)`. Warnings never affect passed. The
 // caller decides whether to surface the report as a CLI output or an
@@ -208,19 +209,27 @@ func runFullReview(projectPath string) (*reviewReport, error) {
 		rep.EDDWarnings = append(rep.EDDWarnings, eddWarns...)
 	}
 
-	// 6. Table call graph — orphan `perform <Name>` calls become hard
-	// errors because the runtime would fail with "table not found" the
-	// moment those rules execute. Filing these at review time means
-	// they're caught before deploy rather than at runtime.
+	// 6. Table call graph — orphan `perform <Name>` calls surface as
+	// warnings (not errors). They're real bugs in the sense that the
+	// runtime would fail with "table not found" if the offending rule
+	// fires, but a project can have orphan references in branches
+	// that aren't reachable from any actual entry table or that are
+	// gated by conditions never satisfied in production. Demoting
+	// from error to warning keeps the finding visible without
+	// gating deployment; consumers can promote to error via their
+	// own policy if they want stricter behavior.
 	graph, graphErr := analysis.AnalyzeTableCallGraph(xmlDir)
 	if graphErr == nil && graph != nil {
 		for _, o := range graph.OrphanCalls {
-			rep.Errors = append(rep.Errors, reviewError{
-				Category: reviewCategoryCallGraph,
-				File:     o.DTFile,
-				Table:    o.Caller,
-				Message:  fmt.Sprintf("calls undefined table %q — runtime would fail with table-not-found", o.Callee),
-			})
+			w := decisiontable.Warning{
+				Table:        o.Caller,
+				Column:       0,
+				ConditionRow: -1,
+				Kind:         "orphan perform target",
+				Reason: fmt.Sprintf("calls undefined table %q (in %s) — runtime would fail with table-not-found if this rule fires",
+					o.Callee, o.DTFile),
+			}
+			rep.Warnings = append(rep.Warnings, w)
 		}
 	}
 

--- a/cmd/dtrules/review_test.go
+++ b/cmd/dtrules/review_test.go
@@ -252,12 +252,13 @@ func TestEnforceReviewGate_Passes(t *testing.T) {
 	}
 }
 
-// TestRunFullReview_OrphanCallIsError pins the #776 piece-A integration:
-// a `perform <X>` referencing a table that isn't defined must surface as
-// a hard error in the review report. The runtime would fail with
-// "table not found" the moment that rule fired; static review must
-// catch it.
-func TestRunFullReview_OrphanCallIsError(t *testing.T) {
+// TestRunFullReview_OrphanCallIsWarning pins the #776 piece-A
+// integration: a `perform <X>` referencing a table that isn't defined
+// must surface as a warning in the review report. The runtime would
+// fail with "table not found" if the offending rule fires, but the
+// reference may sit on an unreachable branch, so we surface but don't
+// gate.
+func TestRunFullReview_OrphanCallIsWarning(t *testing.T) {
 	dir := t.TempDir()
 	xmlDir := filepath.Join(dir, "xml")
 	if err := os.MkdirAll(xmlDir, 0755); err != nil {
@@ -315,20 +316,27 @@ func TestRunFullReview_OrphanCallIsError(t *testing.T) {
 		t.Fatal("expected report, got nil")
 	}
 
-	// Find the call-graph error.
+	// Find the orphan-call warning.
 	var found bool
-	for _, e := range rep.Errors {
-		if e.Category == reviewCategoryCallGraph &&
-			e.Table == "Caller_Table" &&
-			strings.Contains(e.Message, "Definitely_Missing_Table") {
+	for _, w := range rep.Warnings {
+		if w.Kind == "orphan perform target" &&
+			w.Table == "Caller_Table" &&
+			strings.Contains(w.Reason, "Definitely_Missing_Table") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected call_graph error pointing at Definitely_Missing_Table, got errors: %+v", rep.Errors)
+		t.Errorf("expected orphan-perform-target warning pointing at Definitely_Missing_Table, got warnings: %+v", rep.Warnings)
 	}
-	if rep.Passed {
-		t.Errorf("expected passed=false with orphan call error, got passed=true")
+	// Orphan-call findings must NOT land in rep.Errors — that's the
+	// behavioral change from PR #842's error policy to this warning
+	// policy. Other unrelated errors (e.g. missing excel/ dir on this
+	// minimal fixture) are fine; we just need no error tagged with
+	// the orphan-call shape.
+	for _, e := range rep.Errors {
+		if strings.Contains(e.Message, "Definitely_Missing_Table") {
+			t.Errorf("orphan-call surfaced as error instead of warning: %+v", e)
+		}
 	}
 }


### PR DESCRIPTION
PR #842 wired orphan-perform-target detection into `runFullReview` as **hard errors**. That's the strictest reading — the runtime would fail with "table not found" if the offending rule fires — but it overstates the impact: the reference may sit on an unreachable branch (a condition never true in production data, a fallback never selected). For a project that ships sample content with known orphan calls (TaxReturn has 4), turning those into deployment-gating errors blocks releases for findings that aren't runtime bugs in practice.

## What changes

| | Before | After |
|---|---|---|
| Surface | `rep.Errors` (reviewError, category=call_graph) | `rep.Warnings` (decisiontable.Warning, Kind="orphan perform target") |
| Gates `rep.Passed`? | Yes | No |
| Gates `dtrules build --require-review`? | Yes | No |
| Still visible in `dtrules review` output? | Yes | Yes |
| Still in JSON report? | Yes | Yes (under warnings) |

## Why

- The reference may be on an unreachable branch — not all `perform <X>` calls fire.
- Sample projects ship with known orphans that are deliberate placeholders.
- Consumers who want strict behavior can layer their own escalation policy on top of `rep.Warnings`.

## Files

- `cmd/dtrules/review.go`: step 6 appends to `rep.Warnings` via `decisiontable.Warning`. `reviewCategoryCallGraph` constant removed (no longer referenced).
- `cmd/dtrules/mcp_tools.go`: tool description updated.
- `cmd/dtrules/review_test.go`: `TestRunFullReview_OrphanCallIsError` → `TestRunFullReview_OrphanCallIsWarning`. New assertions: orphan-call lands in warnings, NOT in errors.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)