### PR TITLE
Bring back `is the <R> of` (#927)

### DIFF
--- a/docs/el-reference.md
+++ b/docs/el-reference.md
@@ -700,7 +700,7 @@ Pure dates (midnight UTC) serialize back as `YYYY-MM-DD`; timestamps serialize a
 **Syntax**: `eexpr IS strexpr OF eexpr`
 **Semantics**: Tests a named relationship between two entities.
 **Example (EL)**: `client is "parent" of applicant`
-**Compiled postfix**: `"relationship-is-of form is not supported (findmatch was removed)" elstmterror false`
+**Compiled postfix**: `applicant "parent" getrelationship client req`
 
 #### Is in context
 

--- a/pkg/dtrules/authoring/el_check.go
+++ b/pkg/dtrules/authoring/el_check.go
@@ -62,3 +62,62 @@ func CheckContext(elStr string, symbols map[string]string) (postfix string, err 
 	}
 	return c.CompileContext(strings.TrimSpace(elStr))
 }
+
+// tableCompiler compiles every row of one decision table through a single EL
+// compiler, so locals a context row declares are in scope for the conditions
+// and actions beneath it (#965).
+//
+// `Compiler.ResetLocals` documents the rule — "within a single table, locals
+// persist across Context/Condition/Action calls" — but CheckCondition and
+// friends each build a fresh compiler, so a table written like
+//
+//	context:     local entity ApplyingClient = client
+//	condition 1: ApplyingClient == client
+//
+// compiled the condition with no knowledge of the slot and emitted
+// `ApplyingClient` as a bare name. It parsed, it produced plausible postfix,
+// and it died at execute with "The Name 'ApplyingClient' was not defined by
+// any Entity on the Entity Stack". CHIP's Calculate_Group_Size had been dead
+// that way for as long as the sample existed.
+//
+// Rows must be compiled in table order — contexts first — for the slots to be
+// declared before they are referenced. syncToXML already writes them that way.
+type tableCompiler struct {
+	c *el.Compiler
+}
+
+// newTableCompiler starts a fresh local scope for one table.
+func newTableCompiler(symbols map[string]string) *tableCompiler {
+	c := el.NewCompiler()
+	if symbols != nil {
+		c.SetSymbols(symbols)
+	}
+	// Slot indices must not bleed in from whatever was compiled before.
+	c.ResetLocals()
+	return &tableCompiler{c: c}
+}
+
+// compile returns the postfix for one row, or "" when the DSL is empty or does
+// not compile. An empty result lets the loader's hand-coded-postfix check flag
+// the table rather than silently preserving a stale prior compile.
+func (tc *tableCompiler) compile(dsl, kind string) string {
+	if strings.TrimSpace(dsl) == "" {
+		return ""
+	}
+	var (
+		postfix string
+		err     error
+	)
+	switch kind {
+	case "context":
+		postfix, err = tc.c.CompileContext(strings.TrimSpace(dsl))
+	case "condition":
+		postfix, err = tc.c.CompileCondition(strings.TrimSpace(dsl))
+	case "action":
+		postfix, err = tc.c.CompileAction(strings.TrimSpace(dsl))
+	}
+	if err != nil {
+		return ""
+	}
+	return postfix
+}

--- a/pkg/dtrules/authoring/policy_statement_test.go
+++ b/pkg/dtrules/authoring/policy_statement_test.go
@@ -127,3 +127,71 @@ func postfixFor(t *Table, column string) string {
 	}
 	return ""
 }
