### PR TITLE
fix(el): correct forall operand order in boolean aggregations (#877)

### DIFF
--- a/pkg/dtrules/boolean_aggregation_exec_test.go
+++ b/pkg/dtrules/boolean_aggregation_exec_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtrules_test
+
+import (
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+	"github.com/DTRules/DTRules/pkg/dtrules/entity"
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// TestBooleanAggregationExecution exercises the forall boolean-aggregation
+// constructs (#877, the follow-up #867 explicitly flagged) end to end. Like the
+// numeric folds they lower to `seed { body op } arr forall`. Token-only tests
+// cannot catch a reversed forall (the tokens are identical) — this compiles the
+// EL, runs it over real entities, and asserts the boolean result. Before the
+// operand-order fix these throw "non-Entity entry in array" at runtime because
+// forall iterates the body block instead of the array.
+func TestBooleanAggregationExecution(t *testing.T) {
+	rs := session.NewRuleSet("boolagg")
+	sess, err := rs.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ef := sess.GetEntityFactory().(*entity.Factory)
+
+	// kid { tax: integer }
+	kidName := dtrules.GetRName("kid")
+	kidRef, err := ef.FindCreateRefEntity(true, kidName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kidRef.AddAttribute(dtrules.GetRName("tax"), "", dtrules.GetRIntegerValue(0), true, true, dtrules.TypeInteger, "", "", "", "")
+
+	// root { kids: array of kid; flag: boolean }
+	rootName := dtrules.GetRName("root")
+	rootRef, err := ef.FindCreateRefEntity(true, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootRef.AddAttribute(dtrules.GetRName("kids"), "", nil, true, true, dtrules.TypeArray, "kid", "", "", "")
+	rootRef.AddAttribute(dtrules.GetRName("flag"), "", dtrules.GetRBoolean(false), true, true, dtrules.TypeBoolean, "", "", "", "")
+
+	// kids = [5, -3, 10, 0, 7].
+	elems := make([]dtrules.Object, 0, 5)
+	for _, v := range []int{5, -3, 10, 0, 7} {
+		k, err := ef.CreateEntity(sess, kidName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		k.Put(dtrules.GetRName("tax"), dtrules.GetRIntegerValue(int64(v)))
+		elems = append(elems, k)
+	}
+	arr, err := dtrules.NewArrayWithElements(sess, true, elems, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := ef.CreateEntity(sess, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root.Put(dtrules.GetRName("kids"), arr)
+
+	state := sess.GetState().(*interpreter.DTState)
+	elc := el.NewCompiler()
+	elc.SetSymbols(map[string]string{"kids": "array", "tax": "integer", "flag": "boolean"})
+
+	run := func(expr string) (bool, error) {
+		postfix, err := elc.CompileAction("set flag = " + expr)
+		if err != nil {
+			return false, err
+		}
+		obj, err := sess.Compile(postfix)
+		if err != nil {
+			return false, err
+		}
+		state.EntityPush(root)
+		if err := obj.Execute(state); err != nil {
+			state.EntityPop()
+			return false, err
+		}
+		state.EntityPop()
+		val, err := root.Get(dtrules.GetRName("flag"))
+		if err != nil || val == nil {
+			return false, err
+		}
+		return val.BooleanValue()
+	}
+
+	for _, c := range []struct {
+		expr string
+		want bool
+	}{
+		{"all kids have tax > 0", false},        // -3 and 0 fail
+		{"all kids have tax >= -3", true},       // all in range
+		{"one of kids has a tax > 5", true},     // 10, 7
+		{"one of kids has a tax > 100", false},  // none
+	} {
+		got, err := run(c.expr)
+		if err != nil {
+			t.Errorf("%q: exec error: %v", c.expr, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("%q = %v, want %v", c.expr, got, c.want)
+		}
+	}
+}

--- a/pkg/dtrules/compiler/el/match_forall_order_test.go
+++ b/pkg/dtrules/compiler/el/match_forall_order_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import "testing"
+
+// TestMatchForallOperandOrder pins the corrected forall operand order for the
+// nested `there is match for all … to … in …` construct (#877). Both folds
+// must emit the block BEFORE the array (opForall is ( body array -- )); the
+// reorder changes the token SEQUENCE, so an exact-postfix match catches a
+// regression even though the token multiset is unchanged.
+//
+// This construct is exercised by exact-postfix rather than execution because
+// its runtime semantics are an approximation (entity-attribute matching across
+// two arrays); the operand-order bug manifested as a compile-shape error that
+// this pins precisely. The other reachable forall aggregations (`all … have`,
+// `one of … has a`) are covered by execution in
+// pkg/dtrules/boolean_aggregation_exec_test.go. The `there is … in … where`
+// array variants (boolThereIsInArrayWhere/NoInArrayWhere) are unreachable —
+// the entity alternatives shadow them in the grammar — so the fix to those is
+// defensive only.
+func TestMatchForallOperandOrder(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{"kids": "array", "cases": "array", "tax": "integer"})
+
+	got, err := c.CompileCondition("there is match for all kids to tax in cases")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	// Inner fold: `false { … or } cases forall`; outer: `true { … and } kids forall`.
+	// Both arrays (cases, kids) appear AFTER their blocks.
+	want := "true { false { tax 1 entityfetch == or } cases forall and } kids forall"
+	if got != want {
+		t.Errorf("operand order wrong\n got: %q\nwant: %q", got, want)
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -4943,23 +4943,26 @@ func (e *PostfixEmitter) VisitEntityColonRef(ctx *EntityColonRefContext) interfa
 //   eexpr HASA str WHERE bexpr      # boolEntityHasaWhere       →  ifelse on hasrelationship
 
 func (e *PostfixEmitter) VisitBoolAllHave(ctx *BoolAllHaveContext) interface{} {
+	// opForall is ( body array -- ): the block must be emitted BEFORE the
+	// array, else forall iterates the block as the array (#867 / #877).
 	e.emit("true")
-	e.Visit(ctx.ArrayExpr())
 	e.emit("{")
 	e.Visit(ctx.Bexpr())
 	e.emit("and")
 	e.emit("}")
+	e.Visit(ctx.ArrayExpr())
 	e.emit("forall")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitBoolOneOfHasa(ctx *BoolOneOfHasaContext) interface{} {
+	// Block before array — opForall is ( body array -- ). See #877.
 	e.emit("false")
-	e.Visit(ctx.ArrayExpr())
 	e.emit("{")
 	e.Visit(ctx.Bexpr())
 	e.emit("or")
 	e.emit("}")
+	e.Visit(ctx.ArrayExpr())
 	e.emit("forall")
 	return nil
 }
@@ -4996,23 +4999,25 @@ func (e *PostfixEmitter) VisitBoolThereIsNoInEntityWhere(ctx *BoolThereIsNoInEnt
 }
 
 func (e *PostfixEmitter) VisitBoolThereIsInArrayWhere(ctx *BoolThereIsInArrayWhereContext) interface{} {
+	// Block before array — opForall is ( body array -- ). See #877.
 	e.emit("false")
-	e.Visit(ctx.ArrayExpr())
 	e.emit("{")
 	e.Visit(ctx.Bexpr())
 	e.emit("or")
 	e.emit("}")
+	e.Visit(ctx.ArrayExpr())
 	e.emit("forall")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitBoolThereIsNoInArrayWhere(ctx *BoolThereIsNoInArrayWhereContext) interface{} {
+	// Block before array — opForall is ( body array -- ). See #877.
 	e.emit("false")
-	e.Visit(ctx.ArrayExpr())
 	e.emit("{")
 	e.Visit(ctx.Bexpr())
 	e.emit("or")
 	e.emit("}")
+	e.Visit(ctx.ArrayExpr())
 	e.emit("forall")
 	e.emit("not")
 	return nil
@@ -5294,12 +5299,14 @@ func (e *PostfixEmitter) VisitRemoveEachWhere(ctx *RemoveEachWhereContext) inter
 // stack at depth 1). Semantic approximation; runtime correctness depends
 // on the specific types of arr1/arr2/nexpr.
 func (e *PostfixEmitter) VisitBoolMatchForall(ctx *BoolMatchForallContext) interface{} {
+	// Both folds emit the block before the array — opForall is
+	// ( body array -- ). Reordering tokens does not change the runtime
+	// entity-stack depth (forall pushes each element while running the
+	// body), so `entityfetch 1` still resolves the outer element. See #877.
 	e.emit("true")
-	e.Visit(ctx.ArrayExpr(0))
 	e.emit("{")
 	// Inner existence check over arr2
 	e.emit("false")
-	e.Visit(ctx.ArrayExpr(1))
 	e.emit("{")
 	e.Visit(ctx.Nexpr())     // y.<nexpr>
 	e.emit("1")              // depth 1 = outer element x
@@ -5307,10 +5314,12 @@ func (e *PostfixEmitter) VisitBoolMatchForall(ctx *BoolMatchForallContext) inter
 	e.emit("==")
 	e.emit("or")
 	e.emit("}")
+	e.Visit(ctx.ArrayExpr(1))
 	e.emit("forall")
 	// AND with outer accumulator
 	e.emit("and")
 	e.emit("}")
+	e.Visit(ctx.ArrayExpr(0))
 	e.emit("forall")
 	return nil
 }


### PR DESCRIPTION
Fixes #877. Follow-up to #867.

## Bug
The boolean-aggregation constructs emitted `seed <array> { body op } forall`, but `opForall` is `( body array -- )` and pops the array off the top — so `forall` iterated the **body block** as the array → runtime crash `"non-Entity entry in array"`. Identical to the bug #867 fixed for the numeric folds; the #867 commit explicitly flagged these as the likely twin.

## Fix
Reordered all five emitters to put the block before the array (`seed { body op } <arr> forall`), matching the working `number of … where` / `sum of … in` template:

- `VisitBoolAllHave`
- `VisitBoolOneOfHasa`
- `VisitBoolThereIsInArrayWhere`
- `VisitBoolThereIsNoInArrayWhere`
- both folds of `VisitBoolMatchForall` (outer + inner)

Reordering tokens does not change runtime entity-stack depth (forall pushes each element while running the body), so `MatchForall`'s `entityfetch 1` still resolves the outer element.

## Test
`TestBooleanAggregationExecution` compiles `all … have` / `one of … has a` and **runs** them over real entities, asserting boolean results. It reproduces the exact `"non-Entity entry in array"` crash on the old code and passes with the fix. Token-only tests can't catch this — the tokens are identical regardless of order.

Coverage note: the two array `there is … where` variants and `MatchForall` require `eexpr`/two-array setups not in this harness; they share the identical one-line reorder with the two execution-tested constructs. A broader cross-construct execution harness is tracked under #879.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)