### PR TITLE
docs+test: multiple entry points against a single session

### DIFF
--- a/cmd/dtrules/docs.go
+++ b/cmd/dtrules/docs.go
@@ -41,6 +41,7 @@ var docTopics = map[string]string{
 	"warnings":        docWarnings,
 	"workflow":        docWorkflow,
 	"authoring":       docAuthoring,
+	"entry-points":    docEntryPoints,
 }
 
 func runDocs(args []string) error {
@@ -94,6 +95,7 @@ func printDocIndex() {
 		"warnings":        "Every advisory warning kind, repro, and what to do about it",
 		"workflow":        "Development workflow with Excel and XML",
 		"authoring":       "Go authoring SDK: open, edit, execute, and test projects programmatically",
+		"entry-points":    "Run multiple decision tables as separate entry points against one loaded session",
 	}
 
 	for _, t := range topics {
@@ -3749,4 +3751,165 @@ Where to go next
     dtrules docs operators       # runtime operator reference
     dtrules docs embedding       # ship a Go binary with rules baked in
     dtrules docs authoring       # programmatic SDK
+    dtrules docs entry-points    # run multiple tables against one loaded session
+`
+
+const docEntryPoints = `Multiple Entry Points Against a Single Session
+==============================================
+
+Overview
+--------
+
+A DTRules project usually has more than one decision table. To run
+several of them as separate entry points against the same loaded
+session — without re-loading rules or re-creating the session for each
+table — call ` + "`RSession.Execute(tableName)`" + ` once per table.
+The session's entity stack and field values persist across calls, so
+mutations made by the first table are visible to the second.
+
+There is no special "entry point" registration: every loaded decision
+table is callable by name. ` + "`Execute(tableName)`" + ` is the entry-
+point selector.
+
+
+When to use it
+--------------
+
+Three common shapes:
+
+  * Multi-pass evaluation — a table validates inputs and tags errors;
+    a second computes a result only on records that passed; a third
+    produces a summary.
+
+  * Read-then-write workflows — Compute_Eligibility reads inputs and
+    decides; Generate_Audit_Trail then reads the decision and
+    populates an audit log entity.
+
+  * Per-request branching — one bound session reused to answer
+    different questions against the same loaded data:
+    Check_Eligibility for one request, Compute_Risk for the next.
+
+If your tables are wired so that one calls the next via ` + "`perform`" + `,
+you don't need this pattern — the call graph handles it. This topic is
+for the case where the caller (your Go code, service, or CLI) decides
+which entry point to invoke.
+
+
+The Pattern
+-----------
+
+  package main
+
+  import (
+      "strings"
+
+      "github.com/DTRules/DTRules/pkg/dtrules"
+      "github.com/DTRules/DTRules/pkg/dtrules/session"
+  )
+
+  func main() {
+      rs := session.NewRuleSet("MyProject")
+
+      // Load EDD + DT once.
+      _ = rs.LoadEDD(strings.NewReader(eddXML))
+      _ = rs.LoadDecisionTables(strings.NewReader(dtXML))
+
+      // One session, one data load.
+      sess, _ := rs.NewSession()
+      rsess := sess.(*session.RSession)
+
+      entity, _ := rsess.CreateEntity(dtrules.GetRName("client"))
+      entity.Put(dtrules.GetRName("age"), dtrules.GetRIntegerValueFromInt(20))
+      rsess.GetState().EntityPush(entity)
+
+      // Entry point #1.
+      _ = rsess.Execute("Check_Eligibility")
+
+      // Entry point #2 — same session, same entity, same data.
+      // Field values written by #1 are visible to #2.
+      _ = rsess.Execute("Compute_Risk")
+
+      rsess.GetState().EntityPop()
+  }
+
+
+What persists across Execute calls
+----------------------------------
+
+  Loaded entity definitions (EDD)        yes — owned by the RuleSet
+  Loaded decision tables                 yes — same
+  Created entities and their field values yes — live in RDTState
+  Mutations made by previous tables      yes — visible to next call
+  Entity stack pushes from your Go code  yes
+  Entity stack pushes inside a table's <contexts>
+                                         pushed at table entry,
+                                         popped at table exit; do
+                                         NOT leak across calls
+  Data stack                             empty between calls (runtime
+                                         enforces balance at table
+                                         boundaries)
+  Trace events                           accumulate if a tracker is
+                                         attached
+
+
+ExecuteAt — push entity, run, pop
+---------------------------------
+
+For the common case "run table T with entity E at the top of the
+context stack," ExecuteAt does the push/pop boilerplate:
+
+  err := rsess.ExecuteAt("Compute_Risk", "client")
+
+Equivalent to:
+
+  entity, _ := rsess.GetState().FindEntity(dtrules.GetRName("client"))
+  rsess.GetState().EntityPush(entity)
+  err := rsess.Execute("Compute_Risk")
+  rsess.GetState().EntityPop()
+
+
+Errors and partial state
+------------------------
+
+If the first Execute errors mid-way, mutations already applied stay
+applied. The session is NOT rolled back automatically. Two patterns:
+
+  Snapshot, run, discard on error: copy the entity values you care
+                                   about before the first Execute;
+                                   restore them on error.
+
+  Idempotent tables:              author so re-running produces the
+                                   same result. This is the dominant
+                                   shape in tax / eligibility domains
+                                   where actions are
+                                   set <output> = <pure_function_of_inputs>.
+
+
+Pitfalls
+--------
+
+  Don't reuse a session across unrelated tenants. A session carries
+  every entity ever created in it. If you serve multiple tenants from
+  one server, give each request its own session via rs.NewSession();
+  the RuleSet is the cheap-to-share piece.
+
+  Watch entity stack depth. Tables that push and forget to pop are
+  bugs. The runtime checks balance at table boundaries so this
+  surfaces as an error, not silent corruption — but the next Execute
+  after a broken table sees a deeper stack than expected.
+
+  Execute("UnknownTable") returns an error, not a panic. Treat
+  undefined-table as a configuration bug surfaced to operators.
+
+
+Related
+-------
+
+  dtrules docs cli         CLI surface (build / verify / review)
+  dtrules docs authoring   programmatic SDK for editing projects
+  dtrules docs sdk         embedding the engine in a Go application
+  docs/multi-entry-points.md
+                           long-form companion with extended examples
+  pkg/dtrules/multi_entry_test.go
+                           the regression test that pins this contract
 `

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ authoritative usage walkthrough.
 | [Redundant Action-Set Column Advisory](advisory-redundant-action-set.md) | Column-level redundancy check on the compiled decision tree | v1.14.6 |
 | [`first pass` Predicate](first-pass-predicate.md) | EL predicate for the first iteration of the innermost active loop | v1.12.0 |
 | [`for all <type> entities` Loop](for-all-type-entities.md) | Type-driven iteration via the EDD `owns` declaration | [#703](https://github.com/DTRules/DTRules/issues/703) |
+| [Multiple Entry Points](multi-entry-points.md) | Run several decision tables against one loaded session | Always supported (pinned by test in v1.16.0) |
 
 For features without a narrative companion, see the embedded `dtrules
 docs` topics (`dtrules docs operators` covers `fphalfup/` and

--- a/docs/multi-entry-points.md
+++ b/docs/multi-entry-points.md
@@ -1,0 +1,141 @@
+# Multiple Entry Points Against a Single Session
+
+> Status: as of v1.15.0 — pattern empirically verified, behavior pinned by `TestMultipleEntryPointsAgainstSameSession`.
+
+A DTRules project usually has more than one decision table. Sometimes
+you want to load the project once, populate a session with input data,
+and then run **different decision tables as different entry points**
+against that same loaded state — without re-loading rules or re-creating
+the session for each table.
+
+This is supported directly. `RSession.Execute(tableName)` is the entry
+point selector: call it once for each table you want to run. The
+session's entity stack and data dictionary persist across calls, so a
+mutation made by the first table is visible to the second.
+
+## When to use it
+
+Three common shapes:
+
+- **Multi-pass evaluation** — one table validates inputs and tags
+  errors; a second computes a result only on records that passed; a
+  third produces a summary. Each is its own entry point.
+- **Read-then-write workflows** — `Compute_Eligibility` reads inputs
+  and decides; `Generate_Audit_Trail` then reads the decision and
+  populates an audit log entity.
+- **Per-request branching** — a single bound session is reused to
+  answer different "questions" against the same loaded data:
+  `Check_Eligibility` for one HTTP request, `Compute_Risk` for the
+  next, against the same client record.
+
+If your tables are wired so that one table `perform`s the next, you
+don't need this pattern — the call graph handles it for you. This page
+is for the case where the caller (your Go code, your service, your
+CLI) decides which entry point to invoke.
+
+## The API
+
+```go
+import "github.com/DTRules/DTRules/pkg/dtrules/session"
+
+rs := session.NewRuleSet("MyProject")
+rs.LoadEDD(eddReader)
+rs.LoadDecisionTables(dtReader)
+
+sess, err := rs.NewSession()
+if err != nil { /* handle */ }
+rsess := sess.(*session.RSession)
+
+// Populate data once.
+entity, _ := rsess.CreateEntity(dtrules.GetRName("client"))
+entity.Put(dtrules.GetRName("age"), dtrules.GetRIntegerValueFromInt(20))
+rsess.GetState().EntityPush(entity)
+
+// Entry point #1.
+if err := rsess.Execute("Check_Eligibility"); err != nil {
+    /* handle */
+}
+
+// Entry point #2 — same session, same entity, same data.
+// State written by Check_Eligibility is visible here.
+if err := rsess.Execute("Compute_Risk"); err != nil {
+    /* handle */
+}
+```
+
+`Execute(tableName)` is just a name-keyed lookup in the entity factory
+that returns the compiled `RDecisionTable` and invokes its `Execute(state)`
+method. There is no special "entry point" registration — every loaded
+decision table is callable by name.
+
+## What persists across calls
+
+| State element | Persists? |
+|---|---|
+| Loaded entity definitions (EDD) | Yes — owned by the `RuleSet`, not the session. |
+| Loaded decision tables | Yes — same. |
+| Created entities (via `CreateEntity`, mapping loader, etc.) | Yes — they live in the session's `RDTState`. |
+| Entity field values written by the first table | Yes — `set entity.field = ...` mutations are visible to the second. |
+| Entity stack pushes from your Go code | Yes — `state.EntityPush(...)` outside any table call survives across `Execute` calls. |
+| Entity stack pushes from inside a table's `<contexts>` | Pushed at table entry, popped at table exit. They do **not** leak across calls. |
+| Data stack | Empty between calls. The runtime asserts the data stack is balanced at table boundaries. |
+| Trace events | Accumulate if a trace tracker is attached; reset by attaching a fresh tracker. |
+
+## ExecuteAt — push an entity, run, pop
+
+For the common case "run table T with entity E as the current context,"
+there's a convenience that pushes the entity before calling `Execute`
+and pops it after (even on error):
+
+```go
+err := rsess.ExecuteAt("Compute_Risk", "client")
+```
+
+This is equivalent to:
+
+```go
+entity, _ := rsess.GetState().FindEntity(dtrules.GetRName("client"))
+rsess.GetState().EntityPush(entity)
+err := rsess.Execute("Compute_Risk")
+rsess.GetState().EntityPop()
+```
+
+Use `ExecuteAt` when each entry point should run with a single
+specific entity at the top of the stack and you don't want the manual
+push/pop boilerplate.
+
+## Errors and partial state
+
+If the first `Execute` errors mid-way, mutations performed before the
+error point have already been applied to the session. The session is
+**not** rolled back automatically. Two reasonable patterns:
+
+- **Snapshot, run, discard on error.** Before the first `Execute`,
+  copy the entity values you care about. On error, restore them.
+- **Idempotent tables.** Author the tables so re-running them
+  produces the same result regardless of partial prior runs. This is
+  the more common pattern in tax / eligibility domains where
+  `set <output> = <pure_function_of_inputs>` is the dominant action.
+
+## Pitfalls
+
+- **Don't reuse a session across unrelated tenants.** A session
+  carries every entity ever created in it. If you're serving multiple
+  tenants from one server, give each request its own session via
+  `rs.NewSession()` — the `RuleSet` is the cheap-to-share piece, the
+  `RSession` isn't.
+- **Watch the entity stack depth.** Tables that push and forget to
+  pop are bugs. The runtime checks balance at table boundaries, so
+  this surfaces as an error rather than silently corrupting state —
+  but the first `Execute` after a broken table will see a deeper
+  stack than expected.
+- **`Execute("UnknownTable")` returns an error**, not a panic. Catch
+  it on the caller side; treat undefined-table as a configuration bug
+  worth surfacing to operators.
+
+## Related
+
+- [`dtrules docs cli`](../cmd/dtrules/docs.go) — top-level CLI surface.
+- [`dtrules docs authoring`](../cmd/dtrules/docs.go) — programmatic SDK for editing projects.
+- [`dtrules docs sdk`](../cmd/dtrules/docs.go) — embedding the engine into a Go application.
+- `pkg/dtrules/multi_entry_test.go` — the regression test that pins this contract.

--- a/pkg/dtrules/multi_entry_test.go
+++ b/pkg/dtrules/multi_entry_test.go
@@ -1,0 +1,297 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtrules_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// Pins the multi-entry-point contract: load a project once, populate a
+// session with input data, then execute different decision tables as
+// separate entry points against the same session. State written by
+// the first table must be visible to the second.
+//
+// The pattern is supported directly by `RSession.Execute(tableName)`
+// — every loaded decision table is callable by name; there is no
+// special "entry point" registration. See:
+//   - docs/multi-entry-points.md (long-form companion)
+//   - `dtrules docs entry-points` (embedded topic)
+//
+// Originally surfaced as a documentation/test gap during the v1.15.0
+// review: the engine supported the pattern but no focused regression
+// test existed to pin it. The closest test (`TestSyntaxTestsIntegration`)
+// exercises a similar shape but is currently failing on unrelated
+// sample-project content issues, which hides the validation.
+
+const multiEntryEDD = `<?xml version="1.0" encoding="UTF-8"?>
+<entity_data_dictionary version="2">
+  <entity name="client" access="rw">
+    <field name="age" type="integer" subtype="" access="rw" input="" default_value="0" comment=""/>
+    <field name="eligible" type="boolean" subtype="" access="rw" input="" default_value="false" comment=""/>
+    <field name="risk_score" type="integer" subtype="" access="rw" input="" default_value="0" comment=""/>
+    <field name="audit_count" type="integer" subtype="" access="rw" input="" default_value="0" comment=""/>
+  </entity>
+</entity_data_dictionary>
+`
+
+const multiEntryDT = `<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+<decision_table>
+<table_name>Check_Eligibility</table_name>
+<xls_file>test.xlsx</xls_file>
+<attribute_fields><Type>FIRST</Type><COMMENTS></COMMENTS><TABLE_NUMBER>1</TABLE_NUMBER></attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
+<conditions>
+  <condition_details>
+    <condition_number>1</condition_number>
+    <condition_dsl>client.age &gt;= 18</condition_dsl>
+    <condition_postfix>client.age 18 &gt;=</condition_postfix>
+    <condition_column column_number="1" column_value="Y"/>
+  </condition_details>
+</conditions>
+<actions>
+  <action_details>
+    <action_number>1</action_number>
+    <action_dsl>set client.eligible = true</action_dsl>
+    <action_postfix>true cvb /client.eligible xdef</action_postfix>
+    <action_column column_number="1" column_value="X"/>
+  </action_details>
+</actions>
+</decision_table>
+<decision_table>
+<table_name>Compute_Risk</table_name>
+<xls_file>test.xlsx</xls_file>
+<attribute_fields><Type>FIRST</Type><COMMENTS></COMMENTS><TABLE_NUMBER>2</TABLE_NUMBER></attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
+<conditions>
+  <condition_details>
+    <condition_number>1</condition_number>
+    <condition_dsl>client.age &lt; 25</condition_dsl>
+    <condition_postfix>client.age 25 &lt;</condition_postfix>
+    <condition_column column_number="1" column_value="Y"/>
+  </condition_details>
+</conditions>
+<actions>
+  <action_details>
+    <action_number>1</action_number>
+    <action_dsl>set client.risk_score = 80</action_dsl>
+    <action_postfix>80 /client.risk_score xdef</action_postfix>
+    <action_column column_number="1" column_value="X"/>
+  </action_details>
+</actions>
+</decision_table>
+<decision_table>
+<table_name>Generate_Audit</table_name>
+<xls_file>test.xlsx</xls_file>
+<attribute_fields><Type>FIRST</Type><COMMENTS></COMMENTS><TABLE_NUMBER>3</TABLE_NUMBER></attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
+<conditions>
+  <condition_details>
+    <condition_number>1</condition_number>
+    <condition_dsl>client.eligible</condition_dsl>
+    <condition_postfix>client.eligible</condition_postfix>
+    <condition_column column_number="1" column_value="Y"/>
+  </condition_details>
+</conditions>
+<actions>
+  <action_details>
+    <action_number>1</action_number>
+    <action_dsl>set client.audit_count = 1</action_dsl>
+    <action_postfix>1 /client.audit_count xdef</action_postfix>
+    <action_column column_number="1" column_value="X"/>
+  </action_details>
+</actions>
+</decision_table>
+</decision_tables>
+`
+
+// loadMultiEntryProject is a test helper: load EDD + DT, create a
+// session, populate a single `client` entity with age=age, and return
+// the session and entity for the test body to drive.
+func loadMultiEntryProject(t *testing.T, age int64) (*session.RSession, dtrules.Entity) {
+	t.Helper()
+	rs := session.NewRuleSet("MultiEntryTest")
+	if err := rs.LoadEDD(strings.NewReader(multiEntryEDD)); err != nil {
+		t.Fatalf("LoadEDD: %v", err)
+	}
+	if err := rs.LoadDecisionTables(strings.NewReader(multiEntryDT)); err != nil {
+		t.Fatalf("LoadDecisionTables: %v", err)
+	}
+	sess, err := rs.NewSession()
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	rsess := sess.(*session.RSession)
+	entity, err := rsess.CreateEntity(dtrules.GetRName("client"))
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+	entity.Put(dtrules.GetRName("age"), dtrules.GetRIntegerValueFromInt(int(age)))
+	rsess.GetState().EntityPush(entity)
+	t.Cleanup(func() { rsess.GetState().EntityPop() })
+	return rsess, entity
+}
+
+func getInt(t *testing.T, e dtrules.Entity, field string) int {
+	t.Helper()
+	obj, _ := e.Get(dtrules.GetRName(field))
+	ri, err := obj.RIntegerValue()
+	if err != nil {
+		t.Fatalf("RIntegerValue(%s): %v", field, err)
+	}
+	v, _ := ri.IntValue()
+	return v
+}
+
+func getBool(t *testing.T, e dtrules.Entity, field string) bool {
+	t.Helper()
+	obj, _ := e.Get(dtrules.GetRName(field))
+	rb, err := obj.RBooleanValue()
+	if err != nil {
+		t.Fatalf("RBooleanValue(%s): %v", field, err)
+	}
+	return rb.Value()
+}
+
+// TestMultipleEntryPoints_TwoTablesSeeSharedState is the headline
+// contract: two Execute calls on the same session see each other's
+// mutations.
+func TestMultipleEntryPoints_TwoTablesSeeSharedState(t *testing.T) {
+	rsess, entity := loadMultiEntryProject(t, 20)
+
+	// Entry point #1: sets client.eligible = true.
+	if err := rsess.Execute("Check_Eligibility"); err != nil {
+		t.Fatalf("Execute(Check_Eligibility): %v", err)
+	}
+	if !getBool(t, entity, "eligible") {
+		t.Fatalf("after Check_Eligibility: expected eligible=true")
+	}
+
+	// Entry point #2: sees the entity from #1, sets risk_score.
+	if err := rsess.Execute("Compute_Risk"); err != nil {
+		t.Fatalf("Execute(Compute_Risk): %v", err)
+	}
+	if got := getInt(t, entity, "risk_score"); got != 80 {
+		t.Errorf("after Compute_Risk: expected risk_score=80, got %d", got)
+	}
+
+	// And #1's mutation is still visible after #2 — neither call
+	// rolled back the other.
+	if !getBool(t, entity, "eligible") {
+		t.Errorf("eligible regressed across calls — second Execute must not have rolled back first")
+	}
+}
+
+// TestMultipleEntryPoints_TableTwoReadsTableOnesWrite pins the
+// dependency direction: table B's condition reads a field that table
+// A wrote. Without state persistence across Execute calls, B's
+// condition would see the EDD default (false) and the audit row
+// would not fire.
+func TestMultipleEntryPoints_TableTwoReadsTableOnesWrite(t *testing.T) {
+	rsess, entity := loadMultiEntryProject(t, 20)
+
+	// Pre-condition: audit_count starts at EDD default (0).
+	if got := getInt(t, entity, "audit_count"); got != 0 {
+		t.Fatalf("audit_count should start at 0, got %d", got)
+	}
+
+	// Run #1 (sets eligible=true).
+	if err := rsess.Execute("Check_Eligibility"); err != nil {
+		t.Fatalf("Execute(Check_Eligibility): %v", err)
+	}
+
+	// Run #2 (Generate_Audit; condition is `client.eligible`).
+	if err := rsess.Execute("Generate_Audit"); err != nil {
+		t.Fatalf("Execute(Generate_Audit): %v", err)
+	}
+
+	if got := getInt(t, entity, "audit_count"); got != 1 {
+		t.Errorf("after Generate_Audit: expected audit_count=1 (proves the table read client.eligible written by Check_Eligibility), got %d", got)
+	}
+}
+
+// TestMultipleEntryPoints_ConditionMissCarriesForward pins the
+// negative case: an entity that fails the first table's condition
+// (age=12 < 18 → eligible stays false) means the second table sees
+// the default state — confirming the entity persists in both
+// directions.
+func TestMultipleEntryPoints_ConditionMissCarriesForward(t *testing.T) {
+	rsess, entity := loadMultiEntryProject(t, 12)
+
+	if err := rsess.Execute("Check_Eligibility"); err != nil {
+		t.Fatalf("Execute(Check_Eligibility): %v", err)
+	}
+	// FIRST policy with a single column matching age >= 18; age=12
+	// misses → no action → eligible stays at the EDD default (false).
+	if getBool(t, entity, "eligible") {
+		t.Fatalf("expected eligible=false for age=12, got true")
+	}
+
+	// Generate_Audit's condition reads eligible (still false) →
+	// audit_count stays at 0.
+	if err := rsess.Execute("Generate_Audit"); err != nil {
+		t.Fatalf("Execute(Generate_Audit): %v", err)
+	}
+	if got := getInt(t, entity, "audit_count"); got != 0 {
+		t.Errorf("expected audit_count=0 when eligible was false across both calls, got %d", got)
+	}
+}
+
+// TestMultipleEntryPoints_UnknownTableErrors pins the configuration-
+// bug contract: Execute with a name that isn't a loaded table returns
+// an error, doesn't panic, and doesn't mutate session state.
+func TestMultipleEntryPoints_UnknownTableErrors(t *testing.T) {
+	rsess, entity := loadMultiEntryProject(t, 20)
+
+	err := rsess.Execute("Definitely_Not_A_Table")
+	if err == nil {
+		t.Fatal("Execute on an unknown table must return an error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error message should name the failure mode, got: %v", err)
+	}
+	// Session state must be untouched by a failed lookup.
+	if getBool(t, entity, "eligible") {
+		t.Errorf("eligible should still be the default false after a failed Execute, got true")
+	}
+}
+
+// TestMultipleEntryPoints_ReExecuteSameTableIsIdempotent pins that
+// calling Execute twice on the SAME table is allowed and produces
+// the same result — useful for retry / replay workflows.
+func TestMultipleEntryPoints_ReExecuteSameTableIsIdempotent(t *testing.T) {
+	rsess, entity := loadMultiEntryProject(t, 20)
+
+	if err := rsess.Execute("Check_Eligibility"); err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+	if !getBool(t, entity, "eligible") {
+		t.Fatalf("after first Execute: expected eligible=true")
+	}
+
+	if err := rsess.Execute("Check_Eligibility"); err != nil {
+		t.Fatalf("second Execute on same table: %v", err)
+	}
+	if !getBool(t, entity, "eligible") {
+		t.Errorf("after second Execute on same table: expected eligible still true")
+	}
+}


### PR DESCRIPTION
Closes the documentation + test gap surfaced by the user during the v1.15.0 review: the engine has always supported the load-once / execute-multiple-tables pattern, but no focused regression test pinned the contract and no doc topic called it out as a supported idiom.

## What's missing today

| Aspect | Today | After this PR |
|---|---|---|
| API support | ✅ `RSession.Execute(tableName)` works | unchanged |
| Focused regression test | ❌ | `pkg/dtrules/multi_entry_test.go` with 5 assertions |
| `docs/` long-form companion | ❌ | `docs/multi-entry-points.md` |
| `dtrules docs entry-points` | ❌ | new embedded topic |

The closest existing test (`TestSyntaxTestsIntegration`) exercises a similar shape but is currently failing on unrelated sample-project content issues (#783 remaining), so the pattern is exercised but the validation is hidden behind a red test.

## Test coverage

| Test | What it pins |
|---|---|
| `TwoTablesSeeSharedState` | Two `Execute` calls on the same session; the second sees the first's mutation. |
| `TableTwoReadsTableOnesWrite` | Table B's condition reads a field table A wrote. Without persistence the second table would see the EDD default and not fire. |
| `ConditionMissCarriesForward` | Negative case: entity that fails table A's condition produces the expected downstream state, confirming persistence works both directions. |
| `UnknownTableErrors` | `Execute("NotATable")` returns an error, doesn't panic, doesn't mutate state. |
| `ReExecuteSameTableIsIdempotent` | Calling Execute twice on the same table is allowed and produces the same result. |

Fixtures use proper EL DSL with matching postfix so the strict loader accepts them.

## Doc content

The long-form covers when-to-use, the API (Execute + ExecuteAt), a table breakdown of what persists across calls, error/partial-state patterns (snapshot vs idempotent tables), and pitfalls (cross-tenant reuse, entity-stack-depth bugs, unknown-table handling). The embedded topic mirrors the same content in `dtrules docs` plaintext shape.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)