+
+// TestContextLocalsAreVisibleToRows guards #965.
+//
+// A table can declare a local in a context row and refer to it from its
+// conditions and actions. Compiling each row through its own EL compiler lost
+// the slot, so the name was emitted bare and the rule died at execute with
+// "The Name 'ApplyingClient' was not defined by any Entity on the Entity
+// Stack". CHIP's Calculate_Group_Size had been dead that way for as long as
+// the sample existed, and ChipApp, KidAid and SyntaxTests use the same idiom.
+func TestContextLocalsAreVisibleToRows(t *testing.T) {
+	symbols := map[string]string{
+		"client":          "entity",
+		"client.applying": "boolean",
+		"clients":         "array",
+	}
+	tbl := newTable(&excel.DecisionTableXML{
+		TableName: "Calculate_Group_Size",
+		Contexts: excel.ContextsField{Details: []excel.ContextDetailXML{
+			{Number: 1, DSL: "for all clients"},
+			{Number: 2, DSL: "local entity ApplyingClient = client"},
+		}},
+		Conditions: []excel.ConditionXML{
+			{Number: "1", DSL: "ApplyingClient == client"},
+		},
+	}, symbols)
+
+	// Force a write-out, which is where postfix is generated.
+	if err := tbl.UpdateCondition(1, Condition{
+		Number:  1,
+		DSL:     "ApplyingClient == client",
+		Columns: map[int]string{1: "Y"},
+	}); err != nil {
+		t.Fatalf("UpdateCondition: %v", err)
+	}
+
+	got := strings.Join(strings.Fields(tbl.xml.Conditions[0].Postfix), " ")
+	if strings.Contains(got, "ApplyingClient") {
+		t.Errorf("the local is emitted as a bare name and will not resolve at run time: %s", got)
+	}
+	if !strings.Contains(got, "local@") {
+		t.Errorf("condition postfix does not reference a local slot: %s", got)
+	}
+}
+
+// TestLocalSlotsDoNotBleedBetweenTables: each table gets a fresh scope, so
+// slot indices from one table's contexts cannot be reused by another's rows.
+func TestLocalSlotsDoNotBleedBetweenTables(t *testing.T) {
+	symbols := map[string]string{"client": "entity", "clients": "array"}
+	build := func(name string) string {
+		tbl := newTable(&excel.DecisionTableXML{
+			TableName: name,
+			Contexts: excel.ContextsField{Details: []excel.ContextDetailXML{
+				{Number: 1, DSL: "for all clients"},
+				{Number: 2, DSL: "local entity Held = client"},
+			}},
+			Conditions: []excel.ConditionXML{{Number: "1", DSL: "Held == client"}},
+		}, symbols)
+		if err := tbl.UpdateCondition(1, Condition{Number: 1, DSL: "Held == client", Columns: map[int]string{1: "Y"}}); err != nil {
+			t.Fatalf("UpdateCondition: %v", err)
+		}
+		return strings.Join(strings.Fields(tbl.xml.Conditions[0].Postfix), " ")
+	}
+
+	first, second := build("First_Table"), build("Second_Table")
+	if first != second {
+		t.Errorf("slot indices differ between tables that declare the same locals:\n  %s\n  %s", first, second)
+	}
+}

--- a/pkg/dtrules/authoring/table.go
+++ b/pkg/dtrules/authoring/table.go
@@ -193,6 +193,12 @@ func (t *Table) syncFromXML() {
 //     original. ActionPostfix is regenerated from the carried ActionDSL.
 //   - Contexts: position-by-position over the Details slice.
 func (t *Table) syncToXML() {
+	// One compiler for the whole table, so a local declared in a context row
+	// is in scope for the conditions and actions beneath it (#965). Rows are
+	// compiled below in table order — contexts, initial actions, conditions,
+	// actions — which is the order the slots have to be declared in.
+	tc := newTableCompiler(t.symbols)
+
 	t.xml.TableName = t.Name
 	t.xml.AttributeFields.Type = t.Policy
 	// Only write a number when one is set, so an unspecified number keeps the
@@ -215,7 +221,7 @@ func (t *Table) syncToXML() {
 			entry.Name = origDetails[i].Name
 			entry.Description = origDetails[i].Description
 		}
-		entry.Postfix = compileDSLOrEmpty(c.DSL, t.symbols, "context")
+		entry.Postfix = tc.compile(c.DSL, "context")
 		newDetails = append(newDetails, entry)
 	}
 	t.xml.Contexts.Details = newDetails
@@ -228,9 +234,9 @@ func (t *Table) syncToXML() {
 		if i < len(origInits) {
 			entry.Comment = origInits[i].Comment
 			entry.ActionDSL = origInits[i].ActionDSL
-			entry.ActionPostfix = compileDSLOrEmpty(origInits[i].ActionDSL, t.symbols, "action")
+			entry.ActionPostfix = tc.compile(origInits[i].ActionDSL, "action")
 		}
-		entry.Postfix = compileDSLOrEmpty(ia.DSL, t.symbols, "action")
+		entry.Postfix = tc.compile(ia.DSL, "action")
 		newInits = append(newInits, entry)
 	}
 	t.xml.InitialActions = newInits
@@ -259,7 +265,7 @@ func (t *Table) syncToXML() {
 			DSL:     c.DSL,
 			Columns: cols,
 		}
-		entry.Postfix = compileDSLOrEmpty(c.DSL, t.symbols, "condition")
+		entry.Postfix = tc.compile(c.DSL, "condition")
 		t.xml.Conditions = append(t.xml.Conditions, entry)
 	}
 
