### PR TITLE
fix(el): forall-fold operand order (runtime crash) (#867)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -1427,35 +1427,51 @@ func (e *PostfixEmitter) VisitIntNumberOf(ctx *IntNumberOfContext) interface{} {
 }
 
 // VisitIntNumberOfWhere: `number of <arrayExpr> where <bexpr>` — count
-// elements matching bexpr. Emit a count-accumulator fold: seed 0, iterate
-// the array with forall (auto-pushes element entity), and for each element
-// increment the accumulator when bexpr is true.
+// elements matching bexpr. Emit a count-accumulator fold:
+//
+//	0 { { 1 + } <bexpr> if } <arrayExpr> forall
+//
+// Two stack-discipline rules govern the operand order (both verified by the
+// predicated-fold execution test, and both matched by the working
+// VisitForallWhere template):
+//
+//  1. forall is ( body array -- ): opForall pops the ARRAY off the TOP, then
+//     the body block. So the array is emitted LAST, after the body — emitting
+//     it before leaves the body block on top and forall iterates the block's
+//     tokens ("non-Entity entry in array").
+//  2. if is ( body boolean -- ): it pops the boolean off the top, then the
+//     body. So the inner block goes BEFORE the predicate: `{ 1 + } bexpr if`.
+//
+// The seed 0 stays on the data stack below the body and array, untouched by
+// forall's two pops, and the body accumulates into it per element.
 func (e *PostfixEmitter) VisitIntNumberOfWhere(ctx *IntNumberOfWhereContext) interface{} {
 	e.emit("0")
-	e.Visit(ctx.ArrayExpr())
 	e.emit("{")
-	e.Visit(ctx.Bexpr())
 	e.emit("{")
 	e.emit("1")
 	e.emit("+")
 	e.emit("}")
+	e.Visit(ctx.Bexpr())
 	e.emit("if")
 	e.emit("}")
+	e.Visit(ctx.ArrayExpr())
 	e.emit("forall")
 	return nil
 }
 
 // VisitIntSumOf: `sum of <iexpr> in <arrayExpr>` — fold the array
 // accumulating <iexpr> per element. Element entity is auto-pushed by
-// forall, so <iexpr> may reference the element's fields directly.
-// Pre-fix this rule silently emitted nothing.
+// forall, so <iexpr> may reference the element's fields directly. Emits
+// `0 { <iexpr> + } <arrayExpr> forall` — body before array, since opForall
+// pops the array off the top (see VisitIntNumberOfWhere for the full
+// stack-discipline note).
 func (e *PostfixEmitter) VisitIntSumOf(ctx *IntSumOfContext) interface{} {
 	e.emit("0")
-	e.Visit(ctx.ArrayExpr())
 	e.emit("{")
 	e.Visit(ctx.Iexpr())
 	e.emit("+")
 	e.emit("}")
+	e.Visit(ctx.ArrayExpr())
 	e.emit("forall")
 	return nil
 }
