### PR TITLE
fix(debug): explorer puts the self-reference field first, non-navigable

### DIFF
--- a/pkg/dtrules/apiserver/debug_entity.go
+++ b/pkg/dtrules/apiserver/debug_entity.go
@@ -35,6 +35,10 @@ type entityValue struct {
 	// Entity references
 	Entity string `json:"entity,omitempty"` // entity name
 	ID     int    `json:"id,omitempty"`     // instance id (fetch /api/debug/entity?id=)
+	// Self marks the conventional self-reference field every entity
+	// carries (the field that just points back at this instance) — shown
+	// first and not navigable.
+	Self bool `json:"self,omitempty"`
 
 	// Arrays
 	ArrayID int `json:"arrayId,omitempty"` // fetch /api/debug/array?id=
@@ -103,7 +107,20 @@ func (s *Server) handleDebugEntity(w http.ResponseWriter, r *http.Request) {
 		}
 		fields = append(fields, entityField{Name: name, entityValue: classifyObject(v)})
 	}
-	sort.Slice(fields, func(i, j int) bool { return fields[i].Name < fields[j].Name })
+	// The conventional self-reference (a ref back to this very instance)
+	// leads the list; everything else stays alphabetical.
+	selfID := e.GetID()
+	for i := range fields {
+		if fields[i].Kind == "entity" && fields[i].ID == selfID {
+			fields[i].Self = true
+		}
+	}
+	sort.Slice(fields, func(i, j int) bool {
+		if fields[i].Self != fields[j].Self {
+			return fields[i].Self
+		}
+		return fields[i].Name < fields[j].Name
+	})
 
 	jsonResponse(w, map[string]interface{}{
 		"success": true,

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -689,6 +689,8 @@ export interface ExplorerValue {
   value?: string;
   entity?: string;
   id?: number;
+  /** The conventional self-reference field — listed first, not navigable. */
+  self?: boolean;
   arrayId?: number;
   length?: number;
 }

--- a/ui/src/components/EntityExplorer.tsx
+++ b/ui/src/components/EntityExplorer.tsx
@@ -95,6 +95,16 @@ function EntityNode({ id, depth, defaultOpen, initialName }: { id: number; depth
 
 /** One field row: scalar inline; entity/array expandable. */
 function FieldRow({ field, depth }: { field: ExplorerField; depth: number }) {
+  if (field.self) {
+    // The conventional self-reference: identifies the instance, goes
+    // nowhere — no navigation into itself.
+    return (
+      <div className="leading-5 flex gap-2" style={{ paddingLeft: 12 }}>
+        <span className="text-muted-foreground shrink-0">{field.name}</span>
+        <span className="text-muted-foreground/70 italic">this {field.entity}</span>
+      </div>
+    );
+  }
   if (field.kind === 'entity' && field.id) {
     return (
       <div className="leading-5" style={{ paddingLeft: 12 }}>


### PR DESCRIPTION
Every entity carries a conventional field referring back to itself. The
explorer detects it (an entity ref whose id equals the inspected
instance) and shows it as the first row — "staking_transaction  this
staking_transaction" — as identity, not a link: navigating into it would
only loop back here.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