@@ -279,7 +285,7 @@ func (t *Table) syncToXML() {
 			DSL:     a.DSL,
 			Columns: cols,
 		}
-		entry.Postfix = compileDSLOrEmpty(a.DSL, t.symbols, "action")
+		entry.Postfix = tc.compile(a.DSL, "action")
 		t.xml.Actions = append(t.xml.Actions, entry)
 	}
 
@@ -337,39 +343,6 @@ func (t *Table) DeletePolicyStatement(column int) error {
 		}
 	}
 	return fmt.Errorf("no policy statement for column %d", column)
-}
-
-// compileDSLOrEmpty compiles a single element's DSL via the EL compiler
-// and returns the postfix. Empty DSL returns empty postfix. A compile
-// failure also returns empty — the mutation entry points all validate
-// via CheckXxx before storing, so a compile failure here means the
-// underlying XML was loaded with broken DSL; surfacing it as empty
-// postfix lets the loader's hand-coded-postfix check flag the table
-// rather than silently preserving a stale prior compile.
-//
-// Per #817, this is the ONLY path that writes <*_postfix> bytes in
-// the authoring round-trip. There is no carry-through from the
-// original XML's postfix content.
-func compileDSLOrEmpty(dsl string, symbols map[string]string, kind string) string {
-	if strings.TrimSpace(dsl) == "" {
-		return ""
-	}
-	var (
-		postfix string
-		err     error
-	)
-	switch kind {
-	case "context":
-		postfix, err = CheckContext(dsl, symbols)
-	case "condition":
-		postfix, err = CheckCondition(dsl, symbols)
-	case "action":
-		postfix, err = CheckAction(dsl, symbols)
-	}
-	if err != nil {
-		return ""
-	}
-	return postfix
 }
 
 // Columns returns the number of rule columns in this table.

