### PR TITLE
feat(debug): entity explorer — drill into any stack instance

### DIFF
--- a/pkg/dtrules/apiserver/debug_entity.go
+++ b/pkg/dtrules/apiserver/debug_entity.go
@@ -1,0 +1,168 @@
+// Copyright 2026 DTRules contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+)
+
+// entityValue is one classified value for the entity explorer: a scalar
+// with display text, an entity reference (drill via its id), or an array
+// (drill via its arrayId). Nested composition is fetched lazily by the
+// UI — one request per expansion, so arbitrarily deep structures stay
+// cheap.
+type entityValue struct {
+	Kind  string `json:"kind"` // "value" | "entity" | "array"
+	Type  string `json:"type,omitempty"`
+	Value string `json:"value,omitempty"` // scalars: display text
+
+	// Entity references
+	Entity string `json:"entity,omitempty"` // entity name
+	ID     int    `json:"id,omitempty"`     // instance id (fetch /api/debug/entity?id=)
+
+	// Arrays
+	ArrayID int `json:"arrayId,omitempty"` // fetch /api/debug/array?id=
+	Length  int `json:"length,omitempty"`
+}
+
+// entityField is one attribute of an inspected instance.
+type entityField struct {
+	Name string `json:"name"`
+	entityValue
+}
+
+// classifyObject renders a value for the explorer.
+func classifyObject(v dtrules.Object) entityValue {
+	if v == nil {
+		return entityValue{Kind: "value", Value: ""}
+	}
+	if e, ok := v.(dtrules.Entity); ok {
+		return entityValue{Kind: "entity", Entity: e.GetName().StringValue(), ID: e.GetID()}
+	}
+	if ar, ok := v.(*dtrules.RArray); ok {
+		return entityValue{Kind: "array", ArrayID: ar.GetID(), Length: ar.Size()}
+	}
+	typ := ""
+	if t := v.Type(); t != nil {
+		typ = t.String()
+	}
+	return entityValue{Kind: "value", Type: typ, Value: v.StringValue()}
+}
+
+// handleDebugEntity inspects one entity instance at the current replay
+// position: every attribute, classified for drilling.
+// GET /api/debug/entity?id=<instance id>
+func (s *Server) handleDebugEntity(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		jsonError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		jsonError(w, "id is required", http.StatusBadRequest)
+		return
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.debug == nil {
+		jsonError(w, "No trace loaded", http.StatusBadRequest)
+		return
+	}
+	e := s.debug.trace.EntityByID(id)
+	if e == nil {
+		jsonError(w, "No such entity instance at the current position", http.StatusNotFound)
+		return
+	}
+
+	fields := []entityField{}
+	for _, n := range e.GetAttributeNames() {
+		name := n.StringValue()
+		if name == "" {
+			continue
+		}
+		v, err := e.Get(n)
+		if err != nil {
+			continue
+		}
+		fields = append(fields, entityField{Name: name, entityValue: classifyObject(v)})
+	}
+	sort.Slice(fields, func(i, j int) bool { return fields[i].Name < fields[j].Name })
+
+	jsonResponse(w, map[string]interface{}{
+		"success": true,
+		"name":    e.GetName().StringValue(),
+		"id":      e.GetID(),
+		"fields":  fields,
+	})
+}
+
+// handleDebugArray lists an array's elements at the current replay
+// position, classified for drilling, with offset/limit paging.
+// GET /api/debug/array?id=<arrayId>[&offset=0][&limit=200]
+func (s *Server) handleDebugArray(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		jsonError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	id, err := strconv.Atoi(r.URL.Query().Get("id"))
+	if err != nil {
+		jsonError(w, "numeric id is required", http.StatusBadRequest)
+		return
+	}
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	if limit <= 0 || limit > 1000 {
+		limit = 200
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.debug == nil {
+		jsonError(w, "No trace loaded", http.StatusBadRequest)
+		return
+	}
+	ar := s.debug.trace.ArrayByID(id)
+	if ar == nil {
+		jsonError(w, "No such array at the current position", http.StatusNotFound)
+		return
+	}
+
+	total := ar.Size()
+	elements := []entityValue{}
+	for i := offset; i < total && i < offset+limit; i++ {
+		v, gerr := ar.Get(i)
+		if gerr != nil {
+			elements = append(elements, entityValue{Kind: "value", Value: "(error)"})
+			continue
+		}
+		elements = append(elements, classifyObject(v))
+	}
+
+	jsonResponse(w, map[string]interface{}{
+		"success":  true,
+		"id":       id,
+		"total":    total,
+		"offset":   offset,
+		"elements": elements,
+	})
+}

--- a/pkg/dtrules/apiserver/server.go
+++ b/pkg/dtrules/apiserver/server.go
@@ -428,6 +428,8 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("/api/debug/load", s.handleDebugLoad)
 	mux.HandleFunc("/api/debug/status", s.handleDebugStatus)
 	mux.HandleFunc("/api/debug/find", s.handleDebugFind)
+	mux.HandleFunc("/api/debug/entity", s.handleDebugEntity)
+	mux.HandleFunc("/api/debug/array", s.handleDebugArray)
 	mux.HandleFunc("/api/debug/report", s.handleDebugReport)
 	mux.HandleFunc("/api/debug/speculate", s.handleDebugSpeculate)
 	mux.HandleFunc("/api/debug/speculate/reset", s.handleDebugSpeculateReset)

--- a/pkg/dtrules/trace/trace.go
+++ b/pkg/dtrules/trace/trace.go
@@ -553,6 +553,17 @@ func (t *Trace) handleRemoveAt(node *TraceNode) error {
 	return nil
 }
 
+// EntityByID returns the replayed entity instance for a recorded id, or
+// nil. Valid for the position the trace was last replayed to.
+func (t *Trace) EntityByID(id string) dtrules.Entity {
+	return t.entityTable[id]
+}
+
+// ArrayByID returns the replayed array for a recorded arrayId, or nil.
+func (t *Trace) ArrayByID(id int) *dtrules.RArray {
+	return t.arrayTable[id]
+}
+
 // InstancesOf returns all entities of the given type that were created
 // up to the current position.
 func (t *Trace) InstancesOf(entityName string) []dtrules.Entity {

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -680,6 +680,45 @@ export async function saveReportSpec(name: string, spec: ReportSpec): Promise<{ 
   return fetchJSON(`${API_BASE}/reports`, { method: 'POST', body: JSON.stringify({ name, spec }) });
 }
 
+// ── entity explorer ──────────────────────────────────────────────────
+
+/** One classified value: a scalar, an entity reference, or an array. */
+export interface ExplorerValue {
+  kind: 'value' | 'entity' | 'array';
+  type?: string;
+  value?: string;
+  entity?: string;
+  id?: number;
+  arrayId?: number;
+  length?: number;
+}
+
+export interface ExplorerField extends ExplorerValue {
+  name: string;
+}
+
+/** Inspects one entity instance at the current replay position. */
+export async function debugEntity(id: number | string): Promise<{
+  success: boolean;
+  error?: string;
+  name?: string;
+  id?: number;
+  fields?: ExplorerField[];
+}> {
+  return fetchJSON(`${API_BASE}/debug/entity?id=${encodeURIComponent(String(id))}`);
+}
+
+/** Lists an array's elements at the current replay position. */
+export async function debugArray(id: number, offset = 0, limit = 200): Promise<{
+  success: boolean;
+  error?: string;
+  total?: number;
+  offset?: number;
+  elements?: ExplorerValue[];
+}> {
+  return fetchJSON(`${API_BASE}/debug/array?id=${id}&offset=${offset}&limit=${limit}`);
+}
+
 /** Replays to a trace node ("run to here" / stepping). */
 export async function debugPosition(node: number): Promise<DebugPositionResponse> {
   return fetchJSON(`${API_BASE}/debug/position`, { method: 'POST', body: JSON.stringify({ node }) });

--- a/ui/src/components/DebugPanel.tsx
+++ b/ui/src/components/DebugPanel.tsx
@@ -33,6 +33,7 @@ import {
 import { FileBrowser } from '@/components/FileBrowser';
 import { DebugTableView } from '@/components/DebugTableView';
 import { ReportPanel } from '@/components/ReportPanel';
+import { EntityExplorer } from '@/components/EntityExplorer';
 import {
   ancestorsOf,
   bucketSize,
@@ -260,6 +261,8 @@ export function DebugPanel() {
   // Per-entity-name expand/collapse for the stack panel; unset = default
   // (top frame open, others collapsed).
   const [stackOpen, setStackOpen] = useState<Record<string, boolean>>({});
+  // Entity explorer overlay: which stack instance is being inspected.
+  const [explorer, setExplorer] = useState<{ id: number; name: string } | null>(null);
   // Find-writes panel: query text, results, and which hit's why-chain is open.
   const [findQuery, setFindQuery] = useState('');
   const [findHits, setFindHits] = useState<FindHit[] | null>(null);
@@ -687,7 +690,16 @@ export function DebugPanel() {
   // ── debugger ────────────────────────────────────────────────────────
   const verifyClean = (info.verifyMismatches || []).length === 0;
   return (
-    <div className="h-full flex flex-col overflow-hidden">
+    <div className="h-full flex flex-col overflow-hidden relative">
+      {explorer && (
+        <EntityExplorer
+          key={`${explorer.id}-${position}`}
+          rootId={explorer.id}
+          rootName={explorer.name}
+          position={position}
+          onClose={() => setExplorer(null)}
+        />
+      )}
       {/* Trust strip */}
       <div className="px-4 py-1.5 border-b border-amber-500/25 bg-amber-500/[0.07] flex items-center gap-3 text-xs flex-wrap">
         <span className="font-mono">{info.tracePath?.split('/').pop()}</span>
@@ -998,8 +1010,18 @@ export function DebugPanel() {
                         top of stack
                       </span>
                     )}
+                    <button
+                      className="ml-auto text-muted-foreground hover:text-foreground text-[10px] px-1"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setExplorer({ id: f.id, name: f.name });
+                      }}
+                      title="Open the entity explorer — drill into this instance's fields, entities, and arrays"
+                    >
+                      ⤢ explore
+                    </button>
                     {!open && (
-                      <span className="ml-auto text-[10px] text-muted-foreground">
+                      <span className="text-[10px] text-muted-foreground">
                         {Object.keys(f.attrs).length} fields
                       </span>
                     )}

--- a/ui/src/components/EntityExplorer.tsx
+++ b/ui/src/components/EntityExplorer.tsx
@@ -1,0 +1,179 @@
+/**
+ * EntityExplorer - structural inspector for one entity instance at the
+ * current replay position.
+ *
+ * Launched from a frame on the debugger's entity stack. Shows the
+ * instance's actual fields and drills into what composes it: entity
+ * references expand into THEIR fields, arrays expand into elements
+ * (which may themselves be entities), with paging for long arrays.
+ * Everything is fetched lazily — one request per expansion — so deep
+ * structures stay cheap. Values reflect the current replay position;
+ * the panel refreshes when the position moves (it is remounted keyed
+ * by position).
+ *
+ * @module components/EntityExplorer
+ */
+
+import { useEffect, useState } from 'react';
+import { debugArray, debugEntity, type ExplorerField, type ExplorerValue } from '@/api/client';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { X } from 'lucide-react';
+
+export function EntityExplorer({
+  rootId,
+  rootName,
+  position,
+  onClose,
+}: {
+  rootId: number;
+  rootName: string;
+  position: number;
+  onClose: () => void;
+}) {
+  return (
+    <div className="absolute inset-0 z-20 bg-background/60" onClick={onClose}>
+      <div
+        className="absolute right-0 top-0 bottom-0 w-[520px] border-l border-border bg-background shadow-2xl flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-4 py-2 border-b border-border/50 flex items-center gap-2">
+          <span className="text-sm font-semibold">Entity explorer</span>
+          <span className="font-mono text-xs text-muted-foreground">
+            {rootName} #{rootId} · at node {position.toLocaleString()}
+          </span>
+          <Button variant="ghost" size="icon" className="h-6 w-6 ml-auto" onClick={onClose} title="Close (Esc)">
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+        <ScrollArea className="flex-1">
+          <div className="p-3 font-mono text-xs">
+            <EntityNode id={rootId} depth={0} defaultOpen />
+          </div>
+        </ScrollArea>
+      </div>
+    </div>
+  );
+}
+
+/** One entity instance: name #id with its fields beneath. */
+function EntityNode({ id, depth, defaultOpen, initialName }: { id: number; depth: number; defaultOpen?: boolean; initialName?: string }) {
+  const [open, setOpen] = useState(!!defaultOpen);
+  const [fields, setFields] = useState<ExplorerField[] | null>(null);
+  const [name, setName] = useState(initialName || '');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || fields) return;
+    debugEntity(id).then((r) => {
+      if (r.success) {
+        setFields(r.fields || []);
+        setName(r.name || '');
+      } else {
+        setError(r.error || 'not found at this position');
+      }
+    });
+  }, [open, fields, id]);
+
+  return (
+    <div style={{ paddingLeft: depth > 1 ? 12 : 0, display: defaultOpen ? 'block' : 'inline-block', verticalAlign: 'top' }}>
+      {!defaultOpen && (
+        <button className="text-blue-400 hover:underline" onClick={() => setOpen(!open)}>
+          {open ? '▾' : '▸'} {name || 'entity'}
+          <span className="text-muted-foreground">#{id}</span>
+        </button>
+      )}
+      {error && <div className="text-amber-400 pl-4">{error}</div>}
+      {open &&
+        fields &&
+        fields
+          .filter((f) => !f.name.includes('*'))
+          .map((f) => <FieldRow key={f.name} field={f} depth={depth + 1} />)}
+    </div>
+  );
+}
+
+/** One field row: scalar inline; entity/array expandable. */
+function FieldRow({ field, depth }: { field: ExplorerField; depth: number }) {
+  if (field.kind === 'entity' && field.id) {
+    return (
+      <div className="leading-5" style={{ paddingLeft: 12 }}>
+        <span className="text-muted-foreground">{field.name} </span>
+        <EntityNode id={field.id} depth={1} initialName={field.entity} />
+      </div>
+    );
+  }
+  if (field.kind === 'array' && field.arrayId) {
+    return (
+      <div className="leading-5" style={{ paddingLeft: 12 }}>
+        <span className="text-muted-foreground">{field.name} </span>
+        <ArrayNode arrayId={field.arrayId} length={field.length || 0} depth={depth} />
+      </div>
+    );
+  }
+  return (
+    <div className="leading-5 flex gap-2" style={{ paddingLeft: 12 }}>
+      <span className="text-muted-foreground shrink-0">{field.name}</span>
+      <span className="truncate" title={`${field.type || ''} ${field.value || ''}`.trim()}>
+        {field.value === '' || field.value === undefined ? <span className="text-muted-foreground/60">—</span> : field.value}
+      </span>
+    </div>
+  );
+}
+
+/** An array: expandable element list with paging. */
+function ArrayNode({ arrayId, length, depth }: { arrayId: number; length: number; depth: number }) {
+  const [open, setOpen] = useState(false);
+  const [elements, setElements] = useState<ExplorerValue[]>([]);
+  const [total, setTotal] = useState(length);
+  const [loading, setLoading] = useState(false);
+
+  const loadMore = async () => {
+    setLoading(true);
+    const r = await debugArray(arrayId, elements.length, 100);
+    setLoading(false);
+    if (r.success) {
+      setElements((e) => [...e, ...(r.elements || [])]);
+      setTotal(r.total ?? length);
+    }
+  };
+
+  useEffect(() => {
+    if (open && elements.length === 0 && total > 0) loadMore();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  return (
+    <span>
+      <button className="text-blue-400 hover:underline" onClick={() => setOpen(!open)}>
+        {open ? '▾' : '▸'} [{total.toLocaleString()} element{total === 1 ? '' : 's'}]
+      </button>
+      {open && (
+        <div>
+          {elements.map((el, i) => (
+            <div key={i} className="leading-5" style={{ paddingLeft: 12 }}>
+              <span className="text-muted-foreground">[{i}] </span>
+              {el.kind === 'entity' && el.id ? (
+                <EntityNode id={el.id} depth={1} initialName={el.entity} />
+              ) : el.kind === 'array' && el.arrayId ? (
+                <ArrayNode arrayId={el.arrayId} length={el.length || 0} depth={depth + 1} />
+              ) : (
+                <span title={el.type}>{el.value || '—'}</span>
+              )}
+            </div>
+          ))}
+          {elements.length < total && (
+            <button
+              className="text-blue-400 hover:underline"
+              style={{ paddingLeft: 12 }}
+              onClick={loadMore}
+              disabled={loading}
+            >
+              {loading ? 'loading…' : `load more (${elements.length} of ${total.toLocaleString()})`}
+            </button>
+          )}
+        </div>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
An "explore" button on every entity-stack frame opens a structural
inspector for that instance at the current replay position: its actual
fields, with entity references expanding into THEIR fields, arrays
expanding into elements (paged, 100 at a time), and nested composition
all the way down. Everything is fetched lazily — one request per
expansion — via two new endpoints backed by the replay tables:

  GET /api/debug/entity?id=N     one instance, fields classified as
                                 value / entity-ref / array
  GET /api/debug/array?id=N      elements with offset/limit paging

The panel is keyed by position, so stepping refreshes it: the same
instance shows the values it had at the new point in the execution.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
