### PR TITLE
Editor: show the resolved rules directory; warn on whole-tree multi-project sweeps

### DIFF
--- a/cmd/dtrules/edit_cmd.go
+++ b/cmd/dtrules/edit_cmd.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -146,6 +147,8 @@ reverse proxy that provides TLS and access control.`)
 	if err := server.LoadProject(absPath); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not open project %s: %v\n", absPath, err)
 		fmt.Fprintln(os.Stderr, "The editor will start without a project; open one from the UI.")
+	} else {
+		reportProjectScope(server)
 	}
 
 	// Preload a trace so the Debug tab opens ready (the `dtrules debug` flow).
@@ -218,6 +221,55 @@ reverse proxy that provides TLS and access control.`)
 }
 
 // launchBrowser best-effort opens the system browser at url.
+// reportProjectScope prints where the editor actually got its rules, and
+// warns when the scan fell back to the project root and swept rule files
+// out of multiple nested directories — the signature of launching from a
+// repo root that contains several projects (the whole tree gets walked,
+// and same-named tables from unrelated projects silently collide).
+func reportProjectScope(server *apiserver.Server) {
+	projectPath, rulesDir, dtFiles, eddFiles := server.ProjectSummary()
+	if projectPath == "" {
+		return
+	}
+	fmt.Printf("Project:   %s\n", projectPath)
+	fmt.Printf("Rules dir: %s  (%d decision-table files, %d EDD files)\n",
+		rulesDir, len(dtFiles), len(eddFiles))
+
+	if rulesDir != projectPath {
+		return
+	}
+	// Fallback-to-root scan: warn when NO decision tables live at the scan
+	// root itself and several subdirectories contributed them — a real
+	// project keeps its main *_dt.xml at its top level (subfolders like
+	// states/ are fine), while a repo root has everything nested under
+	// unrelated directories.
+	tops := map[string]bool{}
+	rootFiles := 0
+	for _, f := range dtFiles {
+		parts := strings.SplitN(filepath.ToSlash(f), "/", 2)
+		if len(parts) == 2 {
+			tops[parts[0]] = true
+		} else {
+			rootFiles++
+		}
+	}
+	if rootFiles == 0 && len(tops) > 1 {
+		names := make([]string, 0, len(tops))
+		for t := range tops {
+			names = append(names, t)
+		}
+		sort.Strings(names)
+		fmt.Fprintf(os.Stderr, `
+WARNING: no DTRules.xml or xml/ directory here, so the WHOLE tree was
+scanned and rule files were found under %d different top-level
+directories (%s).
+Tables from unrelated projects can collide. Run the editor from a
+project directory, or pass one:  dtrules edit <project-dir>
+
+`, len(tops), strings.Join(names, ", "))
+	}
+}
+
 func launchBrowser(url string) {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {

--- a/pkg/dtrules/apiserver/debug.go
+++ b/pkg/dtrules/apiserver/debug.go
@@ -83,10 +83,33 @@ func (s *Server) configPayload() map[string]interface{} {
 	if err != nil {
 		rel = xmlDir
 	}
+	// A fallback-to-root scan that found decision tables under more than
+	// one top-level subdirectory almost certainly swept several unrelated
+	// projects (e.g. the editor was launched from a repo root). Surface
+	// that so the UI can warn instead of showing a truthful-but-useless
+	// "rules: .".
+	multiRoot := false
+	if rel == "." {
+		tops := map[string]bool{}
+		rootFiles := 0
+		for _, f := range s.dtFiles {
+			parts := strings.SplitN(filepath.ToSlash(f), "/", 2)
+			if len(parts) == 2 {
+				tops[parts[0]] = true
+			} else {
+				rootFiles++
+			}
+		}
+		// A real project keeps its main *_dt.xml at the scan root
+		// (subfolders like states/ are fine); a repo-root sweep has
+		// everything nested under several unrelated directories.
+		multiRoot = rootFiles == 0 && len(tops) > 1
+	}
 	return map[string]interface{}{
-		"xmlDir":   rel,
-		"entry":    cfg.Entry,
-		"declared": cfg.XMLDir != "" || cfg.Entry != "",
+		"xmlDir":    rel,
+		"entry":     cfg.Entry,
+		"declared":  cfg.XMLDir != "" || cfg.Entry != "",
+		"multiRoot": multiRoot,
 	}
 }
 

--- a/pkg/dtrules/apiserver/server.go
+++ b/pkg/dtrules/apiserver/server.go
@@ -803,6 +803,7 @@ func (s *Server) handleProjectCurrent(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, map[string]interface{}{
 		"success":  true,
 		"path":     s.projectPath,
+		"rulesDir": projectXMLDir(s.projectPath),
 		"config":   s.configPayload(),
 		"eddFiles": s.eddFiles,
 		"dtFiles":  s.dtFiles,
@@ -880,6 +881,22 @@ func (s *Server) LoadProject(reqPath string) error {
 	s.ruleSet = buildRuleSetFromXML("ui-project", s.projectPath, s.eddFiles, s.dtFiles, logLoadWarning)
 
 	return nil
+}
+
+// ProjectSummary reports where the loaded project actually got its rules:
+// the project root, the resolved rules directory that was scanned
+// (DTRules.xml xml_dir override, else xml/, else the root itself), and the
+// discovered file lists (paths relative to the project root). `dtrules
+// edit` prints this at startup so a fallback-to-root scan that sweeps
+// multiple nested projects is visible instead of silent.
+func (s *Server) ProjectSummary() (projectPath, rulesDir string, dtFiles, eddFiles []string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.projectPath == "" {
+		return "", "", nil, nil
+	}
+	return s.projectPath, projectXMLDir(s.projectPath),
+		append([]string(nil), s.dtFiles...), append([]string(nil), s.eddFiles...)
 }
 
 func (s *Server) handleProjectSave(w http.ResponseWriter, r *http.Request) {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -125,12 +125,21 @@ function App() {
               {/* Effective configuration (DTRules.xml) — visible, not hidden in a file */}
               {projectConfig && (
                 <span className="ml-auto flex items-center gap-2 text-xs font-mono shrink-0">
-                  <span
-                    className="px-2 py-0.5 rounded-full border border-border text-muted-foreground"
-                    title="Where this project's rules load from (DTRules.xml xml_dir)"
-                  >
-                    rules: {projectConfig.xmlDir}
-                  </span>
+                  {projectConfig.multiRoot ? (
+                    <span
+                      className="px-2 py-0.5 rounded-full border border-amber-500 text-amber-500"
+                      title="No DTRules.xml or xml/ directory here, so the whole tree was scanned and rule files were found under multiple top-level directories — tables from unrelated projects can collide. Open a specific project directory instead."
+                    >
+                      ⚠ rules: whole tree (multiple projects)
+                    </span>
+                  ) : (
+                    <span
+                      className="px-2 py-0.5 rounded-full border border-border text-muted-foreground"
+                      title="Where this project's rules load from (DTRules.xml xml_dir, else xml/, else this directory)"
+                    >
+                      rules: {projectConfig.xmlDir}
+                    </span>
+                  )}
                   {projectConfig.entry && (
                     <span
                       className="px-2 py-0.5 rounded-full border border-border text-muted-foreground"

--- a/ui/src/stores/projectStore.ts
+++ b/ui/src/stores/projectStore.ts
@@ -37,6 +37,10 @@ export interface ProjectConfig {
   xmlDir: string;
   entry: string;
   declared: boolean;
+  /** True when a fallback whole-tree scan found decision tables under
+   * multiple top-level directories — likely several unrelated projects
+   * swept together (e.g. the editor was launched from a repo root). */
+  multiRoot?: boolean;
 }
 
 /** localStorage key for the recently-opened-projects list. */


### PR DESCRIPTION
Launching `dtrules edit` from the repo root silently swept 259 DT files out of four unrelated top-level directories with no indication of scope. The resolution order (DTRules.xml `xml_dir` → `./xml` → whole-tree fallback) was invisible.

- Startup now prints the resolved project root, rules dir, and file counts.
- A fallback whole-tree scan that finds tables only under multiple top-level subdirectories (none at the root — repo-root signature, so a flat project with a `states/` subfolder stays quiet) warns loudly in the CLI and turns the UI's rules chip amber.
- `/api/project/current` exposes `rulesDir`; config payload gains `multiRoot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)