### PR TITLE
docs: v1.15.1 changelog — multi-entry-point docs + tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # DTRules Changelog
 
+## v1.15.1 — 2026-06-08
+
+Documents and pins the multi-entry-point pattern that the engine has
+always supported but no test or doc page called out.
+
+### Background
+
+`RSession.Execute(tableName)` lets a caller load a project once,
+populate the session with input data, and then run different decision
+tables as separate entry points against the same loaded state — with
+mutations made by the first table visible to the second. The contract
+was supported but undocumented and untested as a focused regression.
+A user reviewing v1.15.0 surfaced the gap: "is this documented and
+tested?"
+
+### Added
+
+- `docs/multi-entry-points.md` — long-form companion. Covers when to
+  use the pattern (multi-pass evaluation, read-then-write workflows,
+  per-request branching), the `Execute` and `ExecuteAt` API, a
+  table breakdown of what persists across calls, error / partial-
+  state patterns, and the common pitfalls (cross-tenant reuse,
+  entity-stack-depth bugs, unknown-table handling).
+- `dtrules docs entry-points` — new embedded topic mirroring the same
+  content in the in-binary `dtrules docs` plaintext shape.
+  `dtrules docs` lists it in the topic index.
+- `pkg/dtrules/multi_entry_test.go` — focused regression test with
+  five assertions:
+    - Two tables on one session see each other's mutations.
+    - The dependency direction works (B's condition reads A's write).
+    - Negative case: an entity that misses A's condition produces the
+      expected downstream state.
+    - `Execute("UnknownTable")` returns an error rather than panic,
+      and doesn't mutate session state on a failed lookup.
+    - Re-running the same table on the same session is idempotent.
+
+### Why a patch release
+
+No engine changes; this release pins existing behavior with tests
+and documents it. The new `dtrules docs entry-points` topic is the
+only new visible surface, and it documents pre-existing capability.
+
+### PRs included
+
+- #847 — docs + test for the multi-entry-point pattern
+
 ## v1.15.0 — 2026-05-30
 
 Cross-table EDD usage analysis, static table call graph, and final

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ authoritative usage walkthrough.
 | [Redundant Action-Set Column Advisory](advisory-redundant-action-set.md) | Column-level redundancy check on the compiled decision tree | v1.14.6 |
 | [`first pass` Predicate](first-pass-predicate.md) | EL predicate for the first iteration of the innermost active loop | v1.12.0 |
 | [`for all <type> entities` Loop](for-all-type-entities.md) | Type-driven iteration via the EDD `owns` declaration | [#703](https://github.com/DTRules/DTRules/issues/703) |
-| [Multiple Entry Points](multi-entry-points.md) | Run several decision tables against one loaded session | Always supported (pinned by test in v1.16.0) |
+| [Multiple Entry Points](multi-entry-points.md) | Run several decision tables against one loaded session | Always supported (pinned + documented in v1.15.1) |
 
 For features without a narrative companion, see the embedded `dtrules
 docs` topics (`dtrules docs operators` covers `fphalfup/` and


### PR DESCRIPTION
v1.15.1 changelog entry.

Patch release: no engine changes. Documents and pins the multi-entry-point pattern that the engine has always supported but no focused test or doc page called out. Surfaced by a v1.15.0 review question.

## What's in

- `docs/multi-entry-points.md` — long-form companion
- `dtrules docs entry-points` — new embedded topic
- `pkg/dtrules/multi_entry_test.go` — 5 regression assertions pinning the contract

All shipped in PR #847.

Once this PR lands, I'll tag `v1.15.1` on the merge commit and cut the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)