### PR TITLE
fix(authoring): unify EDD symbol builder; recursive nested-EDD discovery (#879)

### DIFF
--- a/cmd/dtrules/build.go
+++ b/cmd/dtrules/build.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/DTRules/DTRules/pkg/dtrules/analysis"
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
 	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
 	"github.com/DTRules/DTRules/pkg/dtrules/decisiontable"
 	"github.com/DTRules/DTRules/pkg/dtrules/excel"
@@ -40,7 +41,7 @@ import (
 func newWorkbookImporter(xmlDir string) *excel.WorkbookImporter {
 	imp := excel.NewWorkbookImporter()
 	imp.SetELCompiler(el.NewCompiler())
-	if syms := loadEDDSymbols(xmlDir); len(syms) > 0 {
+	if syms := authoring.LoadEDDSymbols(xmlDir); len(syms) > 0 {
 		imp.SetSymbols(syms)
 	}
 	return imp

--- a/pkg/dtrules/authoring/edd_symbols.go
+++ b/pkg/dtrules/authoring/edd_symbols.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Paul Snow
+// Copyright 2026 Paul Snow
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package authoring
 
 import (
 	"encoding/xml"
@@ -21,11 +21,20 @@ import (
 	"strings"
 )
 
-// loadEDDSymbols walks the *_edd.xml files under root (or root's directory if
-// root is a file) and returns a map of EDD symbol name → type. Both the bare
-// field name and the qualified "entity.field" form are recorded. It feeds the
-// EL compiler's type resolution during build.
-func loadEDDSymbols(root string) map[string]string {
+// LoadEDDSymbols walks the *_edd.xml files under root (recursively, so nested
+// EDDs like xml/states/CO_edd.xml are found) and returns a map of EDD symbol
+// name → type. Both the bare field name and the entity-qualified
+// "entity.field" form are recorded, because DSL references fields by bare name
+// while qualified references need the dotted key.
+//
+// If root is a file rather than a directory, its containing directory is
+// walked. Read/parse errors on individual files are skipped so a single bad
+// EDD doesn't blank the whole symbol table.
+//
+// This is the single source of truth for EDD→symbol construction shared by the
+// authoring Save path (Project.loadEDD) and the cmd/dtrules build path, so the
+// two cannot drift in discovery scope or key form (#874, #879).
+func LoadEDDSymbols(root string) map[string]string {
 	type eddField struct {
 		Name string `xml:"name,attr"`
 		Type string `xml:"type,attr"`
@@ -38,8 +47,6 @@ func loadEDDSymbols(root string) map[string]string {
 		Entities []eddEntity `xml:"entity"`
 	}
 
-	// Decide which directory tree to walk. If root is a *_dt.xml file we
-	// look in its containing directory; otherwise we walk root itself.
 	walkDir := root
 	if info, err := os.Stat(root); err == nil && !info.IsDir() {
 		walkDir = filepath.Dir(root)

--- a/pkg/dtrules/authoring/edd_symbols_test.go
+++ b/pkg/dtrules/authoring/edd_symbols_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+// TestLoadEDDSymbols is the parity unit for the single EDD→symbol builder that
+// both the authoring Save path and the cmd/dtrules build path now share
+// (#879). It pins: recursive discovery (top-level + nested EDDs), both the bare
+// and entity-qualified key forms, and skipping of empty/typeless fields.
+func TestLoadEDDSymbols(t *testing.T) {
+	dir := t.TempDir()
+	xmlDir := filepath.Join(dir, "xml")
+	statesDir := filepath.Join(xmlDir, "states")
+	if err := os.MkdirAll(statesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	topEDD := `<entity_data_dictionary version='2'>
+		<entity name='budget'>
+			<field name='supply_limit' type='fixed'></field>
+			<field name='' type='fixed'></field>
+		</entity>
+	</entity_data_dictionary>`
+	nestedEDD := `<entity_data_dictionary version='2'>
+		<entity name='state'>
+			<field name='rate' type='double'></field>
+		</entity>
+	</entity_data_dictionary>`
+
+	if err := os.WriteFile(filepath.Join(xmlDir, "budget_edd.xml"), []byte(topEDD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(statesDir, "co_edd.xml"), []byte(nestedEDD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	syms := authoring.LoadEDDSymbols(xmlDir)
+
+	want := map[string]string{
+		"supply_limit":        "fixed", // top-level, bare
+		"budget.supply_limit": "fixed", // top-level, qualified
+		"rate":                "double", // nested, bare (recursive discovery)
+		"state.rate":          "double", // nested, qualified
+	}
+	for k, v := range want {
+		if syms[k] != v {
+			t.Errorf("LoadEDDSymbols[%q] = %q, want %q", k, syms[k], v)
+		}
+	}
+	// Empty-named field must be skipped (no bare "" key, no "budget." key).
+	if _, ok := syms[""]; ok {
+		t.Error("empty field name was registered")
+	}
+	if _, ok := syms["budget."]; ok {
+		t.Error("empty qualified key was registered")
+	}
+}

--- a/pkg/dtrules/authoring/nested_edd_test.go
+++ b/pkg/dtrules/authoring/nested_edd_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+const nestedFixedEDD = `<entity_data_dictionary version='2'>
+	<entity name='budget' access='rw' comment=''>
+		<field name='supply_limit' type='fixed' access='r' comment=''></field>
+		<field name='acme_issued' type='fixed' access='r' comment=''></field>
+		<field name='unissued_supply' type='fixed' access='w' comment=''></field>
+	</entity>
+</entity_data_dictionary>`
+
+const nestedFixedDT = `<?xml version="1.0" encoding="UTF-8"?>
+<decision_tables>
+<decision_table el_compiled="true">
+<table_name>Calculate_Budget</table_name>
+<xls_file>budget_dt.xlsx</xls_file>
+<attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>1</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions>
+</initial_actions>
+<conditions>
+</conditions>
+<actions>
+<action_details>
+<action_number>1</action_number>
+<action_comment>Compute unissued supply</action_comment>
+<action_dsl>set unissued_supply = supply_limit - acme_issued</action_dsl>
+<action_postfix>
+supply_limit acme_issued - cvi /unissued_supply xdef
+</action_postfix>
+<action_column column_number="1" column_value="X"></action_column>
+</action_details>
+</actions>
+<policy_statements>
+</policy_statements>
+</decision_table>
+</decision_tables>
+`
+
+// TestNestedEDDIsLoaded (#879): loadEDD must discover EDD files in
+// subdirectories (e.g. xml/states/budget_edd.xml), the same recursive scope
+// loadDTFiles and the build path use. A flat Glob missed nested EDDs, so the
+// fields they declare stayed untyped and the emitter degraded their fixed ops
+// to integer (`-`/`cvi`) — a #874-class divergence on a different vector.
+//
+// Here the EDD lives under xml/states/ while the table lives at xml/; the
+// fixed subtraction must still compile to fp-/cvfp through the Save path.
+func TestNestedEDDIsLoaded(t *testing.T) {
+	dir := t.TempDir()
+	xmlDir := filepath.Join(dir, "xml")
+	statesDir := filepath.Join(xmlDir, "states")
+	if err := os.MkdirAll(statesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dtPath := filepath.Join(xmlDir, "budget_dt.xml")
+	if err := os.WriteFile(filepath.Join(statesDir, "budget_edd.xml"), []byte(nestedFixedEDD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dtPath, []byte(nestedFixedDT), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := authoring.OpenProject(dir)
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+	tbl := p.Table("Calculate_Budget")
+	if tbl == nil {
+		t.Fatal("table Calculate_Budget not found")
+	}
+	a := tbl.Actions[0]
+	if err := tbl.UpdateAction(1, authoring.Action{DSL: a.DSL, Comment: a.Comment}); err != nil {
+		t.Fatalf("UpdateAction: %v", err)
+	}
+	if err := p.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	out, err := os.ReadFile(dtPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	postfix := extractActionPostfix(t, string(out))
+	if !strings.Contains(postfix, "fp-") || !strings.Contains(postfix, "cvfp") {
+		t.Errorf("nested EDD not loaded: expected fixed ops fp-/cvfp, got %q", postfix)
+	}
+}

--- a/pkg/dtrules/authoring/project.go
+++ b/pkg/dtrules/authoring/project.go
@@ -159,51 +159,15 @@ func NewInMemoryProject(dir string) (*Project, error) {
 	return p, nil
 }
 
-// loadEDD parses *_edd.xml files and extracts field names+types for validation.
+// loadEDD populates p.symbols with EDD field names+types for type-aware
+// compilation. It delegates to LoadEDDSymbols (the shared builder also used by
+// the cmd/dtrules build path) so discovery scope and key form cannot drift:
+// both walk xmlDir recursively (finding nested EDDs like xml/states/CO_edd.xml)
+// and register both the bare and entity-qualified keys. A flat Glob here used
+// to miss nested EDDs, degrading their fixed/double ops to integer (#874/#879).
 func (p *Project) loadEDD(xmlDir string) error {
-	entries, err := filepath.Glob(filepath.Join(xmlDir, "*_edd.xml"))
-	if err != nil {
-		return err
-	}
-
-	type eddField struct {
-		Name string `xml:"name,attr"`
-		Type string `xml:"type,attr"`
-	}
-	type eddEntity struct {
-		Name   string     `xml:"name,attr"`
-		Fields []eddField `xml:"field"`
-	}
-	type eddFile struct {
-		Entities []eddEntity `xml:"entity"`
-	}
-
-	for _, path := range entries {
-		data, err := os.ReadFile(path)
-		if err != nil {
-			continue
-		}
-		var f eddFile
-		if err := xml.Unmarshal(data, &f); err != nil {
-			continue
-		}
-		for _, ent := range f.Entities {
-			for _, field := range ent.Fields {
-				if field.Name == "" || field.Type == "" {
-					continue
-				}
-				// Register both the bare and entity-qualified keys, matching
-				// excel.eddSymbols (the workbook-import path). DSL references
-				// fields by bare name (`supply_limit - acme_issued`), so the
-				// postfix emitter must find the bare key to pick fixed-point
-				// ops (`fp-`, `cvfp`) over integer ops (`-`, `cvi`) — without
-				// it, Save() silently degrades fixed-point postfix (#874).
-				p.symbols[field.Name] = field.Type
-				if ent.Name != "" {
-					p.symbols[ent.Name+"."+field.Name] = field.Type
-				}
-			}
-		}
+	for k, v := range LoadEDDSymbols(xmlDir) {
+		p.symbols[k] = v
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #879.

## Findings (the audit's two claims, verified)
- **Discovery scope — REAL.** authoring `loadEDD` used a flat `filepath.Glob`, while `loadDTFiles` and the `cmd/dtrules` build path walk recursively. A nested `xml/states/CO_edd.xml` was invisible to authoring Save → its fields stayed untyped → the emitter degraded their fixed/double ops to integer (`-`/`cvi`). A #874-class bug on a different vector.
- **Case-sensitivity — NOT real.** The audit suspected the workbook importer lowercased EDD entity/field *names*. It doesn't: `entityName`/`fieldName` are `TrimSpace(getCellValue(...))`; the `ToLower` calls in that file are for cell-marker detection (header/type strings), not names. No fix needed.

## Fix: one builder, no drift
Extracted the canonical `authoring.LoadEDDSymbols(root)` — recursive walk, both bare and entity-qualified keys, skip empty name/type, tolerate unreadable files. `Project.loadEDD` and `cmd/dtrules build` both call it now, so the two file-discovery generators **cannot diverge again**. The duplicate `cmd/dtrules/edd_symbols.go` is removed. (The third generator, `excel.eddSymbols`, operates on an already-parsed `EDDXML` rather than file discovery, and produces the same bare+qualified key forms.)

## Tests
- `TestLoadEDDSymbols` — parity unit for the shared builder: recursive discovery (top-level + nested), both key forms, empty-field skip.
- `TestNestedEDDIsLoaded` — end-to-end: a fixed subtraction whose EDD lives under `xml/states/` compiles to `fp-`/`cvfp` through Save. Fails on the old flat-Glob code with `-`/`cvi`.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)