### PR TITLE
feat(trace): instrument execution tracing end to end; verified replay

### DIFF
--- a/cmd/dtrules/run_cmd.go
+++ b/cmd/dtrules/run_cmd.go
@@ -29,6 +29,8 @@ import (
 	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
 	"github.com/DTRules/DTRules/pkg/dtrules/mapping"
 	"github.com/DTRules/DTRules/pkg/dtrules/session"
+	"github.com/DTRules/DTRules/pkg/dtrules/trace"
+	"github.com/DTRules/DTRules/pkg/dtrules/version"
 	webpkg "github.com/DTRules/DTRules/pkg/dtrules/web"
 )
 
@@ -38,7 +40,7 @@ import (
 // value hasn't been provided (#850/#854).
 func (c *CLI) runRun(args []string) int {
 	path, entry, input, resultEntity := ".", "", "", "result"
-	var save, data, review string
+	var save, data, review, tracePath string
 	interactive, web, noOpen := false, false, false
 	port := "0" // 0 = let the OS pick a free port
 	for i := 0; i < len(args); i++ {
@@ -66,6 +68,11 @@ func (c *CLI) runRun(args []string) int {
 		case "--review":
 			if i+1 < len(args) {
 				review = args[i+1]
+				i++
+			}
+		case "--trace":
+			if i+1 < len(args) {
+				tracePath = args[i+1]
 				i++
 			}
 		case "--result-entity":
@@ -128,6 +135,34 @@ func (c *CLI) runRun(args []string) int {
 		return 1
 	}
 
+	// Trace capture: enabled before data loading so the trace records the
+	// initial data, then execution, then the resulting state — a complete
+	// document the trace debugger can replay and verify.
+	var traceFile *os.File
+	if tracePath != "" {
+		dts, ok := sess.GetState().(*interpreter.DTState)
+		if !ok {
+			fmt.Fprintln(os.Stderr, "Error: tracing unavailable for this session state")
+			return 1
+		}
+		traceFile, err = os.Create(tracePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating trace file: %v\n", err)
+			return 1
+		}
+		defer traceFile.Close()
+		fingerprint, ferr := trace.FingerprintRules(xmlDir)
+		if ferr != nil {
+			fingerprint = ""
+		}
+		trace.WriteHeader(traceFile, trace.Provenance{
+			DTRulesVersion:   version.Version,
+			RulesFingerprint: fingerprint,
+		})
+		dts.SetOutput(traceFile, nil)
+		dts.EnableTrace()
+	}
+
 	// Initialize entities (and optionally load input data) via the mapping.
 	if err := initMapping(sess, xmlDir, input); err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing data: %v\n", err)
@@ -165,8 +200,17 @@ func (c *CLI) runRun(args []string) int {
 		return 1
 	}
 	if err := dt.Execute(state); err != nil {
+		if traceFile != nil {
+			trace.WriteFooter(traceFile)
+		}
 		fmt.Fprintf(os.Stderr, "Error executing %q: %v\n", entry, err)
 		return 1
+	}
+
+	if traceFile != nil {
+		trace.WriteFinalState(traceFile, state)
+		trace.WriteFooter(traceFile)
+		fmt.Fprintf(os.Stderr, "Trace written: %s\n", tracePath)
 	}
 
 	// Save the collected dataset as canonical, mapping-free data XML — an
@@ -336,6 +380,9 @@ Options:
   --data <file.xml>      Load canonical (mapping-free) data, authoritative
   --review <file.xml>    Load canonical data for re-interview (pre-filled, asked)
   --save <file.xml>      Save the collected data as canonical XML after the run
+  --trace <file.xml>     Write a complete execution trace (initial data,
+                         every table/column/action, resulting state) with
+                         DTRules version + rules fingerprint for replay
   --interactive, -i      Prompt for any reached collect field not supplied
   --web                  Serve an interactive web interview instead of a CLI run
   --port <n>             Port for --web (default: an unused port chosen by the OS)

--- a/pkg/dtrules/array.go
+++ b/pkg/dtrules/array.go
@@ -16,6 +16,7 @@
 package dtrules
 
 import (
+	"strconv"
 	"strings"
 )
 
@@ -44,7 +45,7 @@ func NewArray(session Session, duplicates bool, executable bool) (*RArray, error
 	if session != nil {
 		state := session.GetState()
 		if state != nil && state.TestState(TraceFlag) {
-			state.TraceInfo("newarray", "arrayId", intToStr(ar.id), "")
+			state.TraceInfo("newarray", "", "arrayId", intToStr(ar.id))
 		}
 	}
 	return ar, nil
@@ -57,9 +58,9 @@ func NewArrayWithElements(session Session, duplicates bool, elements []Object, e
 
 	state := session.GetState()
 	if state != nil && state.TestState(TraceFlag) {
-		state.TraceInfo("newarray", "arrayId", intToStr(ar.id), "")
+		state.TraceInfo("newarray", "", "arrayId", intToStr(ar.id))
 		for _, v := range elements {
-			state.TraceInfo("addto", "arrayId", intToStr(ar.id), v.PostFix())
+			state.TraceInfo("addto", v.PostFix(), "arrayId", intToStr(ar.id))
 		}
 	}
 	return ar, nil
@@ -114,7 +115,7 @@ const TraceFlag = 1
 
 // intToStr is a helper to convert int to string
 func intToStr(i int) string {
-	return strings.TrimPrefix(strings.TrimPrefix(string(rune('0'+i/100000000)), "0"), "0")
+	return strconv.Itoa(i)
 }
 
 // uncache ensures the array is in mutable form.
@@ -250,6 +251,42 @@ func (r *RArray) StringValue() string {
 		sb.WriteString("]")
 	}
 	return sb.String()
+}
+
+
+// TraceArrayAdd emits the addto trace event for an element added to ar.
+// Entities are recorded by reference (entity + id attributes) since they
+// cannot be reconstructed from a postfix body; other values record their
+// postfix so replay can recompute them. Callers that mutate arrays outside
+// RArray's session-aware constructors must call this for replay fidelity.
+func TraceArrayAdd(state State, ar *RArray, element Object) {
+	if state == nil || ar == nil || element == nil {
+		return
+	}
+	if e, ok := element.(Entity); ok {
+		state.TraceInfo("addto", "",
+			"arrayId", intToStr(ar.id),
+			"entity", e.GetName().StringValue(),
+			"id", intToStr(e.GetID()))
+		return
+	}
+	state.TraceInfo("addto", element.PostFix(), "arrayId", intToStr(ar.id))
+}
+
+// TraceArrayRemove emits the remove trace event for an element removed
+// from ar, mirroring TraceArrayAdd's entity-reference form.
+func TraceArrayRemove(state State, ar *RArray, element Object) {
+	if state == nil || ar == nil || element == nil {
+		return
+	}
+	if e, ok := element.(Entity); ok {
+		state.TraceInfo("remove", "",
+			"arrayId", intToStr(ar.id),
+			"entity", e.GetName().StringValue(),
+			"id", intToStr(e.GetID()))
+		return
+	}
+	state.TraceInfo("remove", element.PostFix(), "arrayId", intToStr(ar.id))
 }
 
 // PostFix returns the postfix representation.

--- a/pkg/dtrules/decisiontable/anode.go
+++ b/pkg/dtrules/decisiontable/anode.go
@@ -107,6 +107,16 @@ func (a *ANode) Execute(state dtrules.State) error {
 	if cb := a.decisionTable.ColumnSelectedCallback; cb != nil && len(a.columns) > 0 {
 		cb(a.columns[0])
 	}
+
+	// Trace: the fired column wraps its actions; each action is an open
+	// element so a performed table's trace nests inside it.
+	col := ""
+	if len(a.columns) > 0 {
+		col = fmt.Sprintf("%d", a.columns[0])
+	}
+	state.TraceOpen("column", "n", col)
+	defer state.TraceClose("column")
+
 	for i, action := range a.actions {
 		num := a.actionNumbers[i]
 
@@ -118,11 +128,14 @@ func (a *ANode) Execute(state dtrules.State) error {
 		state.SetCurrentTableSection("Action", num)
 
 		// Execute the action
+		state.TraceOpen("action", "n", fmt.Sprintf("%d", num+1))
 		if err := state.Evaluate(action); err != nil {
 			// Restore section and return error with context
+			state.TraceClose("action")
 			state.SetCurrentTableSection(section, numHld)
 			return fmt.Errorf("action %d in table %s: %w", num+1, a.decisionTable.GetName(), err)
 		}
+		state.TraceClose("action")
 
 		// Restore section
 		state.SetCurrentTableSection(section, numHld)

--- a/pkg/dtrules/decisiontable/cnode.go
+++ b/pkg/dtrules/decisiontable/cnode.go
@@ -100,6 +100,12 @@ func (c *CNode) Execute(state dtrules.State) error {
 			c.conditionNumber+1, c.decisionTable.GetName(), err)
 	}
 
+	// Trace: record which condition ran and how it evaluated, so a loaded
+	// trace can annotate the grid with actual results.
+	state.TraceInfo("condition", "",
+		"n", fmt.Sprintf("%d", c.conditionNumber+1),
+		"result", fmt.Sprintf("%t", result))
+
 	// Follow the appropriate branch
 	if result {
 		if c.IfTrue != nil {

--- a/pkg/dtrules/decisiontable/table.go
+++ b/pkg/dtrules/decisiontable/table.go
@@ -354,6 +354,12 @@ func (dt *RDecisionTable) Execute(state dtrules.State) error {
 		return err
 	}
 
+	// Trace: one <decisiontable> element wraps everything this table does,
+	// including its context evaluation — so performed tables nest and each
+	// context iteration appears as its own <execute_table> pass.
+	state.TraceOpen("decisiontable", "name", dt.name.StringValue())
+	defer state.TraceClose("decisiontable")
+
 	// If there's a context, execute it (the context will call ExecuteTable internally)
 	// If no context, execute the table directly
 	if dt.rcontext != nil {
@@ -374,13 +380,21 @@ func (dt *RDecisionTable) ExecuteTable(state dtrules.State) error {
 		return err
 	}
 
+	// Trace: one <execute_table> element per pass of the table body (a
+	// context that iterates produces one per iteration).
+	state.TraceOpen("execute_table")
+	defer state.TraceClose("execute_table")
+
 	// Execute initial actions
 	for i, action := range dt.rinitialActions {
 		if action != nil {
 			state.SetCurrentTableSection("InitialAction", i)
+			state.TraceOpen("initialaction", "n", fmt.Sprintf("%d", i+1))
 			if err := state.Evaluate(action); err != nil {
+				state.TraceClose("initialaction")
 				return err
 			}
+			state.TraceClose("initialaction")
 		}
 	}
 

--- a/pkg/dtrules/interpreter/state.go
+++ b/pkg/dtrules/interpreter/state.go
@@ -110,6 +110,10 @@ type DTState struct {
 	// false, since "first pass of nothing" has no defensible meaning.
 	loopIterations []int
 
+	// traceBound records entity ids whose arraybind events were emitted,
+	// so repeated pushes of one entity bind only once.
+	traceBound map[int]bool
+
 	// collector, when non-nil, enables interactive data collection (#852):
 	// it is consulted at each field read in Find. nil means batch execution
 	// — Find is unchanged and adds at most one nil-check.
@@ -397,7 +401,16 @@ func (s *DTState) EntityPush(entity dtrules.Entity) error {
 			"id", fmt.Sprintf("%d", entity.GetID()))
 		// Bind the entity's array-valued attributes to their array ids so
 		// trace replay can attach <addto> events to the right attribute.
-		// Idempotent across repeated pushes of the same entity.
+		// Emitted once per entity — a forall pushing the same entity every
+		// iteration must not bloat the trace with repeated binds.
+		if s.traceBound == nil {
+			s.traceBound = make(map[int]bool)
+		}
+		if s.traceBound[entity.GetID()] {
+			s.entityStk = append(s.entityStk, entity)
+			return nil
+		}
+		s.traceBound[entity.GetID()] = true
 		for _, attr := range entity.GetAttributeNames() {
 			if v, err := entity.Get(attr); err == nil {
 				if arr, ok := v.(*dtrules.RArray); ok {
@@ -739,10 +752,11 @@ func (s *DTState) traceAttrs(attrs []string) {
 	}
 }
 
-// traceEscape escapes XML-special characters in trace output.
+// traceEscaper escapes XML-special characters in trace output.
+var traceEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", "\"", "&quot;")
+
 func traceEscape(v string) string {
-	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", "\"", "&quot;")
-	return r.Replace(v)
+	return traceEscaper.Replace(v)
 }
 
 // TraceInfo emits a leaf trace element: <tag attrs...>body</tag>.

--- a/pkg/dtrules/interpreter/state.go
+++ b/pkg/dtrules/interpreter/state.go
@@ -216,7 +216,7 @@ func (s *DTState) DataPush(obj dtrules.Object) error {
 	}
 	s.dataStk = append(s.dataStk, obj)
 	if s.TestState(VERBOSE) {
-		s.TraceInfo("datapush", "attribs", obj.PostFix(), "")
+		s.TraceInfo("datapush", "", "attribs", obj.PostFix())
 	}
 	return nil
 }
@@ -230,7 +230,7 @@ func (s *DTState) DataPop() (dtrules.Object, error) {
 	obj := s.dataStk[idx]
 	s.dataStk = s.dataStk[:idx]
 	if s.TestState(VERBOSE) {
-		s.TraceInfo("datapop", "", "", obj.StringValue())
+		s.TraceInfo("datapop", obj.StringValue())
 	}
 	return obj, nil
 }
@@ -392,7 +392,22 @@ func (s *DTState) EntityPush(entity dtrules.Entity) error {
 		return dtrules.StackOverflowError("EntityPush", "Entity Stack overflow")
 	}
 	if s.TestState(TRACE) {
-		s.TraceInfo("entitypush", "entity", entity.GetName().StringValue(), fmt.Sprintf("id=%d", entity.GetID()))
+		s.TraceInfo("entitypush", "",
+			"entity", entity.GetName().StringValue(),
+			"id", fmt.Sprintf("%d", entity.GetID()))
+		// Bind the entity's array-valued attributes to their array ids so
+		// trace replay can attach <addto> events to the right attribute.
+		// Idempotent across repeated pushes of the same entity.
+		for _, attr := range entity.GetAttributeNames() {
+			if v, err := entity.Get(attr); err == nil {
+				if arr, ok := v.(*dtrules.RArray); ok {
+					s.TraceInfo("arraybind", "",
+						"id", fmt.Sprintf("%d", entity.GetID()),
+						"attr", attr.StringValue(),
+						"arrayId", fmt.Sprintf("%d", arr.GetID()))
+				}
+			}
+		}
 	}
 	s.entityStk = append(s.entityStk, entity)
 	return nil
@@ -404,7 +419,7 @@ func (s *DTState) EntityPop() (dtrules.Entity, error) {
 		return nil, dtrules.NewRulesError("Entity Stack Underflow", "EntityPop", "Entity Stack underflow")
 	}
 	if s.TestState(TRACE) {
-		s.TraceInfo("entitypop", "", "", "")
+		s.TraceInfo("entitypop", "")
 	}
 	idx := len(s.entityStk) - 1
 	entity := s.entityStk[idx]
@@ -612,9 +627,12 @@ func (s *DTState) Def(name *dtrules.RName, value dtrules.Object, trace bool) (bo
 	}
 
 	if trace && s.TestState(TRACE) {
-		s.TraceInfo("def",
+		// Body carries the value's postfix so trace replay can recompute
+		// the assigned value (matches the historical trace format).
+		s.TraceInfo("def", value.PostFix(),
 			"entity", entity.GetName().StringValue(),
-			fmt.Sprintf("name=%s id=%d", name.StringValue(), entity.GetID()))
+			"name", name.GetName(),
+			"id", fmt.Sprintf("%d", entity.GetID()))
 	}
 
 	// Use attribute-only name for Put (without entity prefix)
@@ -714,51 +732,46 @@ func (s *DTState) Evaluate(c dtrules.Object) error {
 
 // Trace output
 
-// TraceInfo outputs trace information in XML format.
-func (s *DTState) TraceInfo(tag, attr, value, content string) {
-	if s.TestState(TRACE) {
-		if s.traceOut != nil {
-			fmt.Fprintf(s.traceOut, "<%s", tag)
-			if attr != "" {
-				fmt.Fprintf(s.traceOut, " %s=\"%s\"", attr, value)
-			}
-			if content != "" {
-				fmt.Fprintf(s.traceOut, ">%s</%s>\n", content, tag)
-			} else {
-				fmt.Fprintf(s.traceOut, "/>\n")
-			}
+// traceAttrs writes alternating name, value attribute pairs.
+func (s *DTState) traceAttrs(attrs []string) {
+	for i := 0; i+1 < len(attrs); i += 2 {
+		fmt.Fprintf(s.traceOut, " %s=\"%s\"", attrs[i], traceEscape(attrs[i+1]))
+	}
+}
+
+// traceEscape escapes XML-special characters in trace output.
+func traceEscape(v string) string {
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", "\"", "&quot;")
+	return r.Replace(v)
+}
+
+// TraceInfo emits a leaf trace element: <tag attrs...>body</tag>.
+func (s *DTState) TraceInfo(tag, body string, attrs ...string) {
+	if s.TestState(TRACE) && s.traceOut != nil {
+		fmt.Fprintf(s.traceOut, "<%s", tag)
+		s.traceAttrs(attrs)
+		if body != "" {
+			fmt.Fprintf(s.traceOut, ">%s</%s>\n", traceEscape(body), tag)
+		} else {
+			fmt.Fprint(s.traceOut, "/>\n")
 		}
 	}
 }
 
-// TraceTable traces decision table entry/exit.
-func (s *DTState) TraceTable(tableName string, entering bool) {
-	if s.TestState(TRACE) {
-		if s.traceOut != nil {
-			if entering {
-				fmt.Fprintf(s.traceOut, "<table name=\"%s\">\n", tableName)
-			} else {
-				fmt.Fprintf(s.traceOut, "</table>\n")
-			}
-		}
+// TraceOpen emits an opening trace element; nested trace output lands
+// inside until the matching TraceClose.
+func (s *DTState) TraceOpen(tag string, attrs ...string) {
+	if s.TestState(TRACE) && s.traceOut != nil {
+		fmt.Fprintf(s.traceOut, "<%s", tag)
+		s.traceAttrs(attrs)
+		fmt.Fprint(s.traceOut, ">\n")
 	}
 }
 
-// TraceCondition traces condition evaluation.
-func (s *DTState) TraceCondition(condNum int, result bool) {
-	if s.TestState(TRACE) {
-		if s.traceOut != nil {
-			fmt.Fprintf(s.traceOut, "  <condition num=\"%d\" result=\"%t\"/>\n", condNum, result)
-		}
-	}
-}
-
-// TraceAction traces action execution.
-func (s *DTState) TraceAction(actionNum int) {
-	if s.TestState(TRACE) {
-		if s.traceOut != nil {
-			fmt.Fprintf(s.traceOut, "  <action num=\"%d\"/>\n", actionNum)
-		}
+// TraceClose emits the closing element for TraceOpen.
+func (s *DTState) TraceClose(tag string) {
+	if s.TestState(TRACE) && s.traceOut != nil {
+		fmt.Fprintf(s.traceOut, "</%s>\n", tag)
 	}
 }
 

--- a/pkg/dtrules/mapping/data_loader.go
+++ b/pkg/dtrules/mapping/data_loader.go
@@ -431,6 +431,15 @@ func (l *dataLoader) updateReferences(entity dtrules.Entity, info *EntityInfo) e
 				isSame, _ := topEntity.GetName().Equals(entityRName)
 				if !isSame {
 					topEntity.Put(entityRName, entity)
+					// Entity-reference attribute: record by reference so
+					// replay can rebind it (a postfix body cannot rebuild
+					// an entity value).
+					l.state.TraceInfo("def", "",
+						"entity", topEntity.GetName().StringValue(),
+						"id", fmt.Sprintf("%d", topEntity.GetID()),
+						"name", entityRName.StringValue(),
+						"refentity", entity.GetName().StringValue(),
+						"refid", fmt.Sprintf("%d", entity.GetID()))
 				}
 			}
 		}

--- a/pkg/dtrules/mapping/data_loader.go
+++ b/pkg/dtrules/mapping/data_loader.go
@@ -134,6 +134,11 @@ func (l *dataLoader) handleStartElement(elem xml.StartElement) error {
 			mappingKey := dtrules.GetRName("mapping*key")
 			if mappingKey != nil {
 				entity.Put(mappingKey, dtrules.NewRString(code))
+				// Direct Put bypasses Def; trace the write for replay.
+				l.state.TraceInfo("def", dtrules.NewRString(code).PostFix(),
+					"entity", entity.GetName().StringValue(),
+					"name", "mapping*key",
+					"id", fmt.Sprintf("%d", entity.GetID()))
 			}
 
 			// Push onto entity stack
@@ -369,7 +374,7 @@ func (l *dataLoader) setAttribute(pending pendingAttrib, body string, createdEnt
 	}
 
 	// Use def to set the attribute in the current context
-	_, err = l.state.Def(attrName, value, false)
+	_, err = l.state.Def(attrName, value, true)
 	return err
 }
 
@@ -410,6 +415,7 @@ func (l *dataLoader) updateReferences(entity dtrules.Entity, info *EntityInfo) e
 			// Add entity to array if not already present
 			if !arr.Contains(entity) {
 				arr.Add(entity)
+				dtrules.TraceArrayAdd(l.state, arr, entity)
 			}
 		}
 	}

--- a/pkg/dtrules/mapping/json_data_loader.go
+++ b/pkg/dtrules/mapping/json_data_loader.go
@@ -135,6 +135,11 @@ func (l *jsonDataLoader) processEntityObject(tag string, info *EntityInfo, obj m
 	mappingKey := dtrules.GetRName("mapping*key")
 	if mappingKey != nil {
 		entity.Put(mappingKey, dtrules.NewRString(code))
+		// Direct Put bypasses Def, so trace the write explicitly for replay.
+		l.state.TraceInfo("def", dtrules.NewRString(code).PostFix(),
+			"entity", entity.GetName().StringValue(),
+			"name", "mapping*key",
+			"id", fmt.Sprintf("%d", entity.GetID()))
 	}
 
 	// Push entity onto the entity stack
@@ -179,7 +184,7 @@ func (l *jsonDataLoader) processEntityObject(tag string, info *EntityInfo, obj m
 		}
 		value := l.goValueToDTRules(childValue)
 		if value != nil {
-			l.state.Def(attrName, value, false)
+			l.state.Def(attrName, value, true)
 		}
 	}
 
@@ -237,7 +242,7 @@ func (l *jsonDataLoader) processAttributeValue(tag string, aInfo *AttributeInfo,
 
 	value := l.convertToAttributeType(attrib.Type, body, goValue)
 	if value != nil {
-		l.state.Def(attrName, value, false)
+		l.state.Def(attrName, value, true)
 	}
 
 	return nil
@@ -385,6 +390,7 @@ func (l *jsonDataLoader) goValueToDTRules(value interface{}) dtrules.Object {
 			dtItem := l.goValueToDTRules(item)
 			if dtItem != nil {
 				arr.Add(dtItem)
+				dtrules.TraceArrayAdd(l.state, arr, dtItem)
 			}
 		}
 		return arr

--- a/pkg/dtrules/object.go
+++ b/pkg/dtrules/object.go
@@ -220,8 +220,17 @@ type State interface {
 	// PStack prints all stacks for debugging
 	PStack()
 
-	// TraceInfo outputs trace information
-	TraceInfo(tag, attr, value, content string)
+	// TraceInfo emits a leaf trace element: <tag attrs...>body</tag>.
+	// attrs are alternating name, value pairs.
+	TraceInfo(tag, body string, attrs ...string)
+
+	// TraceOpen emits an opening trace element: <tag attrs...>. Nested
+	// trace output (performed tables, actions) lands inside until the
+	// matching TraceClose.
+	TraceOpen(tag string, attrs ...string)
+
+	// TraceClose emits the closing trace element for TraceOpen.
+	TraceClose(tag string)
 
 	// Evaluate executes code and verifies stack is balanced
 	Evaluate(code Object) error

--- a/pkg/dtrules/operators/array.go
+++ b/pkg/dtrules/operators/array.go
@@ -71,6 +71,7 @@ func opAddTo(state dtrules.State) error {
 		return err
 	}
 	arr.Add(element)
+	dtrules.TraceArrayAdd(state, arr, element)
 	return nil
 }
 
@@ -178,6 +179,7 @@ func opRemove(state dtrules.State) error {
 		return err
 	}
 	arr.Remove(element)
+	dtrules.TraceArrayRemove(state, arr, element)
 	return nil
 }
 

--- a/pkg/dtrules/testsupport/harness.go
+++ b/pkg/dtrules/testsupport/harness.go
@@ -28,6 +28,8 @@ import (
 	"github.com/DTRules/DTRules/pkg/dtrules"
 	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
 	"github.com/DTRules/DTRules/pkg/dtrules/session"
+	"github.com/DTRules/DTRules/pkg/dtrules/trace"
+	"github.com/DTRules/DTRules/pkg/dtrules/version"
 )
 
 // TestHarness provides test execution and comparison capabilities for DTRules.
@@ -295,8 +297,11 @@ func (th *TestHarness) RunFile(num int, path, filename string) error {
 		if th.Verbose {
 			state.EnableVerbose()
 		}
-		// Write trace header
-		fmt.Fprintln(traceFile, "<DTRulesTrace>")
+		// Write trace header with provenance. The harness has no single
+		// rules directory to fingerprint (rules come via the repository
+		// config), so only the DTRules version is recorded here;
+		// `dtrules run --trace` records the full fingerprint.
+		trace.WriteHeader(traceFile, trace.Provenance{DTRulesVersion: version.Version})
 	}
 
 	// Load test data
@@ -311,7 +316,7 @@ func (th *TestHarness) RunFile(num int, path, filename string) error {
 		if err := rsess.Execute(th.DecisionTableName); err != nil {
 			th.writeError(resultsFile, err)
 			if th.Trace && traceFile != nil {
-				fmt.Fprintln(traceFile, "</DTRulesTrace>")
+				trace.WriteFooter(traceFile)
 			}
 			return fmt.Errorf("execution error: %w", err)
 		}
@@ -321,7 +326,8 @@ func (th *TestHarness) RunFile(num int, path, filename string) error {
 	th.printReport(rsess, resultsFile, testData)
 
 	if th.Trace && traceFile != nil {
-		fmt.Fprintln(traceFile, "</DTRulesTrace>")
+		trace.WriteFinalState(traceFile, rsess.GetState())
+		trace.WriteFooter(traceFile)
 	}
 
 	if th.Console {

--- a/pkg/dtrules/trace/roundtrip_test.go
+++ b/pkg/dtrules/trace/roundtrip_test.go
@@ -1,0 +1,156 @@
+// Copyright 2025 DTRules contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+	"github.com/DTRules/DTRules/pkg/dtrules/mapping"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// TestGoTraceRoundTrip pins the full trace loop against a Go-produced trace
+// (the older tests use Java-era fixtures): execute KidAid with real input
+// data while tracing, load the trace back, check the recorded structure,
+// replay to the end, and verify the replayed state against the recorded
+// final state.
+func TestGoTraceRoundTrip(t *testing.T) {
+	base := getTestDataPath()
+	if base == "" {
+		t.Skip("Sample project not available")
+	}
+	xmlDir := filepath.Join(base, "xml")
+	input := filepath.Join(base, "testfiles", "TestCase_001.xml")
+	if _, err := os.Stat(input); err != nil {
+		t.Skip("KidAid test input not available")
+	}
+
+	// --- Execute with tracing ---
+	rs := session.NewRuleSet("kidaid")
+	if err := rs.LoadFromDirectory(xmlDir); err != nil {
+		t.Fatalf("load rules: %v", err)
+	}
+	sess, err := rs.NewSession()
+	if err != nil {
+		t.Fatalf("session: %v", err)
+	}
+	state, ok := sess.GetState().(*interpreter.DTState)
+	if !ok {
+		t.Fatalf("state is not *interpreter.DTState")
+	}
+
+	tracePath := filepath.Join(t.TempDir(), "roundtrip_trace.xml")
+	f, err := os.Create(tracePath)
+	if err != nil {
+		t.Fatalf("create trace: %v", err)
+	}
+	fingerprint, err := FingerprintRules(xmlDir)
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	WriteHeader(f, Provenance{DTRulesVersion: "test", RulesFingerprint: fingerprint})
+	state.SetOutput(f, nil)
+	state.EnableTrace()
+
+	// Load mapping + input data (the same path `dtrules run` takes), so
+	// the trace records the initial data as def events.
+	mapFile, err := os.Open(filepath.Join(xmlDir, "kidaid_map.xml"))
+	if err != nil {
+		t.Fatalf("open map: %v", err)
+	}
+	defer mapFile.Close()
+	m := mapping.NewMapping(sess)
+	if err := m.LoadMapping(mapFile); err != nil {
+		t.Fatalf("load mapping: %v", err)
+	}
+	if err := m.Initialize(); err != nil {
+		t.Fatalf("init mapping: %v", err)
+	}
+	dataFile, err := os.Open(input)
+	if err != nil {
+		t.Fatalf("open input: %v", err)
+	}
+	defer dataFile.Close()
+	if err := m.LoadData(dataFile); err != nil {
+		t.Fatalf("load data: %v", err)
+	}
+
+	rsess := sess.(*session.RSession)
+	if err := rsess.Execute("Compute_Eligibility"); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	WriteFinalState(f, state)
+	WriteFooter(f)
+	f.Close()
+
+	// --- Load the trace back ---
+	tr := NewTrace()
+	root, err := tr.Load(tracePath)
+	if err != nil {
+		t.Fatalf("load trace: %v", err)
+	}
+
+	p := tr.Provenance()
+	if p.DTRulesVersion != "test" || p.RulesFingerprint != fingerprint {
+		t.Errorf("provenance did not round-trip: %+v", p)
+	}
+
+	// Structure: the entry table with an execute_table pass, a fired
+	// column with actions, condition results, and recorded defs.
+	counts := map[string]int{}
+	var walk func(n *TraceNode)
+	walk = func(n *TraceNode) {
+		counts[n.Name]++
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	walk(root)
+	for _, tag := range []string{"decisiontable", "execute_table", "column", "action", "condition", "def", "entitypush"} {
+		if counts[tag] == 0 {
+			t.Errorf("trace records no <%s> events", tag)
+		}
+	}
+	if fsNode := tr.FinalState(); fsNode == nil || len(fsNode.Children) == 0 {
+		t.Fatalf("trace records no final state")
+	}
+
+	// --- Replay to the very end and verify against the recorded state ---
+	rs2 := session.NewRuleSet("kidaid-replay")
+	if err := rs2.LoadFromDirectory(xmlDir); err != nil {
+		t.Fatalf("load rules for replay: %v", err)
+	}
+	// Replay everything before the finalState node.
+	fsNode := tr.FinalState()
+	replaySess, err := tr.SetState(rs2, fsNode)
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+
+	mismatches := tr.VerifyFinalState(replaySess.GetState())
+	if len(mismatches) > 0 {
+		for i, m := range mismatches {
+			if i >= 15 {
+				t.Errorf("... and %d more", len(mismatches)-15)
+				break
+			}
+			t.Errorf("final-state mismatch: %s", m)
+		}
+	}
+}

--- a/pkg/dtrules/trace/trace.go
+++ b/pkg/dtrules/trace/trace.go
@@ -245,6 +245,28 @@ func (t *Trace) handleDef(node *TraceNode) error {
 		}
 	}
 
+	// Entity-reference defs record the referenced entity's identity in
+	// refentity/refid attributes; a postfix body cannot rebuild an entity.
+	if refid := node.Attributes["refid"]; refid != "" {
+		ref, ok := t.entityTable[refid]
+		if !ok {
+			name := dtrules.GetRName(node.Attributes["refentity"])
+			if name == nil {
+				return nil
+			}
+			var err error
+			ref, err = t.session.CreateEntity(name)
+			if err != nil {
+				return nil
+			}
+			t.entityTable[refid] = ref
+		}
+		if rname := dtrules.GetRName(attrName); rname != nil {
+			return entity.Put(rname, ref)
+		}
+		return nil
+	}
+
 	// Parse and execute the body to get the value
 	var value dtrules.Object
 	if body == "" {

--- a/pkg/dtrules/trace/trace.go
+++ b/pkg/dtrules/trace/trace.go
@@ -166,6 +166,14 @@ func (t *Trace) replayNode(node *TraceNode, target *TraceNode) error {
 		t.handleNewArray(node)
 	}
 
+	// Handle arraybind: attach an entity's array attribute to the traced
+	// array instance so subsequent addto/remove events reach it.
+	if node.Name == "arraybind" {
+		if err := t.handleArrayBind(node); err != nil {
+			return err
+		}
+	}
+
 	// Handle addto
 	if node.Name == "addto" {
 		if err := t.handleAddTo(node); err != nil {
@@ -303,6 +311,34 @@ func (t *Trace) parseSimpleValue(body string) dtrules.Object {
 	return dtrules.NewRString(body)
 }
 
+// handleArrayBind attaches an entity attribute to the traced array with the
+// recorded id, creating the array if no newarray/addto has been seen yet.
+// Without this binding, replayed addto events would populate arrays no
+// entity references.
+func (t *Trace) handleArrayBind(node *TraceNode) error {
+	entityID := node.Attributes["id"]
+	attrName := node.Attributes["attr"]
+	arrayID := node.GetArrayID()
+	if entityID == "" || attrName == "" || arrayID == 0 {
+		return nil
+	}
+
+	entity, ok := t.entityTable[entityID]
+	if !ok {
+		return nil // entity not seen yet; a later push will re-bind
+	}
+	ar, ok := t.arrayTable[arrayID]
+	if !ok {
+		ar = dtrules.NewArrayTraceInterface(arrayID, true, false)
+		t.arrayTable[arrayID] = ar
+	}
+	rname := dtrules.GetRName(attrName)
+	if rname == nil {
+		return nil
+	}
+	return entity.Put(rname, ar)
+}
+
 // handleNewArray creates a new array from a trace node.
 func (t *Trace) handleNewArray(node *TraceNode) {
 	id := node.GetArrayID()
@@ -326,6 +362,21 @@ func (t *Trace) handleAddTo(node *TraceNode) error {
 		// Create the array if it doesn't exist
 		ar = dtrules.NewArrayTraceInterface(id, true, false)
 		t.arrayTable[id] = ar
+	}
+
+	// Entity elements are recorded by reference (entity + id attributes),
+	// not as a postfix body.
+	if eid := node.Attributes["id"]; eid != "" {
+		e, ok := t.entityTable[eid]
+		if !ok {
+			var err error
+			e, err = t.getOrCreateEntity(node)
+			if err != nil {
+				return err
+			}
+		}
+		ar.Add(e)
+		return nil
 	}
 
 	// Get the value to add
@@ -360,6 +411,14 @@ func (t *Trace) handleRemove(node *TraceNode) error {
 
 	ar, ok := t.arrayTable[id]
 	if !ok {
+		return nil
+	}
+
+	// Entity elements are recorded by reference (entity + id attributes).
+	if eid := node.Attributes["id"]; eid != "" {
+		if e, ok := t.entityTable[eid]; ok {
+			ar.Remove(e)
+		}
 		return nil
 	}
 

--- a/pkg/dtrules/trace/writer.go
+++ b/pkg/dtrules/trace/writer.go
@@ -113,6 +113,9 @@ func WriteFinalState(w io.Writer, state StackState) {
 		}
 		sort.Strings(sorted)
 		for _, s := range sorted {
+			if s == "" {
+				continue
+			}
 			v, err := e.Get(byName[s])
 			val := ""
 			if err == nil && v != nil {

--- a/pkg/dtrules/trace/writer.go
+++ b/pkg/dtrules/trace/writer.go
@@ -1,0 +1,214 @@
+// Copyright 2025 DTRules contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+)
+
+// Provenance identifies what produced a trace: the DTRules build and a
+// fingerprint of the rules that ran. Loading a trace under a different
+// DTRules version or different rules warrants a warning — replayed state
+// may diverge from what actually happened.
+type Provenance struct {
+	DTRulesVersion   string
+	RulesFingerprint string
+}
+
+// FingerprintRules hashes the project's XML rule files (sorted by relative
+// path, names included) so a trace can record exactly which rules ran.
+// The result is "sha256:<hex>".
+func FingerprintRules(xmlDir string) (string, error) {
+	var files []string
+	err := filepath.Walk(xmlDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		if strings.HasSuffix(strings.ToLower(path), ".xml") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(files)
+
+	h := sha256.New()
+	for _, f := range files {
+		rel, _ := filepath.Rel(xmlDir, f)
+		data, err := os.ReadFile(f)
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(h, "%s\n", rel)
+		h.Write(data)
+	}
+	return fmt.Sprintf("sha256:%x", h.Sum(nil)), nil
+}
+
+// StackState is the slice of session state the trace writer reads: the
+// entity stack at the end of execution.
+type StackState interface {
+	EntityDepth() int
+	EntityFetch(i int) (dtrules.Entity, error)
+}
+
+// WriteHeader opens a DTRulesTrace document, recording provenance as root
+// attributes. Empty fields are omitted so old-style consumers see the same
+// bare <DTRulesTrace> they always did.
+func WriteHeader(w io.Writer, p Provenance) {
+	fmt.Fprint(w, "<DTRulesTrace")
+	if p.DTRulesVersion != "" {
+		fmt.Fprintf(w, " dtrules_version=\"%s\"", escapeXML(p.DTRulesVersion))
+	}
+	if p.RulesFingerprint != "" {
+		fmt.Fprintf(w, " rules_fingerprint=\"%s\"", escapeXML(p.RulesFingerprint))
+	}
+	fmt.Fprintln(w, ">")
+}
+
+// WriteFinalState records the resulting entity stack — every entity with
+// every attribute value — so a loaded trace can be verified against the
+// state its replay reconstructs.
+func WriteFinalState(w io.Writer, state StackState) {
+	fmt.Fprintln(w, "<finalState>")
+	depth := state.EntityDepth()
+	// Bottom of stack first, matching the order entities were pushed.
+	// EntityFetch(0) is the bottom of the stack.
+	for i := 0; i < depth; i++ {
+		e, err := state.EntityFetch(i)
+		if err != nil || e == nil {
+			continue
+		}
+		fmt.Fprintf(w, "\t<entity name=\"%s\" id=\"%d\">\n",
+			escapeXML(e.GetName().StringValue()), e.GetID())
+		names := e.GetAttributeNames()
+		sorted := make([]string, 0, len(names))
+		byName := make(map[string]*dtrules.RName, len(names))
+		for _, n := range names {
+			s := n.StringValue()
+			sorted = append(sorted, s)
+			byName[s] = n
+		}
+		sort.Strings(sorted)
+		for _, s := range sorted {
+			v, err := e.Get(byName[s])
+			val := ""
+			if err == nil && v != nil {
+				val = v.StringValue()
+			}
+			fmt.Fprintf(w, "\t\t<attr name=\"%s\">%s</attr>\n", escapeXML(s), escapeXML(val))
+		}
+		fmt.Fprintln(w, "\t</entity>")
+	}
+	fmt.Fprintln(w, "</finalState>")
+}
+
+// WriteFooter closes the DTRulesTrace document.
+func WriteFooter(w io.Writer) {
+	fmt.Fprintln(w, "</DTRulesTrace>")
+}
+
+// Provenance returns the provenance recorded in a loaded trace's root
+// element. Fields are empty for traces that predate provenance recording.
+func (t *Trace) Provenance() Provenance {
+	if t.root == nil {
+		return Provenance{}
+	}
+	return Provenance{
+		DTRulesVersion:   t.root.Attributes["dtrules_version"],
+		RulesFingerprint: t.root.Attributes["rules_fingerprint"],
+	}
+}
+
+// FinalState returns the trace's recorded <finalState> node, or nil for
+// traces that did not record one.
+func (t *Trace) FinalState() *TraceNode {
+	if t.root == nil {
+		return nil
+	}
+	for _, c := range t.root.Children {
+		if c.Name == "finalState" {
+			return c
+		}
+	}
+	return nil
+}
+
+// VerifyFinalState compares a state (typically one reconstructed by replay)
+// against the trace's recorded final state, entity by entity and attribute
+// by attribute. It returns a description of every mismatch; an empty result
+// means the replay faithfully reproduced the recorded end state. The
+// debugger runs this on every loaded trace.
+func (t *Trace) VerifyFinalState(state StackState) []string {
+	fs := t.FinalState()
+	if fs == nil {
+		return []string{"trace records no finalState"}
+	}
+
+	var mismatches []string
+	depth := state.EntityDepth()
+	if depth != len(fs.Children) {
+		mismatches = append(mismatches, fmt.Sprintf(
+			"entity stack depth: replay has %d, trace recorded %d", depth, len(fs.Children)))
+	}
+
+	n := depth
+	if len(fs.Children) < n {
+		n = len(fs.Children)
+	}
+	for i := 0; i < n; i++ {
+		recorded := fs.Children[i]
+		e, err := state.EntityFetch(i)
+		if err != nil || e == nil {
+			mismatches = append(mismatches, fmt.Sprintf("stack[%d]: missing in replay", i))
+			continue
+		}
+		name := recorded.Attributes["name"]
+		if got := e.GetName().StringValue(); got != name {
+			mismatches = append(mismatches, fmt.Sprintf(
+				"stack[%d]: entity %q in replay, %q recorded", i, got, name))
+			continue
+		}
+		for _, attr := range recorded.Children {
+			if attr.Name != "attr" {
+				continue
+			}
+			attrName := attr.Attributes["name"]
+			if attrName == "" {
+				continue
+			}
+			v, err := e.Get(dtrules.GetRName(attrName))
+			got := ""
+			if err == nil && v != nil {
+				got = v.StringValue()
+			}
+			if got != attr.Body {
+				mismatches = append(mismatches, fmt.Sprintf(
+					"%s.%s: replay %q, trace recorded %q", name, attrName, got, attr.Body))
+			}
+		}
+	}
+	return mismatches
+}


### PR DESCRIPTION
Brings the trace subsystem up to snuff for the trace debugger. The loader/replayer was built against Java-era fixtures; the Go engine never actually produced usable traces. Full defect list and fixes in the commit message — highlights:

- **Executor instrumented** (`decisiontable` / `execute_table` / `condition` results / fired `column` / nesting `action` elements) — the table/column/action trace methods previously had **zero callers**.
- **`def` events now carry the assigned value's postfix**; previously no value was recorded at all.
- **`intToStr` was broken** (`string(rune('0'+i/1e8))` → `""` for any id < 100M): every array trace event ever emitted had an empty arrayId.
- **New `arraybind` event** ties entity attributes to array ids — without it, replayed arrays floated in a side table no entity referenced (a gap dating to the Java era; the fixtures' tests never verified attached-array contents).
- **Mapping loads now trace** (were explicitly `trace=false`), including the direct `mapping*key` Puts; runtime `addto`/`remove` operators trace, with entity elements recorded by reference.
- **Provenance + final state**: `WriteHeader` records DTRules version + rules fingerprint (sha256 over project XML) per the debugger design; `WriteFinalState` records the full entity stack; `VerifyFinalState` compares replayed state against it attribute-by-attribute.
- **`dtrules run --trace <file>`** produces the complete document; the harness emits the same format.

`TestGoTraceRoundTrip` pins the whole loop on KidAid with real input: execute-with-trace → load → structural assertions → full replay → **zero final-state mismatches**. Java-fixture tests unchanged and passing; `make check` green.

Known follow-ups: `addat`/`removeat` operators still untraced (rare; same helper applies); the harness still doesn't load its test input files (pre-existing, surfaced during this work — separate fix); staking-side trace production goes through the staking repo's SDK wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)