### PR TITLE
fix(el): fp dispatch for fexpr mul/div; divide-rounding operands coerced to fixed (#903)

### DIFF
--- a/pkg/dtrules/compiler/el/issue_903_test.go
+++ b/pkg/dtrules/compiler/el/issue_903_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #903: the fexpr mul/div visitors emitted fmul/fdiv unconditionally,
+// so the top-level multiply of a `divide … rounding by` dividend degraded to
+// double math even for fixed×fixed operands — while the identical expression
+// in a plain `set` dispatched to fp* correctly. Same class as #874/#884:
+// fp dispatch missed in one emitter context.
+
+func issue903Symbols() map[string]string {
+	return map[string]string{
+		"weekly_budget":           "fixed",
+		"rate_fixed":              "fixed",
+		"withholding_denom":       "fixed",
+		"withholding_rate_num":    "integer",
+		"staker_budget":           "fixed",
+		"unissued_supply":         "fixed",
+		"token_issuance_rate_num": "integer",
+		"budget_denom":            "fixed",
+		"dbl":                     "double",
+	}
+}
+
+// TestIssue903_DividendMultiplyDispatchesFp covers the four repro shapes from
+// the issue: plain product dividend, cast operand, parenthesized dividend, and
+// the three-factor dividend whose OUTER multiply used to emit fmul while the
+// inner one got fp*.
+func TestIssue903_DividendMultiplyDispatchesFp(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue903Symbols())
+
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"plain-product", "set staker_budget = divide weekly_budget * rate_fixed by withholding_denom rounding by 0.5fp"},
+		{"cast-operand", "set staker_budget = divide weekly_budget * (fixed) withholding_rate_num by withholding_denom rounding by 0.5fp"},
+		{"parenthesized", "set staker_budget = divide (weekly_budget * rate_fixed) by withholding_denom rounding by 0.5fp"},
+		{"three-factor", "set staker_budget = divide unissued_supply * 7fp * (fixed) token_issuance_rate_num by budget_denom rounding by 0.5fp"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pf, err := c.CompileAction(tc.src)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			if strings.Contains(pf, "fmul") {
+				t.Errorf("dividend multiply degraded to fmul (double): %s", pf)
+			}
+			if !strings.Contains(pf, "fp*") {
+				t.Errorf("expected fp* dispatch for fixed operands, got: %s", pf)
+			}
+			if !strings.Contains(pf, "fphalfup/") {
+				t.Errorf("expected fphalfup/ fold, got: %s", pf)
+			}
+		})
+	}
+}
+
+// TestIssue903_ThreeFactorAllMultipliesFp: the three-factor dividend must fp*
+// BOTH multiplies (the outer one used to be the stray fmul).
+func TestIssue903_ThreeFactorAllMultipliesFp(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue903Symbols())
+
+	pf, err := c.CompileAction(
+		"set staker_budget = divide unissued_supply * 7fp * (fixed) token_issuance_rate_num by budget_denom rounding by 0.5fp")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if got := strings.Count(pf, "fp*"); got != 2 {
+		t.Errorf("expected 2 fp* multiplies, got %d in: %s", got, pf)
+	}
+}
+
+// TestIssue903_PlainFexprArithAlsoFixed: the fix is in the shared fexpr
+// mul/div visitors, so fixed×fixed dispatches to fp-family ops in any fexpr
+// context, not just inside divide-rounding-by. A genuinely double operand
+// still dispatches to the double ops.
+func TestIssue903_PlainFexprArithAlsoFixed(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue903Symbols())
+
+	// fixed * fp-literal parses through an fexpr multiply alternative.
+	pf, err := c.CompileAction("set staker_budget = weekly_budget * 7fp")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if strings.Contains(pf, "fmul") || !strings.Contains(pf, "fp*") {
+		t.Errorf("fixed * fp-literal should dispatch fp*, got: %s", pf)
+	}
+
+	// double * double stays on the double op.
+	pf, err = c.CompileAction("set dbl = dbl * 2.0")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if !strings.Contains(pf, "fmul") {
+		t.Errorf("double * double should still dispatch fmul, got: %s", pf)
+	}
+}
+
+// TestIssue903_IntegerOperandsPromoteToFixed: divide-rounding-by promotes
+// integer/bigint operands to fixed via cvfp — the fp-family divide ops
+// require fixed operands.
+func TestIssue903_IntegerOperandsPromoteToFixed(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue903Symbols())
+
+	pf, err := c.CompileAction(
+		"set staker_budget = divide withholding_rate_num by withholding_denom rounding by 0.5fp")
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if !strings.Contains(pf, "cvfp") {
+		t.Errorf("integer dividend should promote via cvfp, got: %s", pf)
+	}
+	if !strings.Contains(pf, "fphalfup/") {
+		t.Errorf("expected fphalfup/, got: %s", pf)
+	}
+}
+
+// TestIssue903_DoubleOperandRejected: a double operand in divide-rounding-by
+// is a compile error (per the #876 no-implicit-double-promotion policy) —
+// authors must cast explicitly.
+func TestIssue903_DoubleOperandRejected(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(issue903Symbols())
+
+	src := "action set staker_budget = divide dbl by withholding_denom rounding by 0.5fp;"
+	_, err := c.Compile(src)
+	if err == nil {
+		t.Fatal("expected compile error for double operand, got nil")
+	}
+	if !strings.Contains(err.Error(), "fixed operands") {
+		t.Errorf("expected fixed-operands message, got: %v", err)
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -312,18 +312,50 @@ func (e *PostfixEmitter) getExprType(ctx antlr.ParseTree) string {
 		return e.getExprType(c.Iexpr())
 	}
 
+	// Float ARITHMETIC compounds promote through their operands, mirroring
+	// what their emitters actually produce (emitMixedFloatArith): two fixed
+	// operands that matched the grammar's fexpr alternative yield a fixed
+	// result (fp-family op), not a double (#903). Without this, a nested
+	// `a * b` dividend types as double and downstream dispatch degrades.
+	switch c := ctx.(type) {
+	case *FloatAddFloatContext:
+		return promoteArithType(e.getExprType(c.Fexpr(0)), e.getExprType(c.Fexpr(1)))
+	case *FloatSubFloatContext:
+		return promoteArithType(e.getExprType(c.Fexpr(0)), e.getExprType(c.Fexpr(1)))
+	case *FloatMulFloatContext:
+		return promoteArithType(e.getExprType(c.Fexpr(0)), e.getExprType(c.Fexpr(1)))
+	case *FloatDivFloatContext:
+		return promoteArithType(e.getExprType(c.Fexpr(0)), e.getExprType(c.Fexpr(1)))
+	case *FloatAddIntContext:
+		return promoteArithType(e.getExprType(c.Fexpr()), e.getExprType(c.Iexpr()))
+	case *FloatSubIntContext:
+		return promoteArithType(e.getExprType(c.Fexpr()), e.getExprType(c.Iexpr()))
+	case *FloatMulIntContext:
+		return promoteArithType(e.getExprType(c.Fexpr()), e.getExprType(c.Iexpr()))
+	case *FloatDivIntContext:
+		return promoteArithType(e.getExprType(c.Fexpr()), e.getExprType(c.Iexpr()))
+	case *IntAddFloatContext:
+		return promoteArithType(e.getExprType(c.Iexpr()), e.getExprType(c.Fexpr()))
+	case *IntSubFloatContext:
+		return promoteArithType(e.getExprType(c.Iexpr()), e.getExprType(c.Fexpr()))
+	case *IntMulFloatContext:
+		return promoteArithType(e.getExprType(c.Iexpr()), e.getExprType(c.Fexpr()))
+	case *IntDivFloatContext:
+		return promoteArithType(e.getExprType(c.Iexpr()), e.getExprType(c.Fexpr()))
+	}
+
 	// Float-VALUED expressions (literals, explicit (double) casts, float
-	// arithmetic) produce a double. Typed-name fexprs were resolved above;
+	// negation) produce a double. Typed-name fexprs were resolved above;
 	// what reaches here is genuinely double — so a double literal mixed with a
 	// fixed/bigint field is caught by the double/exact reject (#894).
 	switch c := ctx.(type) {
 	case *FloatLiteralContext, *FloatFromStrContext, *FloatFromIntContext,
-		*FloatFromIndexContext, *FloatAddFloatContext, *FloatSubFloatContext,
-		*FloatMulFloatContext, *FloatDivFloatContext, *FloatAddIntContext,
-		*FloatSubIntContext, *FloatMulIntContext, *FloatDivIntContext,
-		*FloatNegateContext, *IntAddFloatContext, *IntSubFloatContext,
-		*IntMulFloatContext, *IntDivFloatContext:
+		*FloatFromIndexContext, *FloatNegateContext:
 		return TypeDouble
+	case *DivideRoundingByContext:
+		// The fp-family divide ops (fp/, fphalfup/, fpdivr/) always produce
+		// a fixed result.
+		return TypeFixed
 	case *FloatParenContext:
 		return e.getExprType(c.Fexpr())
 	}
@@ -1767,17 +1799,18 @@ func (e *PostfixEmitter) VisitFloatSubFloat(ctx *FloatSubFloatContext) interface
 	return nil
 }
 
+// Mul/div route through emitMixedFloatArith exactly like the fexpr add/sub
+// visitors: a fixed field that matched the grammar's fexpr alternative (e.g.
+// the dividend of `divide … rounding by`) must dispatch to fp*/fp/, not the
+// double ops — staking mantissas exceed a double's exact-integer range, so an
+// unconditional fmul silently loses precision (#903, same class as #874/#884).
 func (e *PostfixEmitter) VisitFloatMulFloat(ctx *FloatMulFloatContext) interface{} {
-	e.Visit(ctx.Fexpr(0))
-	e.Visit(ctx.Fexpr(1))
-	e.emit("fmul")
+	e.emitMixedFloatArith(ctx.Fexpr(0), ctx.Fexpr(1), e.getExprType(ctx.Fexpr(0)), e.getExprType(ctx.Fexpr(1)), "*", "b*", "fmul", "fp*")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitFloatDivFloat(ctx *FloatDivFloatContext) interface{} {
-	e.Visit(ctx.Fexpr(0))
-	e.Visit(ctx.Fexpr(1))
-	e.emit("fdiv")
+	e.emitMixedFloatArith(ctx.Fexpr(0), ctx.Fexpr(1), e.getExprType(ctx.Fexpr(0)), e.getExprType(ctx.Fexpr(1)), "/", "b/", "fdiv", "fp/")
 	return nil
 }
 
@@ -1792,16 +1825,12 @@ func (e *PostfixEmitter) VisitFloatSubInt(ctx *FloatSubIntContext) interface{} {
 }
 
 func (e *PostfixEmitter) VisitFloatMulInt(ctx *FloatMulIntContext) interface{} {
-	e.Visit(ctx.Fexpr())
-	e.Visit(ctx.Iexpr())
-	e.emit("fmul")
+	e.emitMixedFloatArith(ctx.Fexpr(), ctx.Iexpr(), e.getExprType(ctx.Fexpr()), e.getExprType(ctx.Iexpr()), "*", "b*", "fmul", "fp*")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitFloatDivInt(ctx *FloatDivIntContext) interface{} {
-	e.Visit(ctx.Fexpr())
-	e.Visit(ctx.Iexpr())
-	e.emit("fdiv")
+	e.emitMixedFloatArith(ctx.Fexpr(), ctx.Iexpr(), e.getExprType(ctx.Fexpr()), e.getExprType(ctx.Iexpr()), "/", "b/", "fdiv", "fp/")
 	return nil
 }
 
@@ -1818,8 +1847,20 @@ func (e *PostfixEmitter) VisitFloatDivInt(ctx *FloatDivIntContext) interface{} {
 // is currently impossible by grammar; if the rule is ever relaxed, the
 // emitter falls through to the ternary path with the visited expression.
 func (e *PostfixEmitter) VisitDivideRoundingBy(ctx *DivideRoundingByContext) interface{} {
-	e.Visit(ctx.Fexpr(0))
-	e.Visit(ctx.Fexpr(1))
+	// The fp-family divide ops require fixed operands. Integer/bigint
+	// operands are promoted via cvfp; a double operand is rejected per the
+	// #876 policy (the runtime will not promote double→fixed implicitly, and
+	// staking mantissas exceed a double's exact-integer range) — authors opt
+	// in with an explicit `(fixed)` cast. (#903)
+	for i := 0; i < 2; i++ {
+		if t := e.getExprType(ctx.Fexpr(i)); t == TypeDouble {
+			e.emitError("divide … rounding by requires fixed operands; " +
+				"cast the double operand explicitly (e.g. \"(fixed) x\")")
+			return nil
+		}
+	}
+	e.emitWithTypeConversion(ctx.Fexpr(0), TypeFixed)
+	e.emitWithTypeConversion(ctx.Fexpr(1), TypeFixed)
 
 	rText := ctx.FP_LITERAL().GetText()
 	rMantissa, err := parseFpLiteralToMantissa(rText)
@@ -2138,16 +2179,12 @@ func (e *PostfixEmitter) VisitIntSubFloat(ctx *IntSubFloatContext) interface{} {
 }
 
 func (e *PostfixEmitter) VisitIntMulFloat(ctx *IntMulFloatContext) interface{} {
-	e.Visit(ctx.Iexpr())
-	e.Visit(ctx.Fexpr())
-	e.emit("fmul")
+	e.emitMixedFloatArith(ctx.Iexpr(), ctx.Fexpr(), e.getExprType(ctx.Iexpr()), e.getExprType(ctx.Fexpr()), "*", "b*", "fmul", "fp*")
 	return nil
 }
 
 func (e *PostfixEmitter) VisitIntDivFloat(ctx *IntDivFloatContext) interface{} {
-	e.Visit(ctx.Iexpr())
-	e.Visit(ctx.Fexpr())
-	e.emit("fdiv")
+	e.emitMixedFloatArith(ctx.Iexpr(), ctx.Fexpr(), e.getExprType(ctx.Iexpr()), e.getExprType(ctx.Fexpr()), "/", "b/", "fdiv", "fp/")
 	return nil
 }
 

--- a/pkg/dtrules/issue_903_exec_test.go
+++ b/pkg/dtrules/issue_903_exec_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtrules_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+	"github.com/DTRules/DTRules/pkg/dtrules/entity"
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// TestIssue903Execution (#903) runs the staking budget shape end-to-end at a
+// mantissa scale beyond double's exact-integer range (2^53). Before the fix
+// the dividend multiply compiled to fmul, so the product went through a
+// float64 and the low-order mantissa digits were lost; a token test alone
+// can't prove the fp path is actually exact at runtime.
+func TestIssue903Execution(t *testing.T) {
+	rs := session.NewRuleSet("i903")
+	sess, err := rs.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ef := sess.GetEntityFactory().(*entity.Factory)
+
+	rootName := dtrules.GetRName("root")
+	rootRef, err := ef.FindCreateRefEntity(true, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range []string{"weekly_budget", "rate_fixed", "withholding_denom", "staker_budget"} {
+		rootRef.AddAttribute(dtrules.GetRName(n), "", nil, true, true, dtrules.TypeFixed, "", "", "", "")
+	}
+	root, err := ef.CreateEntity(sess, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mustFp := func(mantissa string) *dtrules.RFixed {
+		t.Helper()
+		m, ok := new(big.Int).SetString(mantissa, 10)
+		if !ok {
+			t.Fatalf("bad mantissa %q", mantissa)
+		}
+		fp, err := dtrules.GetRFixedFromMantissa(m)
+		if err != nil {
+			t.Fatalf("mantissa %s: %v", mantissa, err)
+		}
+		return fp
+	}
+
+	// weekly_budget mantissa = 2^53 + 1: the first integer a float64 cannot
+	// represent. ~9.007e15 nanoACME-scale units, i.e. staking magnitude.
+	// rate = 1.00000001 keeps the result mantissa odd and above 2^53, so the
+	// expected value is NOT float64-representable (checked below).
+	weeklyBudget := mustFp("9007199254740993")
+	rate := mustFp("100000001")
+	denom := mustFp("100000000") // 1.0
+	root.Put(dtrules.GetRName("weekly_budget"), weeklyBudget)
+	root.Put(dtrules.GetRName("rate_fixed"), rate)
+	root.Put(dtrules.GetRName("withholding_denom"), denom)
+
+	// Expected value via the exact RFixed API: trunc-mul then half-up divide.
+	product, err := weeklyBudget.Mul(rate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := product.DivRoundHalfUp(denom)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Teeth check: the expected mantissa must NOT be float64-representable,
+	// otherwise a regression to double math could still pass this test.
+	if _, acc := new(big.Float).SetInt(want.Mantissa()).Float64(); acc == big.Exact {
+		t.Fatalf("expected mantissa %s is float64-exact; pick operands whose result exceeds 2^53 and is odd", want.Mantissa())
+	}
+
+	elc := el.NewCompiler()
+	elc.SetSymbols(map[string]string{
+		"weekly_budget":     "fixed",
+		"rate_fixed":        "fixed",
+		"withholding_denom": "fixed",
+		"staker_budget":     "fixed",
+	})
+	pf, err := elc.CompileAction(
+		"set staker_budget = divide weekly_budget * rate_fixed by withholding_denom rounding by 0.5fp")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	obj, err := sess.Compile(pf)
+	if err != nil {
+		t.Fatalf("assemble %q: %v", pf, err)
+	}
+
+	state := sess.GetState().(*interpreter.DTState)
+	state.EntityPush(root)
+	if err := obj.Execute(state); err != nil {
+		state.EntityPop()
+		t.Fatalf("execute %q: %v", pf, err)
+	}
+	state.EntityPop()
+
+	got, err := root.Get(dtrules.GetRName("staker_budget"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotFp, ok := got.(*dtrules.RFixed)
+	if !ok {
+		t.Fatalf("staker_budget is %T, want *RFixed (postfix: %s)", got, pf)
+	}
+	if gotFp.Mantissa().Cmp(want.Mantissa()) != 0 {
+		t.Errorf("staker_budget mantissa = %s, want %s (postfix: %s)",
+			gotFp.Mantissa(), want.Mantissa(), pf)
+	}
+}


### PR DESCRIPTION
Fixes #903.

The fexpr mul/div visitors (`floatMulFloat`, `floatMulInt`, `intMulFloat`, and the three div twins) emitted `fmul`/`fdiv` unconditionally, so the top-level multiply of a `divide … rounding by` dividend degraded to double math even for fixed×fixed operands — while the identical expression in a plain `set` dispatched to `fp*` correctly. Same class as #874/#884: fp dispatch missed in one emitter context.

## Changes

- Route all six fexpr mul/div visitors through `emitMixedFloatArith` (promote + cvfp + arithOp), exactly like the fexpr add/sub visitors fixed in #884.
- `getExprType` now propagates operand types through float arithmetic compounds instead of hardcoding double, so nested products type correctly; genuine double-valued fexprs (literals, casts, negation) still type as double.
- `divideRoundingBy` types as fixed, promotes integer/bigint operands via `cvfp`, and rejects double operands with a cast hint per the #876 policy (the fp-family divide ops require fixed operands).

## Repro coverage

All four shapes from the issue now emit `fp*` (verified before/after):

| shape | before | after |
|---|---|---|
| `divide a * b by d rounding by 0.5fp` | `fmul` | `fp*` |
| cast operand `a * (fixed) n` | `cvfp fmul` | `cvfp fp*` |
| parenthesized `(a * b)` | `fmul` | `fp*` |
| three-factor (outer multiply) | `fp* fmul` | `fp* fp*` |

## Tests

- `TestIssue903_*` token tests in `compiler/el` for the four repro shapes, the double-op reject, and integer→fixed promotion.
- `TestIssue903Execution` in `pkg/dtrules` runs the staking budget shape end-to-end with a result mantissa chosen to be **non-float64-representable** (fatal teeth-check enforces this), so a regression to double math cannot pass.
- Full `./pkg/dtrules/...` suite green, no existing tests changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)