### PR TITLE
fix(el): reject implicit double/exact-type mix (#876)

### DIFF
--- a/pkg/dtrules/compiler/el/compiler.go
+++ b/pkg/dtrules/compiler/el/compiler.go
@@ -24,11 +24,19 @@
 package el
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/antlr4-go/antlr/v4"
 )
+
+// errEmission marks a failure that occurred after a clean parse, while the
+// emitter was producing postfix (e.g. a type error). CompileAction uses it to
+// distinguish a definitive emission failure from a parse-structure mismatch:
+// the former must not trigger the raw-statement fallback, which would reparse
+// and report a confusing parse error that masks the real diagnostic.
+var errEmission = errors.New("emission errors")
 
 // Compiler compiles Expression Language (EL) to postfix notation.
 type Compiler struct {
@@ -119,6 +127,13 @@ func (c *Compiler) CompileAction(el string) (string, error) {
 		return result, nil
 	}
 
+	// A clean parse that failed only at emission (e.g. a type error) is
+	// definitive — don't fall back to the raw-statement attempt, which would
+	// reparse and report a confusing parse error that hides the real one.
+	if errors.Is(err, errEmission) {
+		return "", err
+	}
+
 	// Try without action prefix (might be a raw statement)
 	result, err = c.compile(el)
 	if err == nil {
@@ -202,7 +217,7 @@ func (c *Compiler) compile(el string) (string, error) {
 		for i, err := range errs {
 			errStrs[i] = err.Error()
 		}
-		return "", fmt.Errorf("emission errors: %s", strings.Join(errStrs, "; "))
+		return "", fmt.Errorf("%w: %s", errEmission, strings.Join(errStrs, "; "))
 	}
 
 	return c.emitter.Emit(), nil

--- a/pkg/dtrules/compiler/el/mixed_double_reject_test.go
+++ b/pkg/dtrules/compiler/el/mixed_double_reject_test.go
@@ -43,6 +43,7 @@ func TestMixedDoubleExactRejected(t *testing.T) {
 		"set bi = bi2 + db",
 		"set bi = db + bi2", // order independent
 		"set fx = the minimum of fx2 and db",
+		"set fx = the maximum of fx2 and db",
 	}
 	for _, src := range badActions {
 		c := NewCompiler()
@@ -57,9 +58,13 @@ func TestMixedDoubleExactRejected(t *testing.T) {
 		}
 	}
 
-	// conditions that must fail to compile
+	// conditions that must fail to compile. Cover both comparison paths:
+	// bare `name OP name` (name path: ==/!= → VisitBoolNameEq/Neq, ordering →
+	// VisitBoolIntGt/…) and an iexpr context (`fx2 + fx == db` → VisitBoolIntEq).
 	badConds := []string{
-		"fx > db", "fx == db", "fx != db", "bi <= db", "db >= bi",
+		"fx > db", "fx < db", "fx >= db", "bi <= db", "db >= bi", // ordering
+		"fx == db", "fx != db", // equality, name path
+		"fx2 + fx == db", "fx2 + fx != db", // equality, iexpr path
 	}
 	for _, src := range badConds {
 		c := NewCompiler()

--- a/pkg/dtrules/compiler/el/mixed_double_reject_test.go
+++ b/pkg/dtrules/compiler/el/mixed_double_reject_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+func mdSymbols() map[string]string {
+	return map[string]string{
+		"fx": TypeFixed, "fx2": TypeFixed,
+		"db": TypeDouble, "db2": TypeDouble,
+		"bi": TypeBigInt, "bi2": TypeBigInt,
+		"it": TypeInteger,
+	}
+}
+
+// TestMixedDoubleExactRejected (#876): mixing a double with an exact type
+// (fixed or bigint) in arithmetic or a comparison must be rejected at compile
+// time, not silently compiled to an op that crashes at runtime. The runtime
+// deliberately refuses to promote double→fixed implicitly; authors opt in with
+// an explicit cast.
+func TestMixedDoubleExactRejected(t *testing.T) {
+	// action statements that must fail to compile
+	badActions := []string{
+		"set fx = fx2 + db",
+		"set fx = fx2 - db",
+		"set fx = fx2 * db",
+		"set fx = fx2 / db",
+		"set bi = bi2 + db",
+		"set bi = db + bi2", // order independent
+		"set fx = the minimum of fx2 and db",
+	}
+	for _, src := range badActions {
+		c := NewCompiler()
+		c.SetSymbols(mdSymbols())
+		pf, err := c.CompileAction(src)
+		if err == nil {
+			t.Errorf("%q: expected compile error, got postfix %q", src, pf)
+			continue
+		}
+		if !strings.Contains(err.Error(), "cannot combine double with") {
+			t.Errorf("%q: error should explain the double/exact mix, got: %v", src, err)
+		}
+	}
+
+	// conditions that must fail to compile
+	badConds := []string{
+		"fx > db", "fx == db", "fx != db", "bi <= db", "db >= bi",
+	}
+	for _, src := range badConds {
+		c := NewCompiler()
+		c.SetSymbols(mdSymbols())
+		if pf, err := c.CompileCondition(src); err == nil {
+			t.Errorf("%q: expected compile error, got postfix %q", src, pf)
+		}
+	}
+}
+
+// TestMixedDoubleExactAllowedForms confirms the reject does not over-fire: an
+// explicit cast and the legitimate widening cases still compile.
+func TestMixedDoubleExactAllowedForms(t *testing.T) {
+	ok := []string{
+		"set fx = fx2 + (fixed) db", // explicit opt-in
+		"set db = db2 + (double) fx", // explicit opt-in the other way
+		"set fx = fx2 + it",          // fixed + integer (auto cvfp)
+		"set fx = fx2 + bi",          // fixed + bigint (both exact)
+		"set db = db2 + it",          // double + integer (widen)
+		"set db = db2 + db",          // double + double
+		"set bi = bi2 + it",          // bigint + integer
+	}
+	for _, src := range ok {
+		c := NewCompiler()
+		c.SetSymbols(mdSymbols())
+		if _, err := c.CompileAction(src); err != nil {
+			t.Errorf("%q: expected clean compile, got error: %v", src, err)
+		}
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -307,6 +307,42 @@ func promoteArithType(a, b string) string {
 	return TypeInteger
 }
 
+// isDoubleExactMix reports whether one operand is double and the other is an
+// exact type (fixed or bigint) — a combination DTRules will not promote
+// implicitly.
+func isDoubleExactMix(a, b string) bool {
+	isExact := func(t string) bool { return t == TypeFixed || t == TypeBigInt }
+	return (a == TypeDouble && isExact(b)) || (b == TypeDouble && isExact(a))
+}
+
+// promote is the emission-site wrapper over promoteArithType. It records a
+// compile error when a double is mixed with an exact type (fixed or bigint)
+// instead of silently emitting a cast: the runtime deliberately refuses to
+// promote double→fixed implicitly (see RFixed.promote), and truncating
+// double→bigint would silently drop precision. Authors must opt in with an
+// explicit cast, e.g. `(double) x` or `(fixed) x`. (#876)
+func (e *PostfixEmitter) promote(a, b string) string {
+	if isDoubleExactMix(a, b) {
+		e.emitDoubleMixError(exactOf(a, b))
+	}
+	return promoteArithType(a, b)
+}
+
+// exactOf returns whichever of a/b is the exact type in a double/exact mix.
+func exactOf(a, b string) string {
+	if a == TypeDouble {
+		return b
+	}
+	return a
+}
+
+// emitDoubleMixError records the standard #876 diagnostic for an implicit
+// double/exact-type combination.
+func (e *PostfixEmitter) emitDoubleMixError(exact string) {
+	e.emitError("cannot combine double with %s implicitly; add an explicit cast "+
+		"(e.g. \"(%s) x\" to keep exactness, or \"(double) x\" to compute in double)", exact, exact)
+}
+
 // arithOp picks the correct postfix opcode for an arithmetic or comparison
 // operation based on the promoted expression type.
 // arithOp picks the right operator name for the promoted target type.
@@ -606,7 +642,7 @@ func (e *PostfixEmitter) VisitBoolIntEq(ctx *BoolIntEqContext) interface{} {
 		return nil
 	}
 
-	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	target := e.promote(e.getExprType(left), e.getExprType(right))
 	e.emitWithTypeConversion(left, target)
 	e.emitWithTypeConversion(right, target)
 	e.emit(arithOp(target, "==", "b==", "f==", "fp=="))
@@ -624,7 +660,7 @@ func (e *PostfixEmitter) VisitBoolIntNeq(ctx *BoolIntNeqContext) interface{} {
 		return nil
 	}
 
-	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	target := e.promote(e.getExprType(left), e.getExprType(right))
 	e.emitWithTypeConversion(left, target)
 	e.emitWithTypeConversion(right, target)
 	switch target {
@@ -643,7 +679,7 @@ func (e *PostfixEmitter) VisitBoolIntNeq(ctx *BoolIntNeqContext) interface{} {
 
 func (e *PostfixEmitter) VisitBoolIntGt(ctx *BoolIntGtContext) interface{} {
 	left, right := ctx.Iexpr(0), ctx.Iexpr(1)
-	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	target := e.promote(e.getExprType(left), e.getExprType(right))
 	e.emitWithTypeConversion(left, target)
 	e.emitWithTypeConversion(right, target)
 	e.emit(arithOp(target, ">", "b>", "f>", "fp>"))
@@ -652,7 +688,7 @@ func (e *PostfixEmitter) VisitBoolIntGt(ctx *BoolIntGtContext) interface{} {
 
 func (e *PostfixEmitter) VisitBoolIntGte(ctx *BoolIntGteContext) interface{} {
 	left, right := ctx.Iexpr(0), ctx.Iexpr(1)
-	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	target := e.promote(e.getExprType(left), e.getExprType(right))
 	e.emitWithTypeConversion(left, target)
 	e.emitWithTypeConversion(right, target)
 	e.emit(arithOp(target, ">=", "b>=", "f>=", "fp>="))
@@ -661,7 +697,7 @@ func (e *PostfixEmitter) VisitBoolIntGte(ctx *BoolIntGteContext) interface{} {
 
 func (e *PostfixEmitter) VisitBoolIntLt(ctx *BoolIntLtContext) interface{} {
 	left, right := ctx.Iexpr(0), ctx.Iexpr(1)
-	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	target := e.promote(e.getExprType(left), e.getExprType(right))
 	e.emitWithTypeConversion(left, target)
 	e.emitWithTypeConversion(right, target)
 	e.emit(arithOp(target, "<", "b<", "f<", "fp<"))
@@ -670,7 +706,7 @@ func (e *PostfixEmitter) VisitBoolIntLt(ctx *BoolIntLtContext) interface{} {
 
 func (e *PostfixEmitter) VisitBoolIntLte(ctx *BoolIntLteContext) interface{} {
 	left, right := ctx.Iexpr(0), ctx.Iexpr(1)
-	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	target := e.promote(e.getExprType(left), e.getExprType(right))
 	e.emitWithTypeConversion(left, target)
 	e.emitWithTypeConversion(right, target)
 	e.emit(arithOp(target, "<=", "b<=", "f<=", "fp<="))
@@ -1149,12 +1185,20 @@ func (e *PostfixEmitter) VisitBoolNameEq(ctx *BoolNameEqContext) interface{} {
 	// string forms happen to match. Dispatch to the proper family with
 	// Fixed > BigInt > Integer promotion when both sides are numeric.
 	if t0, t1 := e.identNumericType(name0), e.identNumericType(name1); t0 != "" && t1 != "" {
-		target := promoteArithType(t0, t1)
+		target := e.promote(t0, t1)
 		e.Visit(ctx.Nexpr(0))
 		e.emitTypeCast(t0, target)
 		e.Visit(ctx.Nexpr(1))
 		e.emitTypeCast(t1, target)
 		e.emit(arithOp(target, "==", "b==", "f==", "fp=="))
+		return nil
+	}
+
+	// The numeric block above excludes double, so fixed/bigint == double would
+	// otherwise fall through to a meaningless string compare. Reject the
+	// implicit mix the same way the arithmetic path does (#876).
+	if t0, t1 := e.lookupType(name0), e.lookupType(name1); isDoubleExactMix(t0, t1) {
+		e.emitDoubleMixError(exactOf(t0, t1))
 		return nil
 	}
 
@@ -1196,7 +1240,7 @@ func (e *PostfixEmitter) VisitBoolNameNeq(ctx *BoolNameNeqContext) interface{} {
 	// Fixed > BigInt > Integer promotion as BoolNameEq; fp!= and b!=
 	// are distinct ops, integer falls back to the historic `== not`.
 	if t0, t1 := e.identNumericType(name0), e.identNumericType(name1); t0 != "" && t1 != "" {
-		target := promoteArithType(t0, t1)
+		target := e.promote(t0, t1)
 		e.Visit(ctx.Nexpr(0))
 		e.emitTypeCast(t0, target)
 		e.Visit(ctx.Nexpr(1))
@@ -1210,6 +1254,12 @@ func (e *PostfixEmitter) VisitBoolNameNeq(ctx *BoolNameNeqContext) interface{} {
 			e.emit("==")
 			e.emit("not")
 		}
+		return nil
+	}
+
+	// Reject an implicit fixed/bigint != double the same way == does (#876).
+	if t0, t1 := e.lookupType(name0), e.lookupType(name1); isDoubleExactMix(t0, t1) {
+		e.emitDoubleMixError(exactOf(t0, t1))
 		return nil
 	}
 
@@ -1362,7 +1412,7 @@ func (e *PostfixEmitter) VisitIntAdd(ctx *IntAddContext) interface{} {
 		return nil
 	}
 
-	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	target := e.promote(e.getExprType(left), e.getExprType(right))
 	e.emitWithTypeConversion(left, target)
 	e.emitWithTypeConversion(right, target)
 	e.emit(arithOp(target, "+", "b+", "f+", "fp+"))
@@ -1371,7 +1421,7 @@ func (e *PostfixEmitter) VisitIntAdd(ctx *IntAddContext) interface{} {
 
 func (e *PostfixEmitter) VisitIntSub(ctx *IntSubContext) interface{} {
 	left, right := ctx.Iexpr(0), ctx.Iexpr(1)
-	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	target := e.promote(e.getExprType(left), e.getExprType(right))
 	e.emitWithTypeConversion(left, target)
 	e.emitWithTypeConversion(right, target)
 	e.emit(arithOp(target, "-", "b-", "f-", "fp-"))
@@ -1380,7 +1430,7 @@ func (e *PostfixEmitter) VisitIntSub(ctx *IntSubContext) interface{} {
 
 func (e *PostfixEmitter) VisitIntMul(ctx *IntMulContext) interface{} {
 	left, right := ctx.Iexpr(0), ctx.Iexpr(1)
-	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	target := e.promote(e.getExprType(left), e.getExprType(right))
 	e.emitWithTypeConversion(left, target)
 	e.emitWithTypeConversion(right, target)
 	e.emit(arithOp(target, "*", "b*", "fmul", "fp*"))
@@ -1389,7 +1439,7 @@ func (e *PostfixEmitter) VisitIntMul(ctx *IntMulContext) interface{} {
 
 func (e *PostfixEmitter) VisitIntDiv(ctx *IntDivContext) interface{} {
 	left, right := ctx.Iexpr(0), ctx.Iexpr(1)
-	target := promoteArithType(e.getExprType(left), e.getExprType(right))
+	target := e.promote(e.getExprType(left), e.getExprType(right))
 	e.emitWithTypeConversion(left, target)
 	e.emitWithTypeConversion(right, target)
 	e.emit(arithOp(target, "/", "b/", "fdiv", "fp/"))
@@ -1576,7 +1626,7 @@ func minMaxOp(target, intOp, dblOp, fpOp string) string {
 
 func (e *PostfixEmitter) VisitIntMinOf(ctx *IntMinOfContext) interface{} {
 	l, r := ctx.Iexpr(0), ctx.Iexpr(1)
-	target := promoteArithType(e.getExprType(l), e.getExprType(r))
+	target := e.promote(e.getExprType(l), e.getExprType(r))
 	e.emitWithTypeConversion(l, target)
 	e.emitWithTypeConversion(r, target)
 	e.emit(minMaxOp(target, "min", "fmin", "fpmin"))
@@ -1585,7 +1635,7 @@ func (e *PostfixEmitter) VisitIntMinOf(ctx *IntMinOfContext) interface{} {
 
 func (e *PostfixEmitter) VisitIntMinOfComma(ctx *IntMinOfCommaContext) interface{} {
 	l, r := ctx.Iexpr(0), ctx.Iexpr(1)
-	target := promoteArithType(e.getExprType(l), e.getExprType(r))
+	target := e.promote(e.getExprType(l), e.getExprType(r))
 	e.emitWithTypeConversion(l, target)
 	e.emitWithTypeConversion(r, target)
 	e.emit(minMaxOp(target, "min", "fmin", "fpmin"))
@@ -1594,7 +1644,7 @@ func (e *PostfixEmitter) VisitIntMinOfComma(ctx *IntMinOfCommaContext) interface
 
 func (e *PostfixEmitter) VisitIntMaxOf(ctx *IntMaxOfContext) interface{} {
 	l, r := ctx.Iexpr(0), ctx.Iexpr(1)
-	target := promoteArithType(e.getExprType(l), e.getExprType(r))
+	target := e.promote(e.getExprType(l), e.getExprType(r))
 	e.emitWithTypeConversion(l, target)
 	e.emitWithTypeConversion(r, target)
 	e.emit(minMaxOp(target, "max", "fmax", "fpmax"))
@@ -1603,7 +1653,7 @@ func (e *PostfixEmitter) VisitIntMaxOf(ctx *IntMaxOfContext) interface{} {
 
 func (e *PostfixEmitter) VisitIntMaxOfComma(ctx *IntMaxOfCommaContext) interface{} {
 	l, r := ctx.Iexpr(0), ctx.Iexpr(1)
-	target := promoteArithType(e.getExprType(l), e.getExprType(r))
+	target := e.promote(e.getExprType(l), e.getExprType(r))
 	e.emitWithTypeConversion(l, target)
 	e.emitWithTypeConversion(r, target)
 	e.emit(minMaxOp(target, "max", "fmax", "fpmax"))


### PR DESCRIPTION
Fixes #876.

## Bug
Mixing a `double` with an exact type (`fixed`/`bigint`) emitted the wider type's op with the **double operand un-cast**:

| DSL | old postfix | runtime |
|---|---|---|
| `set fx = fx2 - db` | `fx2 db fp- …` | ✗ "cannot promote double to fixed implicitly" |
| `set bi = bi2 + db` | `bi2 db b+ …` | ✗ IntValue on RDouble |
| `fx > db` | `fx db fp>` | ✗ |

Same class as #790 / #874: `promoteArithType` makes the exact type win, but `emitTypeCast` never cast `double→fixed`/`double→bigint`.

## Decision: reject, don't auto-cast
Per maintainer call, the compiler now **rejects** the implicit mix instead of silently casting — consistent with the runtime guard (`RFixed.promote`) that already refuses implicit `double→fixed`. Silent auto-cast would reintroduce exactly the precision loss that guard exists to prevent. Authors opt in with an explicit cast.

```
set budget = supply - rate     // supply: fixed, rate: double
  emission errors: cannot combine double with fixed implicitly;
  add an explicit cast (e.g. "(fixed) x" to keep exactness,
  or "(double) x" to compute in double)
```

## Changes
- `e.promote(a,b)` — emission-site wrapper over `promoteArithType` that flags a double/exact mix on every arithmetic, ordering-comparison, and min/max site. Bare `promoteArithType` stays for type inference (no false positives on nested subexpressions).
- Name-path `==`/`!=` — the numeric dispatch skips `double` and would emit a meaningless `streq` for `fixed/bigint == double`; it now gets the same reject.
- `CompileAction` — stops masking an emission error with the raw-statement fallback's parse error. A clean-parse/failed-emission is definitive (sentinel `errEmission`), so the real diagnostic surfaces instead of `mismatched input 'set'`.

## Tests
- `TestMixedDoubleExactRejected` — `+ - * /`, `min`, and comparisons across fixed/bigint × double all reject with the cast guidance.
- `TestMixedDoubleExactAllowedForms` — explicit casts and the legitimate int/double widening cases still compile (guards against over-rejection).

`make check` green — no existing test or sample project relied on the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)