### PR TITLE
fix(el): substring length bug; add emitter execution tests (#889)

### DIFF
--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -1923,9 +1923,16 @@ func emitMulDivBy(e *PostfixEmitter, lhs, rhs antlr.ParseTree, intOp, bigOp, dbl
 // result). Without this override the entire substring call silently
 // disappeared from the postfix.
 func (e *PostfixEmitter) VisitStrSubstring(ctx *StrSubstringContext) interface{} {
+	// Grammar is `from <start> to <end>` (end exclusive, by character index),
+	// but opSubstring is ( str start length -- ). Compute length = end - start
+	// instead of passing the end index as the length — the latter was correct
+	// only when start == 0 (where end == length) and silently wrong otherwise
+	// (#889). Stack: str start end -> over (copy start back) -> `-` = end-start.
 	e.Visit(ctx.Strexpr())
-	e.Visit(ctx.Iexpr(0))
-	e.Visit(ctx.Iexpr(1))
+	e.Visit(ctx.Iexpr(0)) // start
+	e.Visit(ctx.Iexpr(1)) // end
+	e.emit("over")
+	e.emit("-")
 	e.emit("substring")
 	return nil
 }

--- a/pkg/dtrules/float_minmax_exec_test.go
+++ b/pkg/dtrules/float_minmax_exec_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtrules_test
+
+import (
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+	"github.com/DTRules/DTRules/pkg/dtrules/entity"
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// TestFloatMinMaxExecution (#889) fills the execution gap for the float
+// min/max family: `the minimum/maximum of <double> and <double>` lowers to
+// fmin/fmax. The fractional values verify a double-precision result (an
+// integer min/max would truncate).
+func TestFloatMinMaxExecution(t *testing.T) {
+	rs := session.NewRuleSet("fmm")
+	sess, err := rs.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ef := sess.GetEntityFactory().(*entity.Factory)
+
+	rootName := dtrules.GetRName("root")
+	rootRef, err := ef.FindCreateRefEntity(true, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"d1", "d2", "res"} {
+		rootRef.AddAttribute(dtrules.GetRName(f), "", dtrules.GetRDoubleValue(0), true, true, dtrules.TypeDouble, "", "", "", "")
+	}
+	root, err := ef.CreateEntity(sess, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	state := sess.GetState().(*interpreter.DTState)
+	elc := el.NewCompiler()
+	elc.SetSymbols(map[string]string{"d1": "double", "d2": "double", "res": "double"})
+
+	run := func(expr string, a, b float64) float64 {
+		t.Helper()
+		root.Put(dtrules.GetRName("d1"), dtrules.GetRDoubleValue(a))
+		root.Put(dtrules.GetRName("d2"), dtrules.GetRDoubleValue(b))
+		pf, err := elc.CompileAction("set res = " + expr)
+		if err != nil {
+			t.Fatalf("%q compile: %v", expr, err)
+		}
+		obj, err := sess.Compile(pf)
+		if err != nil {
+			t.Fatalf("%q assemble %q: %v", expr, pf, err)
+		}
+		state.EntityPush(root)
+		if err := obj.Execute(state); err != nil {
+			state.EntityPop()
+			t.Fatalf("%q execute %q: %v", expr, pf, err)
+		}
+		state.EntityPop()
+		v, _ := root.Get(dtrules.GetRName("res"))
+		f, _ := v.DoubleValue()
+		return f
+	}
+
+	for _, c := range []struct {
+		expr    string
+		a, b    float64
+		want    float64
+	}{
+		{"the minimum of d1 and d2", 1.5, 2.5, 1.5},
+		{"the minimum of d1 and d2", 2.5, 1.5, 1.5},
+		{"the maximum of d1 and d2", 1.5, 2.5, 2.5},
+		{"the maximum of d1 and d2", 2.5, 1.5, 2.5},
+		{"the minimum of d1 and d2", -0.25, 0.25, -0.25},
+	} {
+		if got := run(c.expr, c.a, c.b); got != c.want {
+			t.Errorf("%q (%v,%v) = %v, want %v", c.expr, c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/pkg/dtrules/substring_exec_test.go
+++ b/pkg/dtrules/substring_exec_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtrules_test
+
+import (
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+	"github.com/DTRules/DTRules/pkg/dtrules/entity"
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// TestSubstringExecution (#889): `substring of s from <start> to <end>` is
+// documented as "extract characters start..end-1" (end exclusive, by character
+// index). The emitter passed the END index straight to opSubstring, whose
+// third operand is a LENGTH — so the result was only correct when start==0
+// (where end == length). A token test can't catch it: the tokens are identical.
+// This runs the construct and asserts the extracted string for start>0.
+func TestSubstringExecution(t *testing.T) {
+	rs := session.NewRuleSet("sub")
+	sess, err := rs.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ef := sess.GetEntityFactory().(*entity.Factory)
+
+	rootName := dtrules.GetRName("root")
+	rootRef, err := ef.FindCreateRefEntity(true, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootRef.AddAttribute(dtrules.GetRName("src"), "", dtrules.NewRString(""), true, true, dtrules.TypeString, "", "", "", "")
+	rootRef.AddAttribute(dtrules.GetRName("dst"), "", dtrules.NewRString(""), true, true, dtrules.TypeString, "", "", "", "")
+	root, err := ef.CreateEntity(sess, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root.Put(dtrules.GetRName("src"), dtrules.NewRString("hello"))
+
+	state := sess.GetState().(*interpreter.DTState)
+	elc := el.NewCompiler()
+	elc.SetSymbols(map[string]string{"src": "string", "dst": "string"})
+
+	run := func(expr string) string {
+		t.Helper()
+		pf, err := elc.CompileAction("set dst = " + expr)
+		if err != nil {
+			t.Fatalf("%q compile: %v", expr, err)
+		}
+		obj, err := sess.Compile(pf)
+		if err != nil {
+			t.Fatalf("%q assemble %q: %v", expr, pf, err)
+		}
+		state.EntityPush(root)
+		if err := obj.Execute(state); err != nil {
+			state.EntityPop()
+			t.Fatalf("%q execute %q: %v", expr, pf, err)
+		}
+		state.EntityPop()
+		v, _ := root.Get(dtrules.GetRName("dst"))
+		return v.StringValue()
+	}
+
+	for _, c := range []struct {
+		expr, want string
+	}{
+		{"substring of src from 0 to 5", "hello"}, // full (masks the bug)
+		{"substring of src from 0 to 2", "he"},
+		{"substring of src from 2 to 4", "ll"},  // was "llo" (end used as length)
+		{"substring of src from 1 to 3", "el"},  // was "ell"
+		{"substring of src from 3 to 5", "lo"},
+	} {
+		if got := run(c.expr); got != c.want {
+			t.Errorf("%q = %q, want %q", c.expr, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Addresses #889 (execution-test hardening) — and the first test written found a real bug.

## Bug: substring uses end index as length
`substring of s from <start> to <end>` lowers to `opSubstring`, which is `( str start length -- )`. The emitter passed the **end** index straight through as the length:

| EL | old result | correct |
|---|---|---|
| `substring of "hello" from 0 to 5` | "hello" | "hello" (start 0 masks it) |
| `substring of "hello" from 2 to 4` | **"llo"** | "ll" |
| `substring of "hello" from 1 to 3` | **"ell"** | "el" |

Correct only when `start == 0` (where `end == length`). Docs define `from a to b` as characters a..b-1. Token-presence tests can't catch it — the tokens are identical.

**Fix:** emit `start end over -` so opSubstring receives `length = end - start`.

## Tests
- `TestSubstringExecution` — compiles and **runs** substring, asserting the extracted string for `start > 0` (reproduces the bug on old code).
- `TestFloatMinMaxExecution` — fills the untested float min/max family (`the minimum/maximum of <double> and <double>` → fmin/fmax); fractional values confirm a double result.

This is the pattern #889 is about: execution tests catch operand/semantic bugs that the ~57-vs-613 token-heavy emitter suite misses. More families (date extraction, mixed comparisons) remain for follow-up under #889.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)