--- a/pkg/dtrules/chip_perf_test.go
+++ b/pkg/dtrules/chip_perf_test.go
@@ -112,15 +112,15 @@ func BenchmarkCHIPDecisionTable(b *testing.B) {
 
 // TestCHIPPerformance runs timing tests on CHIP decision tables
 func TestCHIPPerformance(t *testing.T) {
-	// Skipped: CHIP does not execute. Calculate_Group_Size declares
-	// `local entity ApplyingClient = client` in a context row and refers to it
-	// from every condition and action, but rows compile independently of their
-	// table's context locals, so the name resolves against nothing at run time
-	// (#965). Tracked for CHIP as #962.
+	// Skipped: CHIP still does not execute end to end. Calculate_Group_Size
+	// works now — context locals resolve (#965) and `is the <R> of` compiles
+	// again (#927) — and execution reaches Compute_Eligibility action 3,
+	// which refers to `fpl` with nothing on the entity stack to resolve it.
+	// One more authoring defect, tracked in #962.
 	//
 	// This test asserted a successful run while the mapping loaded nothing
-	// into the entities it read, so it passed on a run that did nothing.
-	t.Skip("CHIP execution is broken — see #962, blocked on #965")
+	// into the entities it read, so it used to pass on a run that did nothing.
+	t.Skip("CHIP execution is incomplete — see #962")
 
 	chipDir := findCHIPDir(t)
 	if chipDir == "" {

--- a/pkg/dtrules/chip_simple_test.go
+++ b/pkg/dtrules/chip_simple_test.go
@@ -33,6 +33,16 @@ import (
 
 // TestCHIPSimpleExecution performs a simple load and execution test
 func TestCHIPSimpleExecution(t *testing.T) {
+	// Skipped: CHIP still does not execute end to end. Calculate_Group_Size
+	// works now — context locals resolve (#965) and `is the <R> of` compiles
+	// again (#927) — and execution reaches Compute_Eligibility action 3,
+	// which refers to `fpl` with nothing on the entity stack to resolve it.
+	// One more authoring defect, tracked in #962.
+	//
+	// This test asserted a successful run while the mapping loaded nothing
+	// into the entities it read, so it used to pass on a run that did nothing.
+	t.Skip("CHIP execution is incomplete — see #962")
+
 	// Skipped: CHIP does not execute. Calculate_Group_Size declares
 	// `local entity ApplyingClient = client` in a context row and refers to it
 	// from every condition and action, but rows compile independently of their
@@ -41,7 +51,6 @@ func TestCHIPSimpleExecution(t *testing.T) {
 	//
 	// This test asserted a successful run while the mapping loaded nothing
 	// into the entities it read, so it passed on a run that did nothing.
-	t.Skip("CHIP execution is broken — see #962, blocked on #965")
 
 	// Skipped: CHIP's rules do not execute — `Calculate_Group_Size` resolves
 	// `ThisClient` against nothing (#962). This test asserted a successful run

--- a/pkg/dtrules/compiler/el/compiler_test.go
+++ b/pkg/dtrules/compiler/el/compiler_test.go
@@ -943,3 +943,50 @@ func TestCompile_RejectsTrailingTokens(t *testing.T) {
 		t.Errorf("expected 'unexpected tokens' in error, got: %v", err)
 	}
 }
+
+// TestRelationshipIsOf covers `<e1> is the <R> of <e2>` (#927).
+//
+// The form means exactly one thing: e2's R field holds e1. It compiles to the
+// same getrelationship the `"role" of entity` form uses, since that operator
+// is a field read by name. Between findmatch's removal and this, the form
+// parsed and emitted an elstmterror that killed the rule at run time.
+func TestRelationshipIsOf(t *testing.T) {
+	symbols := map[string]string{
+		"client":         "entity",
+		"ApplyingClient": "entity",
+	}
+	tests := []struct {
+		name string
+		el   string
+		want string
+	}{
+		{
+			name: "article is dropped from the relationship name",
+			el:   "the client is the parent of ApplyingClient",
+			want: `ApplyingClient "parent" getrelationship client req`,
+		},
+		{
+			name: "no article",
+			el:   "client is the sibling of ApplyingClient",
+			want: `ApplyingClient "sibling" getrelationship client req`,
+		},
+		{
+			name: "operand order is e2's field against e1",
+			el:   "ApplyingClient is the child of client",
+			want: `client "child" getrelationship ApplyingClient req`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCompiler()
+			c.SetSymbols(symbols)
+			got, err := c.CompileCondition(tt.el)
+			if err != nil {
+				t.Fatalf("CompileCondition(%q): %v", tt.el, err)
+			}
+			if normalized := strings.Join(strings.Fields(got), " "); normalized != tt.want {
+				t.Errorf("CompileCondition(%q)\n got %s\nwant %s", tt.el, normalized, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -6033,15 +6033,46 @@ func (e *PostfixEmitter) VisitSubDestColon(ctx *SubDestColonContext) interface{}
 	return nil
 }
 
-// VisitBoolEntityIsOf: `<e1> is <type> of <e2>` — the findmatch/relationship
-// lookup op this used to call was removed alongside the hash-table ops. The
-// emit now produces an elstmterror so the form parses but errors at runtime
-// with a clear message until a replacement relationship primitive lands.
+// VisitBoolEntityIsOf: `<e1> is the <R> of <e2>` — true when e2's R field
+// holds e1.
+//
+//	the client is the parent of ApplyingClient   ->   ApplyingClient.parent == client
+//
+// That is all the relationship means: the entity is held by the named field
+// of the other entity. The form used to call a findmatch-era lookup that went
+// away with the hash-table ops, and since then it emitted an elstmterror so
+// the row parsed and died at runtime (#927).
+//
+// It compiles to the same `getrelationship` the `"role" of entity` form uses
+// — that operator reads the named field off an entity, which is the whole of
+// the semantics:
+//
+//	<e2> "<R>" getrelationship <e1> req
 func (e *PostfixEmitter) VisitBoolEntityIsOf(ctx *BoolEntityIsOfContext) interface{} {
-	e.emit("\"relationship-is-of form is not supported (findmatch was removed)\"")
-	e.emit("elstmterror")
-	e.emit("false")
+	field := relationshipFieldName(ctx.Strexpr().GetText())
+	if field == "" {
+		e.emitError("relationship name is empty in `is ... of`")
+		e.emit("false")
+		return nil
+	}
+
+	e.Visit(ctx.Eexpr(1))
+	e.emit("\"" + field + "\"")
+	e.emit("getrelationship")
+	e.Visit(ctx.Eexpr(0))
+	e.emit("req")
 	return nil
+}
+
+// relationshipFieldName strips the article and any quoting from the
+// relationship in `is the <R> of`, leaving the field name to read.
+func relationshipFieldName(text string) string {
+	name := strings.TrimSpace(text)
+	name = strings.Trim(name, "\"'")
+	for _, article := range []string{"the ", "The ", "a ", "an "} {
+		name = strings.TrimPrefix(strings.TrimSpace(name), article)
+	}
+	return strings.TrimSpace(name)
 }
 
 func (e *PostfixEmitter) VisitEntityRelationship(ctx *EntityRelationshipContext) interface{} {

--- a/sampleprojects/CHIP/xml/CHIP_dt.xml
+++ b/sampleprojects/CHIP/xml/CHIP_dt.xml
@@ -258,7 +258,7 @@ dup clients forall pop
 <condition_comment>Are we consider the client themselves?</condition_comment>
 <condition_dsl>ApplyingClient == client</condition_dsl>
 <condition_postfix>
-ApplyingClient client req
+0 local@ client req
 </condition_postfix>
 <condition_column column_number="1" column_value="Y" />
 <condition_column column_number="2" column_value="Y" />
@@ -329,7 +329,7 @@ client.age 18 &gt;
 <action_comment>Count the Client himself and particular relatives</action_comment>
 <action_dsl>add 1 to ApplyingClient's IncomeGroupCount</action_dsl>
 <action_postfix>
-1 ApplyingClient entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop
+1 0 local@ entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop
 </action_postfix>
 <action_column column_number="1" column_value="X" />
 <action_column column_number="2" column_value="X" />
@@ -344,7 +344,7 @@ client.age 18 &gt;
 <action_comment>Add 1 for each of the expected babies for a pregnant person</action_comment>
 <action_dsl>add expectedChildren to ApplyingClient's IncomeGroupCount</action_dsl>
 <action_postfix>
-expectedChildren ApplyingClient entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop
+expectedChildren 0 local@ entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop
 </action_postfix>
 <action_column column_number="2" column_value="X" />
 <action_column column_number="4" column_value="X" />
@@ -355,7 +355,7 @@ expectedChildren ApplyingClient entitypush IncomeGroupCount + /IncomeGroupCount 
 <action_comment>Add this person's Income to the ThisPerson's total group income</action_comment>
 <action_dsl>add the client.totalIncome to ApplyingClient's totalGroupIncome</action_dsl>
 <action_postfix>
-client.totalIncome ApplyingClient entitypush totalGroupIncome + /totalGroupIncome xdef entitypop
+client.totalIncome 0 local@ entitypush totalGroupIncome + /totalGroupIncome xdef entitypop
 </action_postfix>
 <action_column column_number="9" column_value="X" />
 <action_column column_number="10" column_value="X" />

--- a/sampleprojects/CHIP/xml/CHIP_dt.xml
+++ b/sampleprojects/CHIP/xml/CHIP_dt.xml
@@ -269,7 +269,7 @@ dup clients forall pop
 <condition_comment>Include ApplyingClient's parents</condition_comment>
 <condition_dsl>the client is the parent of ApplyingClient</condition_dsl>
 <condition_postfix>
-"relationship-is-of form is not supported (findmatch was removed)" elstmterror false
+0 local@ "parent" getrelationship client req
 </condition_postfix>
 <condition_column column_number="3" column_value="Y" />
 <condition_column column_number="4" column_value="Y" />
@@ -280,7 +280,7 @@ dup clients forall pop
 <condition_comment>Include ApplyingClient's siblings</condition_comment>
 <condition_dsl>the client is the sibling of ApplyingClient</condition_dsl>
 <condition_postfix>
-"relationship-is-of form is not supported (findmatch was removed)" elstmterror false
+0 local@ "sibling" getrelationship client req
 </condition_postfix>
 <condition_column column_number="5" column_value="Y" />
 <condition_column column_number="6" column_value="Y" />
@@ -291,7 +291,7 @@ dup clients forall pop
 <condition_comment>Include ApplyingClient's children</condition_comment>
 <condition_dsl>the client is the child of ApplyingClient</condition_dsl>
 <condition_postfix>
-"relationship-is-of form is not supported (findmatch was removed)" elstmterror false
+0 local@ "child" getrelationship client req
 </condition_postfix>
 <condition_column column_number="7" column_value="Y" />
 <condition_column column_number="12" column_value="Y" />


### PR DESCRIPTION
Closes #927.

> All this means is that the entity is held by the parent field of the next entity.

```
the client is the parent of ApplyingClient   ==   ApplyingClient.parent holds client
```

That is exactly what the existing `getrelationship` operator does — read the named field off an entity — so the form now compiles to the same op the `"role" of entity` form already used, rather than needing anything new:

```
ApplyingClient "parent" getrelationship client req
```

Since findmatch was removed the form emitted an `elstmterror` instead, so every row using it parsed, compiled, produced plausible postfix, and killed the rule at run time.

The article is stripped, so `is the parent of` and `is parent of` mean the same thing. Operand order is covered by a test: `X is the R of Y` reads R off **Y** and compares with **X**.

## Effect on CHIP

`Calculate_Group_Size` has three such rows. With this plus the context-locals fix (#965) they compile to real postfix and the table executes:

```
0 local@ "parent" getrelationship client req
```

CHIP still doesn't finish — execution now reaches `Compute_Eligibility` action 3, which refers to `fpl` with nothing on the entity stack to resolve it. One more authoring defect, tracked in #962. Its tests stay skipped, with the reason updated to say exactly how far it now gets.

Worth flagging: **CHIP's EDD models relationships as a separate `relationship` entity** with `source`/`target`/`type`, not as a `client.parent` field — its own comment says *"Source is the &lt;relationship type&gt; of the target"*. So these rows will compile and execute correctly under the semantics you described, but return false against CHIP's current data shape until either the EDD grows the fields or the rows are re-authored to search relationships. That's a CHIP data-model decision, not part of this change.

## The doc gate earned its keep

`docs/el-reference.md` documented the `elstmterror` as this form's compiled output. `TestELReference_PostfixMatchesCompiler` failed the moment the compiler changed:

```
el-reference.md:702: documented postfix is not what the compiler emits
  EL:       client is "parent" of applicant
  document: "relationship-is-of form is not supported (findmatch was removed)" elstmterror false
  compiler: applicant "parent" getrelationship client req
```

Regenerated. `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)