### PR TITLE
feat(debug): find/why provenance, EDD-driven reports with diffs, speculative reruns

### DIFF
--- a/cmd/dtrules/cli.go
+++ b/cmd/dtrules/cli.go
@@ -96,6 +96,8 @@ func (c *CLI) Run(args []string) int {
 		return c.runRun(cmdArgs)
 	case "debug":
 		return c.runDebug(cmdArgs)
+	case "report":
+		return c.runReport(cmdArgs)
 	case "verify":
 		return c.runVerify(cmdArgs)
 	case "sync":

--- a/cmd/dtrules/main.go
+++ b/cmd/dtrules/main.go
@@ -71,6 +71,7 @@ var subcommands = map[string]bool{
 	"build":    true,
 	"run":      true,
 	"debug":    true,
+	"report":   true,
 	"verify":   true,
 	"sync":     true,
 	"internal": true,

--- a/cmd/dtrules/report_cmd.go
+++ b/cmd/dtrules/report_cmd.go
@@ -1,0 +1,200 @@
+// Copyright 2026 DTRules contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+	"github.com/DTRules/DTRules/pkg/dtrules/trace"
+)
+
+// runReport handles `dtrules report <trace.xml> --spec <file> [options]`:
+// generate an EDD-driven report from a trace, optionally diffed against a
+// baseline trace run with the same spec.
+func (c *CLI) runReport(args []string) int {
+	path, specPath, baselinePath, tracePath := ".", "", "", ""
+	asJSON := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--spec":
+			if i+1 < len(args) {
+				specPath = args[i+1]
+				i++
+			}
+		case "--baseline":
+			if i+1 < len(args) {
+				baselinePath = args[i+1]
+				i++
+			}
+		case "--project":
+			if i+1 < len(args) {
+				path = args[i+1]
+				i++
+			}
+		case "--json":
+			asJSON = true
+		case "-h", "--help":
+			fmt.Println(`Usage: dtrules report <trace.xml> --spec <report.json> [options]
+
+Generates an EDD-driven report from a trace: the spec picks entities (all
+instances the run created, or elements of an array like
+staking_transaction.to), their fields, filters, and sort order.
+
+Options:
+  --spec <file>      Report spec (JSON). Sections:
+                     {"entity"|"source", "fields", "where", "sort", "key"}
+  --baseline <file>  A second trace: the report runs on both and the
+                     row-level diff (added/removed/changed) is appended
+  --project <dir>    Project root (default .)
+  --json             Emit JSON instead of markdown
+
+Example spec:
+  {"name": "Payouts", "sections": [
+    {"title": "Recipients", "source": "staking_transaction.to",
+     "fields": ["url", "amount"], "sort": "amount", "key": "url"}]}`)
+			return 0
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", args[i])
+				return 1
+			}
+			if tracePath == "" {
+				tracePath = args[i]
+			}
+		}
+	}
+	if tracePath == "" || specPath == "" {
+		fmt.Fprintln(os.Stderr, "Error: dtrules report <trace.xml> --spec <report.json>")
+		return 1
+	}
+
+	specData, err := os.ReadFile(specPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading spec: %v\n", err)
+		return 1
+	}
+	var spec trace.ReportSpec
+	if err := json.Unmarshal(specData, &spec); err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing spec: %v\n", err)
+		return 1
+	}
+	if spec.Name == "" {
+		spec.Name = strings.TrimSuffix(filepath.Base(specPath), ".report.json")
+	}
+
+	xmlDir, _, err := resolveDirs(mustAbs(path), "", "")
+	if err != nil || !dirExists(xmlDir) {
+		fmt.Fprintf(os.Stderr, "Error: could not find rules under %s\n", path)
+		return 1
+	}
+	rs := session.NewRuleSet("report")
+	if err := rs.LoadFromDirectory(xmlDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading rules: %v\n", err)
+		return 1
+	}
+
+	report, err := reportFromTrace(rs, tracePath, spec)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	var diff *trace.ReportDiff
+	if baselinePath != "" {
+		base, err := reportFromTrace(rs, baselinePath, spec)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error on baseline: %v\n", err)
+			return 1
+		}
+		diff = trace.DiffReports(base, report)
+	}
+
+	if asJSON {
+		out := map[string]interface{}{"report": report}
+		if diff != nil {
+			out["diff"] = diff
+		}
+		data, _ := json.MarshalIndent(out, "", "  ")
+		fmt.Println(string(data))
+		return 0
+	}
+
+	fmt.Print(report.Markdown())
+	if diff != nil {
+		fmt.Print(diffMarkdown(diff))
+	}
+	return 0
+}
+
+// reportFromTrace loads a trace, replays to its final state, and runs spec.
+func reportFromTrace(rs *session.RuleSet, tracePath string, spec trace.ReportSpec) (*trace.Report, error) {
+	tr := trace.NewTrace()
+	if _, err := tr.Load(tracePath); err != nil {
+		return nil, fmt.Errorf("load trace %s: %w", tracePath, err)
+	}
+	fs := tr.FinalState()
+	if fs == nil {
+		return nil, fmt.Errorf("%s records no finalState", tracePath)
+	}
+	sess, err := tr.SetState(rs, fs)
+	if err != nil {
+		return nil, fmt.Errorf("replay %s: %w", tracePath, err)
+	}
+	return tr.GenerateReport(sess, spec), nil
+}
+
+// diffMarkdown renders a report diff compactly.
+func diffMarkdown(d *trace.ReportDiff) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "\n# Changes vs baseline\n")
+	for _, s := range d.Sections {
+		if len(s.Added) == 0 && len(s.Removed) == 0 && len(s.Changed) == 0 {
+			continue
+		}
+		fmt.Fprintf(&sb, "\n## %s — %d added, %d removed, %d changed\n\n",
+			s.Title, len(s.Added), len(s.Removed), len(s.Changed))
+		for _, r := range s.Added {
+			fmt.Fprintf(&sb, "+ %s\n", rowLine(r, s.Fields))
+		}
+		for _, r := range s.Removed {
+			fmt.Fprintf(&sb, "- %s\n", rowLine(r, s.Fields))
+		}
+		for _, ch := range s.Changed {
+			fmt.Fprintf(&sb, "~ %s:", ch.Key)
+			for _, f := range ch.Fields {
+				fmt.Fprintf(&sb, "  %s %s → %s", f, ch.Before[f], ch.After[f])
+			}
+			fmt.Fprintln(&sb)
+		}
+	}
+	if len(d.Sections) == 0 {
+		fmt.Fprintln(&sb, "\n_no sections_")
+	}
+	return sb.String()
+}
+
+// rowLine formats one row on a single line, fields in order.
+func rowLine(row map[string]string, fields []string) string {
+	parts := make([]string, 0, len(fields))
+	for _, f := range fields {
+		parts = append(parts, fmt.Sprintf("%s=%s", f, row[f]))
+	}
+	return strings.Join(parts, "  ")
+}

--- a/pkg/dtrules/apiserver/debug.go
+++ b/pkg/dtrules/apiserver/debug.go
@@ -105,6 +105,13 @@ type debugSession struct {
 	provenance       trace.Provenance
 	fingerprintMatch string // "match", "mismatch", or "unknown"
 	verifyMismatches []string
+
+	// baseline holds the original trace while a speculative run is the
+	// active session (nil otherwise). Reports diff against it; reset
+	// restores it.
+	baseline     *trace.Trace
+	baselinePath string
+	speculative  bool
 }
 
 // consoleBlocked are mutating operators the debug console refuses: the
@@ -193,6 +200,7 @@ func debugSessionPayload(ds *debugSession) map[string]interface{} {
 		"rulesFingerprint": ds.provenance.RulesFingerprint,
 		"fingerprintMatch": ds.fingerprintMatch,
 		"verifyMismatches": ds.verifyMismatches,
+		"speculative":      ds.speculative,
 	}
 }
 