@@ -2161,11 +2177,11 @@ func (e *PostfixEmitter) VisitFloatRoundedBoundry(ctx *FloatRoundedBoundryContex
 // floatSumOf reachable. See TestIssue803_FloatSumOf_Unreachable.
 func (e *PostfixEmitter) VisitFloatSumOf(ctx *FloatSumOfContext) interface{} {
 	e.emit("0.0")
-	e.Visit(ctx.ArrayExpr())
 	e.emit("{")
 	e.Visit(ctx.TypedDouble())
 	e.emit("f+")
 	e.emit("}")
+	e.Visit(ctx.ArrayExpr())
 	e.emit("forall")
 	return nil
 }

--- a/pkg/dtrules/predicated_fold_exec_test.go
+++ b/pkg/dtrules/predicated_fold_exec_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtrules_test
+
+import (
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+	"github.com/DTRules/DTRules/pkg/dtrules/entity"
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// TestForallFoldExecution exercises the forall-fold aggregations (#867) end to
+// end: `sum of … in …` and `number of … where …`. They lower to
+// `seed { body } arr forall`. Token-only tests cannot catch a reversed forall
+// or if operand order (the tokens are identical) — this compiles the EL, runs
+// it over real entities, and asserts the result. Before the operand-order fix
+// these throw "non-Entity entry in array" / "no boolean value" at runtime.
+func TestForallFoldExecution(t *testing.T) {
+	rs := session.NewRuleSet("fold")
+	sess, err := rs.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ef := sess.GetEntityFactory().(*entity.Factory)
+
+	// kid { tax: integer }
+	kidName := dtrules.GetRName("kid")
+	kidRef, err := ef.FindCreateRefEntity(true, kidName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kidRef.AddAttribute(dtrules.GetRName("tax"), "", dtrules.GetRIntegerValue(0), true, true, dtrules.TypeInteger, "", "", "", "")
+
+	// root { kids: array of kid; total: integer }
+	rootName := dtrules.GetRName("root")
+	rootRef, err := ef.FindCreateRefEntity(true, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootRef.AddAttribute(dtrules.GetRName("kids"), "", nil, true, true, dtrules.TypeArray, "kid", "", "", "")
+	rootRef.AddAttribute(dtrules.GetRName("total"), "", dtrules.GetRIntegerValue(0), true, true, dtrules.TypeInteger, "", "", "", "")
+
+	// kids = [5, -3, 10, 0, 7]: all sum to 19; 3 are > 0.
+	elems := make([]dtrules.Object, 0, 5)
+	for _, v := range []int{5, -3, 10, 0, 7} {
+		k, err := ef.CreateEntity(sess, kidName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		k.Put(dtrules.GetRName("tax"), dtrules.GetRIntegerValue(int64(v)))
+		elems = append(elems, k)
+	}
+	arr, err := dtrules.NewArrayWithElements(sess, true, elems, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := ef.CreateEntity(sess, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root.Put(dtrules.GetRName("kids"), arr)
+
+	state := sess.GetState().(*interpreter.DTState)
+	elc := el.NewCompiler()
+	elc.SetSymbols(map[string]string{"kids": "array", "tax": "integer", "total": "integer"})
+
+	// Compile `set total = <expr>` as an action, run with root on the entity
+	// stack, then read root.total back.
+	run := func(expr string) (int, error) {
+		postfix, err := elc.CompileAction("set total = " + expr)
+		if err != nil {
+			return 0, err
+		}
+		obj, err := sess.Compile(postfix)
+		if err != nil {
+			return 0, err
+		}
+		state.EntityPush(root)
+		if err := obj.Execute(state); err != nil {
+			state.EntityPop()
+			return 0, err
+		}
+		state.EntityPop()
+		val, err := root.Get(dtrules.GetRName("total"))
+		if err != nil || val == nil {
+			return 0, err
+		}
+		return val.IntValue()
+	}
+
+	for _, c := range []struct {
+		expr string
+		want int
+	}{
+		{"sum of tax in kids", 19},                 // 5-3+10+0+7
+		{"number of kids where tax > 0", 3},        // predicated count
+		{"number of kids where tax > 100", 0},      // predicate always false → balanced 0
+		{"number of kids", 5},                      // unfiltered count
+	} {
+		got, err := run(c.expr)
+		if err != nil {
+			t.Errorf("%q: exec error: %v", c.expr, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("%q = %d, want %d", c.expr, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #867.

The forall-fold emitters `sum of … in …` and `number of … where …` emitted operands in the wrong order and **threw at runtime**:

- **forall** is `( body array -- )` — pops the array off the top. The emitters left the body block on top, so `forall` iterated the block's tokens (`non-Entity entry in array`).
- **if** (`where` variant) is `( body boolean -- )` — the emitters left the block on top, so `if` read it as the boolean (`no boolean value`).

Reordered to the working `VisitForallWhere` shape: `seed { { body } bexpr if } arr forall`.

**Verified by execution**, not tokens: added `TestForallFoldExecution`, which compiles EL and runs it over real entities, asserting `sum of`=19, predicated count=3, predicate-false=0, count=5. It fails on the old order and passes on the new. (The previous tests only checked token presence — which is why this shipped broken; the one integration test that would have caught it is `t.Skip`-archived, #520.)

Scope: the three emitters that exist on `main` (`VisitIntSumOf`, `VisitFloatSumOf`, `VisitIntNumberOfWhere`). The new `sum of … where` (#864) carries the same fix on its own branch (#866). The **boolean aggregations** share the shape and likely the same bug — left as a follow-up under #867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)