### PR TITLE
feat(ui): draggable panel dividers; entity numbers in the explorer

### DIFF
--- a/cmd/dtrules/build.go
+++ b/cmd/dtrules/build.go
@@ -226,7 +226,14 @@ func dupGate(xmlDir string) int {
 // a copyProject is unreliable because mtimes and hashes drift on
 // copy. Direct invocation pins the behavior end-to-end.
 func runNoSyncAdvisory(xmlDir string) int {
-	fmt.Println("Nothing to sync — running advisory pass on existing XML.")
+	fmt.Println("Nothing to sync — normalizing XML and running the advisory pass.")
+	// Normalization (section renumbering, entity-number backfill) is
+	// idempotent — run it even when Excel and XML are in sync, so a plain
+	// `dtrules build` always leaves normalized files.
+	if err := normalizeDTXMLFiles(xmlDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Error normalizing XML: %v\n", err)
+		return 1
+	}
 	step := &dtrsync.StepSummary{}
 	runStaticAnalysis(xmlDir, step)
 	if len(step.Warnings) > 0 {
@@ -338,24 +345,42 @@ func exportStatsToStep(s *excel.ExportStats) *dtrsync.StepSummary {
 	return step
 }
 
-// normalizeDTXMLFiles rewrites every *_dt.xml under xmlDir through the
-// canonical WriteXML funnel, which renumbers all sections sequentially.
+// normalizeDTXMLFiles rewrites every *_dt.xml AND *_edd.xml under xmlDir
+// through the canonical WriteXML funnels, which renumber DT sections
+// sequentially and backfill missing entity numbers (the 100 grid).
 func normalizeDTXMLFiles(xmlDir string) error {
 	return filepath.WalkDir(xmlDir, func(p string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(strings.ToLower(d.Name()), "_dt.xml") {
+		if err != nil || d.IsDir() {
 			return err
 		}
-		before, rerr := os.ReadFile(p)
-		if rerr != nil {
-			return rerr
-		}
-		doc, perr := excel.UnmarshalDecisionTablesXML(before)
-		if perr != nil {
-			return fmt.Errorf("%s: %w", p, perr)
-		}
-		imp := excel.NewDTImporter()
-		if werr := imp.WriteXML(doc, p); werr != nil {
-			return fmt.Errorf("%s: %w", p, werr)
+		lower := strings.ToLower(d.Name())
+		switch {
+		case strings.HasSuffix(lower, "_dt.xml"):
+			before, rerr := os.ReadFile(p)
+			if rerr != nil {
+				return rerr
+			}
+			doc, perr := excel.UnmarshalDecisionTablesXML(before)
+			if perr != nil {
+				return fmt.Errorf("%s: %w", p, perr)
+			}
+			imp := excel.NewDTImporter()
+			if werr := imp.WriteXML(doc, p); werr != nil {
+				return fmt.Errorf("%s: %w", p, werr)
+			}
+		case strings.HasSuffix(lower, "_edd.xml"):
+			before, rerr := os.ReadFile(p)
+			if rerr != nil {
+				return rerr
+			}
+			doc, perr := excel.UnmarshalEDDXML(before)
+			if perr != nil {
+				return fmt.Errorf("%s: %w", p, perr)
+			}
+			imp := excel.NewEDDImporter()
+			if werr := imp.WriteXML(doc, p); werr != nil {
+				return fmt.Errorf("%s: %w", p, werr)
+			}
 		}
 		return nil
 	})
@@ -640,6 +665,22 @@ func (c *CLI) syncMAPFiles(xmlDir, excelDir, direction string, verbose bool) err
 		}
 		if mapXML == nil || len(mapXML.Entries) == 0 {
 			return nil
+		}
+		// Clobber guard: a sheet written before the structural-section
+		// round-trip fix carries no createentity / cardinality /
+		// initialization rows. Overwriting an XML that HAS them with a
+		// model that has none would silently break the project's data
+		// loading — carry the existing sections forward and warn.
+		if len(mapXML.CreateEntities)+len(mapXML.EntityDecls)+len(mapXML.InitialEntities) == 0 {
+			if existing, lerr := excel.LoadMapXMLFromFile(xmlPath); lerr == nil {
+				if len(existing.CreateEntities)+len(existing.EntityDecls)+len(existing.InitialEntities) > 0 {
+					mapXML.CreateEntities = existing.CreateEntities
+					mapXML.EntityDecls = existing.EntityDecls
+					mapXML.InitialEntities = existing.InitialEntities
+					fmt.Printf("  Warning: %s has no structural sections (pre-fix sheet); kept the sections from %s — re-export to refresh the sheet\n",
+						filepath.Base(path), filepath.Base(xmlPath))
+				}
+			}
 		}
 		if err := os.MkdirAll(filepath.Dir(xmlPath), 0755); err != nil {
 			return err

--- a/pkg/dtrules/apiserver/debug_entity.go
+++ b/pkg/dtrules/apiserver/debug_entity.go
@@ -125,11 +125,19 @@ func (s *Server) handleDebugEntity(w http.ResponseWriter, r *http.Request) {
 		return fields[i].Name < fields[j].Name
 	})
 
+	// The EDD assigns every entity a number (the 100-grid ordering) —
+	// carried here so the explorer can show it alongside the instance.
+	entityNumber := ""
+	if ed := s.findEntity(entityName); ed != nil {
+		entityNumber = ed.Number
+	}
+
 	jsonResponse(w, map[string]interface{}{
-		"success": true,
-		"name":    e.GetName().StringValue(),
-		"id":      e.GetID(),
-		"fields":  fields,
+		"success":      true,
+		"name":         entityName,
+		"id":           e.GetID(),
+		"entityNumber": entityNumber,
+		"fields":       fields,
 	})
 }
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useProjectStore } from '@/stores/projectStore';
+import { useStoredWidth } from '@/lib/resize';
 import { useOnboardingStore } from '@/stores/onboardingStore';
 import { ProjectExplorer } from '@/components/ProjectExplorer';
 import { EDDEditor } from '@/components/EDDEditor';
@@ -19,6 +20,7 @@ import { deriveProjectName } from '@/lib/utils';
 
 function App() {
   const { activeTab, setActiveTabWithHistory, projectPath, projectConfig, error, clearError, isLoading, adoptProject, autoSelectFirstItems, setReadOnly, setProjectConfig } = useProjectStore();
+  const { width: sidebarWidth, onDragStart: onSidebarDrag } = useStoredWidth('dtrules.sidebarWidth', 256, 160, 520);
   const { showWelcome } = useOnboardingStore();
   const { toast } = useToast();
   const [backendConnected, setBackendConnected] = useState(false);
@@ -97,13 +99,19 @@ function App() {
 
       {/* Main content */}
       <div className="flex-1 flex overflow-hidden">
-        {/* Project Explorer */}
+        {/* Project Explorer (drag the divider to resize) */}
         <div
-          className="w-64 border-r border-border/50 overflow-hidden flex flex-col"
+          className="overflow-hidden flex flex-col shrink-0"
+          style={{ width: sidebarWidth }}
           data-tutorial="project-explorer"
         >
           <ProjectExplorer />
         </div>
+        <div
+          className="w-1 shrink-0 cursor-col-resize bg-border/50 hover:bg-blue-500/60 transition-colors"
+          onMouseDown={onSidebarDrag}
+          title="Drag to resize the Project Explorer"
+        />
 
         {/* Editor Area */}
         <div className="flex-1 flex flex-col overflow-hidden">

--- a/ui/src/components/DebugPanel.tsx
+++ b/ui/src/components/DebugPanel.tsx
@@ -34,6 +34,7 @@ import { FileBrowser } from '@/components/FileBrowser';
 import { DebugTableView } from '@/components/DebugTableView';
 import { ReportPanel } from '@/components/ReportPanel';
 import { EntityExplorer } from '@/components/EntityExplorer';
+import { useStoredWidth } from '@/lib/resize';
 import {
   ancestorsOf,
   bucketSize,
@@ -261,6 +262,7 @@ export function DebugPanel() {
   // Per-entity-name expand/collapse for the stack panel; unset = default
   // (top frame open, others collapsed).
   const [stackOpen, setStackOpen] = useState<Record<string, boolean>>({});
+  const { width: railWidth, onDragStart: onRailDrag } = useStoredWidth('dtrules.debugRailWidth', 320, 220, 700);
   // Entity explorer overlay: which stack instance is being inspected.
   const [explorer, setExplorer] = useState<{ id: number; name: string } | null>(null);
   // Find-writes panel: query text, results, and which hit's why-chain is open.
@@ -846,9 +848,9 @@ export function DebugPanel() {
         </div>
       )}
 
-      {/* Tree + stack */}
-      <div className="flex-1 grid grid-cols-[1fr_320px] overflow-hidden">
-        <ScrollArea className="border-r border-border/50">
+      {/* Tree + stack (drag the divider to resize the rail) */}
+      <div className="flex-1 grid overflow-hidden" style={{ gridTemplateColumns: `1fr 4px ${railWidth}px` }}>
+        <ScrollArea>
           {viewMode === 'report' ? (
             <ReportPanel />
           ) : viewMode === 'table' ? (
@@ -892,6 +894,11 @@ export function DebugPanel() {
             </div>
           )}
         </ScrollArea>
+        <div
+          className="cursor-col-resize bg-border/50 hover:bg-blue-500/60 transition-colors"
+          onMouseDown={onRailDrag}
+          title="Drag to resize the entity stack"
+        />
         <ScrollArea className="[&_[data-radix-scroll-area-viewport]>div]:!block min-w-0">
           <div className="p-3 space-y-2 min-w-0">
             <div className="text-[11px] font-semibold tracking-widest uppercase text-muted-foreground">

--- a/ui/src/components/EntityExplorer.tsx
+++ b/ui/src/components/EntityExplorer.tsx
@@ -31,6 +31,7 @@ export function EntityExplorer({
   position: number;
   onClose: () => void;
 }) {
+  const [rootNumber, setRootNumber] = useState('');
   return (
     <div className="absolute inset-0 z-20 bg-background/60" onClick={onClose}>
       <div
@@ -40,7 +41,9 @@ export function EntityExplorer({
         <div className="px-4 py-2 border-b border-border/50 flex items-center gap-2">
           <span className="text-sm font-semibold">Entity explorer</span>
           <span className="font-mono text-xs text-muted-foreground">
-            {rootName} #{rootId} · at node {position.toLocaleString()}
+            {rootName}
+            {rootNumber && <span title="EDD entity number"> №{rootNumber}</span>} #{rootId} · at node{' '}
+            {position.toLocaleString()}
           </span>
           <Button variant="ghost" size="icon" className="h-6 w-6 ml-auto" onClick={onClose} title="Close (Esc)">
             <X className="h-4 w-4" />
@@ -48,7 +51,7 @@ export function EntityExplorer({
         </div>
         <ScrollArea className="flex-1">
           <div className="p-3 font-mono text-xs">
-            <EntityNode id={rootId} depth={0} defaultOpen />
+            <EntityNode id={rootId} depth={0} defaultOpen onNumber={setRootNumber} />
           </div>
         </ScrollArea>
       </div>
@@ -57,10 +60,11 @@ export function EntityExplorer({
 }
 
 /** One entity instance: name #id with its fields beneath. */
-function EntityNode({ id, depth, defaultOpen, initialName }: { id: number; depth: number; defaultOpen?: boolean; initialName?: string }) {
+function EntityNode({ id, depth, defaultOpen, initialName, onNumber }: { id: number; depth: number; defaultOpen?: boolean; initialName?: string; onNumber?: (n: string) => void }) {
   const [open, setOpen] = useState(!!defaultOpen);
   const [fields, setFields] = useState<ExplorerField[] | null>(null);
   const [name, setName] = useState(initialName || '');
+  const [number, setNumber] = useState('');
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -69,6 +73,9 @@ function EntityNode({ id, depth, defaultOpen, initialName }: { id: number; depth
       if (r.success) {
         setFields(r.fields || []);
         setName(r.name || '');
+        const num = (r as { entityNumber?: string }).entityNumber || '';
+        setNumber(num);
+        onNumber?.(num);
       } else {
         setError(r.error || 'not found at this position');
       }
@@ -80,6 +87,7 @@ function EntityNode({ id, depth, defaultOpen, initialName }: { id: number; depth
       {!defaultOpen && (
         <button className="text-blue-400 hover:underline" onClick={() => setOpen(!open)}>
           {open ? '▾' : '▸'} {name || 'entity'}
+          {number && <span className="text-muted-foreground" title="EDD entity number"> №{number}</span>}
           <span className="text-muted-foreground">#{id}</span>
         </button>
       )}

--- a/ui/src/lib/resize.ts
+++ b/ui/src/lib/resize.ts
@@ -1,0 +1,40 @@
+/**
+ * useStoredWidth - a draggable panel width persisted to localStorage.
+ *
+ * Returns the current width and a mouse-down handler for a divider bar.
+ * `fromRight` measures from the window's right edge (for right-docked
+ * panels like the debugger's entity-stack rail).
+ */
+import { useCallback, useState } from 'react';
+
+export function useStoredWidth(key: string, initial: number, min: number, max: number, fromRight = false) {
+  const [width, setWidth] = useState(() => {
+    const saved = parseInt(localStorage.getItem(key) || '', 10);
+    return Number.isFinite(saved) ? Math.min(max, Math.max(min, saved)) : initial;
+  });
+
+  const onDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const move = (ev: MouseEvent) => {
+        const w = fromRight ? window.innerWidth - ev.clientX : ev.clientX;
+        const clamped = Math.min(max, Math.max(min, w));
+        setWidth(clamped);
+        localStorage.setItem(key, String(clamped));
+      };
+      const up = () => {
+        window.removeEventListener('mousemove', move);
+        window.removeEventListener('mouseup', up);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+      };
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      window.addEventListener('mousemove', move);
+      window.addEventListener('mouseup', up);
+    },
+    [key, min, max, fromRight]
+  );
+
+  return { width, onDragStart };
+}


### PR DESCRIPTION
- The Project Explorer / main divider and the debug view / entity-stack
  divider are draggable (widths persist in localStorage), so long field
  names get room instead of getting dropped.

- Every entity carries an EDD entity number; the explorer now shows it
  (№800) beside the instance id, at the root header and on every
  drilled entity node. Served via entityNumber on /api/debug/entity.

- dtrules build backfills entity numbers on the XML-authored path AND on
  the nothing-to-sync branch (normalization is idempotent, so a plain
  build always leaves normalized files — EDD numbers included). Plus a
  map clobber guard: importing a pre-fix sheet with no structural
  sections no longer wipes createentity / cardinality / initialization
  from the XML — the existing sections carry forward with a warning to
  re-export the sheet.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
