### PR TITLE
fix(el): route array operands of there-is-in-where to the forall fold (#869)

### DIFF
--- a/pkg/dtrules/compiler/el/issue_869_test.go
+++ b/pkg/dtrules/compiler/el/issue_869_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"testing"
+)
+
+// Issue #869: the grammar's entity alternatives (boolThereIsInEntityWhere /
+// boolThereIsNoInEntityWhere) shadow the array alternatives entirely —
+// typedEntity and typedArray both come from IDENT — so `there is x in <array>
+// where p` compiled to `<arr> entitypush …`, which crashes at runtime when
+// entitypush calls REntityValue on the array. The emitter now routes by the
+// operand's declared type. Execution coverage lives in
+// pkg/dtrules/issue_869_exec_test.go; these pin the compile shapes.
+
+func TestIssue869_ArrayOperandRoutesToForallFold(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{"kids": "array", "tax": "integer", "house": "entity"})
+
+	got, err := c.CompileCondition("there is k in kids where tax > 5")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	want := "false { tax 5 > or } kids forall"
+	if got != want {
+		t.Errorf("array operand shape\n got: %q\nwant: %q", got, want)
+	}
+
+	got, err = c.CompileCondition("there is no k in kids where tax > 5")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	want = "false { tax 5 > or } kids forall not"
+	if got != want {
+		t.Errorf("negated array operand shape\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestIssue869_EntityOperandKeepsEntityScope(t *testing.T) {
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{"kids": "array", "tax": "integer", "house": "entity"})
+
+	got, err := c.CompileCondition("there is k in house where tax > 5")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	want := "house entitypush tax 5 > entitypop swap pop"
+	if got != want {
+		t.Errorf("entity operand shape\n got: %q\nwant: %q", got, want)
+	}
+}

--- a/pkg/dtrules/compiler/el/match_forall_order_test.go
+++ b/pkg/dtrules/compiler/el/match_forall_order_test.go
@@ -28,9 +28,10 @@ import "testing"
 // this pins precisely. The other reachable forall aggregations (`all … have`,
 // `one of … has a`) are covered by execution in
 // pkg/dtrules/boolean_aggregation_exec_test.go. The `there is … in … where`
-// array variants (boolThereIsInArrayWhere/NoInArrayWhere) are unreachable —
-// the entity alternatives shadow them in the grammar — so the fix to those is
-// defensive only.
+// array variants (boolThereIsInArrayWhere/NoInArrayWhere) are shadowed by the
+// entity alternatives in the grammar; the entity visitors route array-typed
+// operands to the same fold shape (#869), covered by
+// pkg/dtrules/issue_869_exec_test.go.
 func TestMatchForallOperandOrder(t *testing.T) {
 	c := NewCompiler()
 	c.SetSymbols(map[string]string{"kids": "array", "cases": "array", "tax": "integer"})

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -5119,7 +5119,50 @@ func (e *PostfixEmitter) VisitBoolThereIsNoWhere(ctx *BoolThereIsNoWhereContext)
 	return nil
 }
 