--- a/pkg/dtrules/apiserver/debug_find.go
+++ b/pkg/dtrules/apiserver/debug_find.go
@@ -1,0 +1,249 @@
+// Copyright 2026 DTRules contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/trace"
+)
+
+// findMaxHits caps a single find response; the total match count is still
+// reported so the UI can say "showing 200 of 1,431".
+const findMaxHits = 200
+
+// normalizeTraceValue reduces a def body's postfix to a comparable literal:
+// quotes stripped, the fp suffix and cvdate/cvb conversion tails removed,
+// whitespace trimmed. "689938.39835729fp" and `"2008-09-12" cvdate` become
+// plain text a user would type.
+func normalizeTraceValue(body string) string {
+	s := strings.TrimSpace(body)
+	for _, tail := range []string{" cvdate", " cvi", " cvb"} {
+		s = strings.TrimSuffix(s, tail)
+	}
+	s = strings.TrimSuffix(s, "fp")
+	s = strings.Trim(s, "\"")
+	return strings.TrimSpace(s)
+}
+
+// valuesMatch compares a normalized trace value against the user's query
+// value: case-insensitive text equality, or numeric equality when both
+// parse (so "500" matches "500.00000000").
+func valuesMatch(traceVal, queryVal string) bool {
+	if strings.EqualFold(traceVal, queryVal) {
+		return true
+	}
+	tv, terr := strconv.ParseFloat(traceVal, 64)
+	qv, qerr := strconv.ParseFloat(queryVal, 64)
+	return terr == nil && qerr == nil && tv == qv
+}
+
+// findConditionStep is one condition of a fired column in the why-chain:
+// what the column REQUIRED and what actually happened.
+type findConditionStep struct {
+	Number   int    `json:"number"`   // ordinal position (matches every view)
+	DSL      string `json:"dsl"`      // condition text from the table definition
+	Required string `json:"required"` // the fired column's cell: Y / N / - (blank = don't care)
+	Actual   string `json:"actual"`   // recorded result: true / false / "" (not evaluated)
+}
+
+// findChainLink is one frame of the why-chain, innermost first: the table
+// whose fired column's action performed the write (or performed the table
+// below it in the chain).
+type findChainLink struct {
+	Table      string              `json:"table"`
+	Pass       int                 `json:"pass"`      // 1-based iteration ordinal
+	PassCount  int                 `json:"passCount"` // total iterations of that table node
+	Column     string              `json:"column"`    // fired column
+	Action     string              `json:"action"`    // ordinal of the acting action
+	PassNode   int                 `json:"passNode"`  // trace node of the pass (for jumping)
+	Conditions []findConditionStep `json:"conditions"`
+}
+
+// findHit is one recorded write of the searched field.
+type findHit struct {
+	Node   int             `json:"node"` // the def node — jump target
+	Entity string          `json:"entity"`
+	ID     string          `json:"id"`
+	Attr   string          `json:"attr"`
+	Value  string          `json:"value"`
+	Chain  []findChainLink `json:"chain"`
+}
+
+// handleDebugFind searches the loaded trace for writes of a field.
+// GET /api/debug/find?attr=<name>&entity=<name>&value=<v>
+//   - attr is required; entity and value are optional narrowing filters.
+//   - All name matching is case-insensitive (EL semantics).
+//
+// Each hit carries the why-chain: for the write's table and every caller up
+// the stack, the fired column's conditions with their required cells and
+// actual results — "all the conditions that had to be met" for the write.
+func (s *Server) handleDebugFind(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		jsonError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	attr := strings.TrimSpace(r.URL.Query().Get("attr"))
+	entity := strings.TrimSpace(r.URL.Query().Get("entity"))
+	value := strings.TrimSpace(r.URL.Query().Get("value"))
+	if attr == "" {
+		jsonError(w, "attr is required (optionally entity and value)", http.StatusBadRequest)
+		return
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.debug == nil {
+		jsonError(w, "No trace loaded", http.StatusBadRequest)
+		return
+	}
+
+	root := s.debug.trace.Root()
+	hits := []findHit{}
+	total := 0
+
+	var walk func(n *trace.TraceNode)
+	walk = func(n *trace.TraceNode) {
+		if n.Name == "def" &&
+			strings.EqualFold(n.Attributes["name"], attr) &&
+			(entity == "" || strings.EqualFold(n.Attributes["entity"], entity)) {
+			v := normalizeTraceValue(n.Body)
+			if value == "" || valuesMatch(v, value) {
+				total++
+				if len(hits) < findMaxHits {
+					hits = append(hits, findHit{
+						Node:   n.Number,
+						Entity: n.Attributes["entity"],
+						ID:     n.Attributes["id"],
+						Attr:   n.Attributes["name"],
+						Value:  v,
+						Chain:  s.whyChain(n),
+					})
+				}
+			}
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	walk(root)
+
+	jsonResponse(w, map[string]interface{}{
+		"success": true,
+		"total":   total,
+		"hits":    hits,
+	})
+}
+
+// whyChain walks up from a trace node collecting, for each enclosing
+// decision-table pass, the fired column's condition requirements joined
+// with their actual recorded results. Innermost table first. Caller holds
+// s.mu (read).
+func (s *Server) whyChain(n *trace.TraceNode) []findChainLink {
+	chain := []findChainLink{}
+	var action, column *trace.TraceNode
+	for cur := n.Parent; cur != nil; cur = cur.Parent {
+		switch cur.Name {
+		case "action", "initialaction":
+			if action == nil {
+				action = cur
+			}
+		case "column":
+			if column == nil {
+				column = cur
+			}
+		case "execute_table":
+			link := s.chainLink(cur, column, action)
+			chain = append(chain, link)
+			// Reset per-frame context; the next levels up describe the caller.
+			action, column = nil, nil
+		}
+	}
+	return chain
+}
+
+// chainLink builds one why-chain frame from a pass node and the acting
+// column/action within it.
+func (s *Server) chainLink(pass, column, action *trace.TraceNode) findChainLink {
+	link := findChainLink{Pass: 1, PassCount: 1, PassNode: pass.Number}
+	if column != nil {
+		link.Column = column.Attributes["n"]
+	}
+	if action != nil {
+		link.Action = action.Attributes["n"]
+	}
+
+	dt := pass.Parent
+	if dt != nil && dt.Name == "decisiontable" {
+		link.Table = dt.Attributes["name"]
+		ord, count := 0, 0
+		for _, c := range dt.Children {
+			if c.Name == "execute_table" {
+				count++
+				if c.Number == pass.Number {
+					ord = count
+				}
+			}
+		}
+		link.Pass, link.PassCount = ord, count
+	}
+
+	// Actual condition results recorded in this pass, by ordinal.
+	actual := map[int]string{}
+	for _, c := range pass.Children {
+		if c.Name == "condition" {
+			if num, err := strconv.Atoi(c.Attributes["n"]); err == nil {
+				actual[num] = c.Attributes["result"]
+			}
+		}
+	}
+
+	// Join with the table definition: the fired column's required cells.
+	if td := s.findTable(link.Table); td != nil && link.Column != "" {
+		for i, cond := range td.Conditions {
+			required := strings.TrimSpace(strings.ToUpper(cellValue(cond.Columns, link.Column)))
+			if required == "" || required == "-" || required == "*" {
+				continue // don't-care cells put no requirement on the column
+			}
+			dsl := cond.Description
+			if dsl == "" {
+				dsl = cond.Postfix
+			}
+			link.Conditions = append(link.Conditions, findConditionStep{
+				Number:   i + 1,
+				DSL:      dsl,
+				Required: required,
+				Actual:   actual[i+1],
+			})
+		}
+	}
+	return link
+}
+
+// cellValue reads a column cell from the {"1": "Y", ...} map, tolerating
+// numeric-string key variants.
+func cellValue(columns map[string]string, col string) string {
+	if v, ok := columns[col]; ok {
+		return v
+	}
+	if n, err := strconv.Atoi(col); err == nil {
+		if v, ok := columns[strconv.Itoa(n)]; ok {
+			return v
+		}
+	}
+	return ""
+}

--- a/pkg/dtrules/apiserver/debug_report.go
+++ b/pkg/dtrules/apiserver/debug_report.go
@@ -1,0 +1,153 @@
+// Copyright 2026 DTRules contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/trace"
+)
+
+// handleDebugReport runs a report spec against the active debug trace —
+// and, when a speculative session is active, against the baseline too,
+// returning the row-level diff.
+// POST /api/debug/report {spec}
+func (s *Server) handleDebugReport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		jsonError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var spec trace.ReportSpec
+	if err := s.limitedDecode(w, r, &spec); err != nil {
+		jsonError(w, "Invalid report spec", http.StatusBadRequest)
+		return
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.debug == nil {
+		jsonError(w, "No trace loaded", http.StatusBadRequest)
+		return
+	}
+
+	report, err := s.runReportLocked(s.debug.trace, spec)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	resp := map[string]interface{}{"success": true, "report": report}
+
+	// Speculative session: run the same spec on the baseline and diff.
+	if s.debug.baseline != nil {
+		if base, err := s.runReportLocked(s.debug.baseline, spec); err == nil {
+			resp["baseline"] = base
+			resp["diff"] = trace.DiffReports(base, report)
+		}
+	}
+	jsonResponse(w, resp)
+}
+
+// runReportLocked replays tr to its end in a fresh session and generates
+// the report. Caller holds s.mu (read).
+func (s *Server) runReportLocked(tr *trace.Trace, spec trace.ReportSpec) (*trace.Report, error) {
+	fs := tr.FinalState()
+	if fs == nil {
+		return nil, fmt.Errorf("trace records no finalState")
+	}
+	sess, err := tr.SetState(s.ruleSet, fs)
+	if err != nil {
+		return nil, fmt.Errorf("replay failed: %v", err)
+	}
+	return tr.GenerateReport(sess, spec), nil
+}
+
+// reportSpecName validates saveable spec names: word characters and
+// dashes only, no path structure.
+var reportSpecName = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+
+// handleReportSpecs lists and saves report specs under <project>/reports/.
+// GET  /api/reports          → {"specs": [{"name", "spec"}]}
+// POST /api/reports          → {"name": "...", "spec": {...}} saves
+func (s *Server) handleReportSpecs(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	projectPath := s.projectPath
+	s.mu.RUnlock()
+	if projectPath == "" {
+		jsonError(w, "No project open", http.StatusBadRequest)
+		return
+	}
+	dir := filepath.Join(projectPath, "reports")
+
+	switch r.Method {
+	case "GET":
+		specs := []map[string]interface{}{}
+		entries, _ := os.ReadDir(dir)
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".report.json") {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+			if err != nil {
+				continue
+			}
+			var spec trace.ReportSpec
+			if json.Unmarshal(data, &spec) != nil {
+				continue
+			}
+			specs = append(specs, map[string]interface{}{
+				"name": strings.TrimSuffix(e.Name(), ".report.json"),
+				"spec": spec,
+			})
+		}
+		jsonResponse(w, map[string]interface{}{"success": true, "specs": specs})
+
+	case "POST":
+		if s.cfg.ReadOnly {
+			jsonError(w, "Server is read-only", http.StatusForbidden)
+			return
+		}
+		var req struct {
+			Name string           `json:"name"`
+			Spec trace.ReportSpec `json:"spec"`
+		}
+		if err := s.limitedDecode(w, r, &req); err != nil {
+			jsonError(w, "Invalid request body", http.StatusBadRequest)
+			return
+		}
+		if !reportSpecName.MatchString(req.Name) {
+			jsonError(w, "Report name must be letters, digits, _ or -", http.StatusBadRequest)
+			return
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			jsonError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		data, _ := json.MarshalIndent(req.Spec, "", "  ")
+		if err := os.WriteFile(filepath.Join(dir, req.Name+".report.json"), data, 0o644); err != nil {
+			jsonError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		jsonResponse(w, map[string]interface{}{"success": true, "name": req.Name})
+
+	default:
+		jsonError(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}

--- a/pkg/dtrules/apiserver/debug_speculate.go
+++ b/pkg/dtrules/apiserver/debug_speculate.go
@@ -1,0 +1,325 @@
+// Copyright 2026 DTRules contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+	el "github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+	"github.com/DTRules/DTRules/pkg/dtrules/entity"
+	"github.com/DTRules/DTRules/pkg/dtrules/excel"
+	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+	"github.com/DTRules/DTRules/pkg/dtrules/trace"
+)
+
+// handleDebugSpeculate reruns the loaded trace's execution against a
+// speculative edit of ONE decision table: the project rules are copied to
+// a scratch overlay, the edited table's DSL is applied and compiled, the
+// original trace's recorded initial data seeds a fresh session (the SAME
+// inputs — no input file needed), and the entry table executes with
+// tracing. The speculative trace becomes the active debug session; the
+// original stays as the baseline for reports, diffs, and restore. Project
+// files are never touched.
+//
+// POST /api/debug/speculate   {<DecisionTableData>}
+// POST /api/debug/speculate/reset
+func (s *Server) handleDebugSpeculate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		jsonError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var table DecisionTableData
+	if err := s.limitedDecode(w, r, &table); err != nil {
+		jsonError(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if table.TableName == "" {
+		jsonError(w, "table needs a tableName", http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.debug == nil {
+		jsonError(w, "No trace loaded", http.StatusBadRequest)
+		return
+	}
+
+	// Speculations always build on the ORIGINAL rules + this one edit —
+	// re-speculating replaces the previous speculation, it doesn't stack.
+	baselineTrace := s.debug.trace
+	baselinePath := s.debug.tracePath
+	if s.debug.baseline != nil {
+		baselineTrace = s.debug.baseline
+		baselinePath = s.debug.baselinePath
+	}
+
+	specPath, err := s.runSpeculation(baselinePath, &table)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	ds, err := s.loadDebugSessionLocked(specPath)
+	if err != nil {
+		jsonError(w, fmt.Sprintf("speculative trace failed to load: %v", err), http.StatusInternalServerError)
+		return
+	}
+	ds.speculative = true
+	ds.baseline = baselineTrace
+	ds.baselinePath = baselinePath
+	// The overlay's rules legitimately differ from the project's — the
+	// SPECULATIVE flag carries that message; a scary mismatch chip would
+	// mislead.
+	ds.fingerprintMatch = "speculative"
+
+	jsonResponse(w, debugSessionPayload(ds))
+}
+
+// handleDebugSpeculateReset restores the baseline trace session.
+func (s *Server) handleDebugSpeculateReset(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		jsonError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.debug == nil || s.debug.baseline == nil {
+		jsonError(w, "No speculation active", http.StatusBadRequest)
+		return
+	}
+	ds, err := s.loadDebugSessionLocked(s.debug.baselinePath)
+	if err != nil {
+		jsonError(w, fmt.Sprintf("restore failed: %v", err), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, debugSessionPayload(ds))
+}
+
+// runSpeculation builds the overlay rules with the table edit applied,
+// seeds a session from the baseline trace's initial data, executes the
+// entry table with tracing, and returns the speculative trace path.
+// Caller holds s.mu.
+func (s *Server) runSpeculation(baselinePath string, table *DecisionTableData) (string, error) {
+	// 1. Overlay: copy the resolved rules dir.
+	srcDir := projectXMLDir(s.projectPath)
+	overlay, err := os.MkdirTemp("", "dtrules-spec-*")
+	if err != nil {
+		return "", err
+	}
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return "", err
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(strings.ToLower(e.Name()), ".xml") {
+			continue
+		}
+		data, rerr := os.ReadFile(filepath.Join(srcDir, e.Name()))
+		if rerr != nil {
+			return "", rerr
+		}
+		if werr := os.WriteFile(filepath.Join(overlay, e.Name()), data, 0o644); werr != nil {
+			return "", werr
+		}
+	}
+
+	// 2. Apply the edit (and compile its DSL) into the overlay.
+	if err := applySpeculativeEdit(overlay, table); err != nil {
+		return "", err
+	}
+
+	// 3. Modified ruleset.
+	rs := session.NewRuleSet("speculative")
+	if err := rs.LoadFromDirectory(overlay); err != nil {
+		return "", fmt.Errorf("load modified rules: %v", err)
+	}
+
+	// 4. Seed from the baseline trace's recorded initial data: a fresh
+	// copy of the trace replayed to the first decisiontable node.
+	tr := trace.NewTrace()
+	root, err := tr.Load(baselinePath)
+	if err != nil {
+		return "", fmt.Errorf("reload baseline trace: %v", err)
+	}
+	entryNode := firstDecisionTable(root)
+	if entryNode == nil {
+		return "", fmt.Errorf("baseline trace has no decision table execution")
+	}
+	entry := entryNode.Attributes["name"]
+	sess, err := tr.SetState(rs, entryNode)
+	if err != nil {
+		return "", fmt.Errorf("seed initial data: %v", err)
+	}
+	state, ok := sess.GetState().(*interpreter.DTState)
+	if !ok {
+		return "", fmt.Errorf("unexpected state type %T", sess.GetState())
+	}
+
+	// The seeded session must allocate NEW ids above everything the
+	// baseline recorded — otherwise entities/arrays created during the
+	// speculative run collide with spliced initial-data ids and the trace
+	// cannot replay.
+	if fac, ok := sess.GetEntityFactory().(*entity.Factory); ok {
+		fac.EnsureUniqueIDAbove(maxRecordedID(root))
+	}
+
+	// 5. Execute the entry table with tracing into the overlay. The
+	// baseline's initial-data section (everything between the header and
+	// the first decisiontable) is spliced in verbatim: the seeding replay
+	// above ran untraced, and without those defs the speculative trace
+	// could neither verify nor replay the input data.
+	specPath := filepath.Join(overlay, "speculative.trace.xml")
+	f, err := os.Create(specPath)
+	if err != nil {
+		return "", err
+	}
+	fingerprint, _ := trace.FingerprintRules(overlay)
+	trace.WriteHeader(f, trace.Provenance{
+		DTRulesVersion:   s.debug.provenance.DTRulesVersion,
+		RulesFingerprint: fingerprint,
+	})
+	if raw, rerr := os.ReadFile(baselinePath); rerr == nil {
+		text := string(raw)
+		start := strings.Index(text, "\n")
+		end := strings.Index(text, "<decisiontable")
+		if start >= 0 && end > start {
+			if _, werr := f.WriteString(text[start+1 : end]); werr != nil {
+				f.Close()
+				return "", werr
+			}
+		}
+	}
+	state.SetOutput(f, nil)
+	state.EnableTrace()
+
+	rsess, ok := sess.(*session.RSession)
+	if !ok {
+		f.Close()
+		return "", fmt.Errorf("unexpected session type %T", sess)
+	}
+	execErr := rsess.Execute(entry)
+	trace.WriteFinalState(f, state)
+	trace.WriteFooter(f)
+	f.Close()
+	if execErr != nil {
+		return "", fmt.Errorf("speculative run failed: %v", execErr)
+	}
+	return specPath, nil
+}
+
+// applySpeculativeEdit replaces one table's editable fields in the overlay
+// XML and recompiles its DSL rows (conditions and actions) so the rerun
+// executes the edit, not the stale postfix.
+func applySpeculativeEdit(overlay string, table *DecisionTableData) error {
+	files, _ := filepath.Glob(filepath.Join(overlay, "*_dt.xml"))
+	for _, path := range files {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		doc, err := excel.UnmarshalDecisionTablesXML(data)
+		if err != nil {
+			continue
+		}
+		for i := range doc.Tables {
+			if !strings.EqualFold(doc.Tables[i].TableName, table.TableName) {
+				continue
+			}
+			applyTableEdits(&doc.Tables[i], table)
+			if err := compileTableDSL(overlay, &doc.Tables[i]); err != nil {
+				return err
+			}
+			imp := excel.NewDTImporter()
+			return imp.WriteXML(doc, path)
+		}
+	}
+	return fmt.Errorf("table %q not found in the rules", table.TableName)
+}
+
+// compileTableDSL recompiles every condition/action row of one table from
+// its DSL, with the overlay's EDD symbols for type-aware dispatch. Rows
+// with no DSL keep their existing postfix.
+func compileTableDSL(overlay string, x *excel.DecisionTableXML) error {
+	c := el.NewCompiler()
+	if syms := authoring.LoadEDDSymbols(overlay); len(syms) > 0 {
+		c.SetSymbols(syms)
+	}
+	for i := range x.Conditions {
+		dsl := strings.TrimSpace(x.Conditions[i].DSL)
+		if dsl == "" {
+			continue
+		}
+		pf, err := c.CompileCondition(dsl)
+		if err != nil {
+			return fmt.Errorf("condition %d: %v", i+1, err)
+		}
+		x.Conditions[i].Postfix = pf
+	}
+	for i := range x.Actions {
+		dsl := strings.TrimSpace(x.Actions[i].DSL)
+		if dsl == "" {
+			continue
+		}
+		pf, err := c.CompileAction(dsl)
+		if err != nil {
+			return fmt.Errorf("action %d: %v", i+1, err)
+		}
+		x.Actions[i].Postfix = pf
+	}
+	return nil
+}
+
+// maxRecordedID scans every id / arrayId attribute in the trace and
+// returns the largest numeric value.
+func maxRecordedID(n *trace.TraceNode) int {
+	max := 0
+	var walk func(x *trace.TraceNode)
+	walk = func(x *trace.TraceNode) {
+		for _, key := range []string{"id", "arrayId"} {
+			if v := x.Attributes[key]; v != "" {
+				if id, err := strconv.Atoi(v); err == nil && id > max {
+					max = id
+				}
+			}
+		}
+		for _, c := range x.Children {
+			walk(c)
+		}
+	}
+	walk(n)
+	return max
+}
+
+// firstDecisionTable finds the first decisiontable node in the trace —
+// the entry table of the recorded run.
+func firstDecisionTable(n *trace.TraceNode) *trace.TraceNode {
+	if n.Name == "decisiontable" {
+		return n
+	}
+	for _, c := range n.Children {
+		if r := firstDecisionTable(c); r != nil {
+			return r
+		}
+	}
+	return nil
+}

--- a/pkg/dtrules/apiserver/server.go
+++ b/pkg/dtrules/apiserver/server.go
@@ -427,6 +427,11 @@ func (s *Server) Routes() http.Handler {
 	// Trace debugger endpoints
 	mux.HandleFunc("/api/debug/load", s.handleDebugLoad)
 	mux.HandleFunc("/api/debug/status", s.handleDebugStatus)
+	mux.HandleFunc("/api/debug/find", s.handleDebugFind)
+	mux.HandleFunc("/api/debug/report", s.handleDebugReport)
+	mux.HandleFunc("/api/debug/speculate", s.handleDebugSpeculate)
+	mux.HandleFunc("/api/debug/speculate/reset", s.handleDebugSpeculateReset)
+	mux.HandleFunc("/api/reports", s.handleReportSpecs)
 	mux.HandleFunc("/api/debug/tree", s.handleDebugTree)
 	mux.HandleFunc("/api/debug/position", s.handleDebugPosition)
 	mux.HandleFunc("/api/debug/console", s.handleDebugConsole)
@@ -455,6 +460,13 @@ func readOnlyGuard(next http.Handler) http.Handler {
 		"/api/debug/load":     true,
 		"/api/debug/position": true,
 		"/api/debug/console":  true,
+		// Reports read replayed state; spec SAVES are guarded inside the
+		// handler itself (403 when read-only).
+		"/api/debug/report": true,
+		// Speculation writes only to a scratch overlay and the in-memory
+		// session — project files are never touched.
+		"/api/debug/speculate":       true,
+		"/api/debug/speculate/reset": true,
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/browse" {

--- a/pkg/dtrules/entity/factory.go
+++ b/pkg/dtrules/entity/factory.go
@@ -67,6 +67,18 @@ func (f *Factory) GetUniqueID() int {
 	return id
 }
 
+// EnsureUniqueIDAbove advances the id counter past floor, so ids handed
+// out from here on cannot collide with ids already in use — a replay that
+// seeds a session from recorded events (which carry their own ids) must
+// call this before live execution allocates new entities or arrays.
+func (f *Factory) EnsureUniqueIDAbove(floor int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.uniqueID <= floor {
+		f.uniqueID = floor + 1
+	}
+}
+
 // Freeze marks the factory as frozen (after first session created).
 func (f *Factory) Freeze() {
 	f.mu.Lock()

--- a/pkg/dtrules/trace/report.go
+++ b/pkg/dtrules/trace/report.go
@@ -1,0 +1,376 @@
+// Copyright 2026 DTRules contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+)
+
+// ReportSpec is the user-composed description of a trace report: which
+// entities to show, which of their EDD fields, filtered and sorted how.
+// Specs are plain JSON, saveable in the project (reports/*.report.json),
+// and run identically against a baseline or a speculative trace — which is
+// what makes outcome diffs possible.
+type ReportSpec struct {
+	Name     string          `json:"name"`
+	Sections []ReportSection `json:"sections"`
+}
+
+// ReportSection selects one set of rows.
+//
+// Instance source, one of:
+//   - Entity: every instance of that entity the run created or touched
+//     (e.g. "token_recipient" lists all recipients built during the run).
+//   - Source "entity.attr": the elements of that array attribute on the
+//     final state (e.g. "staking_report.payouts").
+//
+// Fields are EDD attribute names (empty = every attribute, sorted). Where
+// filters rows; Key names the field used to align rows in diffs (defaults
+// to the first field).
+type ReportSection struct {
+	Title  string         `json:"title,omitempty"`
+	Entity string         `json:"entity,omitempty"`
+	Source string         `json:"source,omitempty"`
+	Fields []string       `json:"fields,omitempty"`
+	Where  []ReportFilter `json:"where,omitempty"`
+	Sort   string         `json:"sort,omitempty"`
+	Key    string         `json:"key,omitempty"`
+}
+
+// ReportFilter is one predicate on a field. Ops: == != > >= < <= contains.
+// Comparison is numeric when both sides parse as numbers, else
+// case-insensitive text (EL semantics).
+type ReportFilter struct {
+	Field string `json:"field"`
+	Op    string `json:"op"`
+	Value string `json:"value"`
+}
+
+// Report is the result of running a spec against a trace.
+type Report struct {
+	Name     string                `json:"name"`
+	Sections []ReportSectionResult `json:"sections"`
+}
+
+// ReportSectionResult is one rendered section: column order in Fields,
+// row values keyed by field name. Total counts rows before filtering.
+type ReportSectionResult struct {
+	Title  string              `json:"title"`
+	Entity string              `json:"entity"`
+	Key    string              `json:"key"`
+	Fields []string            `json:"fields"`
+	Rows   []map[string]string `json:"rows"`
+	Total  int                 `json:"total"`
+	Error  string              `json:"error,omitempty"`
+}
+
+// GenerateReport runs spec against a trace that has been replayed to its
+// end (SetState to the finalState node): instances and final values are
+// read from the replay session.
+func (t *Trace) GenerateReport(sess dtrules.Session, spec ReportSpec) *Report {
+	rep := &Report{Name: spec.Name}
+	for _, sec := range spec.Sections {
+		rep.Sections = append(rep.Sections, t.generateSection(sess, sec))
+	}
+	return rep
+}
+
+func (t *Trace) generateSection(sess dtrules.Session, sec ReportSection) ReportSectionResult {
+	res := ReportSectionResult{Title: sec.Title, Entity: sec.Entity}
+	if res.Title == "" {
+		if sec.Source != "" {
+			res.Title = sec.Source
+		} else {
+			res.Title = sec.Entity
+		}
+	}
+
+	instances, err := t.sectionInstances(sess, sec)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	res.Total = len(instances)
+
+	// Field list: explicit, or every attribute of the first instance.
+	fields := sec.Fields
+	if len(fields) == 0 && len(instances) > 0 {
+		for _, n := range instances[0].GetAttributeNames() {
+			name := n.StringValue()
+			if name == "" || strings.Contains(name, "*") {
+				continue // internal attrs like mapping*key
+			}
+			fields = append(fields, name)
+		}
+		sort.Strings(fields)
+	}
+	res.Fields = fields
+	res.Key = sec.Key
+	if res.Key == "" && len(fields) > 0 {
+		res.Key = fields[0]
+	}
+
+	for _, e := range instances {
+		row := map[string]string{"#id": strconv.Itoa(e.GetID())}
+		for _, f := range fields {
+			row[f] = entityFieldValue(e, f)
+		}
+		if rowMatches(e, sec.Where) {
+			res.Rows = append(res.Rows, row)
+		}
+	}
+
+	if sec.Sort != "" {
+		sortRows(res.Rows, sec.Sort)
+	}
+	return res
+}
+
+// sectionInstances resolves the section's instance source.
+func (t *Trace) sectionInstances(sess dtrules.Session, sec ReportSection) ([]dtrules.Entity, error) {
+	if sec.Source != "" {
+		parts := strings.SplitN(sec.Source, ".", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("source %q must be entity.attribute", sec.Source)
+		}
+		state := sess.GetState()
+		holder, err := state.FindEntity(dtrules.GetRName(parts[1]))
+		if err != nil || holder == nil {
+			// The attribute may not be on the stack path — search instances
+			// of the named entity instead (EL case-insensitive).
+			for _, e := range t.InstancesOf(parts[0]) {
+				holder = e
+				break
+			}
+		}
+		if holder == nil {
+			return nil, fmt.Errorf("no %s on the final state", parts[0])
+		}
+		v, err := holder.Get(dtrules.GetRName(parts[1]))
+		if err != nil || v == nil {
+			return nil, fmt.Errorf("%s has no attribute %s", parts[0], parts[1])
+		}
+		arr, err := v.RArrayValue()
+		if err != nil {
+			return nil, fmt.Errorf("%s is not an array", sec.Source)
+		}
+		var out []dtrules.Entity
+		for i := 0; i < arr.Size(); i++ {
+			el, gerr := arr.Get(i)
+			if gerr != nil {
+				continue
+			}
+			if e, ok := el.(dtrules.Entity); ok {
+				out = append(out, e)
+			}
+		}
+		return out, nil
+	}
+	if sec.Entity == "" {
+		return nil, fmt.Errorf("section needs an entity or a source")
+	}
+	return t.InstancesOf(sec.Entity), nil
+}
+
+// entityFieldValue reads one attribute as display text (EL name matching).
+func entityFieldValue(e dtrules.Entity, field string) string {
+	for _, n := range e.GetAttributeNames() {
+		if strings.EqualFold(n.StringValue(), field) {
+			if v, err := e.Get(n); err == nil && v != nil {
+				return v.StringValue()
+			}
+			return ""
+		}
+	}
+	return ""
+}
+
+// rowMatches applies every filter (AND semantics).
+func rowMatches(e dtrules.Entity, where []ReportFilter) bool {
+	for _, f := range where {
+		val := entityFieldValue(e, f.Field)
+		if !filterMatch(val, f.Op, f.Value) {
+			return false
+		}
+	}
+	return true
+}
+
+func filterMatch(val, op, target string) bool {
+	nv, nerr := strconv.ParseFloat(strings.TrimSpace(val), 64)
+	nt, terr := strconv.ParseFloat(strings.TrimSpace(target), 64)
+	numeric := nerr == nil && terr == nil
+	switch op {
+	case "==", "=", "":
+		if numeric {
+			return nv == nt
+		}
+		return strings.EqualFold(strings.TrimSpace(val), strings.TrimSpace(target))
+	case "!=":
+		return !filterMatch(val, "==", target)
+	case ">":
+		return numeric && nv > nt
+	case ">=":
+		return numeric && nv >= nt
+	case "<":
+		return numeric && nv < nt
+	case "<=":
+		return numeric && nv <= nt
+	case "contains":
+		return strings.Contains(strings.ToLower(val), strings.ToLower(target))
+	}
+	return false
+}
+
+// sortRows orders rows by a field, numerically when values parse.
+func sortRows(rows []map[string]string, field string) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		a, b := rows[i][field], rows[j][field]
+		na, aerr := strconv.ParseFloat(a, 64)
+		nb, berr := strconv.ParseFloat(b, 64)
+		if aerr == nil && berr == nil {
+			return na < nb
+		}
+		return a < b
+	})
+}
+
+// ── diffs ────────────────────────────────────────────────────────────
+
+// ReportDiff compares two runs of the SAME spec (baseline vs modified):
+// per section, rows added, removed, and field-level changes, aligned by
+// the section's key field.
+type ReportDiff struct {
+	Name     string            `json:"name"`
+	Sections []SectionDiffData `json:"sections"`
+}
+
+// SectionDiffData is the row-level delta of one section.
+type SectionDiffData struct {
+	Title   string              `json:"title"`
+	Fields  []string            `json:"fields"`
+	Added   []map[string]string `json:"added"`
+	Removed []map[string]string `json:"removed"`
+	Changed []RowChange         `json:"changed"`
+}
+
+// RowChange is one row present in both runs with differing fields.
+type RowChange struct {
+	Key    string            `json:"key"`
+	Before map[string]string `json:"before"`
+	After  map[string]string `json:"after"`
+	Fields []string          `json:"fields"` // which fields differ
+}
+
+// DiffReports aligns rows by each section's key field and reports adds,
+// removals, and changed fields.
+func DiffReports(baseline, modified *Report) *ReportDiff {
+	diff := &ReportDiff{Name: modified.Name}
+	for i := range modified.Sections {
+		ms := modified.Sections[i]
+		var bs *ReportSectionResult
+		if i < len(baseline.Sections) && baseline.Sections[i].Title == ms.Title {
+			bs = &baseline.Sections[i]
+		} else {
+			for j := range baseline.Sections {
+				if baseline.Sections[j].Title == ms.Title {
+					bs = &baseline.Sections[j]
+					break
+				}
+			}
+		}
+		sd := SectionDiffData{Title: ms.Title, Fields: ms.Fields}
+		if bs == nil {
+			sd.Added = ms.Rows
+			diff.Sections = append(diff.Sections, sd)
+			continue
+		}
+
+		key := ms.Key
+		rowKey := func(r map[string]string) string {
+			if key != "" && r[key] != "" {
+				return r[key]
+			}
+			return r["#id"]
+		}
+		before := map[string]map[string]string{}
+		for _, r := range bs.Rows {
+			before[rowKey(r)] = r
+		}
+		seen := map[string]bool{}
+		for _, r := range ms.Rows {
+			k := rowKey(r)
+			seen[k] = true
+			b, ok := before[k]
+			if !ok {
+				sd.Added = append(sd.Added, r)
+				continue
+			}
+			var changed []string
+			for _, f := range ms.Fields {
+				if b[f] != r[f] {
+					changed = append(changed, f)
+				}
+			}
+			if len(changed) > 0 {
+				sd.Changed = append(sd.Changed, RowChange{Key: k, Before: b, After: r, Fields: changed})
+			}
+		}
+		for _, r := range bs.Rows {
+			if !seen[rowKey(r)] {
+				sd.Removed = append(sd.Removed, r)
+			}
+		}
+		diff.Sections = append(diff.Sections, sd)
+	}
+	return diff
+}
+
+// ── rendering ────────────────────────────────────────────────────────
+
+// Markdown renders the report as markdown tables (the CLI surface).
+func (r *Report) Markdown() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# %s\n", r.Name)
+	for _, s := range r.Sections {
+		fmt.Fprintf(&sb, "\n## %s\n\n", s.Title)
+		if s.Error != "" {
+			fmt.Fprintf(&sb, "_error: %s_\n", s.Error)
+			continue
+		}
+		if len(s.Rows) == 0 {
+			fmt.Fprintf(&sb, "_no rows (%d before filters)_\n", s.Total)
+			continue
+		}
+		fmt.Fprintf(&sb, "| %s |\n", strings.Join(s.Fields, " | "))
+		fmt.Fprintf(&sb, "|%s\n", strings.Repeat(" --- |", len(s.Fields)))
+		for _, row := range s.Rows {
+			vals := make([]string, len(s.Fields))
+			for i, f := range s.Fields {
+				vals[i] = row[f]
+			}
+			fmt.Fprintf(&sb, "| %s |\n", strings.Join(vals, " | "))
+		}
+		if len(s.Rows) < s.Total {
+			fmt.Fprintf(&sb, "\n_%d of %d rows (filtered)_\n", len(s.Rows), s.Total)
+		}
+	}
+	return sb.String()
+}

--- a/pkg/dtrules/trace/trace.go
+++ b/pkg/dtrules/trace/trace.go
@@ -237,6 +237,16 @@ func (t *Trace) getOrCreateEntity(node *TraceNode) (dtrules.Entity, error) {
 		return nil, fmt.Errorf("failed to create entity %s: %w", entityName, err)
 	}
 
+	// Force the RECORDED id onto the replayed instance. A replayed session
+	// that continues executing (speculative reruns) emits trace events with
+	// entity.GetID() — those must match the ids already recorded, or the
+	// produced trace cannot replay.
+	if recorded, aerr := strconv.Atoi(id); aerr == nil {
+		if setter, ok := entity.(interface{ SetID(int) }); ok {
+			setter.SetID(recorded)
+		}
+	}
+
 	t.entityTable[id] = entity
 	return entity, nil
 }
@@ -550,12 +560,37 @@ func (t *Trace) InstancesOf(entityName string) []dtrules.Entity {
 		return nil
 	}
 
+	// Java-era traces identify instances with <createentity> events;
+	// Go traces carry entity + id attributes on entitypush / def / addto
+	// events. Collect from both, first-seen order, deduped.
 	var entityIDs []int
 	t.root.SearchTree(t, entityName, &entityIDs)
 
-	result := make([]dtrules.Entity, 0, len(entityIDs))
+	seen := map[string]bool{}
 	for _, id := range entityIDs {
-		if entity, ok := t.entityTable[strconv.Itoa(id)]; ok {
+		seen[strconv.Itoa(id)] = true
+	}
+	ids := make([]string, 0, len(entityIDs))
+	for _, id := range entityIDs {
+		ids = append(ids, strconv.Itoa(id))
+	}
+	var walk func(n *TraceNode)
+	walk = func(n *TraceNode) {
+		if strings.EqualFold(n.Attributes["entity"], entityName) {
+			if id := n.Attributes["id"]; id != "" && !seen[id] {
+				seen[id] = true
+				ids = append(ids, id)
+			}
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	walk(t.root)
+
+	result := make([]dtrules.Entity, 0, len(ids))
+	for _, id := range ids {
+		if entity, ok := t.entityTable[id]; ok {
 			result = append(result, entity)
 		}
 	}

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -491,8 +491,10 @@ export interface DebugLoadResponse {
   nodes?: number;
   dtrulesVersion?: string;
   rulesFingerprint?: string;
-  fingerprintMatch?: 'match' | 'mismatch' | 'unknown';
+  fingerprintMatch?: 'match' | 'mismatch' | 'unknown' | 'speculative';
   verifyMismatches?: string[];
+  /** True when the active session is a speculative rerun. */
+  speculative?: boolean;
 }
 
 /** Result of positioning the replay session at a trace node. */
@@ -519,6 +521,149 @@ export async function debugTree(): Promise<{ success: boolean; error?: string; t
  *  by `dtrules debug`), with the same fields as debugLoad when it does. */
 export async function debugStatus(): Promise<DebugLoadResponse & { loaded?: boolean }> {
   return fetchJSON(`${API_BASE}/debug/status`);
+}
+
+/** One condition requirement in a find why-chain. */
+export interface FindConditionStep {
+  number: number;
+  dsl: string;
+  required: string;
+  actual: string;
+}
+
+/** One frame of a find why-chain (innermost table first). */
+export interface FindChainLink {
+  table: string;
+  pass: number;
+  passCount: number;
+  column: string;
+  action: string;
+  passNode: number;
+  conditions: FindConditionStep[] | null;
+}
+
+/** One recorded write of a searched field. */
+export interface FindHit {
+  node: number;
+  entity: string;
+  id: string;
+  attr: string;
+  value: string;
+  chain: FindChainLink[];
+}
+
+/** Searches the loaded trace for writes of a field (EL case-insensitive). */
+export async function debugFind(attr: string, entity?: string, value?: string): Promise<{
+  success: boolean;
+  error?: string;
+  total?: number;
+  hits?: FindHit[];
+}> {
+  const q = new URLSearchParams({ attr });
+  if (entity) q.set('entity', entity);
+  if (value) q.set('value', value);
+  return fetchJSON(`${API_BASE}/debug/find?${q}`);
+}
+
+// ── report generator ─────────────────────────────────────────────────
+
+/** One predicate on a report section's rows. */
+export interface ReportFilter {
+  field: string;
+  op: string;
+  value: string;
+}
+
+/** One section of a report spec: entity instances or array elements. */
+export interface ReportSection {
+  title?: string;
+  entity?: string;
+  source?: string;
+  fields?: string[];
+  where?: ReportFilter[];
+  sort?: string;
+  key?: string;
+}
+
+/** A user-composed, saveable report description. */
+export interface ReportSpec {
+  name: string;
+  sections: ReportSection[];
+}
+
+/** One rendered report section. */
+export interface ReportSectionResult {
+  title: string;
+  entity: string;
+  key: string;
+  fields: string[];
+  rows: Record<string, string>[] | null;
+  total: number;
+  error?: string;
+}
+
+export interface ReportResult {
+  name: string;
+  sections: ReportSectionResult[];
+}
+
+export interface RowChange {
+  key: string;
+  before: Record<string, string>;
+  after: Record<string, string>;
+  fields: string[];
+}
+
+export interface SectionDiff {
+  title: string;
+  fields: string[];
+  added: Record<string, string>[] | null;
+  removed: Record<string, string>[] | null;
+  changed: RowChange[] | null;
+}
+
+export interface ReportDiffResult {
+  name: string;
+  sections: SectionDiff[];
+}
+
+/** Runs a report spec against the active debug trace (and the baseline,
+ *  with a diff, when a speculative session is active). */
+export async function debugReport(spec: ReportSpec): Promise<{
+  success: boolean;
+  error?: string;
+  report?: ReportResult;
+  baseline?: ReportResult;
+  diff?: ReportDiffResult;
+}> {
+  return fetchJSON(`${API_BASE}/debug/report`, { method: 'POST', body: JSON.stringify(spec) });
+}
+
+/** Reruns the trace's execution with ONE table speculatively edited —
+ *  same inputs (seeded from the trace), project files untouched. The
+ *  speculative trace becomes the active session; the original stays as
+ *  the baseline for report diffs and restore. */
+export async function debugSpeculate(table: unknown): Promise<DebugLoadResponse> {
+  return fetchJSON(`${API_BASE}/debug/speculate`, { method: 'POST', body: JSON.stringify(table) });
+}
+
+/** Restores the baseline trace session after a speculation. */
+export async function debugSpeculateReset(): Promise<DebugLoadResponse> {
+  return fetchJSON(`${API_BASE}/debug/speculate/reset`, { method: 'POST', body: '{}' });
+}
+
+/** Lists report specs saved in the project (reports/*.report.json). */
+export async function listReportSpecs(): Promise<{
+  success: boolean;
+  error?: string;
+  specs?: { name: string; spec: ReportSpec }[];
+}> {
+  return fetchJSON(`${API_BASE}/reports`);
+}
+
+/** Saves a report spec into the project. */
+export async function saveReportSpec(name: string, spec: ReportSpec): Promise<{ success: boolean; error?: string }> {
+  return fetchJSON(`${API_BASE}/reports`, { method: 'POST', body: JSON.stringify({ name, spec }) });
 }
 
 /** Replays to a trace node ("run to here" / stepping). */

--- a/ui/src/components/DTEditor.tsx
+++ b/ui/src/components/DTEditor.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import type { ReactNode } from 'react';
 import { useProjectStore } from '@/stores/projectStore';
+import { debugSpeculate } from '@/api/client';
 import { AgGridReact } from 'ag-grid-react';
 import 'ag-grid-community/styles/ag-grid.css';
 import 'ag-grid-community/styles/ag-theme-alpine.css';
@@ -144,6 +145,15 @@ export function DTEditor() {
   useEffect(() => {
     if (readOnly) setEditMode(false);
   }, [readOnly]);
+
+  // Speculative edits arrive from the debugger wanting to edit NOW. The
+  // editor stays mounted across tabs, so this keys on table selection —
+  // the speculate flow selects the table as it switches here.
+  useEffect(() => {
+    if (sessionStorage.getItem('dtrules.speculativeEdit') === '1' && !readOnly) {
+      setEditMode(true);
+    }
+  }, [currentTable, readOnly]);
   const [colWidths, setColWidths] = useState<ColWidths>(loadColWidths);
 
   // Table-level navigation history for perform-link jumps (browser-style).
@@ -228,8 +238,24 @@ export function DTEditor() {
     }
   }, [currentTable]);
 
+  // Speculative-edit mode: entered from the debugger. Save does NOT touch
+  // project files — it reruns the trace's execution with this one table
+  // modified, then returns to the Debug tab with the result.
+  const speculative = sessionStorage.getItem('dtrules.speculativeEdit') === '1';
+
   const handleSave = async () => {
     if (!editedTable) return;
+    if (speculative) {
+      const r = await debugSpeculate(editedTable);
+      if (!r.success) {
+        window.alert(`Speculation failed: ${r.error || 'unknown error'}`);
+        return;
+      }
+      sessionStorage.removeItem('dtrules.speculativeEdit');
+      window.dispatchEvent(new CustomEvent('dtrules:speculated', { detail: r }));
+      setActiveTab('debug');
+      return;
+    }
     await updateTable(editedTable);
   };
 
@@ -564,10 +590,17 @@ export function DTEditor() {
                   className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 text-white border-0"
                 >
                   <Save className="h-4 w-4 mr-2" />
-                  Save
+                  {speculative ? 'Run speculation' : 'Save'}
                 </Button>
               )}
             </div>
+
+            {speculative && (
+              <div className="mx-2 mt-1 px-3 py-1.5 rounded border border-amber-500/50 bg-amber-500/10 text-amber-300 text-xs">
+                SPECULATIVE EDIT — “Run speculation” reruns the trace’s execution with this change.
+                Project files are not touched. Esc returns to the debugger.
+              </div>
+            )}
 
             {/* The entire decision table as one grid, in the Excel sheet's
                 order: CONTEXTS, INITIAL ACTIONS, CONDITIONS, ACTIONS, POLICY

--- a/ui/src/components/DebugPanel.tsx
+++ b/ui/src/components/DebugPanel.tsx
@@ -19,16 +19,20 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useProjectStore } from '@/stores/projectStore';
 import {
   debugConsole,
+  debugFind,
   debugLoad,
+  debugSpeculateReset,
   debugStatus,
   debugPosition,
   debugTree,
   type DebugFrame,
   type DebugLoadResponse,
   type DebugNode,
+  type FindHit,
 } from '@/api/client';
 import { FileBrowser } from '@/components/FileBrowser';
 import { DebugTableView } from '@/components/DebugTableView';
+import { ReportPanel } from '@/components/ReportPanel';
 import {
   ancestorsOf,
   bucketSize,
@@ -256,13 +260,18 @@ export function DebugPanel() {
   // Per-entity-name expand/collapse for the stack panel; unset = default
   // (top frame open, others collapsed).
   const [stackOpen, setStackOpen] = useState<Record<string, boolean>>({});
+  // Find-writes panel: query text, results, and which hit's why-chain is open.
+  const [findQuery, setFindQuery] = useState('');
+  const [findHits, setFindHits] = useState<FindHit[] | null>(null);
+  const [findTotal, setFindTotal] = useState(0);
+  const [findOpen, setFindOpen] = useState<number | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [browsing, setBrowsing] = useState(true);
 
   const [consoleLines, setConsoleLines] = useState<{ input: string; output: string; error?: boolean }[]>([]);
   const consoleInput = useRef<HTMLInputElement>(null);
 
-  const [viewMode, setViewMode] = useState<'table' | 'tree'>('table');
+  const [viewMode, setViewMode] = useState<'table' | 'tree' | 'report'>('table');
   const [frame, setFrame] = useState<{ pass: number; focus: Focus } | null>(null);
   const treeRef = useRef<DebugNode | null>(null);
 
@@ -533,6 +542,26 @@ export function DebugPanel() {
     });
   }, [position, goTo]);
 
+  // runFind parses "attr", "entity.attr", or "... = value" and searches
+  // the trace for matching writes.
+  const runFind = useCallback(async () => {
+    const q = findQuery.trim();
+    if (!q) {
+      setFindHits(null);
+      return;
+    }
+    const [lhs, rhs] = q.split('=').map((x) => x.trim());
+    const dot = lhs.indexOf('.');
+    const entity = dot > 0 ? lhs.slice(0, dot) : undefined;
+    const attr = dot > 0 ? lhs.slice(dot + 1) : lhs;
+    const r = await debugFind(attr, entity, rhs || undefined);
+    if (r.success) {
+      setFindHits(r.hits || []);
+      setFindTotal(r.total || 0);
+      setFindOpen(null);
+    }
+  }, [findQuery]);
+
   // adoptSession enters the loaded state for a debug session the server
   // holds — after a load we initiated, or one preloaded by `dtrules debug`.
   const adoptSession = useCallback(async (r: DebugLoadResponse) => {
@@ -557,6 +586,16 @@ export function DebugPanel() {
     await goTo(1);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [goTo]);
+
+  // A completed speculation replaces the server session; adopt it.
+  useEffect(() => {
+    const onSpeculated = (e: Event) => {
+      const detail = (e as CustomEvent).detail as DebugLoadResponse;
+      if (detail?.success) adoptSession(detail);
+    };
+    window.addEventListener('dtrules:speculated', onSpeculated);
+    return () => window.removeEventListener('dtrules:speculated', onSpeculated);
+  }, [adoptSession]);
 
   // On mount, adopt a session the server already holds (dtrules debug /
   // edit --trace preload) so the Debug tab opens ready.
@@ -633,16 +672,18 @@ export function DebugPanel() {
         <span className="px-2 py-0.5 rounded-full border border-border text-muted-foreground">
           DTRules {info.dtrulesVersion || 'unknown'}
         </span>
-        <span
-          className={cn(
-            'px-2 py-0.5 rounded-full border',
-            info.fingerprintMatch === 'match' && 'border-green-500/40 text-green-500',
-            info.fingerprintMatch === 'mismatch' && 'border-amber-500/50 text-amber-400',
-            info.fingerprintMatch === 'unknown' && 'border-border text-muted-foreground'
-          )}
-        >
-          rules {info.fingerprintMatch === 'match' ? 'match' : info.fingerprintMatch === 'mismatch' ? 'DIFFER from workspace' : 'fingerprint unknown'}
-        </span>
+        {!info.speculative && (
+          <span
+            className={cn(
+              'px-2 py-0.5 rounded-full border',
+              info.fingerprintMatch === 'match' && 'border-green-500/40 text-green-500',
+              info.fingerprintMatch === 'mismatch' && 'border-amber-500/50 text-amber-400',
+              info.fingerprintMatch === 'unknown' && 'border-border text-muted-foreground'
+            )}
+          >
+            rules {info.fingerprintMatch === 'match' ? 'match' : info.fingerprintMatch === 'mismatch' ? 'DIFFER from workspace' : 'fingerprint unknown'}
+          </span>
+        )}
         <span
           className={cn(
             'px-2 py-0.5 rounded-full border',
@@ -652,6 +693,25 @@ export function DebugPanel() {
         >
           {verifyClean ? 'end-state verified' : `${info.verifyMismatches!.length} end-state mismatches`}
         </span>
+        {info.speculative && (
+          <>
+            <span className="px-2 py-0.5 rounded-full border border-amber-500/60 text-amber-400 font-semibold">
+              SPECULATIVE — rules modified
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-6 px-2 text-xs"
+              onClick={async () => {
+                const r = await debugSpeculateReset();
+                if (r.success) adoptSession(r);
+              }}
+              title="Discard the speculation and restore the original trace"
+            >
+              Restore baseline
+            </Button>
+          </>
+        )}
         <Button variant="ghost" size="sm" className="h-6 px-2 ml-auto text-xs" onClick={() => setBrowsing(true)}>
           Load another trace
         </Button>
@@ -699,6 +759,13 @@ export function DebugPanel() {
             title="Expert view: the raw execution tree"
           >
             Tree
+          </button>
+          <button
+            className={cn('px-2 py-0.5 rounded', viewMode === 'report' ? 'bg-accent text-foreground' : 'text-muted-foreground')}
+            onClick={() => setViewMode('report')}
+            title="EDD-driven reports over this trace (entities, fields, filters)"
+          >
+            Report
           </button>
         </span>
         <span className="font-mono text-xs text-muted-foreground flex items-center gap-1.5">
@@ -748,7 +815,9 @@ export function DebugPanel() {
       {/* Tree + stack */}
       <div className="flex-1 grid grid-cols-[1fr_320px] overflow-hidden">
         <ScrollArea className="border-r border-border/50">
-          {viewMode === 'table' ? (
+          {viewMode === 'report' ? (
+            <ReportPanel />
+          ) : viewMode === 'table' ? (
             idxRef.current && framePassNode ? (
               <DebugTableView
                 idx={idxRef.current}
@@ -763,6 +832,12 @@ export function DebugPanel() {
                 onOpenTable={(name) => {
                   // Bouncing to the editor is a side-trip: Esc brings the
                   // user straight back to the debug view.
+                  sessionStorage.setItem('dtrules.returnToDebugOnEsc', '1');
+                  selectTable(name);
+                  setActiveTab('dt');
+                }}
+                onSpeculate={(name) => {
+                  sessionStorage.setItem('dtrules.speculativeEdit', '1');
                   sessionStorage.setItem('dtrules.returnToDebugOnEsc', '1');
                   selectTable(name);
                   setActiveTab('dt');
@@ -786,6 +861,88 @@ export function DebugPanel() {
         <ScrollArea>
           <div className="p-3 space-y-2">
             <div className="text-[11px] font-semibold tracking-widest uppercase text-muted-foreground">
+              Find writes
+            </div>
+            <div className="flex gap-1">
+              <input
+                value={findQuery}
+                onChange={(e) => setFindQuery(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && runFind()}
+                placeholder="entity.field = value"
+                className="flex-1 h-7 px-2 rounded border border-input bg-transparent font-mono text-xs"
+                title="Search the trace for writes: field, entity.field, or entity.field = value (case-insensitive)"
+              />
+              <Button variant="outline" size="sm" className="h-7 px-2 text-xs" onClick={runFind}>
+                Find
+              </Button>
+            </div>
+            {findHits && (
+              <div className="space-y-1">
+                <div className="text-[10px] text-muted-foreground">
+                  {findTotal === 0
+                    ? 'No writes found'
+                    : findTotal > findHits.length
+                      ? `Showing ${findHits.length} of ${findTotal.toLocaleString()} writes`
+                      : `${findTotal.toLocaleString()} write${findTotal === 1 ? '' : 's'}`}
+                </div>
+                {findHits.map((h) => (
+                  <div key={h.node} className="border border-border/40 rounded text-xs">
+                    <div
+                      className="px-1.5 py-0.5 flex items-baseline gap-1.5 cursor-pointer hover:bg-accent/40 font-mono"
+                      onClick={() => goTo(h.node)}
+                      title={`Jump to node ${h.node}`}
+                    >
+                      <span
+                        className="w-3 text-muted-foreground shrink-0 cursor-pointer"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setFindOpen(findOpen === h.node ? null : h.node);
+                        }}
+                        title="Show why: the conditions that had to be met"
+                      >
+                        {findOpen === h.node ? '▾' : '▸'}
+                      </span>
+                      <span className="truncate">
+                        {h.entity}
+                        <span className="text-muted-foreground">#{h.id}</span> = {h.value}
+                      </span>
+                      <span className="ml-auto text-[10px] text-muted-foreground shrink-0">
+                        {h.chain[0]?.table} {h.chain[0] && h.chain[0].passCount > 1 ? `${h.chain[0].pass}/${h.chain[0].passCount}` : ''}
+                      </span>
+                    </div>
+                    {findOpen === h.node && (
+                      <div className="px-1.5 pb-1 space-y-1">
+                        {h.chain.map((link, li) => (
+                          <div key={li} className="pl-2 border-l border-border/40">
+                            <button
+                              className="text-blue-400 hover:underline font-mono text-[11px]"
+                              onClick={() => goTo(link.passNode)}
+                              title="Jump to this pass"
+                            >
+                              {link.table}
+                            </button>
+                            <span className="text-[10px] text-muted-foreground font-mono">
+                              {' '}pass {link.pass.toLocaleString()}/{link.passCount.toLocaleString()} · col {link.column}
+                              {link.action && ` · action ${link.action}`}
+                            </span>
+                            {(link.conditions || []).map((c) => (
+                              <div key={c.number} className="font-mono text-[10px] leading-4 truncate" title={c.dsl}>
+                                <span className={c.actual === (c.required === 'Y' ? 'true' : 'false') ? 'text-green-500' : 'text-amber-400'}>
+                                  {c.required === 'Y' ? '✓' : '✗'}
+                                </span>{' '}
+                                <span className="text-muted-foreground">{c.number}.</span> {c.dsl}
+                                <span className="text-muted-foreground"> = {c.actual || '?'}</span>
+                              </div>
+                            ))}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className="text-[11px] font-semibold tracking-widest uppercase text-muted-foreground pt-2">
               Entity stack
             </div>
             {[...stack].reverse().map((f, i, arr) => {

--- a/ui/src/components/DebugTableView.tsx
+++ b/ui/src/components/DebugTableView.tsx
@@ -22,7 +22,7 @@ import type { DebugFrame, DebugNode } from '@/api/client';
 import type { DecisionTable } from '@/types/dtrules';
 import { cn } from '@/lib/utils';
 import { focusTarget, frameInfo, stackValue, type Focus, type TreeIndex } from '@/lib/traceTree';
-import { ChevronLeft, ChevronRight, CornerLeftUp } from 'lucide-react';
+import { ChevronLeft, ChevronRight, CornerLeftUp, Pencil } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 const PERFORM_RE = /\bperform\s+([A-Za-z_][A-Za-z0-9_]*)|\/([A-Za-z_][A-Za-z0-9_]*)\s+performtable\b/gi;
@@ -147,6 +147,7 @@ export function DebugTableView({
   onOut,
   onPass,
   onOpenTable,
+  onSpeculate,
 }: {
   idx: TreeIndex;
   passNode: DebugNode;
@@ -161,6 +162,7 @@ export function DebugTableView({
   onOut: () => void;
   onPass: (passNode: DebugNode) => void;
   onOpenTable: (name: string) => void;
+  onSpeculate: (name: string) => void;
 }) {
   const frame = frameInfo(idx, passNode);
   const [table, setTable] = useState<DecisionTable | null>(null);
@@ -300,6 +302,15 @@ export function DebugTableView({
             <CornerLeftUp className="h-3 w-3 mr-1" /> Out
           </Button>
         )}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 px-2 text-xs text-amber-400/90 hover:text-amber-300"
+          onClick={() => onSpeculate(frame.tableName)}
+          title="Edit this table speculatively and rerun the trace's execution with the same inputs — project files are not touched"
+        >
+          <Pencil className="h-3 w-3 mr-1" /> What if…
+        </Button>
         {/* Iteration navigator: which of N passes is in view */}
         {frame.passes.length === 0 ? (
           <span className="ml-auto text-xs text-amber-400/90">

--- a/ui/src/components/ReportPanel.tsx
+++ b/ui/src/components/ReportPanel.tsx
@@ -1,0 +1,357 @@
+/**
+ * ReportPanel - the EDD-driven report generator over the loaded trace.
+ *
+ * The user composes a report from the EDD: pick an entity (every instance
+ * the run created) or an array source (elements of entity.attr), choose
+ * fields, filter with predicates, sort. Specs save into the project
+ * (reports/*.report.json) and run identically against a baseline or a
+ * speculative run — the server returns a row-level diff when a
+ * speculation is active.
+ *
+ * @module components/ReportPanel
+ */
+
+import { useEffect, useState } from 'react';
+import { useProjectStore } from '@/stores/projectStore';
+import {
+  debugReport,
+  listReportSpecs,
+  saveReportSpec,
+  type ReportDiffResult,
+  type ReportResult,
+  type ReportSection,
+  type ReportSpec,
+} from '@/api/client';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { Play, Plus, Save, Trash2 } from 'lucide-react';
+
+const OPS = ['==', '!=', '>', '>=', '<', '<=', 'contains'];
+
+function emptySection(): ReportSection {
+  return { entity: '', source: '', fields: [], where: [], sort: '', key: '' };
+}
+
+export function ReportPanel() {
+  const { entities, readOnly } = useProjectStore();
+  const [name, setName] = useState('report');
+  const [sections, setSections] = useState<ReportSection[]>([emptySection()]);
+  const [saved, setSaved] = useState<{ name: string; spec: ReportSpec }[]>([]);
+  const [result, setResult] = useState<ReportResult | null>(null);
+  const [diff, setDiff] = useState<ReportDiffResult | null>(null);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    listReportSpecs().then((r) => r.success && setSaved(r.specs || []));
+  }, []);
+
+  const updateSection = (i: number, patch: Partial<ReportSection>) => {
+    setSections((s) => s.map((sec, j) => (j === i ? { ...sec, ...patch } : sec)));
+  };
+
+  const fieldsOf = (sec: ReportSection): string[] => {
+    // Field picker source: the section's entity, or for an array source
+    // the entity the user picked as element type (kept in `entity` too).
+    const ent = entities.find((e) => e.name.toLowerCase() === (sec.entity || '').toLowerCase());
+    return ent ? ent.fields.map((f) => f.name).filter(Boolean) : [];
+  };
+
+  const run = async () => {
+    setRunning(true);
+    setError(null);
+    const spec: ReportSpec = {
+      name,
+      sections: sections.map((s) => ({
+        ...s,
+        // Array sources use entity only for the field picker.
+        entity: s.source ? '' : s.entity,
+        title: s.title || (s.source ? s.source : s.entity),
+      })),
+    };
+    const r = await debugReport(spec);
+    setRunning(false);
+    if (!r.success) {
+      setError(r.error || 'Report failed');
+      return;
+    }
+    setResult(r.report || null);
+    setDiff(r.diff || null);
+  };
+
+  const save = async () => {
+    const r = await saveReportSpec(name, { name, sections });
+    if (r.success) listReportSpecs().then((x) => x.success && setSaved(x.specs || []));
+  };
+
+  const load = (specName: string) => {
+    const s = saved.find((x) => x.name === specName);
+    if (!s) return;
+    setName(s.spec.name || s.name);
+    setSections(s.spec.sections?.length ? s.spec.sections : [emptySection()]);
+  };
+
+  return (
+    <div className="p-4 space-y-4 max-w-5xl">
+      {/* Spec header: name, saved specs, actions */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="text-lg font-bold">Report</span>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="h-7 px-2 rounded border border-input bg-transparent font-mono text-sm w-48"
+          title="Report name (saved as reports/<name>.report.json)"
+        />
+        {saved.length > 0 && (
+          <select
+            className="h-7 px-1 rounded border border-input bg-background text-xs"
+            value=""
+            onChange={(e) => e.target.value && load(e.target.value)}
+            title="Load a saved report spec"
+          >
+            <option value="">Load saved…</option>
+            {saved.map((s) => (
+              <option key={s.name} value={s.name}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        )}
+        <Button variant="outline" size="sm" className="h-7" onClick={run} disabled={running}>
+          <Play className="h-3 w-3 mr-1" /> {running ? 'Running…' : 'Run'}
+        </Button>
+        {!readOnly && (
+          <Button variant="outline" size="sm" className="h-7" onClick={save} title="Save the spec into the project">
+            <Save className="h-3 w-3 mr-1" /> Save
+          </Button>
+        )}
+      </div>
+
+      {/* Sections */}
+      {sections.map((sec, i) => {
+        const fieldOptions = fieldsOf(sec);
+        const chosen = sec.fields || [];
+        return (
+          <div key={i} className="border border-border/40 rounded-md p-3 space-y-2">
+            <div className="flex items-center gap-2 flex-wrap text-xs">
+              <span className="font-semibold text-muted-foreground">Rows:</span>
+              <select
+                className="h-7 px-1 rounded border border-input bg-background"
+                value={sec.entity || ''}
+                onChange={(e) => updateSection(i, { entity: e.target.value, fields: [] })}
+                title="Entity — every instance the run created (or the element type of the array source)"
+              >
+                <option value="">pick entity…</option>
+                {entities.map((e) => (
+                  <option key={e.name} value={e.name}>
+                    {e.name}
+                  </option>
+                ))}
+              </select>
+              <span className="text-muted-foreground">array source (optional):</span>
+              <input
+                value={sec.source || ''}
+                onChange={(e) => updateSection(i, { source: e.target.value })}
+                placeholder="entity.attr e.g. staking_transaction.to"
+                className="h-7 px-2 rounded border border-input bg-transparent font-mono w-64"
+                title="Report the ELEMENTS of this array attribute instead of all instances"
+              />
+              {sections.length > 1 && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 ml-auto"
+                  onClick={() => setSections((s) => s.filter((_, j) => j !== i))}
+                  title="Remove section"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </Button>
+              )}
+            </div>
+
+            {/* Field picker */}
+            {fieldOptions.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {fieldOptions.map((f) => {
+                  const on = chosen.includes(f);
+                  return (
+                    <button
+                      key={f}
+                      className={cn(
+                        'px-1.5 py-0.5 rounded-full border text-[11px] font-mono',
+                        on ? 'border-blue-400/60 text-blue-300 bg-blue-500/10' : 'border-border text-muted-foreground hover:text-foreground'
+                      )}
+                      onClick={() =>
+                        updateSection(i, { fields: on ? chosen.filter((x) => x !== f) : [...chosen, f] })
+                      }
+                    >
+                      {f}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+
+            {/* Filters */}
+            <div className="space-y-1">
+              {(sec.where || []).map((w, wi) => (
+                <div key={wi} className="flex items-center gap-1 text-xs">
+                  <span className="text-muted-foreground">where</span>
+                  <input
+                    value={w.field}
+                    onChange={(e) =>
+                      updateSection(i, {
+                        where: sec.where!.map((x, j) => (j === wi ? { ...x, field: e.target.value } : x)),
+                      })
+                    }
+                    placeholder="field"
+                    className="h-6 px-1.5 w-40 rounded border border-input bg-transparent font-mono"
+                  />
+                  <select
+                    className="h-6 rounded border border-input bg-background"
+                    value={w.op}
+                    onChange={(e) =>
+                      updateSection(i, {
+                        where: sec.where!.map((x, j) => (j === wi ? { ...x, op: e.target.value } : x)),
+                      })
+                    }
+                  >
+                    {OPS.map((o) => (
+                      <option key={o}>{o}</option>
+                    ))}
+                  </select>
+                  <input
+                    value={w.value}
+                    onChange={(e) =>
+                      updateSection(i, {
+                        where: sec.where!.map((x, j) => (j === wi ? { ...x, value: e.target.value } : x)),
+                      })
+                    }
+                    placeholder="value"
+                    className="h-6 px-1.5 w-32 rounded border border-input bg-transparent font-mono"
+                  />
+                  <button
+                    className="text-muted-foreground hover:text-foreground"
+                    onClick={() => updateSection(i, { where: sec.where!.filter((_, j) => j !== wi) })}
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+              <div className="flex items-center gap-3 text-xs">
+                <button
+                  className="text-blue-400 hover:underline"
+                  onClick={() =>
+                    updateSection(i, { where: [...(sec.where || []), { field: '', op: '==', value: '' }] })
+                  }
+                >
+                  + filter
+                </button>
+                <span className="text-muted-foreground">sort:</span>
+                <select
+                  className="h-6 rounded border border-input bg-background"
+                  value={sec.sort || ''}
+                  onChange={(e) => updateSection(i, { sort: e.target.value })}
+                >
+                  <option value="">—</option>
+                  {chosen.map((f) => (
+                    <option key={f}>{f}</option>
+                  ))}
+                </select>
+                <span className="text-muted-foreground" title="Field that identifies a row across runs (for diffs)">
+                  key:
+                </span>
+                <select
+                  className="h-6 rounded border border-input bg-background"
+                  value={sec.key || ''}
+                  onChange={(e) => updateSection(i, { key: e.target.value })}
+                >
+                  <option value="">first field</option>
+                  {chosen.map((f) => (
+                    <option key={f}>{f}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+      <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => setSections((s) => [...s, emptySection()])}>
+        <Plus className="h-3 w-3 mr-1" /> Add section
+      </Button>
+
+      {error && <div className="p-2 rounded bg-red-500/10 border border-red-500/30 text-red-400 text-sm">{error}</div>}
+
+      {/* Diff (speculative runs) */}
+      {diff && diff.sections.some((s) => (s.added?.length || 0) + (s.removed?.length || 0) + (s.changed?.length || 0) > 0) && (
+        <div className="border border-amber-500/40 rounded-md p-3 space-y-2">
+          <div className="text-sm font-semibold text-amber-400">Changes vs baseline</div>
+          {diff.sections.map((s, si) => (
+            <div key={si} className="text-xs font-mono space-y-0.5">
+              {(s.added?.length || 0) + (s.removed?.length || 0) + (s.changed?.length || 0) > 0 && (
+                <div className="text-muted-foreground">{s.title}</div>
+              )}
+              {(s.added || []).map((r, i) => (
+                <div key={`a${i}`} className="text-green-500">
+                  + {s.fields.map((f) => `${f}=${r[f]}`).join('  ')}
+                </div>
+              ))}
+              {(s.removed || []).map((r, i) => (
+                <div key={`r${i}`} className="text-red-400">
+                  − {s.fields.map((f) => `${f}=${r[f]}`).join('  ')}
+                </div>
+              ))}
+              {(s.changed || []).map((ch, i) => (
+                <div key={`c${i}`} className="text-amber-300">
+                  ~ {ch.key}: {ch.fields.map((f) => `${f} ${ch.before[f]} → ${ch.after[f]}`).join('  ')}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Results */}
+      {result &&
+        result.sections.map((s, si) => (
+          <div key={si} className="space-y-1">
+            <div className="text-sm font-semibold">
+              {s.title}{' '}
+              <span className="text-xs text-muted-foreground font-normal">
+                {(s.rows || []).length}
+                {(s.rows || []).length !== s.total ? ` of ${s.total}` : ''} rows
+              </span>
+            </div>
+            {s.error ? (
+              <div className="text-xs text-amber-400">{s.error}</div>
+            ) : (
+              <div className="overflow-x-auto border border-border/40 rounded-md">
+                <table className="border-collapse w-full text-xs font-mono">
+                  <thead>
+                    <tr>
+                      {s.fields.map((f) => (
+                        <th key={f} className="border border-border/40 bg-muted/30 px-2 py-0.5 text-left text-muted-foreground">
+                          {f}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(s.rows || []).map((row, ri) => (
+                      <tr key={ri} className="hover:bg-accent/30">
+                        {s.fields.map((f) => (
+                          <td key={f} className="border border-border/40 px-2 py-0.5 whitespace-nowrap">
+                            {row[f]}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        ))}
+    </div>
+  );
+}


### PR DESCRIPTION
The three analysis features on top of the trace debugger:

## 1. Field provenance — "where was X set, and why"
`GET /api/debug/find` searches the trace for writes of a field (`entity.attr = value`, EL case-insensitive). Every hit carries the **why-chain**: for the writing table and each caller up the stack, the fired column's conditions with their required cells joined to the actual recorded results — all the conditions that had to be met for that write. Debug-rail panel: search, jump to the write, expand the chain.

## 2. EDD-driven report generator
A saveable JSON spec (`reports/*.report.json`) composes reports from the EDD: entities (every instance the run created, or the elements of an array like `staking_transaction.to`), fields, filter predicates, sort, and a diff key. Engine in `pkg/dtrules/trace/report.go`; `POST /api/debug/report`; `dtrules report` CLI (markdown/JSON); a visual builder as the Debug tab's Report view. `InstancesOf` now recognizes Go-trace entity identity (entity+id attrs), not just Java-era `createentity` events.

## 3. Speculative reruns — "What if…"
`POST /api/debug/speculate` applies ONE table edit to a scratch overlay (DSL recompiled with EDD symbols), seeds a fresh session from the baseline trace's **recorded initial data** — the same inputs, no input file needed — and re-executes the entry table with tracing. The speculative trace becomes the active session (SPECULATIVE chip, Restore baseline); reports automatically diff against the baseline. Two replay-fidelity fixes made this sound: replayed entities carry their recorded ids, and the id counter jumps past the baseline max, so the speculative trace verifies clean end to end.

Verified on staking input-184: raising `Filter_Eligible_Accounts`' balance floor to 2000 removes 2 recipients and recomputes 187 amounts; the payouts report shows the row-level diff; Restore returns to the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)