### PR TITLE
fix(el): double literal bypassed exact reject; double-field negate truncated (#894)

### DIFF
--- a/pkg/dtrules/compiler/el/double_literal_reject_test.go
+++ b/pkg/dtrules/compiler/el/double_literal_reject_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+func dlSyms() map[string]string {
+	return map[string]string{"fx": TypeFixed, "bi": TypeBigInt, "db": TypeDouble, "iv": TypeInteger}
+}
+
+// TestDoubleLiteralMixRejected (#894): a fixed/bigint field mixed with a double
+// LITERAL bypassed the #876 reject because the field matched the TypedDouble
+// grammar branch, so VisitFloatAddFloat hardcoded both operands to double. It
+// now resolves each operand's declared type, so the exact/double mix is caught.
+func TestDoubleLiteralMixRejected(t *testing.T) {
+	bad := []string{
+		"set fx = fx + 1.5",
+		"set fx = fx - 1.5",
+		"set fx = 1.5 + fx", // order independent
+		"set bi = bi + 1.5",
+		"set bi = bi - 1.5",
+	}
+	for _, src := range bad {
+		c := NewCompiler()
+		c.SetSymbols(dlSyms())
+		pf, err := c.CompileAction(src)
+		if err == nil {
+			t.Errorf("%q: expected reject, got postfix %q", src, pf)
+			continue
+		}
+		if !strings.Contains(err.Error(), "cannot combine double with") {
+			t.Errorf("%q: error should explain the mix, got: %v", src, err)
+		}
+	}
+
+	// Must NOT over-reject: double+literal, fixed+integer, double+integer.
+	for _, src := range []string{
+		"set db = db + 1.5",
+		"set db = 1.5 + 2.5",
+		"set fx = fx + iv",
+		"set db = db + iv",
+	} {
+		c := NewCompiler()
+		c.SetSymbols(dlSyms())
+		if _, err := c.CompileAction(src); err != nil {
+			t.Errorf("%q: expected clean compile, got: %v", src, err)
+		}
+	}
+}
+
+// TestDoubleNegateOp (#894): `- <double field>` routed through VisitIntNegate's
+// default and emitted integer `negate` (truncates); it now emits `fnegate`.
+func TestDoubleNegateOp(t *testing.T) {
+	cases := map[string]string{
+		"set db = - db": "fnegate",  // double
+		"set fx = - fx": "fpnegate", // fixed
+		"set bi = - bi": "bnegate",  // bigint
+		"set iv = - iv": "negate",   // integer
+	}
+	for src, want := range cases {
+		c := NewCompiler()
+		c.SetSymbols(dlSyms())
+		pf, err := c.CompileAction(src)
+		if err != nil {
+			t.Fatalf("%q compile: %v", src, err)
+		}
+		if !strings.Contains(pf, " "+want+" ") && !strings.Contains(pf, want+" ") {
+			t.Errorf("%q: expected %q in postfix, got %q", src, want, pf)
+		}
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -259,6 +259,42 @@ func (e *PostfixEmitter) getExprType(ctx antlr.ParseTree) string {
 		}
 	}
 
+	// Float-typed NAME contexts: a fixed/bigint/double field that matched the
+	// grammar's TypedDouble alternative. Resolve to the DECLARED type so a
+	// fixed/bigint field used in a float position is still seen as exact and
+	// caught by the double/exact reject — not silently treated as double (#894).
+	if typedCtx, ok := ctx.(*FloatTypedContext); ok {
+		if td := typedCtx.TypedDouble(); td != nil {
+			if ident := td.IDENT(); ident != nil {
+				name := ident.GetText()
+				if lv, ok := e.lookupLocal(name); ok {
+					return lv.Type
+				}
+				if t := e.lookupType(name); t != "" {
+					return t
+				}
+			}
+		}
+	}
+	if colonCtx, ok := ctx.(*FloatColonRefContext); ok {
+		if td := colonCtx.TypedDouble(); td != nil {
+			if ident := td.IDENT(); ident != nil {
+				name := ident.GetText()
+				if lv, ok := e.lookupLocal(name); ok {
+					return lv.Type
+				}
+				if cr := colonCtx.ColonRef(); cr != nil {
+					if t := e.lookupType(cr.GetText() + "." + name); t != "" {
+						return t
+					}
+				}
+				if t := e.lookupType(name); t != "" {
+					return t
+				}
+			}
+		}
+	}
+
 	// For compound expressions, propagate the widest operand type via
 	// promoteArithType (Fixed > BigInt > Double > Integer).
 	switch c := ctx.(type) {
@@ -274,6 +310,22 @@ func (e *PostfixEmitter) getExprType(ctx antlr.ParseTree) string {
 		return e.getExprType(c.Iexpr())
 	case *IntParenContext:
 		return e.getExprType(c.Iexpr())
+	}
+
+	// Float-VALUED expressions (literals, explicit (double) casts, float
+	// arithmetic) produce a double. Typed-name fexprs were resolved above;
+	// what reaches here is genuinely double — so a double literal mixed with a
+	// fixed/bigint field is caught by the double/exact reject (#894).
+	switch c := ctx.(type) {
+	case *FloatLiteralContext, *FloatFromStrContext, *FloatFromIntContext,
+		*FloatFromIndexContext, *FloatAddFloatContext, *FloatSubFloatContext,
+		*FloatMulFloatContext, *FloatDivFloatContext, *FloatAddIntContext,
+		*FloatSubIntContext, *FloatMulIntContext, *FloatDivIntContext,
+		*FloatNegateContext, *IntAddFloatContext, *IntSubFloatContext,
+		*IntMulFloatContext, *IntDivFloatContext:
+		return TypeDouble
+	case *FloatParenContext:
+		return e.getExprType(c.Fexpr())
 	}
 
 	// Fallback: a bare-identifier expression in any wrapper context (Number,
@@ -1471,6 +1523,8 @@ func (e *PostfixEmitter) VisitIntNegate(ctx *IntNegateContext) interface{} {
 		e.emit("fpnegate")
 	case TypeBigInt:
 		e.emit("bnegate")
+	case TypeDouble:
+		e.emit("fnegate") // negate would truncate the double via IntValue (#894)
 	default:
 		e.emit("negate")
 	}
@@ -1705,12 +1759,12 @@ func (e *PostfixEmitter) emitMixedFloatArith(left, right antlr.ParseTree, leftTy
 }
 
 func (e *PostfixEmitter) VisitFloatAddFloat(ctx *FloatAddFloatContext) interface{} {
-	e.emitMixedFloatArith(ctx.Fexpr(0), ctx.Fexpr(1), TypeDouble, TypeDouble, "+", "b+", "f+", "fp+")
+	e.emitMixedFloatArith(ctx.Fexpr(0), ctx.Fexpr(1), e.getExprType(ctx.Fexpr(0)), e.getExprType(ctx.Fexpr(1)), "+", "b+", "f+", "fp+")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitFloatSubFloat(ctx *FloatSubFloatContext) interface{} {
-	e.emitMixedFloatArith(ctx.Fexpr(0), ctx.Fexpr(1), TypeDouble, TypeDouble, "-", "b-", "f-", "fp-")
+	e.emitMixedFloatArith(ctx.Fexpr(0), ctx.Fexpr(1), e.getExprType(ctx.Fexpr(0)), e.getExprType(ctx.Fexpr(1)), "-", "b-", "f-", "fp-")
 	return nil
 }
 
@@ -1729,12 +1783,12 @@ func (e *PostfixEmitter) VisitFloatDivFloat(ctx *FloatDivFloatContext) interface
 }
 
 func (e *PostfixEmitter) VisitFloatAddInt(ctx *FloatAddIntContext) interface{} {
-	e.emitMixedFloatArith(ctx.Fexpr(), ctx.Iexpr(), TypeDouble, e.getExprType(ctx.Iexpr()), "+", "b+", "f+", "fp+")
+	e.emitMixedFloatArith(ctx.Fexpr(), ctx.Iexpr(), e.getExprType(ctx.Fexpr()), e.getExprType(ctx.Iexpr()), "+", "b+", "f+", "fp+")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitFloatSubInt(ctx *FloatSubIntContext) interface{} {
-	e.emitMixedFloatArith(ctx.Fexpr(), ctx.Iexpr(), TypeDouble, e.getExprType(ctx.Iexpr()), "-", "b-", "f-", "fp-")
+	e.emitMixedFloatArith(ctx.Fexpr(), ctx.Iexpr(), e.getExprType(ctx.Fexpr()), e.getExprType(ctx.Iexpr()), "-", "b-", "f-", "fp-")
 	return nil
 }
 
@@ -2075,12 +2129,12 @@ func (e *PostfixEmitter) VisitDateEndOfMonth(ctx *DateEndOfMonthContext) interfa
 }
 
 func (e *PostfixEmitter) VisitIntAddFloat(ctx *IntAddFloatContext) interface{} {
-	e.emitMixedFloatArith(ctx.Iexpr(), ctx.Fexpr(), e.getExprType(ctx.Iexpr()), TypeDouble, "+", "b+", "f+", "fp+")
+	e.emitMixedFloatArith(ctx.Iexpr(), ctx.Fexpr(), e.getExprType(ctx.Iexpr()), e.getExprType(ctx.Fexpr()), "+", "b+", "f+", "fp+")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitIntSubFloat(ctx *IntSubFloatContext) interface{} {
-	e.emitMixedFloatArith(ctx.Iexpr(), ctx.Fexpr(), e.getExprType(ctx.Iexpr()), TypeDouble, "-", "b-", "f-", "fp-")
+	e.emitMixedFloatArith(ctx.Iexpr(), ctx.Fexpr(), e.getExprType(ctx.Iexpr()), e.getExprType(ctx.Fexpr()), "-", "b-", "f-", "fp-")
 	return nil
 }
 

--- a/pkg/dtrules/double_field_negate_exec_test.go
+++ b/pkg/dtrules/double_field_negate_exec_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtrules_test
+
+import (
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+	"github.com/DTRules/DTRules/pkg/dtrules/entity"
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// TestDoubleFieldNegateExecution (#894): negating a bare double field used to
+// emit integer `negate`, truncating the fraction. It now emits `fnegate`.
+// -3.5 must stay -3.5 (a truncating negate gives -3).
+func TestDoubleFieldNegateExecution(t *testing.T) {
+	rs := session.NewRuleSet("dfn")
+	sess, err := rs.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ef := sess.GetEntityFactory().(*entity.Factory)
+
+	rootName := dtrules.GetRName("root")
+	rootRef, err := ef.FindCreateRefEntity(true, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootRef.AddAttribute(dtrules.GetRName("db"), "", dtrules.GetRDoubleValue(0), true, true, dtrules.TypeDouble, "", "", "", "")
+	rootRef.AddAttribute(dtrules.GetRName("out"), "", dtrules.GetRDoubleValue(0), true, true, dtrules.TypeDouble, "", "", "", "")
+	root, err := ef.CreateEntity(sess, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root.Put(dtrules.GetRName("db"), dtrules.GetRDoubleValue(3.5))
+
+	state := sess.GetState().(*interpreter.DTState)
+	elc := el.NewCompiler()
+	elc.SetSymbols(map[string]string{"db": "double", "out": "double"})
+	pf, err := elc.CompileAction("set out = - db")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	obj, err := sess.Compile(pf)
+	if err != nil {
+		t.Fatalf("assemble %q: %v", pf, err)
+	}
+	state.EntityPush(root)
+	if err := obj.Execute(state); err != nil {
+		state.EntityPop()
+		t.Fatalf("execute %q: %v", pf, err)
+	}
+	state.EntityPop()
+	v, _ := root.Get(dtrules.GetRName("out"))
+	got, _ := v.DoubleValue()
+	if got != -3.5 {
+		t.Errorf("- db (db=3.5) = %v, want -3.5 (a truncating negate gives -3)", got)
+	}
+}


### PR DESCRIPTION
Fixes #894. Found in the post-merge **review** of the #876/#884 codegen cluster (adversarial agent + direct verification).

## Bug A — fixed/bigint + double **literal** bypassed the #876 reject
A typed `fixed`/`bigint` field matches the grammar's `TypedDouble` alternative, so `fx + 1.5` parses as `floatAddFloat`. `VisitFloatAddFloat`/`SubFloat` hardcoded both operands to `TypeDouble`, erasing the declared exact type before `e.promote` could see the mix.

| Input | before | after |
|---|---|---|
| `fx + 1.5` | `fx 1.5 f+ cvfp …` (silent snap) | **reject** |
| `bi + 1.5` | `bi 1.5 f+ cvbi …` (bigint→float→bigint) | **reject** |
| `1.5 + fx` | snap | **reject** |
| `db + 1.5`, `fx + iv`, `db + iv` | ok | ok (not over-rejected) |

## Bug B — negating a bare double field truncated
`VisitIntNegate` had `fixed→fpnegate`, `bigint→bnegate`, but no double case → `default → negate` (truncates via IntValue). `- db` now emits `fnegate`.

## Fix
- `getExprType` types float-valued exprs (literals, `(double)` casts, float arithmetic) as `double`, and resolves float-typed name contexts (bare + qualified) to their declared type.
- The float add/sub emitters resolve each operand via `getExprType` instead of hardcoding `TypeDouble`.
- `VisitIntNegate`: `TypeDouble → fnegate`.

## Tests
- `TestDoubleLiteralMixRejected` — fixed/bigint + double literal reject; double+literal / fixed+int / double+int still compile (no over-reject).
- `TestDoubleNegateOp` — per-type negate op selection.
- `TestDoubleFieldNegateExecution` — `- db` (db=3.5) → -3.5, not the truncated -3.

`make check` green; the broad `getExprType` change caused no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)