### PR TITLE
fix(el): reject double→exact in mutation & multiply/divide-by paths (#882)

### DIFF
--- a/pkg/dtrules/compiler/el/mutation_double_reject_test.go
+++ b/pkg/dtrules/compiler/el/mutation_double_reject_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+func mutSyms() map[string]string {
+	return map[string]string{
+		"fx": TypeFixed, "fx2": TypeFixed,
+		"bi": TypeBigInt,
+		"db": TypeDouble, "db2": TypeDouble,
+		"it": TypeInteger,
+	}
+}
+
+// TestMutationAndMulDivDoubleRejected (#882): mixing a double value into a
+// fixed/bigint field via a field mutation (`add/subtract … to/from`) or a
+// `multiply/divide … by` must be rejected — the same #876 policy the binary
+// operators enforce, extended to these paths via the getExprType fallback that
+// resolves the operand's declared type.
+func TestMutationAndMulDivDoubleRejected(t *testing.T) {
+	bad := []string{
+		"add db to fx",
+		"subtract db from fx",
+		"add db to bi",
+		"subtract db from bi",
+		"set fx = multiply fx by db",
+		"set fx = divide fx by db",
+		"set bi = multiply bi by db",
+	}
+	for _, src := range bad {
+		c := NewCompiler()
+		c.SetSymbols(mutSyms())
+		pf, err := c.CompileAction(src)
+		if err == nil {
+			t.Errorf("%q: expected compile error, got postfix %q", src, pf)
+			continue
+		}
+		if !strings.Contains(err.Error(), "cannot combine double with") {
+			t.Errorf("%q: error should explain the double/exact mix, got: %v", src, err)
+		}
+	}
+}
+
+// TestMutationAndMulDivAllowed guards against over-rejection: integer/fixed
+// values, double-into-double, increment, and multiply by int/double still
+// compile. Also covers multi-statement actions (the reject is stateless — a
+// per-parent check, not carried emitter state — so a rejected pattern can't
+// contaminate a later statement).
+func TestMutationAndMulDivAllowed(t *testing.T) {
+	ok := []string{
+		"add it to fx",                 // integer into fixed (cvfp)
+		"add fx2 to fx",                // fixed into fixed
+		"add 5 to fx",                  // integer literal
+		"add db to db2",                // double into double
+		"subtract it from fx",          // integer from fixed
+		"increment fx",                 // +1
+		"set fx = multiply fx by 2",    // fixed by integer
+		"set db = multiply db by 2.0",  // double by float
+		"set db = multiply db by it",   // double by integer
+		"add it to fx; add 1 to fx2",   // multi-statement, both fine
+	}
+	for _, src := range ok {
+		c := NewCompiler()
+		c.SetSymbols(mutSyms())
+		if _, err := c.CompileAction(src); err != nil {
+			t.Errorf("%q: expected clean compile, got error: %v", src, err)
+		}
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -276,6 +276,22 @@ func (e *PostfixEmitter) getExprType(ctx antlr.ParseTree) string {
 		return e.getExprType(c.Iexpr())
 	}
 
+	// Fallback: a bare-identifier expression in any wrapper context (Number,
+	// ArrayExpr, FloatTyped, …) whose specific case isn't enumerated above.
+	// A compound expression's text always contains operators/parens, so an
+	// identifier-only text is necessarily a simple name reference — resolve
+	// its declared type instead of defaulting to integer, which let double/
+	// fixed operands slip past the #876 reject on the mul-by and mutation
+	// paths (#882).
+	if name := ctx.GetText(); isIdentifier(name) {
+		if lv, ok := e.lookupLocal(name); ok {
+			return lv.Type
+		}
+		if t := e.lookupType(name); t != "" {
+			return t
+		}
+	}
+
 	return TypeInteger
 }
 
@@ -1889,6 +1905,13 @@ func emitMulDivBy(e *PostfixEmitter, lhs, rhs antlr.ParseTree, intOp, bigOp, dbl
 	target := e.lookupType(name)
 	if target == "" {
 		target = TypeInteger
+	}
+	// Reject `multiply/divide <fixed|bigint> by <double>` rather than feed the
+	// exact-type op an un-cast double (a runtime promote error) or silently
+	// snap it — same policy as the binary-op reject (#876/#882).
+	if rt := e.getExprType(rhs); isDoubleExactMix(rt, target) {
+		e.emitDoubleMixError(exactOf(rt, target))
+		return
 	}
 	e.Visit(lhs)
 	e.emitWithTypeConversion(rhs, target)
@@ -4694,6 +4717,9 @@ func (e *PostfixEmitter) VisitSubDestDouble(ctx *SubDestDoubleContext) interface
 // VisitSubtractNum: `subtract <number> from <subtodest>` → push the number,
 // then delegate to subtodest which computes field - value and stores.
 func (e *PostfixEmitter) VisitSubtractNum(ctx *SubtractNumContext) interface{} {
+	if e.rejectMutationDoubleMix(ctx.Number(), ctx.Subtodest()) {
+		return nil
+	}
 	e.Visit(ctx.Number())
 	e.Visit(ctx.Subtodest())
 	return nil
@@ -5777,6 +5803,10 @@ func (e *PostfixEmitter) VisitAddArrayToArray(ctx *AddArrayToArrayContext) inter
 	if colonRefCtx, ok := destExpr.(*ArrayColonRefContext); ok {
 		fieldName := colonRefCtx.TypedArray().GetText()
 		if isNumericType(e.lookupType(fieldName)) {
+			if vt := e.getExprType(ctx.ArrayExpr(0)); isDoubleExactMix(vt, e.lookupType(fieldName)) {
+				e.emitDoubleMixError(exactOf(vt, e.lookupType(fieldName)))
+				return nil
+			}
 			e.Visit(ctx.ArrayExpr(0))
 			if possChain, ok := colonRefCtx.ColonRef().PossessiveRef().(*PossessiveChainContext); ok {
 				tokens := possChain.AllPOSSESSIVE()
@@ -5802,6 +5832,10 @@ func (e *PostfixEmitter) VisitAddArrayToArray(ctx *AddArrayToArrayContext) inter
 			if typedCtx, ok := arrayExpr2.(*ArrayTypedContext); ok {
 				fieldName := typedCtx.TypedArray().GetText()
 				if isNumericType(e.mutationType(fieldName)) {
+					if vt := e.getExprType(ctx.ArrayExpr(0)); isDoubleExactMix(vt, e.mutationType(fieldName)) {
+						e.emitDoubleMixError(exactOf(vt, e.mutationType(fieldName)))
+						return nil
+					}
 					e.Visit(ctx.ArrayExpr(0))
 					e.emitTypeAwareAddSub(fieldName, "+")
 					return nil
@@ -5881,9 +5915,31 @@ func (e *PostfixEmitter) VisitAddStrToDest(ctx *AddStrToDestContext) interface{}
 func (e *PostfixEmitter) VisitAddNumToDest(ctx *AddNumToDestContext) interface{} {
 	// Pattern: value field + /field xdef
 	// e.g., "add 5 to client.income" => "5 client.income + /client.income xdef"
+	if e.rejectMutationDoubleMix(ctx.Number(), ctx.Addtodest()) {
+		return nil
+	}
 	e.Visit(ctx.Number())
 	e.Visit(ctx.Addtodest())
 	return nil
+}
+
+// rejectMutationDoubleMix records the #876 error and returns true when a
+// field mutation (`add/subtract <value> to/from <field>`) would fold a double
+// value into a fixed or bigint field — the mutation analogue of the binary-op
+// reject (#882). The dest's text is the bare field name for the common simple
+// target; a complex dest (possessive/colon) that doesn't resolve is left to
+// the existing snap rather than risk a false positive.
+func (e *PostfixEmitter) rejectMutationDoubleMix(value, dest antlr.ParseTree) bool {
+	if dest == nil || value == nil {
+		return false
+	}
+	vt := e.getExprType(value)
+	dt := e.mutationType(dest.GetText())
+	if isDoubleExactMix(vt, dt) {
+		e.emitDoubleMixError(exactOf(vt, dt))
+		return true
+	}
+	return false
 }
 
 // isNumericType reports whether a declared EDD type string is one of the


### PR DESCRIPTION
Fixes #882.

## Bug
#876 rejected an implicit double/exact mix on the binary arithmetic + comparison paths, but the **field-mutation** (`add/subtract … to/from`) and **`multiply/divide … by`** paths still silently snapped a double into a fixed/bigint target:

```
add db to fx        →  db cvfp fx fp+ …    (double snapped to fixed)
multiply fx by db   →  fx db cvfp fp* …    (snapped)
```

## Two root causes, both fixed
1. **`getExprType` typing gap.** It only resolved `IntTyped`/`IntColonRef` name contexts; a double/fixed operand wrapped as `Number`/`ArrayExpr`/`FloatTyped` (the shapes these paths use) fell through to the integer default, hiding the operand's real type from the reject. Added a **fallback**: any bare-identifier expression (a compound expr's text always contains operators) resolves its declared type via the symbol table. `make check` stayed green.
2. **Reject not wired in.** `emitMulDivBy` now rejects when the rhs is double and the target exact. The mutation parents (`VisitSubtractNum`, `VisitAddNumToDest`, `VisitAddArrayToArray`) check the value type against the dest field type via `rejectMutationDoubleMix`. The check is **stateless** (per-parent, no carried emitter state) so a rejected pattern can't contaminate a later statement.

```
add db to fx
  emission errors: cannot combine double with fixed implicitly;
  add an explicit cast (e.g. "(fixed) x" … or "(double) x" …)
```

## Tests
- `TestMutationAndMulDivDoubleRejected` — add/subtract double to/from fixed|bigint, and multiply/divide fixed|bigint by double all reject.
- `TestMutationAndMulDivAllowed` — integer/fixed values, double→double, increment, multiply by int/double, and a multi-statement action all still compile.

## Note
A complex mutation dest (possessive/colon) whose text doesn't resolve to a field is left to the existing behavior rather than risk a false positive — the simple/common targets are covered.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)