### PR TITLE
feat(debug): Find scopes to a particular entity instance

### DIFF
--- a/pkg/dtrules/apiserver/debug_find.go
+++ b/pkg/dtrules/apiserver/debug_find.go
@@ -15,6 +15,7 @@
 package apiserver
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -100,8 +101,11 @@ func (s *Server) handleDebugFind(w http.ResponseWriter, r *http.Request) {
 	attr := strings.TrimSpace(r.URL.Query().Get("attr"))
 	entity := strings.TrimSpace(r.URL.Query().Get("entity"))
 	value := strings.TrimSpace(r.URL.Query().Get("value"))
+	instanceID := strings.TrimSpace(r.URL.Query().Get("id"))
+	keyField := strings.TrimSpace(r.URL.Query().Get("keyField"))
+	keyValue := strings.TrimSpace(r.URL.Query().Get("keyValue"))
 	if attr == "" {
-		jsonError(w, "attr is required (optionally entity and value)", http.StatusBadRequest)
+		jsonError(w, "attr is required (optionally entity, value, id, keyField/keyValue)", http.StatusBadRequest)
 		return
 	}
 
@@ -113,6 +117,39 @@ func (s *Server) handleDebugFind(w http.ResponseWriter, r *http.Request) {
 	}
 
 	root := s.debug.trace.Root()
+
+	// Instance scoping — the usual question is about ONE entity out of
+	// all of them ("why is THIS account ineligible?"). A key field pins
+	// the instance: every id whose keyField was set to keyValue.
+	var wantIDs map[string]bool
+	if instanceID != "" {
+		wantIDs = map[string]bool{instanceID: true}
+	} else if keyField != "" && keyValue != "" {
+		wantIDs = map[string]bool{}
+		var scan func(n *trace.TraceNode)
+		scan = func(n *trace.TraceNode) {
+			if n.Name == "def" &&
+				strings.EqualFold(n.Attributes["name"], keyField) &&
+				(entity == "" || strings.EqualFold(n.Attributes["entity"], entity)) &&
+				valuesMatch(normalizeTraceValue(n.Body), keyValue) {
+				if id := n.Attributes["id"]; id != "" {
+					wantIDs[id] = true
+				}
+			}
+			for _, c := range n.Children {
+				scan(c)
+			}
+		}
+		scan(root)
+		if len(wantIDs) == 0 {
+			jsonResponse(w, map[string]interface{}{
+				"success": true, "total": 0, "hits": []findHit{},
+				"note": fmt.Sprintf("no %s has %s = %s", entityOr(entity, "entity"), keyField, keyValue),
+			})
+			return
+		}
+	}
+
 	hits := []findHit{}
 	total := 0
 
@@ -120,7 +157,8 @@ func (s *Server) handleDebugFind(w http.ResponseWriter, r *http.Request) {
 	walk = func(n *trace.TraceNode) {
 		if n.Name == "def" &&
 			strings.EqualFold(n.Attributes["name"], attr) &&
-			(entity == "" || strings.EqualFold(n.Attributes["entity"], entity)) {
+			(entity == "" || strings.EqualFold(n.Attributes["entity"], entity)) &&
+			(wantIDs == nil || wantIDs[n.Attributes["id"]]) {
 			v := normalizeTraceValue(n.Body)
 			if value == "" || valuesMatch(v, value) {
 				total++
@@ -147,6 +185,14 @@ func (s *Server) handleDebugFind(w http.ResponseWriter, r *http.Request) {
 		"total":   total,
 		"hits":    hits,
 	})
+}
+
+// entityOr returns name or the fallback when name is empty.
+func entityOr(name, fallback string) string {
+	if name == "" {
+		return fallback
+	}
+	return name
 }
 
 // whyChain walks up from a trace node collecting, for each enclosing

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -552,16 +552,30 @@ export interface FindHit {
   chain: FindChainLink[];
 }
 
-/** Searches the loaded trace for writes of a field (EL case-insensitive). */
-export async function debugFind(attr: string, entity?: string, value?: string): Promise<{
+/** Searches the loaded trace for writes of a field (EL case-insensitive).
+ *  Instance scoping: pass id (a specific instance) or keyField/keyValue
+ *  ("the staking_account whose account_url is ...") to ask about ONE
+ *  entity out of all of them. */
+export async function debugFind(opts: {
+  attr: string;
+  entity?: string;
+  value?: string;
+  id?: string;
+  keyField?: string;
+  keyValue?: string;
+}): Promise<{
   success: boolean;
   error?: string;
   total?: number;
   hits?: FindHit[];
+  note?: string;
 }> {
-  const q = new URLSearchParams({ attr });
-  if (entity) q.set('entity', entity);
-  if (value) q.set('value', value);
+  const q = new URLSearchParams({ attr: opts.attr });
+  if (opts.entity) q.set('entity', opts.entity);
+  if (opts.value) q.set('value', opts.value);
+  if (opts.id) q.set('id', opts.id);
+  if (opts.keyField) q.set('keyField', opts.keyField);
+  if (opts.keyValue) q.set('keyValue', opts.keyValue);
   return fetchJSON(`${API_BASE}/debug/find?${q}`);
 }
 

--- a/ui/src/components/DebugPanel.tsx
+++ b/ui/src/components/DebugPanel.tsx
@@ -542,19 +542,41 @@ export function DebugPanel() {
     });
   }, [position, goTo]);
 
-  // runFind parses "attr", "entity.attr", or "... = value" and searches
-  // the trace for matching writes.
+  // runFind parses the query and searches the trace for matching writes.
+  // Forms (all names EL case-insensitive):
+  //   field                                  every write of the field
+  //   entity.field                           scoped to an entity type
+  //   entity[key=value].field                ONE instance, picked by key
+  //   entity#1234.field                      ONE instance, by id
+  //   ...any of the above = value            only writes of that value
   const runFind = useCallback(async () => {
     const q = findQuery.trim();
     if (!q) {
       setFindHits(null);
       return;
     }
-    const [lhs, rhs] = q.split('=').map((x) => x.trim());
-    const dot = lhs.indexOf('.');
-    const entity = dot > 0 ? lhs.slice(0, dot) : undefined;
-    const attr = dot > 0 ? lhs.slice(dot + 1) : lhs;
-    const r = await debugFind(attr, entity, rhs || undefined);
+    // Split lhs/rhs on the first '=' OUTSIDE brackets.
+    let depth = 0;
+    let split = -1;
+    for (let i = 0; i < q.length; i++) {
+      if (q[i] === '[') depth++;
+      else if (q[i] === ']') depth--;
+      else if (q[i] === '=' && depth === 0) {
+        split = i;
+        break;
+      }
+    }
+    const lhs = (split >= 0 ? q.slice(0, split) : q).trim();
+    const rhs = split >= 0 ? q.slice(split + 1).trim() : undefined;
+
+    const m = lhs.match(/^([A-Za-z_]\w*)(?:\[\s*([\w.]+)\s*=\s*(.+?)\s*\]|#(\d+))?\.([A-Za-z_]\w*)$/);
+    let opts;
+    if (m) {
+      opts = { entity: m[1], keyField: m[2], keyValue: m[3], id: m[4], attr: m[5], value: rhs };
+    } else {
+      opts = { attr: lhs, value: rhs };
+    }
+    const r = await debugFind(opts);
     if (r.success) {
       setFindHits(r.hits || []);
       setFindTotal(r.total || 0);
@@ -868,9 +890,9 @@ export function DebugPanel() {
                 value={findQuery}
                 onChange={(e) => setFindQuery(e.target.value)}
                 onKeyDown={(e) => e.key === 'Enter' && runFind()}
-                placeholder="entity.field = value"
+                placeholder="entity[key=val].field = value"
                 className="flex-1 h-7 px-2 rounded border border-input bg-transparent font-mono text-xs"
-                title="Search the trace for writes: field, entity.field, or entity.field = value (case-insensitive)"
+                title="Where was a field set? Forms: field · entity.field · entity[key=value].field (one instance, e.g. staking_account[account_url=acc://x].is_eligible) · entity#id.field — add '= value' to match a value. Case-insensitive."
               />
               <Button variant="outline" size="sm" className="h-7 px-2 text-xs" onClick={runFind}>
                 Find


### PR DESCRIPTION
The question is about ONE entity out of all of them — "why is THIS
account ineligible?" — not 185 aggregate hits. Find now pins the
instance by a key field or id:

  staking_account[account_url=acc://fahad.acme/fahad].is_eligible
  staking_account#27713.is_eligible

The server resolves the key (every id whose keyField was set to that
value, EL case-insensitive) and returns only that instance's writes —
typically one hit that jumps straight to the account's own iteration
(pass 148 of 198) with the full why-chain. Aggregate forms (field,
entity.field) still work for discovery.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
