### PR TITLE
Editor: project discovery and picker replaces whole-tree sweep

### DIFF
--- a/cmd/dtrules/edit_cmd.go
+++ b/cmd/dtrules/edit_cmd.go
@@ -144,7 +144,34 @@ reverse proxy that provides TLS and access control.`)
 	}
 
 	server := apiserver.New(apiserver.Config{ProjectRoot: projectRoot, ReadOnly: readOnly})
-	if err := server.LoadProject(absPath); err != nil {
+
+	// A project is identified by its DTRules.xml (or, for older projects,
+	// the xml/ layout convention). Launching from a directory that is NOT
+	// a project used to silently scan the whole tree — sweeping unrelated
+	// projects together. Instead, discover the projects beneath it and let
+	// the user pick (in the terminal listing or the welcome screen).
+	if apiserver.ProjectMarker(absPath) == "" {
+		server.SetDiscoverRoot(absPath)
+		projects := apiserver.DiscoverProjects(absPath)
+		fmt.Printf("%s is not a project (no DTRules.xml, xml/ directory, or rule XML).\n", absPath)
+		if len(projects) == 0 {
+			fmt.Println("No projects found beneath it either; open one from the editor UI.")
+		} else {
+			fmt.Printf("Projects found beneath it:\n")
+			for _, p := range projects {
+				rel, err := filepath.Rel(absPath, p.Path)
+				if err != nil {
+					rel = p.Path
+				}
+				extra := ""
+				if p.Entry != "" {
+					extra = "  entry: " + p.Entry
+				}
+				fmt.Printf("  %-40s (%s)%s\n", rel, p.Marker, extra)
+			}
+			fmt.Println("Pick one on the editor's welcome screen, or rerun: dtrules edit <dir>")
+		}
+	} else if err := server.LoadProject(absPath); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not open project %s: %v\n", absPath, err)
 		fmt.Fprintln(os.Stderr, "The editor will start without a project; open one from the UI.")
 	} else {
@@ -192,7 +219,11 @@ reverse proxy that provides TLS and access control.`)
 	if !loopback {
 		url = fmt.Sprintf("http://%s:%d", host, boundPort)
 	}
-	fmt.Printf("DTRules editor: %s  (project: %s)\n", url, absPath)
+	if apiserver.ProjectMarker(absPath) == "" {
+		fmt.Printf("DTRules editor: %s  (no project loaded — pick one on the welcome screen)\n", url)
+	} else {
+		fmt.Printf("DTRules editor: %s  (project: %s)\n", url, absPath)
+	}
 	if projectRoot != "" {
 		fmt.Printf("Project access restricted to: %s\n", projectRoot)
 	}