+// eexprIsArray reports whether an eexpr that matched an entity-scope grammar
+// alternative actually names an array (local or declared). The parser cannot
+// tell `there is x in <entity> where …` from the array form — typedEntity and
+// typedArray both come from IDENT — so the entity alternatives shadow
+// boolThereIsInArrayWhere/NoInArrayWhere entirely and an array operand used
+// to compile to `<arr> entitypush …`, crashing at runtime when entitypush
+// calls REntityValue on the array (#869). Route by declared type instead.
+func (e *PostfixEmitter) eexprIsArray(ctx antlr.ParseTree) bool {
+	name := ctx.GetText()
+	if lv, ok := e.lookupLocal(name); ok {
+		return lv.Type == TypeArray
+	}
+	if e.lookupType(name) == TypeArray {
+		return true
+	}
+	// Dotted reference: fall back to the field segment, mirroring the
+	// colon-ref resolution in getExprType.
+	if idx := strings.LastIndex(name, "."); idx > 0 {
+		return e.lookupType(name[idx+1:]) == TypeArray
+	}
+	return false
+}
+
+// emitThereIsInArrayFold lowers `there is <x> in <array> where <p>` to the
+// OR-accumulator fold, same shape as boolOneOfHasa: forall pushes each
+// element onto the entity stack while running the body, so bare attribute
+// names in the predicate resolve against the current element. The bound name
+// <x> carries no scope of its own (exactly like `all … have`).
+func (e *PostfixEmitter) emitThereIsInArrayFold(arr, pred antlr.ParseTree) {
+	// Block before array — opForall is ( body array -- ). See #877.
+	e.emit("false")
+	e.emit("{")
+	e.Visit(pred)
+	e.emit("or")
+	e.emit("}")
+	e.Visit(arr)
+	e.emit("forall")
+}
+
 func (e *PostfixEmitter) VisitBoolThereIsInEntityWhere(ctx *BoolThereIsInEntityWhereContext) interface{} {
+	if e.eexprIsArray(ctx.Eexpr(1)) {
+		e.emitThereIsInArrayFold(ctx.Eexpr(1), ctx.Bexpr())
+		return nil
+	}
 	e.Visit(ctx.Eexpr(1))
 	e.emit("entitypush")
 	e.Visit(ctx.Bexpr())
@@ -5130,6 +5173,11 @@ func (e *PostfixEmitter) VisitBoolThereIsInEntityWhere(ctx *BoolThereIsInEntityW
 }
 
 func (e *PostfixEmitter) VisitBoolThereIsNoInEntityWhere(ctx *BoolThereIsNoInEntityWhereContext) interface{} {
+	if e.eexprIsArray(ctx.Eexpr(1)) {
+		e.emitThereIsInArrayFold(ctx.Eexpr(1), ctx.Bexpr())
+		e.emit("not")
+		return nil
+	}
 	e.Visit(ctx.Eexpr(1))
 	e.emit("entitypush")
 	e.Visit(ctx.Bexpr())

--- a/pkg/dtrules/issue_869_exec_test.go
+++ b/pkg/dtrules/issue_869_exec_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtrules_test
+
+import (
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+	"github.com/DTRules/DTRules/pkg/dtrules/entity"
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// TestIssue869ThereIsInArrayExecution (#869) covers the `there is <x> in
+// <array> where <p>` surface end to end. The grammar's entity alternative
+// shadows boolThereIsInArrayWhere (typedEntity and typedArray both come from
+// IDENT), so an array operand used to compile to `<arr> entitypush …` and
+// crash at runtime when entitypush called REntityValue on the array. The
+// emitter now routes by declared type to the OR-accumulator fold.
+func TestIssue869ThereIsInArrayExecution(t *testing.T) {
+	rs := session.NewRuleSet("i869")
+	sess, err := rs.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ef := sess.GetEntityFactory().(*entity.Factory)
+
+	// kid { tax: integer }
+	kidName := dtrules.GetRName("kid")
+	kidRef, err := ef.FindCreateRefEntity(true, kidName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kidRef.AddAttribute(dtrules.GetRName("tax"), "", dtrules.GetRIntegerValue(0), true, true, dtrules.TypeInteger, "", "", "", "")
+
+	// root { kids: array of kid; flag: boolean }
+	rootName := dtrules.GetRName("root")
+	rootRef, err := ef.FindCreateRefEntity(true, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootRef.AddAttribute(dtrules.GetRName("kids"), "", nil, true, true, dtrules.TypeArray, "kid", "", "", "")
+	rootRef.AddAttribute(dtrules.GetRName("flag"), "", dtrules.GetRBoolean(false), true, true, dtrules.TypeBoolean, "", "", "", "")
+
+	// kids = [5, -3, 10, 0, 7].
+	elems := make([]dtrules.Object, 0, 5)
+	for _, v := range []int{5, -3, 10, 0, 7} {
+		k, err := ef.CreateEntity(sess, kidName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		k.Put(dtrules.GetRName("tax"), dtrules.GetRIntegerValue(int64(v)))
+		elems = append(elems, k)
+	}
+	arr, err := dtrules.NewArrayWithElements(sess, true, elems, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := ef.CreateEntity(sess, rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root.Put(dtrules.GetRName("kids"), arr)
+
+	state := sess.GetState().(*interpreter.DTState)
+	elc := el.NewCompiler()
+	elc.SetSymbols(map[string]string{"kids": "array", "tax": "integer", "flag": "boolean"})
+
+	run := func(expr string) (bool, error) {
+		postfix, err := elc.CompileAction("set flag = " + expr)
+		if err != nil {
+			return false, err
+		}
+		obj, err := sess.Compile(postfix)
+		if err != nil {
+			return false, err
+		}
+		state.EntityPush(root)
+		if err := obj.Execute(state); err != nil {
+			state.EntityPop()
+			return false, err
+		}
+		state.EntityPop()
+		val, err := root.Get(dtrules.GetRName("flag"))
+		if err != nil || val == nil {
+			return false, err
+		}
+		return val.BooleanValue()
+	}
+
+	for _, c := range []struct {
+		expr string
+		want bool
+	}{
+		// Positive form, all three inthe spellings (in/for/on).
+		{"there is k in kids where tax > 5", true},    // 10, 7
+		{"there is k in kids where tax > 100", false}, // none
+		{"there is k for kids where tax < 0", true},   // -3
+		{"there is k on kids where tax == 0", true},   // 0
+		{"is there k in kids where tax > 9", true},    // 10
+		// Negative form.
+		{"there is no k in kids where tax > 100", true},
+		{"there is no k in kids where tax > 5", false},
+	} {
+		got, err := run(c.expr)
+		if err != nil {
+			t.Errorf("%q: exec error: %v", c.expr, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("%q = %v, want %v", c.expr, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #869.

The reorder the issue asked for had already landed in #877/#880 (all five suspect emitters emit block-before-array, execution tests for `all … have` / `one of … has a`, exact-postfix pin for match-forall). This PR completes the issue's remaining half — execution coverage for the `there is … in … where` array variants — and fixes the bug that writing that coverage exposed.

## The bug

`boolThereIsInArrayWhere` / `boolThereIsNoInArrayWhere` are **unreachable**: the grammar's entity alternatives shadow them (`typedEntity` and `typedArray` both come from `IDENT`). So the array surface compiled to the entity lowering:

```
there is k in kids where tax > 5   →   kids entitypush tax 5 > entitypop swap pop
```

`entitypush` calls `REntityValue` on the array and errors at runtime — the construct compiled clean and always crashed.

## The fix

The entity-form visitors route by the operand's declared type (local table first, then EDD symbols, dotted refs included). Array-typed operands lower to the same OR-accumulator fold as `boolOneOfHasa`:

```
there is k in kids where tax > 5      →  false { tax 5 > or } kids forall
there is no k in kids where tax > 5   →  false { tax 5 > or } kids forall not
```

Entity-typed operands keep the existing entitypush/entitypop scope lowering unchanged.

## Tests

- `TestIssue869ThereIsInArrayExecution` (pkg/dtrules): runs over real entities — all three `inthe` spellings (in/for/on), both `there is`/`is there` orders, positive and negative forms.
- `TestIssue869_*` (compiler/el): pins the array→fold and entity→scope compile shapes.
- Full `./pkg/dtrules/...` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)