### PR TITLE
fix(el): bigint min/max via bmin/bmax, no truncation (#899)

### DIFF
--- a/pkg/dtrules/bigint_minmax_exec_test.go
+++ b/pkg/dtrules/bigint_minmax_exec_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtrules_test
+
+import (
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+	"github.com/DTRules/DTRules/pkg/dtrules/entity"
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// TestBigIntMinMaxExecution (#899): `the minimum/maximum of <bigint> and
+// <bigint>` used to emit the integer min/max, truncating operands beyond int64
+// via IntValue. It now emits bmin/bmax. This runs it over values far past
+// int64 and asserts the exact big value survives.
+func TestBigIntMinMaxExecution(t *testing.T) {
+	rs := session.NewRuleSet("bmm")
+	sess, err := rs.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ef := sess.GetEntityFactory().(*entity.Factory)
+
+	rootName := dtrules.GetRName("root")
+	rootRef, err := ef.FindCreateRefEntity(true, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zero, _ := dtrules.GetRBigIntFromString("0")
+	for _, f := range []string{"big1", "big2", "res"} {
+		rootRef.AddAttribute(dtrules.GetRName(f), "", zero, true, true, dtrules.TypeBigInt, "", "", "", "")
+	}
+	root, err := ef.CreateEntity(sess, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	smallStr := "100000000000000000000000000000"  // 1e29, far beyond int64
+	largeStr := "999999999999999999999999999999" // ~1e30
+	small, _ := dtrules.GetRBigIntFromString(smallStr)
+	large, _ := dtrules.GetRBigIntFromString(largeStr)
+	root.Put(dtrules.GetRName("big1"), large)
+	root.Put(dtrules.GetRName("big2"), small)
+
+	state := sess.GetState().(*interpreter.DTState)
+	elc := el.NewCompiler()
+	elc.SetSymbols(map[string]string{"big1": "bigint", "big2": "bigint", "res": "bigint"})
+
+	run := func(expr string) string {
+		t.Helper()
+		pf, err := elc.CompileAction("set res = " + expr)
+		if err != nil {
+			t.Fatalf("%q compile: %v", expr, err)
+		}
+		obj, err := sess.Compile(pf)
+		if err != nil {
+			t.Fatalf("%q assemble %q: %v", expr, pf, err)
+		}
+		state.EntityPush(root)
+		if err := obj.Execute(state); err != nil {
+			state.EntityPop()
+			t.Fatalf("%q execute %q: %v", expr, pf, err)
+		}
+		state.EntityPop()
+		v, _ := root.Get(dtrules.GetRName("res"))
+		bi, err := v.RBigIntValue()
+		if err != nil {
+			t.Fatalf("res not bigint: %v", err)
+		}
+		return bi.BigIntValue().String()
+	}
+
+	if got := run("the minimum of big1 and big2"); got != smallStr {
+		t.Errorf("minimum = %s, want %s (truncation would give a different value)", got, smallStr)
+	}
+	if got := run("the maximum of big1 and big2"); got != largeStr {
+		t.Errorf("maximum = %s, want %s", got, largeStr)
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -1677,16 +1677,15 @@ func (e *PostfixEmitter) VisitIntBytesIndex(ctx *IntBytesIndexContext) interface
 // don't hit IntValue at runtime — closes the same dispatch gap
 // promoteArithType's Double arm opened up.
 //
-// No dedicated `bmin` / `bmax` ops exist, so bigint targets fall back
-// to the integer `min` / `max` — which calls IntValue() on both
-// operands and errors for any bigint exceeding int64 range. That's
-// a pre-existing bug independent of this PR; fixing it cleanly
-// requires registering `bmin` / `bmax` operators that dispatch via
-// RBigInt.Compare. Tracked as a follow-up.
-func minMaxOp(target, intOp, dblOp, fpOp string) string {
+// The bigint path uses the dedicated bmin/bmax ops (compare via big.Int) so a
+// bigint exceeding int64 range is not truncated by the integer min/max's
+// IntValue() (#899).
+func minMaxOp(target, intOp, bigOp, dblOp, fpOp string) string {
 	switch target {
 	case TypeFixed:
 		return fpOp
+	case TypeBigInt:
+		return bigOp
 	case TypeDouble:
 		return dblOp
 	default:
@@ -1699,7 +1698,7 @@ func (e *PostfixEmitter) VisitIntMinOf(ctx *IntMinOfContext) interface{} {
 	target := e.promote(e.getExprType(l), e.getExprType(r))
 	e.emitWithTypeConversion(l, target)
 	e.emitWithTypeConversion(r, target)
-	e.emit(minMaxOp(target, "min", "fmin", "fpmin"))
+	e.emit(minMaxOp(target, "min", "bmin", "fmin", "fpmin"))
 	return nil
 }
 
@@ -1708,7 +1707,7 @@ func (e *PostfixEmitter) VisitIntMinOfComma(ctx *IntMinOfCommaContext) interface
 	target := e.promote(e.getExprType(l), e.getExprType(r))
 	e.emitWithTypeConversion(l, target)
 	e.emitWithTypeConversion(r, target)
-	e.emit(minMaxOp(target, "min", "fmin", "fpmin"))
+	e.emit(minMaxOp(target, "min", "bmin", "fmin", "fpmin"))
 	return nil
 }
 
@@ -1717,7 +1716,7 @@ func (e *PostfixEmitter) VisitIntMaxOf(ctx *IntMaxOfContext) interface{} {
 	target := e.promote(e.getExprType(l), e.getExprType(r))
 	e.emitWithTypeConversion(l, target)
 	e.emitWithTypeConversion(r, target)
-	e.emit(minMaxOp(target, "max", "fmax", "fpmax"))
+	e.emit(minMaxOp(target, "max", "bmax", "fmax", "fpmax"))
 	return nil
 }
 
@@ -1726,7 +1725,7 @@ func (e *PostfixEmitter) VisitIntMaxOfComma(ctx *IntMaxOfCommaContext) interface
 	target := e.promote(e.getExprType(l), e.getExprType(r))
 	e.emitWithTypeConversion(l, target)
 	e.emitWithTypeConversion(r, target)
-	e.emit(minMaxOp(target, "max", "fmax", "fpmax"))
+	e.emit(minMaxOp(target, "max", "bmax", "fmax", "fpmax"))
 	return nil
 }
 

--- a/pkg/dtrules/operators/bigint.go
+++ b/pkg/dtrules/operators/bigint.go
@@ -41,6 +41,9 @@ func init() {
 
 	Register("bnegate", opBigNegate)
 
+	Register("bmin", opBigMin)
+	Register("bmax", opBigMax)
+
 	// BigInt comparison operations
 	Register("b==", opBigEqual)
 
@@ -247,6 +250,55 @@ func opBigNotEqual(state dtrules.State) error {
 	}
 	result := aVal.BigIntValue().Cmp(bVal.BigIntValue()) != 0
 	return state.DataPush(dtrules.GetRBoolean(result))
+}
+
+// opBigMin: ( a b -- min ) returns the smaller of two bigints, compared with
+// big.Int (no int64 truncation, unlike the integer `min`). (#899)
+func opBigMin(state dtrules.State) error {
+	b, err := state.DataPop()
+	if err != nil {
+		return err
+	}
+	a, err := state.DataPop()
+	if err != nil {
+		return err
+	}
+	aVal, err := a.RBigIntValue()
+	if err != nil {
+		return err
+	}
+	bVal, err := b.RBigIntValue()
+	if err != nil {
+		return err
+	}
+	if aVal.BigIntValue().Cmp(bVal.BigIntValue()) <= 0 {
+		return state.DataPush(aVal)
+	}
+	return state.DataPush(bVal)
+}
+
+// opBigMax: ( a b -- max ) returns the larger of two bigints via big.Int. (#899)
+func opBigMax(state dtrules.State) error {
+	b, err := state.DataPop()
+	if err != nil {
+		return err
+	}
+	a, err := state.DataPop()
+	if err != nil {
+		return err
+	}
+	aVal, err := a.RBigIntValue()
+	if err != nil {
+		return err
+	}
+	bVal, err := b.RBigIntValue()
+	if err != nil {
+		return err
+	}
+	if aVal.BigIntValue().Cmp(bVal.BigIntValue()) >= 0 {
+		return state.DataPush(aVal)
+	}
+	return state.DataPush(bVal)
 }
 
 // opBigGreater compares if a > b: ( a b -- bool )

--- a/pkg/dtrules/operators/bigint_test.go
+++ b/pkg/dtrules/operators/bigint_test.go
@@ -953,3 +953,44 @@ func TestBigIntUnaryOperatorEmptyStack(t *testing.T) {
 		t.Error("Expected error for empty stack")
 	}
 }
+
+// TestBigIntMinMax (#899): bmin/bmax compare via big.Int, so a bigint beyond
+// int64 range is returned intact — the integer min/max would truncate it via
+// IntValue.
+func TestBigIntMinMax(t *testing.T) {
+	// Two values far beyond int64 (max int64 ~ 9.2e18).
+	small, _ := dtrules.GetRBigIntFromString("100000000000000000000000000000")
+	large, _ := dtrules.GetRBigIntFromString("999999999999999999999999999999")
+
+	run := func(op string, a, b dtrules.Object) string {
+		state := newBigIntTestState()
+		state.DataPush(a)
+		state.DataPush(b)
+		o, ok := Get(dtrules.GetRName(op))
+		if !ok {
+			t.Fatalf("%s not registered", op)
+		}
+		if err := o.Execute(state); err != nil {
+			t.Fatalf("%s: %v", op, err)
+		}
+		top, _ := state.DataPop()
+		bi, err := top.RBigIntValue()
+		if err != nil {
+			t.Fatalf("%s result not bigint: %v", op, err)
+		}
+		return bi.BigIntValue().String()
+	}
+
+	if got := run("bmin", small, large); got != small.BigIntValue().String() {
+		t.Errorf("bmin(small,large) = %s, want %s", got, small.BigIntValue().String())
+	}
+	if got := run("bmin", large, small); got != small.BigIntValue().String() {
+		t.Errorf("bmin(large,small) = %s, want %s", got, small.BigIntValue().String())
+	}
+	if got := run("bmax", small, large); got != large.BigIntValue().String() {
+		t.Errorf("bmax(small,large) = %s, want %s", got, large.BigIntValue().String())
+	}
+	if got := run("bmax", large, small); got != large.BigIntValue().String() {
+		t.Errorf("bmax(large,small) = %s, want %s", got, large.BigIntValue().String())
+	}
+}

--- a/pkg/dtrules/operators/registration_test.go
+++ b/pkg/dtrules/operators/registration_test.go
@@ -79,6 +79,8 @@ func TestAllOperatorsRegistered(t *testing.T) {
 	"bech32",
 	"beq",
 	"bigintbytes",
+	"bmax",
+	"bmin",
 	"bmod",
 	"bnegate",
 	"bytes!=",


### PR DESCRIPTION
Fixes #899. `minMaxOp` had no bigint case, so `the minimum/maximum of <bigint> and <bigint>` fell back to integer min/max — truncating/erroring for bigints beyond int64. New `bmin`/`bmax` ops compare via big.Int; `minMaxOp` gains a bigint case. Tests: op-level and execution over ~1e30 (the exact value survives). A real fix, not just coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)