### PR TITLE
fix(ui): entity-stack divider drags both ways

### DIFF
--- a/ui/src/components/DebugPanel.tsx
+++ b/ui/src/components/DebugPanel.tsx
@@ -262,7 +262,10 @@ export function DebugPanel() {
   // Per-entity-name expand/collapse for the stack panel; unset = default
   // (top frame open, others collapsed).
   const [stackOpen, setStackOpen] = useState<Record<string, boolean>>({});
-  const { width: railWidth, onDragStart: onRailDrag } = useStoredWidth('dtrules.debugRailWidth', 320, 220, 700);
+  // fromRight: the rail is docked to the window's right edge, so its width
+  // is measured from the right — without this, any grab jumped the rail to
+  // its max and dragging right could never shrink it back.
+  const { width: railWidth, onDragStart: onRailDrag } = useStoredWidth('dtrules.debugRailWidth', 320, 220, 700, true);
   // Entity explorer overlay: which stack instance is being inspected.
   const [explorer, setExplorer] = useState<{ id: number; name: string } | null>(null);
   // Find-writes panel: query text, results, and which hit's why-chain is open.


### PR DESCRIPTION
The rail hook omitted fromRight, so its width was measured from the
LEFT edge: any grab computed ~clientX, clamped to the max — the rail
jumped wide and dragging right could never shrink it. With the width
measured from the right edge, the divider tracks the mouse exactly in
both directions.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