--- a/pkg/dtrules/apiserver/discover.go
+++ b/pkg/dtrules/apiserver/discover.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// DiscoveredProject is one project found under a directory. A project is
+// identified by its DTRules.xml (one per project), or — for projects that
+// predate the config file — by the layout convention: an xml/ directory
+// holding rule XML, or rule XML directly in the directory.
+type DiscoveredProject struct {
+	Path   string `json:"path"`   // absolute directory
+	Name   string `json:"name"`   // directory base name
+	Marker string `json:"marker"` // "DTRules.xml" | "xml/" | "rule files"
+	Entry  string `json:"entry"`  // <entry> from DTRules.xml, when present
+}
+
+// maxDiscoverDepth bounds the walk so discovery stays fast on big trees.
+const maxDiscoverDepth = 5
+
+// skipDirNames are never descended into during discovery.
+var skipDirNames = map[string]bool{
+	".git": true, "node_modules": true, "build": true, "dist": true,
+	"legacy": true, "testdata": true,
+}
+
+// hasRuleXML reports whether dir directly contains at least one *_dt.xml
+// or *edd*.xml file.
+func hasRuleXML(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n := strings.ToLower(e.Name())
+		if !strings.HasSuffix(n, ".xml") {
+			continue
+		}
+		if strings.Contains(n, "_dt") || strings.Contains(n, "edd") {
+			return true
+		}
+	}
+	return false
+}
+
+// ProjectMarker classifies dir as a project. It returns the marker that
+// identifies it, or "" when the directory is not a project.
+func ProjectMarker(dir string) string {
+	if _, err := os.Stat(filepath.Join(dir, "DTRules.xml")); err == nil {
+		return "DTRules.xml"
+	}
+	if xd := filepath.Join(dir, "xml"); dirExists(xd) && hasRuleXML(xd) {
+		return "xml/"
+	}
+	if hasRuleXML(dir) {
+		return "rule files"
+	}
+	return ""
+}
+
+// DiscoverProjects walks root (bounded depth, skipping VCS/build dirs) and
+// returns every directory identified as a project. Once a directory is
+// identified, its subtree is not searched further — a project does not
+// contain other projects.
+func DiscoverProjects(root string) []DiscoveredProject {
+	var found []DiscoveredProject
+	var walk func(dir string, depth int)
+	walk = func(dir string, depth int) {
+		if marker := ProjectMarker(dir); marker != "" {
+			p := DiscoveredProject{
+				Path:   dir,
+				Name:   filepath.Base(dir),
+				Marker: marker,
+			}
+			if marker == "DTRules.xml" {
+				p.Entry = readProjectConfig(dir).Entry
+			}
+			found = append(found, p)
+			return
+		}
+		if depth >= maxDiscoverDepth {
+			return
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return
+		}
+		for _, e := range entries {
+			if !e.IsDir() || skipDirNames[e.Name()] || strings.HasPrefix(e.Name(), ".") {
+				continue
+			}
+			walk(filepath.Join(dir, e.Name()), depth+1)
+		}
+	}
+	// The root itself being a project is the caller's case to handle
+	// (it would just load it); discovery is for the "not a project here,
+	// what is nearby?" question — so start at the children.
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	for _, e := range entries {
+		if !e.IsDir() || skipDirNames[e.Name()] || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		walk(filepath.Join(root, e.Name()), 1)
+	}
+	sort.Slice(found, func(i, j int) bool { return found[i].Path < found[j].Path })
+	return found
+}
+
+// SetDiscoverRoot records the directory `dtrules edit` was launched from
+// when that directory is not itself a project; the welcome screen offers
+// the projects discovered beneath it.
+func (s *Server) SetDiscoverRoot(dir string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.discoverRoot = dir
+}
+
+// handleProjectDiscover lists projects under the launch directory (or an
+// explicit ?path=, validated against the project root restriction).
+func (s *Server) handleProjectDiscover(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		jsonError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	s.mu.RLock()
+	root := s.discoverRoot
+	s.mu.RUnlock()
+	if q := r.URL.Query().Get("path"); q != "" {
+		validated, err := s.validateProjectPath(q)
+		if err != nil {
+			jsonError(w, "invalid path: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		root = validated
+	}
+	if root == "" {
+		jsonResponse(w, map[string]interface{}{"success": true, "root": "", "projects": []DiscoveredProject{}})
+		return
+	}
+	jsonResponse(w, map[string]interface{}{
+		"success":  true,
+		"root":     root,
+		"projects": DiscoverProjects(root),
+	})
+}

--- a/pkg/dtrules/apiserver/server.go
+++ b/pkg/dtrules/apiserver/server.go
@@ -75,6 +75,9 @@ type Server struct {
 	cfg           Config
 	mu            sync.RWMutex
 	projectPath   string
+	// discoverRoot is the non-project directory `dtrules edit` was
+	// launched from; the welcome screen lists projects found beneath it.
+	discoverRoot string
 	ruleSet       *session.RuleSet
 	eddFiles      []string
 	dtFiles       []string
@@ -404,6 +407,7 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("/api/project/save", s.handleProjectSave)
 	mux.HandleFunc("/api/project/files", s.handleProjectFiles)
 	mux.HandleFunc("/api/project/current", s.handleProjectCurrent)
+	mux.HandleFunc("/api/project/discover", s.handleProjectDiscover)
 
 	// EDD endpoints
 	mux.HandleFunc("/api/edd", s.handleEDD)

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -463,6 +463,29 @@ export async function getSampleProjects(): Promise<{
   return fetchJSON(`${API_BASE}/samples`);
 }
 
+/** A project discovered beneath the directory the editor was launched from.
+ * A project is identified by its DTRules.xml (one per project), or by the
+ * xml/-directory layout convention for projects that predate the config. */
+export interface DiscoveredProject {
+  path: string;
+  name: string;
+  marker: string;
+  entry: string;
+}
+
+/**
+ * Lists projects discovered beneath the editor's launch directory. Returns
+ * an empty list when the editor was launched inside a project (nothing to
+ * pick) or when nothing was found.
+ */
+export async function discoverProjects(): Promise<{
+  success: boolean;
+  root: string;
+  projects: DiscoveredProject[];
+}> {
+  return fetchJSON(`${API_BASE}/project/discover`);
+}
+
 // ============================================================================
 // Trace Debugger Endpoints
 // ============================================================================

--- a/ui/src/components/WelcomeScreen.tsx
+++ b/ui/src/components/WelcomeScreen.tsx
@@ -13,7 +13,7 @@ import { useProjectStore } from '@/stores/projectStore';
 import { useOnboardingStore } from '@/stores/onboardingStore';
 import { FileText, Table2, GitBranch, FolderOpen, Play, BookOpen } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { getSampleProjects, type SampleProject } from '@/api/client';
+import { getSampleProjects, discoverProjects, type SampleProject, type DiscoveredProject } from '@/api/client';
 
 interface FeatureCardProps {
   icon: React.ReactNode;
@@ -56,6 +56,8 @@ export function WelcomeScreen() {
   const [customPathDialogOpen, setCustomPathDialogOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [sampleProjects, setSampleProjects] = useState<SampleProject[]>([]);
+  const [discovered, setDiscovered] = useState<DiscoveredProject[]>([]);
+  const [discoveredRoot, setDiscoveredRoot] = useState<string>('');
   const [loadError, setLoadError] = useState<string | null>(null);
 
   // Fetch available sample projects from the backend on mount
@@ -71,6 +73,21 @@ export function WelcomeScreen() {
       }
     };
     fetchSamples();
+    // Projects discovered beneath the launch directory (when the editor was
+    // started somewhere that is not itself a project) — offered for one-click
+    // opening instead of the old whole-tree scan.
+    const fetchDiscovered = async () => {
+      try {
+        const result = await discoverProjects();
+        if (result.success && result.projects) {
+          setDiscovered(result.projects);
+          setDiscoveredRoot(result.root);
+        }
+      } catch (error) {
+        console.error('Failed to discover projects:', error);
+      }
+    };
+    fetchDiscovered();
   }, []);
 
   // Find the CHIP project from the discovered samples
@@ -214,6 +231,31 @@ export function WelcomeScreen() {
             accentColor="green"
           />
         </div>
+
+        {/* Projects discovered beneath the launch directory */}
+        {discovered.length > 0 && (
+          <div className="glass rounded-2xl p-6 space-y-3">
+            <div className="text-sm font-semibold">
+              Projects found under <span className="font-mono text-muted-foreground">{discoveredRoot}</span>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-2 max-h-64 overflow-y-auto">
+              {discovered.map((p) => (
+                <button
+                  key={p.path}
+                  onClick={() => handleOpenCustomProject(p.path)}
+                  disabled={isLoading}
+                  className="flex items-baseline gap-2 px-3 py-2 rounded-lg border border-border/50 hover:border-blue-500/50 hover:bg-accent/50 text-left transition-colors"
+                  title={p.path}
+                >
+                  <span className="font-medium">{p.name}</span>
+                  <span className="text-xs text-muted-foreground font-mono truncate">
+                    {p.marker}{p.entry ? ` · entry: ${p.entry}` : ''}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Action Buttons */}
         <div className="flex flex-col items-center gap-4">


### PR DESCRIPTION
A project is identified by its `DTRules.xml` (one per project), with the `xml/`-directory and bare-rule-file layouts as legacy conventions. Launching `dtrules edit` from a non-project directory now discovers projects beneath it (bounded depth, skipping VCS/build/legacy/testdata, no descent into an identified project) and offers them for picking — in the terminal listing and as a one-click list on the welcome screen (`GET /api/project/discover`). The old behavior silently swept the whole tree (259 DT files from 4 unrelated directories at the repo root). Launching inside a project is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)