### PR TITLE
feat(excel): entity numbers + number backfill for entities and tables

### DIFF
--- a/pkg/dtrules/excel/dt_importer.go
+++ b/pkg/dtrules/excel/dt_importer.go
@@ -513,7 +513,29 @@ func normalizeProvenance(tables *DecisionTablesXML, xmlPath string) {
 	}
 }
 
+// normalizeTableNumbers backfills missing TABLE_NUMBERs. Tables that already
+// carry a numeric number keep it; the rest are assigned numbers in document
+// order, in increments of 100, continuing above the highest existing number
+// (starting at 100 when none are numbered).
+func normalizeTableNumbers(tables *DecisionTablesXML) {
+	max := 0
+	for i := range tables.Tables {
+		if n, err := strconv.Atoi(strings.TrimSpace(tables.Tables[i].AttributeFields.TableNumber)); err == nil && n > max {
+			max = n
+		}
+	}
+	next := (max/100)*100 + 100
+	for i := range tables.Tables {
+		t := &tables.Tables[i]
+		if _, err := strconv.Atoi(strings.TrimSpace(t.AttributeFields.TableNumber)); err != nil {
+			t.AttributeFields.TableNumber = strconv.Itoa(next)
+			next += 100
+		}
+	}
+}
+
 func (i *DTImporter) WriteXML(tables *DecisionTablesXML, filename string) error {
+	normalizeTableNumbers(tables)
 	normalizeProvenance(tables, filename)
 
 	// Open file for writing

--- a/pkg/dtrules/excel/edd_importer.go
+++ b/pkg/dtrules/excel/edd_importer.go
@@ -316,7 +316,6 @@ func (i *EDDImporter) ImportEDDFromDir(dir string) (*EDDXML, error) {
 	return edd, nil
 }
 
-// WriteXML writes the EDD to an XML file
 // normalizeEntityNumbers backfills missing entity numbers. Entities that
 // already carry a numeric number keep it; the rest are assigned numbers in
 // document order, in increments of 100, continuing above the highest
@@ -337,6 +336,7 @@ func normalizeEntityNumbers(edd *EDDXML) {
 	}
 }
 
+// WriteXML writes the EDD to an XML file
 func (i *EDDImporter) WriteXML(edd *EDDXML, filename string) error {
 	if edd.Version == "" {
 		edd.Version = "2"

--- a/pkg/dtrules/excel/edd_importer.go
+++ b/pkg/dtrules/excel/edd_importer.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/xuri/excelize/v2"
@@ -36,6 +37,10 @@ type EDDXML struct {
 // EDDXMLEntity represents an entity in the EDD XML
 type EDDXMLEntity struct {
 	Name    string          `xml:"name,attr"`
+	// Number orders entities like TABLE_NUMBER orders decision tables.
+	// Optional in authored XML; WriteXML backfills missing numbers in
+	// increments of 100 so every emitted EDD is fully numbered.
+	Number  string          `xml:"number,attr,omitempty"`
 	XlsFile string          `xml:"xls_file,attr,omitempty"`
 	Access  string          `xml:"access,attr"`
 	Comment string          `xml:"comment,attr,omitempty"`
@@ -312,10 +317,31 @@ func (i *EDDImporter) ImportEDDFromDir(dir string) (*EDDXML, error) {
 }
 
 // WriteXML writes the EDD to an XML file
+// normalizeEntityNumbers backfills missing entity numbers. Entities that
+// already carry a numeric number keep it; the rest are assigned numbers in
+// document order, in increments of 100, continuing above the highest
+// existing number (starting at 100 when none are numbered).
+func normalizeEntityNumbers(edd *EDDXML) {
+	max := 0
+	for _, e := range edd.Entities {
+		if n, err := strconv.Atoi(strings.TrimSpace(e.Number)); err == nil && n > max {
+			max = n
+		}
+	}
+	next := (max/100)*100 + 100
+	for _, e := range edd.Entities {
+		if _, err := strconv.Atoi(strings.TrimSpace(e.Number)); err != nil {
+			e.Number = strconv.Itoa(next)
+			next += 100
+		}
+	}
+}
+
 func (i *EDDImporter) WriteXML(edd *EDDXML, filename string) error {
 	if edd.Version == "" {
 		edd.Version = "2"
 	}
+	normalizeEntityNumbers(edd)
 
 	output, err := xml.MarshalIndent(edd, "", "\t")
 	if err != nil {

--- a/pkg/dtrules/excel/number_backfill_test.go
+++ b/pkg/dtrules/excel/number_backfill_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 DTRules contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import "testing"
+
+func TestNormalizeEntityNumbers_Backfill(t *testing.T) {
+	edd := &EDDXML{Entities: []*EDDXMLEntity{
+		{Name: "a"},                  // missing -> 400
+		{Name: "b", Number: "250"},   // kept
+		{Name: "c", Number: "bogus"}, // non-numeric -> 500
+		{Name: "d", Number: "300"},   // kept (max)
+	}}
+	normalizeEntityNumbers(edd)
+
+	want := map[string]string{"a": "400", "b": "250", "c": "500", "d": "300"}
+	for _, e := range edd.Entities {
+		if e.Number != want[e.Name] {
+			t.Errorf("entity %s: number = %q, want %q", e.Name, e.Number, want[e.Name])
+		}
+	}
+}
+
+func TestNormalizeEntityNumbers_FromScratch(t *testing.T) {
+	edd := &EDDXML{Entities: []*EDDXMLEntity{{Name: "x"}, {Name: "y"}, {Name: "z"}}}
+	normalizeEntityNumbers(edd)
+	for i, want := range []string{"100", "200", "300"} {
+		if got := edd.Entities[i].Number; got != want {
+			t.Errorf("entity %d: number = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestNormalizeTableNumbers_Backfill(t *testing.T) {
+	tables := &DecisionTablesXML{Tables: []DecisionTableXML{
+		{TableName: "First", AttributeFields: AttributeFieldsXML{TableNumber: "100"}},
+		{TableName: "NoNumber"},
+		{TableName: "High", AttributeFields: AttributeFieldsXML{TableNumber: "1550"}},
+		{TableName: "AlsoMissing"},
+	}}
+	normalizeTableNumbers(tables)
+
+	// Continues above 1550, aligned to the 100 grid: 1600, 1700.
+	want := map[string]string{"First": "100", "NoNumber": "1600", "High": "1550", "AlsoMissing": "1700"}
+	for i := range tables.Tables {
+		name := tables.Tables[i].TableName
+		if got := tables.Tables[i].AttributeFields.TableNumber; got != want[name] {
+			t.Errorf("table %s: number = %q, want %q", name, got, want[name])
+		}
+	}
+}


### PR DESCRIPTION
Entities gain an optional `number` attribute ordering them the way `TABLE_NUMBER` orders decision tables. Both canonical XML emitters normalize numbers on every write, mirroring the provenance backfill from bf6a4db3: numbered elements keep their numbers; unnumbered ones get document-order numbers in increments of 100 continuing above the highest existing (100-grid aligned, starting at 100 from scratch).

Unit tests pin backfill around existing numbers, from-scratch numbering, and continuation above a non-aligned maximum.

First of a 3-PR stack: this → #apiserver → #embedded-editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)