### PR TITLE
fix(el): mixed float +/- emit f+/f-, not truncating integer ops (#884)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -1674,17 +1674,27 @@ func (e *PostfixEmitter) VisitFloatTyped(ctx *FloatTypedContext) interface{} {
 	return nil
 }
 
+// emitMixedFloatArith handles +/- where at least one operand is a float
+// expression (fexpr — always double-typed). It promotes through e.promote so
+// the float forces a double result (f+/f-) with any integer operand promoted
+// by the op, and a fixed/bigint operand mixed with the float is rejected
+// (#876) rather than silently truncated. Without it these visitors emitted a
+// bare integer `+`/`-` that truncated e.g. `db2 + 1.0` at runtime (#884).
+// Pass TypeDouble for an fexpr operand (getExprType only types iexprs).
+func (e *PostfixEmitter) emitMixedFloatArith(left, right antlr.ParseTree, leftType, rightType, intOp, bigOp, dblOp, fpOp string) {
+	target := e.promote(leftType, rightType)
+	e.emitWithTypeConversion(left, target)
+	e.emitWithTypeConversion(right, target)
+	e.emit(arithOp(target, intOp, bigOp, dblOp, fpOp))
+}
+
 func (e *PostfixEmitter) VisitFloatAddFloat(ctx *FloatAddFloatContext) interface{} {
-	e.Visit(ctx.Fexpr(0))
-	e.Visit(ctx.Fexpr(1))
-	e.emit("+")
+	e.emitMixedFloatArith(ctx.Fexpr(0), ctx.Fexpr(1), TypeDouble, TypeDouble, "+", "b+", "f+", "fp+")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitFloatSubFloat(ctx *FloatSubFloatContext) interface{} {
-	e.Visit(ctx.Fexpr(0))
-	e.Visit(ctx.Fexpr(1))
-	e.emit("-")
+	e.emitMixedFloatArith(ctx.Fexpr(0), ctx.Fexpr(1), TypeDouble, TypeDouble, "-", "b-", "f-", "fp-")
 	return nil
 }
 
@@ -1703,16 +1713,12 @@ func (e *PostfixEmitter) VisitFloatDivFloat(ctx *FloatDivFloatContext) interface
 }
 
 func (e *PostfixEmitter) VisitFloatAddInt(ctx *FloatAddIntContext) interface{} {
-	e.Visit(ctx.Fexpr())
-	e.Visit(ctx.Iexpr())
-	e.emit("+")
+	e.emitMixedFloatArith(ctx.Fexpr(), ctx.Iexpr(), TypeDouble, e.getExprType(ctx.Iexpr()), "+", "b+", "f+", "fp+")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitFloatSubInt(ctx *FloatSubIntContext) interface{} {
-	e.Visit(ctx.Fexpr())
-	e.Visit(ctx.Iexpr())
-	e.emit("-")
+	e.emitMixedFloatArith(ctx.Fexpr(), ctx.Iexpr(), TypeDouble, e.getExprType(ctx.Iexpr()), "-", "b-", "f-", "fp-")
 	return nil
 }
 
@@ -2039,16 +2045,12 @@ func (e *PostfixEmitter) VisitDateEndOfMonth(ctx *DateEndOfMonthContext) interfa
 }
 
 func (e *PostfixEmitter) VisitIntAddFloat(ctx *IntAddFloatContext) interface{} {
-	e.Visit(ctx.Iexpr())
-	e.Visit(ctx.Fexpr())
-	e.emit("+")
+	e.emitMixedFloatArith(ctx.Iexpr(), ctx.Fexpr(), e.getExprType(ctx.Iexpr()), TypeDouble, "+", "b+", "f+", "fp+")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitIntSubFloat(ctx *IntSubFloatContext) interface{} {
-	e.Visit(ctx.Iexpr())
-	e.Visit(ctx.Fexpr())
-	e.emit("-")
+	e.emitMixedFloatArith(ctx.Iexpr(), ctx.Fexpr(), e.getExprType(ctx.Iexpr()), TypeDouble, "-", "b-", "f-", "fp-")
 	return nil
 }
 

--- a/pkg/dtrules/float_mixed_arith_exec_test.go
+++ b/pkg/dtrules/float_mixed_arith_exec_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtrules_test
+
+import (
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+	"github.com/DTRules/DTRules/pkg/dtrules/entity"
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// TestFloatMixedArithExecution (#884): adding/subtracting a float operand
+// compiled to the integer `+`/`-`, truncating the fraction at runtime
+// (`db2 + 1.0` with db2=3.5 gave 4, not 4.5). The mixed add/sub visitors now
+// promote through the float, emitting f+/f-. This runs each form and asserts
+// the exact double — a truncating op would fail the fractional results.
+func TestFloatMixedArithExecution(t *testing.T) {
+	rs := session.NewRuleSet("fmix")
+	sess, err := rs.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ef := sess.GetEntityFactory().(*entity.Factory)
+
+	rootName := dtrules.GetRName("root")
+	rootRef, err := ef.FindCreateRefEntity(true, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootRef.AddAttribute(dtrules.GetRName("db"), "", dtrules.GetRDoubleValue(0), true, true, dtrules.TypeDouble, "", "", "", "")
+	rootRef.AddAttribute(dtrules.GetRName("db2"), "", dtrules.GetRDoubleValue(0), true, true, dtrules.TypeDouble, "", "", "", "")
+	rootRef.AddAttribute(dtrules.GetRName("it"), "", dtrules.GetRIntegerValue(0), true, true, dtrules.TypeInteger, "", "", "", "")
+
+	root, err := ef.CreateEntity(sess, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root.Put(dtrules.GetRName("db2"), dtrules.GetRDoubleValue(3.5))
+	root.Put(dtrules.GetRName("it"), dtrules.GetRIntegerValue(2))
+
+	state := sess.GetState().(*interpreter.DTState)
+	elc := el.NewCompiler()
+	elc.SetSymbols(map[string]string{"db": "double", "db2": "double", "it": "integer"})
+
+	run := func(expr string) float64 {
+		t.Helper()
+		postfix, err := elc.CompileAction("set db = " + expr)
+		if err != nil {
+			t.Fatalf("%q compile: %v", expr, err)
+		}
+		obj, err := sess.Compile(postfix)
+		if err != nil {
+			t.Fatalf("%q assemble %q: %v", expr, postfix, err)
+		}
+		state.EntityPush(root)
+		if err := obj.Execute(state); err != nil {
+			state.EntityPop()
+			t.Fatalf("%q execute %q: %v", expr, postfix, err)
+		}
+		state.EntityPop()
+		v, _ := root.Get(dtrules.GetRName("db"))
+		f, _ := v.DoubleValue()
+		return f
+	}
+
+	for _, c := range []struct {
+		expr string
+		want float64
+	}{
+		{"db2 + 1.0", 4.5},  // double + float-literal (was 4 via integer +)
+		{"db2 - 1.0", 2.5},  // double - float-literal
+		{"1.0 + db2", 4.5},  // float-literal + double
+		{"it + 1.5", 3.5},   // integer + float-literal (int promoted)
+		{"2.5 + 1.25", 3.75}, // float + float
+	} {
+		if got := run(c.expr); got != c.want {
+			t.Errorf("%q = %v, want %v", c.expr, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #884.

## Bug
The six mixed add/sub visitors emitted a bare integer `+`/`-`, so any add/sub with a float operand truncated at runtime:

| DSL (db2: double = 3.5) | old | new |
|---|---|---|
| `db2 + 1.0` | `db2 1.0 +` → **4** | `db2 1.0 f+` → 4.5 |
| `db2 - 1.0` | `db2 1.0 -` → 2 | `db2 1.0 f-` → 2.5 |

Affected: `intAddFloat`, `floatAddFloat`, `floatAddInt` and the three MINUS variants. (Multiply/divide were already correct via `fmul`/`fdiv`.)

## Fix
Route all six through a shared `emitMixedFloatArith` that promotes via `e.promote` — the float operand forces a double result (`f+`/`f-`, integer operands promoted by the op), and a fixed/bigint operand mixed with the float is rejected per #876 (when its exact type is resolved).

## Test
`TestFloatMixedArithExecution` runs `db2+1.0`, `db2-1.0`, `1.0+db2`, `it+1.5`, `2.5+1.25` and asserts exact doubles; reproduces the truncation (4 vs 4.5) on the old code.

## Residual (noted, not chased)
`fixed + float-literal` now computes through double (`f+` then `cvfp`) instead of rejecting — `getExprType` doesn't resolve the fixed operand in this nested context. This is an improvement over the prior truncation; the reject-purity belongs with the #882 mixed-path work.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)