### PR TITLE
Stop erasing a table's type, and repair KidAid (#948)

### DIFF
--- a/pkg/dtrules/authoring/table.go
+++ b/pkg/dtrules/authoring/table.go
@@ -93,7 +93,7 @@ type PolicyStatement struct {
 func newTable(x *excel.DecisionTableXML, symbols map[string]string) *Table {
 	t := &Table{
 		Name:    x.TableName,
-		Policy:  x.AttributeFields.Type,
+		Policy:  x.AttributeFields.EffectiveType(),
 		xml:     x,
 		symbols: symbols,
 	}
@@ -116,7 +116,7 @@ func newTableWithProject(x *excel.DecisionTableXML, symbols map[string]string, p
 // can carry it back through write-out.
 func (t *Table) syncFromXML() {
 	t.Name = t.xml.TableName
-	t.Policy = t.xml.AttributeFields.Type
+	t.Policy = t.xml.AttributeFields.EffectiveType()
 	t.Number, _ = strconv.Atoi(strings.TrimSpace(t.xml.AttributeFields.TableNumber))
 
 	t.Contexts = nil
@@ -200,7 +200,11 @@ func (t *Table) syncToXML() {
 	tc := newTableCompiler(t.symbols)
 
 	t.xml.TableName = t.Name
+	// Write the canonical spelling and clear the legacy ones, so a table
+	// cannot end up carrying two different types.
 	t.xml.AttributeFields.Type = t.Policy
+	t.xml.AttributeFields.TypeUppercase = ""
+	t.xml.AttributeFields.TypeLowercase = ""
 	// Only write a number when one is set, so an unspecified number keeps the
 	// value AddTable auto-assigned rather than clobbering it with 0.
 	if t.Number > 0 {

--- a/pkg/dtrules/excel/dt_importer.go
+++ b/pkg/dtrules/excel/dt_importer.go
@@ -221,11 +221,33 @@ func (c *ContextsField) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 }
 
 // AttributeFieldsXML holds metadata fields for the table.
+//
+// The table type has three spellings in real DTRules XML — <Type>, <TYPE>
+// and <type> — and the runtime loader accepts all three. This model used to
+// read only <Type>, so a table written in the legacy uppercase form loaded
+// with an empty type and, on the next authoring write, was SAVED with an
+// empty <Type>: the policy that decides whether a table is FIRST, ALL or
+// BALANCED, silently erased. KidAid's tables are all <TYPE>.
+//
+// EffectiveType resolves the three; the marshaller writes <Type>.
 type AttributeFieldsXML struct {
-	Type        string `xml:"Type"`
-	Comments    string `xml:"COMMENTS"`
-	TableNumber string `xml:"TABLE_NUMBER"`
-	FilePath    string `xml:"FILE_PATH,omitempty"`
+	Type          string `xml:"Type"`
+	TypeUppercase string `xml:"TYPE,omitempty"`
+	TypeLowercase string `xml:"type,omitempty"`
+	Comments      string `xml:"COMMENTS"`
+	TableNumber   string `xml:"TABLE_NUMBER"`
+	FilePath      string `xml:"FILE_PATH,omitempty"`
+}
+
+// EffectiveType returns the table type from whichever spelling carries it.
+func (a AttributeFieldsXML) EffectiveType() string {
+	if a.Type != "" {
+		return a.Type
+	}
+	if a.TypeUppercase != "" {
+		return a.TypeUppercase
+	}
+	return a.TypeLowercase
 }
 
 // valueAfterColon returns everything after the first colon in a "Label: value"
@@ -618,7 +640,7 @@ func (i *DTImporter) writeTable(f *os.File, table *DecisionTableXML) error {
 
 	// Attribute fields
 	f.WriteString("<attribute_fields>\n")
-	f.WriteString(fmt.Sprintf("<Type>%s</Type>\n", xmlEscapeText(table.AttributeFields.Type)))
+	f.WriteString(fmt.Sprintf("<Type>%s</Type>\n", xmlEscapeText(table.AttributeFields.EffectiveType())))
 	f.WriteString(fmt.Sprintf("<COMMENTS>%s</COMMENTS>\n", xmlEscapeText(table.AttributeFields.Comments)))
 	f.WriteString(fmt.Sprintf("<TABLE_NUMBER>%s</TABLE_NUMBER>\n", xmlEscapeText(table.AttributeFields.TableNumber)))
 	if table.AttributeFields.FilePath != "" {

--- a/pkg/dtrules/excel/policy_statement_test.go
+++ b/pkg/dtrules/excel/policy_statement_test.go
@@ -168,3 +168,36 @@ func TestParseExporterFormatSkipsLegacyColumnNumberRow(t *testing.T) {
 		t.Errorf("policy description = %q, want %q", got, "first statement")
 	}
 }
+
+// TestLegacyTypeTagSurvivesAuthoring guards the table's policy against the
+// three spellings of its type element.
+//
+// Real DTRules XML writes <Type>, <TYPE> or <type>, and the runtime loader
+// accepts all three. The authoring model read only <Type>, so a table written
+// in the legacy uppercase form loaded with an empty type and was saved back
+// with an empty <Type> — silently erasing whether the table is FIRST, ALL or
+// BALANCED. Every KidAid table is <TYPE>, and a recompile flattened them all
+// until this was fixed.
+func TestLegacyTypeTagSurvivesAuthoring(t *testing.T) {
+	tests := map[string]AttributeFieldsXML{
+		"canonical": {Type: "FIRST"},
+		"uppercase": {TypeUppercase: "FIRST"},
+		"lowercase": {TypeLowercase: "FIRST"},
+	}
+	for name, attrs := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := attrs.EffectiveType(); got != "FIRST" {
+				t.Errorf("EffectiveType() = %q, want FIRST", got)
+			}
+		})
+	}
+
+	if got := (AttributeFieldsXML{}).EffectiveType(); got != "" {
+		t.Errorf("a table with no type at all reports %q, want empty", got)
+	}
+	// The canonical spelling wins when more than one is present.
+	both := AttributeFieldsXML{Type: "ALL", TypeUppercase: "FIRST"}
+	if got := both.EffectiveType(); got != "ALL" {
+		t.Errorf("EffectiveType() = %q, want the canonical <Type> to win", got)
+	}
+}

--- a/pkg/dtrules/sample_traces_test.go
+++ b/pkg/dtrules/sample_traces_test.go
@@ -80,6 +80,11 @@ func TestSampleProjectsProduceLoadableTraces(t *testing.T) {
 			minColumns: 8,
 		},
 		{
+			project:    "KidAid",
+			input:      "testfiles/TestScenarios/TestCase_001.xml",
+			minColumns: 8,
+		},
+		{
 			project:    "Poker",
 			input:      "testfiles/TestScenarios/basic_scenarios.xml",
 			minColumns: 24, // 12 players, at least two tables deep

--- a/sampleprojects/KidAid/DTRules.xml
+++ b/sampleprojects/KidAid/DTRules.xml
@@ -1,5 +1,8 @@
 <DTRules>
 
+  <!-- Entry table: what `dtrules run`, `dtrules debug` and the editor start from. -->
+  <entry>Compute_Eligibility</entry>
+
   <compileralias name="EL">com.dtrules.compiler.el.EL</compileralias> 
   <compiler>EL</compiler>
   

--- a/sampleprojects/KidAid/xml/kidaid_dt.xml
+++ b/sampleprojects/KidAid/xml/kidaid_dt.xml
@@ -1,766 +1,1038 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <decision_tables>
+
+<!-- TABLE 100: Compute_Eligibility -->
 <decision_table>
+<source>
+<relative_path>KidAid_dt.xls</relative_path>
+<file_name>KidAid_dt.xls</file_name>
+<sheet_number>1</sheet_number>
+</source>
 <table_name>Compute_Eligibility</table_name>
 <xls_file>KidAid_dt.xls</xls_file>
 <attribute_fields>
-<TYPE>FIRST</TYPE>
-<COMMENTS />
-<POLICY_REFERENCE /></attribute_fields>
-<contexts />
-<initial_actions />
+<Type>FIRST</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>100</TABLE_NUMBER>
+</attribute_fields>
+<contexts></contexts>
+<initial_actions></initial_actions>
 <conditions>
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>KidAid</condition_comment>
-<condition_requirement />
 <condition_dsl>job.program == KidAid</condition_dsl>
-<condition_postfix>job.program KidAid streq</condition_postfix>
-<condition_column column_value="Y" column_number="1" /></condition_details>
+<condition_postfix>
+job.program KidAid streq
+</condition_postfix>
+<condition_column column_number="1" column_value="Y" />
+</condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>MEDICAID</condition_comment>
-<condition_requirement />
 <condition_dsl>job.program == MEDICAID</condition_dsl>
-<condition_postfix>job.program MEDICAID streq</condition_postfix>
-<condition_column column_value="Y" column_number="2" /></condition_details>
+<condition_postfix>
+job.program MEDICAID streq
+</condition_postfix>
+<condition_column column_number="2" column_value="Y" />
+</condition_details>
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>FOODSTAMPS</condition_comment>
-<condition_requirement />
 <condition_dsl>job.program == FOODSTAMPS</condition_dsl>
-<condition_postfix>job.program FOODSTAMPS streq</condition_postfix>
-<condition_column column_value="Y" column_number="3" /></condition_details>
+<condition_postfix>
+job.program FOODSTAMPS streq
+</condition_postfix>
+<condition_column column_number="3" column_value="Y" />
+</condition_details>
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>If Not Any of these programs, Report Results Anyway</condition_comment>
-<condition_requirement />
 <condition_dsl>true</condition_dsl>
-<condition_postfix>true</condition_postfix>
-<condition_column column_value="Y" column_number="4" /></condition_details></conditions>
+<condition_postfix>
+true
+</condition_postfix>
+<condition_column column_number="4" column_value="Y" />
+</condition_details>
+</conditions>
 <actions>
 <action_details>
 <action_number>1</action_number>
 <action_comment>Calculate the Individual Incomes</action_comment>
-<action_requirement />
 <action_dsl>Perform Calculate_Individual_Income</action_dsl>
-<action_postfix>/Calculate_Individual_Income performtable</action_postfix>
-<action_column column_value="X" column_number="1" />
-<action_column column_value="X" column_number="2" />
-<action_column column_value="X" column_number="3" /></action_details>
+<action_postfix>
+/Calculate_Individual_Income performtable
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+<action_column column_number="2" column_value="X" />
+<action_column column_number="3" column_value="X" />
+</action_details>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Get the Group Size for each individual</action_comment>
-<action_requirement />
 <action_dsl>Perform Calculate_Group_Size</action_dsl>
-<action_postfix>/Calculate_Group_Size performtable</action_postfix>
-<action_column column_value="X" column_number="1" />
-<action_column column_value="X" column_number="2" />
-<action_column column_value="X" column_number="3" /></action_details>
+<action_postfix>
+/Calculate_Group_Size performtable
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+<action_column column_number="2" column_value="X" />
+<action_column column_number="3" column_value="X" />
+</action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment>Evaluate for KidAid</action_comment>
-<action_requirement />
 <action_dsl>Perform Evaluate_KidAid_Eligibility</action_dsl>
-<action_postfix>/Evaluate_KidAid_Eligibility performtable</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details>
+<action_postfix>
+/Evaluate_KidAid_Eligibility performtable
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
 <action_details>
 <action_number>4</action_number>
 <action_comment>Evaluate for MEDICAID</action_comment>
-<action_requirement />
 <action_dsl>Perform Evaluate_MEDICAID_Eligibility</action_dsl>
-<action_postfix>/Evaluate_MEDICAID_Eligibility performtable</action_postfix>
-<action_column column_value="X" column_number="2" /></action_details>
+<action_postfix>
+/Evaluate_MEDICAID_Eligibility performtable
+</action_postfix>
+<action_column column_number="2" column_value="X" />
+</action_details>
 <action_details>
 <action_number>5</action_number>
 <action_comment>Evaluate for FOODSTAMPS</action_comment>
-<action_requirement />
 <action_dsl>Perform Evaluate_FOODSTAMPS_Eligibility</action_dsl>
-<action_postfix>/Evaluate_FOODSTAMPS_Eligibility performtable</action_postfix>
-<action_column column_value="X" column_number="3" /></action_details>
+<action_postfix>
+/Evaluate_FOODSTAMPS_Eligibility performtable
+</action_postfix>
+<action_column column_number="3" column_value="X" />
+</action_details>
 <action_details>
 <action_number>6</action_number>
 <action_comment>Build a set of Result Objects to report to the caller</action_comment>
-<action_requirement />
 <action_dsl>Perform Evaluate_Results</action_dsl>
-<action_postfix>/Evaluate_Results performtable</action_postfix>
-<action_column column_value="X" column_number="1" />
-<action_column column_value="X" column_number="2" />
-<action_column column_value="X" column_number="3" />
-<action_column column_value="X" column_number="4" /></action_details></actions>
+<action_postfix>
+/Evaluate_Results performtable
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+<action_column column_number="2" column_value="X" />
+<action_column column_number="3" column_value="X" />
+<action_column column_number="4" column_value="X" />
+</action_details>
+</actions>
 <policy_statements>
 <policy_statement column="1">
 <policy_description>Evaluate the clients in the case for the KidAid program</policy_description>
-<policy_statement_postfix>"Evaluate the clients in the case for the KidAid program" </policy_statement_postfix></policy_statement>
+<policy_statement_postfix>"Evaluate the clients in the case for the KidAid program"</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="2">
 <policy_description>Evaluate the clients in the case for Medicaid</policy_description>
-<policy_statement_postfix>"Evaluate the clients in the case for Medicaid" </policy_statement_postfix></policy_statement>
+<policy_statement_postfix>"Evaluate the clients in the case for Medicaid"</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="3">
 <policy_description>Evaluate the clients in the case for Food Stamps</policy_description>
-<policy_statement_postfix>"Evaluate the clients in the case for Food Stamps" </policy_statement_postfix></policy_statement>
+<policy_statement_postfix>"Evaluate the clients in the case for Food Stamps"</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="4">
 <policy_description>No Valid Program was Found</policy_description>
-<policy_statement_postfix>"No Valid Program was Found" </policy_statement_postfix></policy_statement></policy_statements></decision_table>
+<policy_statement_postfix>"No Valid Program was Found"</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- TABLE 200: Calculate_Individual_Income -->
 <decision_table>
+<source>
+<relative_path>KidAid_dt.xls</relative_path>
+<file_name>KidAid_dt.xls</file_name>
+<sheet_number>2</sheet_number>
+</source>
 <table_name>Calculate_Individual_Income</table_name>
 <xls_file>KidAid_dt.xls</xls_file>
 <attribute_fields>
-<TYPE>FIRST</TYPE>
-<COMMENTS />
-<POLICY_REFERENCE /></attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>200</TABLE_NUMBER>
+</attribute_fields>
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_comment />
+<context_comment></context_comment>
 <context_dsl>for all clients</context_dsl>
-<context_postfix>dup clients forall pop</context_postfix></context_details>
+<context_postfix>
+dup clients forall pop
+</context_postfix>
+</context_details>
 <context_details>
 <context_number>2</context_number>
-<context_comment />
+<context_comment></context_comment>
 <context_dsl>for all incomes</context_dsl>
-<context_postfix>dup incomes forall pop</context_postfix></context_details></contexts>
-<initial_actions />
+<context_postfix>
+dup incomes forall pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
 <conditions>
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>We include all earned income</condition_comment>
-<condition_requirement />
 <condition_dsl>income.earned == true</condition_dsl>
-<condition_postfix>income.earned true beq</condition_postfix>
-<condition_column column_value="Y" column_number="1" />
-<condition_column column_value="N" column_number="2" /></condition_details>
+<condition_postfix>
+income.earned true beq
+</condition_postfix>
+<condition_column column_number="1" column_value="Y" />
+<condition_column column_number="2" column_value="N" />
+</condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>We don't include all unearned income types</condition_comment>
-<condition_requirement />
 <condition_dsl>ExcludedIncomeTypes includes the string income.type</condition_dsl>
-<condition_postfix>ExcludedIncomeTypes income.type memberof</condition_postfix>
-<condition_column column_value="N" column_number="2" /></condition_details></conditions>
+<condition_postfix>
+ExcludedIncomeTypes income.type memberof
+</condition_postfix>
+<condition_column column_number="2" column_value="N" />
+</condition_details>
+</conditions>
 <actions>
 <action_details>
 <action_number>1</action_number>
 <action_comment>Add this income to the total income for this client</action_comment>
-<action_requirement />
 <action_dsl>add income.amount to the client.totalIncome</action_dsl>
-<action_postfix>income.amount client.totalIncome swap addto</action_postfix>
-<action_column column_value="X" column_number="1" />
-<action_column column_value="X" column_number="2" /></action_details></actions>
+<action_postfix>
+income.amount client.totalIncome + /client.totalIncome xdef
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+<action_column column_number="2" column_value="X" />
+</action_details>
+</actions>
 <policy_statements>
+<policy_statement column="0">
+<policy_description>The income {income.amount} is not earned and is an excluded income type</policy_description>
+<policy_statement_postfix>"The income " income.amount cvs strconcat " is not earned and is an excluded income type" strconcat</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="1">
 <policy_description>Adding {income.amount} to the client total income</policy_description>
-<policy_statement_postfix>"Adding " income.amount cvs strconcat " to the client total income" strconcat</policy_statement_postfix></policy_statement>
+<policy_statement_postfix>"Adding " income.amount cvs strconcat " to the client total income" strconcat</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="2">
 <policy_description>Adding {income.amount} to the client total income</policy_description>
-<policy_statement_postfix>"Adding " income.amount cvs strconcat " to the client total income" strconcat</policy_statement_postfix></policy_statement>
-<policy_statement column="">
-<policy_description>The income {income.amount} is not earned and is an excluded income type</policy_description>
-<policy_statement_postfix>"The income " income.amount cvs strconcat " is not earned and is an excluded income type" strconcat</policy_statement_postfix></policy_statement></policy_statements></decision_table>
+<policy_statement_postfix>"Adding " income.amount cvs strconcat " to the client total income" strconcat</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- TABLE 300: Calculate_Group_Size -->
 <decision_table>
+<source>
+<relative_path>KidAid_dt.xls</relative_path>
+<file_name>KidAid_dt.xls</file_name>
+<sheet_number>3</sheet_number>
+</source>
 <table_name>Calculate_Group_Size</table_name>
 <xls_file>KidAid_dt.xls</xls_file>
 <attribute_fields>
-<TYPE>ALL</TYPE>
+<Type>ALL</Type>
 <COMMENTS>Calculates the Group Size for Each Person by looking at the relationships between people</COMMENTS>
-<POLICY_REFERENCE /></attribute_fields>
+<TABLE_NUMBER>300</TABLE_NUMBER>
+</attribute_fields>
 <contexts>
 <context_details>
 <context_number>1</context_number>
 <context_comment>For each client in the group, we need to calculate a group size (we only need to do this for applying clients)</context_comment>
 <context_dsl>for all clients whose applying == true</context_dsl>
-<context_postfix>{ { dup execute } applying true beq if } clients forall pop</context_postfix></context_details>
+<context_postfix>
+{ { dup execute } applying true beq if } clients forall pop
+</context_postfix>
+</context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>We want to compare a client against every other client in the case, so we set up a local variable to point to ThisClient</context_comment>
 <context_dsl>local entity ThisClient = client</context_dsl>
-<context_postfix>client cve allocate execute deallocate pop</context_postfix></context_details>
+<context_postfix>
+client cve allocate execute deallocate pop
+</context_postfix>
+</context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment>Now consider the client in respect to all the other clients in the case (We need to consider all clients in the case, even if not applying)</context_comment>
 <context_dsl>for all clients</context_dsl>
-<context_postfix>dup clients forall pop</context_postfix></context_details></contexts>
+<context_postfix>
+dup clients forall pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
 <conditions>
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Are we consider the client themselves?</condition_comment>
-<condition_requirement />
 <condition_dsl>ThisClient == client</condition_dsl>
-<condition_postfix>0 local@ client req</condition_postfix>
-<condition_column column_value="Y" column_number="1" />
-<condition_column column_value="Y" column_number="2" />
-<condition_column column_value="Y" column_number="9" /></condition_details>
+<condition_postfix>
+0 local@ client req
+</condition_postfix>
+<condition_column column_number="1" column_value="Y" />
+<condition_column column_number="2" column_value="Y" />
+<condition_column column_number="9" column_value="Y" />
+</condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Include ThisClient's parents</condition_comment>
-<condition_requirement />
 <condition_dsl>the client is the parent of ThisClient</condition_dsl>
-<condition_postfix>&quot;relationship-is-of form is not supported (findmatch was removed)&quot; elstmterror false</condition_postfix>
-<condition_column column_value="Y" column_number="3" />
-<condition_column column_value="Y" column_number="4" />
-<condition_column column_value="Y" column_number="10" /></condition_details>
+<condition_postfix>
+0 local@ "parent" getrelationship client req
+</condition_postfix>
+<condition_column column_number="3" column_value="Y" />
+<condition_column column_number="4" column_value="Y" />
+<condition_column column_number="10" column_value="Y" />
+</condition_details>
 <condition_details>
 <condition_number>3</condition_number>
 <condition_comment>Include ThisClient's siblings</condition_comment>
-<condition_requirement />
 <condition_dsl>the client is the sibling of ThisClient</condition_dsl>
-<condition_postfix>&quot;relationship-is-of form is not supported (findmatch was removed)&quot; elstmterror false</condition_postfix>
-<condition_column column_value="Y" column_number="5" />
-<condition_column column_value="Y" column_number="6" />
-<condition_column column_value="Y" column_number="11" /></condition_details>
+<condition_postfix>
+0 local@ "sibling" getrelationship client req
+</condition_postfix>
+<condition_column column_number="5" column_value="Y" />
+<condition_column column_number="6" column_value="Y" />
+<condition_column column_number="11" column_value="Y" />
+</condition_details>
 <condition_details>
 <condition_number>4</condition_number>
 <condition_comment>Include ThisClient's children</condition_comment>
-<condition_requirement />
 <condition_dsl>the client is the child of ThisClient</condition_dsl>
-<condition_postfix>&quot;relationship-is-of form is not supported (findmatch was removed)&quot; elstmterror false</condition_postfix>
-<condition_column column_value="Y" column_number="7" />
-<condition_column column_value="Y" column_number="12" /></condition_details>
+<condition_postfix>
+0 local@ "child" getrelationship client req
+</condition_postfix>
+<condition_column column_number="7" column_value="Y" />
+<condition_column column_number="12" column_value="Y" />
+</condition_details>
 <condition_details>
 <condition_number>5</condition_number>
 <condition_comment>Include the unborn children in some cases</condition_comment>
-<condition_requirement />
 <condition_dsl>the client.pregnant == true</condition_dsl>
-<condition_postfix>client.pregnant true beq</condition_postfix>
-<condition_column column_value="N" column_number="1" />
-<condition_column column_value="Y" column_number="2" />
-<condition_column column_value="N" column_number="3" />
-<condition_column column_value="Y" column_number="4" />
-<condition_column column_value="N" column_number="5" />
-<condition_column column_value="Y" column_number="6" /></condition_details>
+<condition_postfix>
+client.pregnant true beq
+</condition_postfix>
+<condition_column column_number="1" column_value="N" />
+<condition_column column_number="2" column_value="Y" />
+<condition_column column_number="3" column_value="N" />
+<condition_column column_number="4" column_value="Y" />
+<condition_column column_number="5" column_value="N" />
+<condition_column column_number="6" column_value="Y" />
+</condition_details>
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>Is this client older than 18</condition_comment>
-<condition_requirement />
 <condition_dsl>client.age &gt; 18</condition_dsl>
-<condition_postfix>client.age 18 &gt;</condition_postfix>
-<condition_column column_value="Y" column_number="9" />
-<condition_column column_value="Y" column_number="10" />
-<condition_column column_value="Y" column_number="11" />
-<condition_column column_value="Y" column_number="12" /></condition_details></conditions>
+<condition_postfix>
+client.age 18 &gt;
+</condition_postfix>
+<condition_column column_number="9" column_value="Y" />
+<condition_column column_number="10" column_value="Y" />
+<condition_column column_number="11" column_value="Y" />
+<condition_column column_number="12" column_value="Y" />
+</condition_details>
+</conditions>
 <actions>
 <action_details>
 <action_number>1</action_number>
 <action_comment>Count the Client himself and particular relatives</action_comment>
-<action_requirement />
 <action_dsl>add 1 to ThisClient's IncomeGroupCount</action_dsl>
-<action_postfix>1 0 local@ entitypush IncomeGroupCount swap addto entitypop</action_postfix>
-<action_column column_value="X" column_number="1" />
-<action_column column_value="X" column_number="2" />
-<action_column column_value="X" column_number="3" />
-<action_column column_value="X" column_number="4" />
-<action_column column_value="X" column_number="5" />
-<action_column column_value="X" column_number="6" />
-<action_column column_value="X" column_number="7" /></action_details>
+<action_postfix>
+1 0 local@ entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+<action_column column_number="2" column_value="X" />
+<action_column column_number="3" column_value="X" />
+<action_column column_number="4" column_value="X" />
+<action_column column_number="5" column_value="X" />
+<action_column column_number="6" column_value="X" />
+<action_column column_number="7" column_value="X" />
+</action_details>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Add 1 for each of the expected babies for a pregnant person</action_comment>
-<action_requirement />
 <action_dsl>add expectedChildren to ThisClient's IncomeGroupCount</action_dsl>
-<action_postfix>expectedChildren ThisClient IncomeGroupCount swap addto</action_postfix>
-<action_column column_value="X" column_number="2" />
-<action_column column_value="X" column_number="4" />
-<action_column column_value="X" column_number="6" /></action_details>
+<action_postfix>
+expectedChildren 0 local@ entitypush IncomeGroupCount + /IncomeGroupCount xdef entitypop
+</action_postfix>
+<action_column column_number="2" column_value="X" />
+<action_column column_number="4" column_value="X" />
+<action_column column_number="6" column_value="X" />
+</action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment>Add this person's Income to the ThisPerson's total group income</action_comment>
-<action_requirement />
 <action_dsl>add the client.totalIncome to ThisClient's totalGroupIncome</action_dsl>
-<action_postfix>client.totalIncome ThisClient totalGroupIncome swap addto</action_postfix>
-<action_column column_value="X" column_number="9" />
-<action_column column_value="X" column_number="10" />
-<action_column column_value="X" column_number="11" />
-<action_column column_value="X" column_number="12" /></action_details></actions>
+<action_postfix>
+client.totalIncome 0 local@ entitypush totalGroupIncome + /totalGroupIncome xdef entitypop
+</action_postfix>
+<action_column column_number="9" column_value="X" />
+<action_column column_number="10" column_value="X" />
+<action_column column_number="11" column_value="X" />
+<action_column column_number="12" column_value="X" />
+</action_details>
+</actions>
 <policy_statements>
+<policy_statement column="0">
+<policy_description>The relationship between the client {client.client_id} and this client {thisclient's client_id} is not self, parent, or sibling</policy_description>
+<policy_statement_postfix>"The relationship between the client " client.client_id cvs strconcat " and this client " strconcat thisclient's client_id cvs strconcat " is not self, parent, or sibling" strconcat</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="1">
 <policy_description>The client {client.client_id} is self, is not pregnant, so add 1 to  This Client's IncomeGroupCount</policy_description>
-<policy_statement_postfix>"The client " client.client_id cvs strconcat " is self, is not pregnant, so add 1 to  This Client's IncomeGroupCount" strconcat</policy_statement_postfix></policy_statement>
+<policy_statement_postfix>"The client " client.client_id cvs strconcat " is self, is not pregnant, so add 1 to  This Client's IncomeGroupCount" strconcat</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="2">
 <policy_description>The client {client.client_id} is self, and pregnant, so add 1 + the number of expected children to this client's IncomeGroupCount</policy_description>
-<policy_statement_postfix>"The client " client.client_id cvs strconcat " is self, and pregnant, so add 1 + the number of expected children to this client's IncomeGroupCount" strconcat</policy_statement_postfix></policy_statement>
+<policy_statement_postfix>"The client " client.client_id cvs strconcat " is self, and pregnant, so add 1 + the number of expected children to this client's IncomeGroupCount" strconcat</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="3">
 <policy_description>The client {client.client_id} is the parent of {ThisClient's client_id} , is not pregnant, so add 1 to this client's IncomeGroupCount</policy_description>
-<policy_statement_postfix>"The client " client.client_id cvs strconcat " is the parent of " s+ 0 local@  entitypush client_id entitypop cvs strconcat " , is not pregnant, so add 1 to this client's IncomeGroupCount" strconcat</policy_statement_postfix></policy_statement>
+<policy_statement_postfix>"The client " client.client_id cvs strconcat " is the parent of " strconcat ThisClient's client_id cvs strconcat " , is not pregnant, so add 1 to this client's IncomeGroupCount" strconcat</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="4">
 <policy_description>The client {client.client_id} is the parent of {ThisClient's client_id}, and is pregnant, so add 1 to this client's IncomeGroupCount</policy_description>
-<policy_statement_postfix>"The client " client.client_id cvs strconcat " is the parent of " s+ 0 local@  entitypush client_id entitypop cvs strconcat ", and is pregnant, so add 1 to this client's IncomeGroupCount" strconcat</policy_statement_postfix></policy_statement>
+<policy_statement_postfix>"The client " client.client_id cvs strconcat " is the parent of " strconcat ThisClient's client_id cvs strconcat ", and is pregnant, so add 1 to this client's IncomeGroupCount" strconcat</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="5">
 <policy_description>The client {client.client_id} is the sibling of {ThisClient's client_id} , is not pregnant, so add 1 to this client's IncomeGroupCount</policy_description>
-<policy_statement_postfix>"The client " client.client_id cvs strconcat " is the sibling of " s+ 0 local@  entitypush client_id entitypop cvs strconcat " , is not pregnant, so add 1 to this client's IncomeGroupCount" strconcat</policy_statement_postfix></policy_statement>
+<policy_statement_postfix>"The client " client.client_id cvs strconcat " is the sibling of " strconcat ThisClient's client_id cvs strconcat " , is not pregnant, so add 1 to this client's IncomeGroupCount" strconcat</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="6">
 <policy_description>The client {client.client_id} is the sibling of {ThisClient's client_id}, and is pregnant, so add 1 to this client's IncomeGroupCount</policy_description>
-<policy_statement_postfix>"The client " client.client_id cvs strconcat " is the sibling of " s+ 0 local@  entitypush client_id entitypop cvs strconcat ", and is pregnant, so add 1 to this client's IncomeGroupCount" strconcat</policy_statement_postfix></policy_statement>
+<policy_statement_postfix>"The client " client.client_id cvs strconcat " is the sibling of " strconcat ThisClient's client_id cvs strconcat ", and is pregnant, so add 1 to this client's IncomeGroupCount" strconcat</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="7">
 <policy_description>The client {client.client_id} is the child of {ThisClient's client_id}, so add 1 to the client's IncomeGroupCount</policy_description>
-<policy_statement_postfix>"The client " client.client_id cvs strconcat " is the child of " s+ 0 local@  entitypush client_id entitypop cvs strconcat ", so add 1 to the client's IncomeGroupCount" strconcat</policy_statement_postfix></policy_statement>
+<policy_statement_postfix>"The client " client.client_id cvs strconcat " is the child of " strconcat ThisClient's client_id cvs strconcat ", so add 1 to the client's IncomeGroupCount" strconcat</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="9">
 <policy_description>The client {client.client_id} is older than 18, so add the total income of the client, ({client.totalIncome}) to This Client's total group income.</policy_description>
-<policy_statement_postfix>"The client " client.client_id cvs strconcat " is older than 18, so add the total income of the client, (" s+ client.totalIncome cvs strconcat ") to This Client's total group income." strconcat</policy_statement_postfix></policy_statement>
+<policy_statement_postfix>"The client " client.client_id cvs strconcat " is older than 18, so add the total income of the client, (" strconcat client.totalIncome cvs strconcat ") to This Client's total group income." strconcat</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="10">
 <policy_description>The client {client.client_id} is older than 18, so add the total income of the client, ({client.totalIncome}) to This Client's total group income.</policy_description>
-<policy_statement_postfix>"The client " client.client_id cvs strconcat " is older than 18, so add the total income of the client, (" s+ client.totalIncome cvs strconcat ") to This Client's total group income." strconcat</policy_statement_postfix></policy_statement>
+<policy_statement_postfix>"The client " client.client_id cvs strconcat " is older than 18, so add the total income of the client, (" strconcat client.totalIncome cvs strconcat ") to This Client's total group income." strconcat</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="11">
 <policy_description>The client {client.client_id} is older than 18, so add the total income of the client, ({client.totalIncome}) to This Client's total group income.</policy_description>
-<policy_statement_postfix>"The client " client.client_id cvs strconcat " is older than 18, so add the total income of the client, (" s+ client.totalIncome cvs strconcat ") to This Client's total group income." strconcat</policy_statement_postfix></policy_statement>
+<policy_statement_postfix>"The client " client.client_id cvs strconcat " is older than 18, so add the total income of the client, (" strconcat client.totalIncome cvs strconcat ") to This Client's total group income." strconcat</policy_statement_postfix>
+</policy_statement>
 <policy_statement column="12">
 <policy_description>The client {client.client_id} is older than 18, so add the total income of the client, ({client.totalIncome}) to This Client's total group income.</policy_description>
-<policy_statement_postfix>"The client " client.client_id cvs strconcat " is older than 18, so add the total income of the client, (" s+ client.totalIncome cvs strconcat ") to This Client's total group income." strconcat</policy_statement_postfix></policy_statement>
-<policy_statement column="">
-<policy_description>The relationship between the client {client.client_id} and this client {thisclient's client_id} is not self, parent, or sibling</policy_description>
-<policy_statement_postfix>"The relationship between the client " client.client_id cvs strconcat " and this client " s+ 0 local@  entitypush client_id entitypop cvs strconcat " is not self, parent, or sibling" strconcat</policy_statement_postfix></policy_statement></policy_statements></decision_table>
+<policy_statement_postfix>"The client " client.client_id cvs strconcat " is older than 18, so add the total income of the client, (" strconcat client.totalIncome cvs strconcat ") to This Client's total group income." strconcat</policy_statement_postfix>
+</policy_statement>
+</policy_statements>
+</decision_table>
+
+<!-- TABLE 400: Evaluate_KidAid_Eligibility -->
 <decision_table>
+<source>
+<relative_path>KidAid_dt.xls</relative_path>
+<file_name>KidAid_dt.xls</file_name>
+<sheet_number>4</sheet_number>
+</source>
 <table_name>Evaluate_KidAid_Eligibility</table_name>
 <xls_file>KidAid_dt.xls</xls_file>
 <attribute_fields>
-<TYPE>FIRST</TYPE>
-<COMMENTS />
-<POLICY_REFERENCE /></attribute_fields>
+<Type>FIRST</Type>
+<COMMENTS></COMMENTS>
+<TABLE_NUMBER>400</TABLE_NUMBER>
+</attribute_fields>
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_comment />
+<context_comment></context_comment>
 <context_dsl>for all clients whose applying == true</context_dsl>
-<context_postfix>{ { dup execute } applying true beq if } clients forall pop</context_postfix></context_details>
+<context_postfix>
+{ { dup execute } applying true beq if } clients forall pop
+</context_postfix>
+</context_details>
 <context_details>
 <context_number>2</context_number>
 <context_comment>FPL = the Federal Poverty Limit calculated for the number of people in this client's Income Group.</context_comment>
 <context_dsl>local int FPL = FPL_Base + FPL_PerAdditionalPerson * (client.IncomeGroupCount - 1 )</context_dsl>
-<context_postfix>FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 - * + cvi allocate execute deallocate pop</context_postfix></context_details>
+<context_postfix>
+FPL_Base FPL_PerAdditionalPerson client.IncomeGroupCount 1 - * + cvi allocate execute deallocate pop
+</context_postfix>
+</context_details>
 <context_details>
 <context_number>3</context_number>
 <context_comment>FPL125 = 125 percent of the Federal Poverty Limit</context_comment>
 <context_dsl>local int FPL125 = FPL * 1.25</context_dsl>
-<context_postfix>0 local@ 1.25 fmul cvi allocate execute deallocate pop</context_postfix></context_details>
+<context_postfix>
+0 local@ 1.25 fmul cvi allocate execute deallocate pop
+</context_postfix>
+</context_details>
 <context_details>
 <context_number>4</context_number>
 <context_comment>FPL150 = 150 percent of the Federal Poverty Limit</context_comment>
 <context_dsl>local int FPL150 = FPL * 1.5</context_dsl>
-<context_postfix>0 local@ 1.5 fmul cvi allocate execute deallocate pop</context_postfix></context_details>
+<context_postfix>
+0 local@ 1.5 fmul cvi allocate execute deallocate pop
+</context_postfix>
+</context_details>
 <context_details>
 <context_number>5</context_number>
 <context_comment>FPL175 = 175 percent of the Federal Poverty Limit</context_comment>
 <context_dsl>local int FPL175 = FPL * 1.75</context_dsl>
-<context_postfix>0 local@ 1.75 fmul cvi allocate execute deallocate pop</context_postfix></context_details>
+<context_postfix>
+0 local@ 1.75 fmul cvi allocate execute deallocate pop
+</context_postfix>
+</context_details>
 <context_details>
 <context_number>6</context_number>
 <context_comment>FPL200 = 200 percent of the Federal Poverty Limit</context_comment>
 <context_dsl>local int FPL200 = FPL * 2</context_dsl>
-<context_postfix>0 local@ 2 * cvi allocate execute deallocate pop</context_postfix></context_details>
+<context_postfix>
+0 local@ 2 * cvi allocate execute deallocate pop
+</context_postfix>
+</context_details>
 <context_details>
 <context_number>7</context_number>
 <context_comment>FPL250 = 250 percent of the Federal Poverty Limit</context_comment>
 <context_dsl>local int FPL250 = FPL * 2.5</context_dsl>
-<context_postfix>0 local@ 2.5 fmul cvi allocate execute deallocate pop</context_postfix></context_details>
+<context_postfix>
+0 local@ 2.5 fmul cvi allocate execute deallocate pop
+</context_postfix>
+</context_details>
 <context_details>
 <context_number>8</context_number>
 <context_comment>FPL300 = 300 percent of the Federal Poverty Limit</context_comment>
 <context_dsl>local int FPL300 = FPL * 3</context_dsl>
-<context_postfix>0 local@ 3 * cvi allocate execute deallocate pop</context_postfix></context_details></contexts>
+<context_postfix>
+0 local@ 3 * cvi allocate execute deallocate pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
 <conditions>
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>You have to be a Citizen</condition_comment>
-<condition_requirement />
 <condition_dsl>validatedCitizenship</condition_dsl>
-<condition_postfix>validatedCitizenship</condition_postfix>
-<condition_column column_value="Y" column_number="1" />
-<condition_column column_value="Y" column_number="2" />
-<condition_column column_value="Y" column_number="3" />
-<condition_column column_value="Y" column_number="5" />
-<condition_column column_value="Y" column_number="6" />
-<condition_column column_value="Y" column_number="7" />
-<condition_column column_value="Y" column_number="9" />
-<condition_column column_value="Y" column_number="11" />
-<condition_column column_value="N" column_number="12" />
-<condition_column column_value="N" column_number="13" /></condition_details>
+<condition_postfix>
+validatedCitizenship
+</condition_postfix>
+<condition_column column_number="1" column_value="Y" />
+<condition_column column_number="2" column_value="Y" />
+<condition_column column_number="3" column_value="Y" />
+<condition_column column_number="5" column_value="Y" />
+<condition_column column_number="6" column_value="Y" />
+<condition_column column_number="7" column_value="Y" />
+<condition_column column_number="9" column_value="Y" />
+<condition_column column_number="11" column_value="Y" />
+<condition_column column_number="12" column_value="N" />
+<condition_column column_number="13" column_value="N" />
+</condition_details>
 <condition_details>
 <condition_number>2</condition_number>
 <condition_comment>Make sure this case is in the appropriate county</condition_comment>
-<condition_requirement />
 <condition_dsl>The CoveredCounties includes the string case.county_Cd</condition_dsl>
-<condition_postfix>CoveredCounties case.county_Cd memberof</condition_postfix>
-<condition_column column_value="Y" column_number="1" />
-<condition_column column_value="Y" column_number="2" />
-<condition_column column_value="Y" column_number="3" />
-<condition_column column_value="Y" column_number="5" />
-<condition_column column_value="Y" column_number="6" />
-<condition_column column_value="Y" column_number="7" />
-<condition_column column_value="Y" column_number="9" />
-<condition_column column_value="Y" column_number="11" />
-<condition_column column_value="N" column_number="12" />
-<condition_column column_value="N" column_number="14" /></condition_details>
+<condition_postfix>
+CoveredCounties case.county_Cd memberof
+</condition_postfix>
+<condition_column column_number="1" column_value="Y" />
+<condition_column column_number="2" column_value="Y" />
+<condition_column column_number="3" column_value="Y" />
+<condition_column column_number="5" column_value="Y" />
+<condition_column column_number="6" column_value="Y" />
+<condition_column column_number="7" column_value="Y" />
+<condition_column column_number="9" column_value="Y" />
+<condition_column column_number="11" column_value="Y" />
+<condition_column column_number="12" column_value="N" />
+<condition_column column_number="14" column_value="N" />
+</condition_details>
 <condition_details>
 <condition_number>3</condition_number>
-<condition_comment />
-<condition_requirement />
+<condition_comment></condition_comment>
 <condition_dsl>client.age &lt; 1</condition_dsl>
-<condition_postfix>client.age 1 &lt;</condition_postfix>
-<condition_column column_value="Y" column_number="1" />
-<condition_column column_value="n" column_number="2" />
-<condition_column column_value="n" column_number="3" />
-<condition_column column_value="Y" column_number="5" />
-<condition_column column_value="n" column_number="6" />
-<condition_column column_value="n" column_number="7" /></condition_details>
+<condition_postfix>
+client.age 1 &lt;
+</condition_postfix>
+<condition_column column_number="1" column_value="Y" />
+<condition_column column_number="2" column_value="n" />
+<condition_column column_number="3" column_value="n" />
+<condition_column column_number="5" column_value="Y" />
+<condition_column column_number="6" column_value="n" />
+<condition_column column_number="7" column_value="n" />
+</condition_details>
 <condition_details>
 <condition_number>4</condition_number>
-<condition_comment />
-<condition_requirement />
+<condition_comment></condition_comment>
 <condition_dsl>client.age &lt; 6</condition_dsl>
-<condition_postfix>client.age 6 &lt;</condition_postfix>
-<condition_column column_value="Y" column_number="2" />
-<condition_column column_value="n" column_number="3" />
-<condition_column column_value="Y" column_number="6" />
-<condition_column column_value="n" column_number="7" /></condition_details>
+<condition_postfix>
+client.age 6 &lt;
+</condition_postfix>
+<condition_column column_number="2" column_value="Y" />
+<condition_column column_number="3" column_value="n" />
+<condition_column column_number="6" column_value="Y" />
+<condition_column column_number="7" column_value="n" />
+</condition_details>
 <condition_details>
 <condition_number>5</condition_number>
-<condition_comment />
-<condition_requirement />
+<condition_comment></condition_comment>
 <condition_dsl>client.age &lt;= 18</condition_dsl>
-<condition_postfix>client.age 18 &lt;=</condition_postfix>
-<condition_column column_value="Y" column_number="3" />
-<condition_column column_value="Y" column_number="7" />
-<condition_column column_value="Y" column_number="9" />
-<condition_column column_value="Y" column_number="11" />
-<condition_column column_value="N" column_number="15" /></condition_details>
+<condition_postfix>
+client.age 18 &lt;=
+</condition_postfix>
+<condition_column column_number="3" column_value="Y" />
+<condition_column column_number="7" column_value="Y" />
+<condition_column column_number="9" column_value="Y" />
+<condition_column column_number="11" column_value="Y" />
+<condition_column column_number="15" column_value="N" />
+</condition_details>
 <condition_details>
 <condition_number>6</condition_number>
 <condition_comment>Exclude under the FPL</condition_comment>
-<condition_requirement />
 <condition_dsl>totalGroupIncome &gt; FPL</condition_dsl>
-<condition_postfix>totalGroupIncome 0 local@ &gt;</condition_postfix>
-<condition_column column_value="Y" column_number="3" /></condition_details>
+<condition_postfix>
+totalGroupIncome 0 local@ &gt;
+</condition_postfix>
+<condition_column column_number="3" column_value="Y" />
+</condition_details>
 <condition_details>
 <condition_number>7</condition_number>
 <condition_comment>Exclude under 125 percent of the FPL</condition_comment>
-<condition_requirement />
 <condition_dsl>totalGroupIncome &gt; FPL125</condition_dsl>
-<condition_postfix>totalGroupIncome 1 local@ &gt;</condition_postfix>
-<condition_column column_value="Y" column_number="2" /></condition_details>
+<condition_postfix>
+totalGroupIncome 1 local@ &gt;
+</condition_postfix>
+<condition_column column_number="2" column_value="Y" />
+</condition_details>
 <condition_details>
 <condition_number>8</condition_number>
 <condition_comment>Exclude under 150 percent of the FPL</condition_comment>
-<condition_requirement />
 <condition_dsl>totalGroupIncome &gt; FPL150</condition_dsl>
-<condition_postfix>totalGroupIncome 2 local@ &gt;</condition_postfix>
-<condition_column column_value="Y" column_number="1" /></condition_details>
+<condition_postfix>
+totalGroupIncome 2 local@ &gt;
+</condition_postfix>
+<condition_column column_number="1" column_value="Y" />
+</condition_details>
 <condition_details>
 <condition_number>9</condition_number>
 <condition_comment>Exclude under 175 percent of the FPL</condition_comment>
-<condition_requirement />
 <condition_dsl>totalGroupIncome &gt; FPL175</condition_dsl>
-<condition_postfix>totalGroupIncome 3 local@ &gt;</condition_postfix>
-<condition_column column_value="Y" column_number="5" />
-<condition_column column_value="Y" column_number="6" />
-<condition_column column_value="Y" column_number="7" /></condition_details>
+<condition_postfix>
+totalGroupIncome 3 local@ &gt;
+</condition_postfix>
+<condition_column column_number="5" column_value="Y" />
+<condition_column column_number="6" column_value="Y" />
+<condition_column column_number="7" column_value="Y" />
+</condition_details>
 <condition_details>
 <condition_number>10</condition_number>
 <condition_comment>Exclude under 200 percent of the FPL</condition_comment>
-<condition_requirement />
 <condition_dsl>totalGroupIncome &gt; FPL200</condition_dsl>
-<condition_postfix>totalGroupIncome 4 local@ &gt;</condition_postfix></condition_details>
+<condition_postfix>
+totalGroupIncome 4 local@ &gt;
+</condition_postfix>
+</condition_details>
 <condition_details>
 <condition_number>11</condition_number>
 <condition_comment>Exclude under 250 percent of the FPL</condition_comment>
-<condition_requirement />
 <condition_dsl>totalGroupIncome &gt; FPL250</condition_dsl>
-<condition_postfix>totalGroupIncome 5 local@ &gt;</condition_postfix></condition_details>
+<condition_postfix>
+totalGroupIncome 5 local@ &gt;
+</condition_postfix>
+</condition_details>
 <condition_details>
 <condition_number>12</condition_number>
 <condition_comment>Include if not excluded and under 175 of the FPL</condition_comment>
-<condition_requirement />
 <condition_dsl>totalGroupIncome &lt;= FPL175</condition_dsl>
-<condition_postfix>totalGroupIncome 3 local@ &lt;=</condition_postfix>
-<condition_column column_value="Y" column_number="1" />
-<condition_column column_value="Y" column_number="2" />
-<condition_column column_value="Y" column_number="3" /></condition_details>
+<condition_postfix>
+totalGroupIncome 3 local@ &lt;=
+</condition_postfix>
+<condition_column column_number="1" column_value="Y" />
+<condition_column column_number="2" column_value="Y" />
+<condition_column column_number="3" column_value="Y" />
+</condition_details>
 <condition_details>
 <condition_number>13</condition_number>
 <condition_comment>Include if not excluded and under 200 of the FPL</condition_comment>
-<condition_requirement />
 <condition_dsl>totalGroupIncome &lt;= FPL200</condition_dsl>
-<condition_postfix>totalGroupIncome 4 local@ &lt;=</condition_postfix>
-<condition_column column_value="Y" column_number="5" />
-<condition_column column_value="N" column_number="9" /></condition_details>
+<condition_postfix>
+totalGroupIncome 4 local@ &lt;=
+</condition_postfix>
+<condition_column column_number="5" column_value="Y" />
+<condition_column column_number="9" column_value="N" />
+</condition_details>
 <condition_details>
 <condition_number>14</condition_number>
 <condition_comment>Include if not excluded and under 250 of the FPL</condition_comment>
-<condition_requirement />
 <condition_dsl>totalGroupIncome &lt;= FPL250</condition_dsl>
-<condition_postfix>totalGroupIncome 5 local@ &lt;=</condition_postfix>
-<condition_column column_value="Y" column_number="6" /></condition_details>
+<condition_postfix>
+totalGroupIncome 5 local@ &lt;=
+</condition_postfix>
+<condition_column column_number="6" column_value="Y" />
+</condition_details>
 <condition_details>
 <condition_number>15</condition_number>
 <condition_comment>Include if not excluded and under 300 of the FPL</condition_comment>
-<condition_requirement />
 <condition_dsl>totalGroupIncome &lt;= FPL300</condition_dsl>
-<condition_postfix>totalGroupIncome 6 local@ &lt;=</condition_postfix>
-<condition_column column_value="Y" column_number="7" /></condition_details></conditions>
+<condition_postfix>
+totalGroupIncome 6 local@ &lt;=
+</condition_postfix>
+<condition_column column_number="7" column_value="Y" />
+</condition_details>
+</conditions>
 <actions>
 <action_details>
 <action_number>1</action_number>
 <action_comment>set the program Level</action_comment>
-<action_requirement />
 <action_dsl>set client.programLevel = FreeCoverage</action_dsl>
-<action_postfix>FreeCoverage cvi /client.programLevel xdef</action_postfix>
-<action_column column_value="X" column_number="1" />
-<action_column column_value="X" column_number="2" />
-<action_column column_value="X" column_number="3" /></action_details>
+<action_postfix>
+FreeCoverage cvs /client.programLevel xdef
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+<action_column column_number="2" column_value="X" />
+<action_column column_number="3" column_value="X" />
+</action_details>
 <action_details>
 <action_number>2</action_number>
-<action_comment />
-<action_requirement />
+<action_comment></action_comment>
 <action_dsl>set client.programLevel = LowCostCoverage</action_dsl>
-<action_postfix>LowCostCoverage cvi /client.programLevel xdef</action_postfix>
-<action_column column_value="X" column_number="5" />
-<action_column column_value="X" column_number="6" />
-<action_column column_value="X" column_number="7" /></action_details>
+<action_postfix>
+LowCostCoverage cvs /client.programLevel xdef
+</action_postfix>
+<action_column column_number="5" column_value="X" />
+<action_column column_number="6" column_value="X" />
+<action_column column_number="7" column_value="X" />
+</action_details>
 <action_details>
 <action_number>3</action_number>
-<action_comment />
-<action_requirement />
+<action_comment></action_comment>
 <action_dsl>set client.programLevel = AtCostCoverage</action_dsl>
-<action_postfix>AtCostCoverage cvi /client.programLevel xdef</action_postfix>
-<action_column column_value="X" column_number="9" /></action_details>
+<action_postfix>
+AtCostCoverage cvs /client.programLevel xdef
+</action_postfix>
+<action_column column_number="9" column_value="X" />
+</action_details>
 <action_details>
 <action_number>4</action_number>
 <action_comment>Provide reasons for rejection</action_comment>
-<action_requirement />
 <action_dsl>set client.eligible = false</action_dsl>
-<action_postfix>false cvb /client.eligible xdef</action_postfix>
-<action_column column_value="X" column_number="11" />
-<action_column column_value="X" column_number="12" />
-<action_column column_value="X" column_number="13" />
-<action_column column_value="X" column_number="14" /></action_details>
+<action_postfix>
+false cvb /client.eligible xdef
+</action_postfix>
+<action_column column_number="11" column_value="X" />
+<action_column column_number="12" column_value="X" />
+<action_column column_number="13" column_value="X" />
+<action_column column_number="14" column_value="X" />
+</action_details>
 <action_details>
 <action_number>5</action_number>
-<action_comment />
-<action_requirement />
+<action_comment></action_comment>
 <action_dsl>Add "Client is eligible for Medicaid, so cannot enroll in KidAid" to client.notes</action_dsl>
-<action_postfix>&quot;Client is eligible for Medicaid, so cannot enroll in KidAid&quot; client.notes swap addto</action_postfix>
-<action_column column_value="X" column_number="11" /></action_details>
+<action_postfix>
+"Client is eligible for Medicaid, so cannot enroll in KidAid" client.notes swap addto
+</action_postfix>
+<action_column column_number="11" column_value="X" />
+</action_details>
 <action_details>
 <action_number>6</action_number>
-<action_comment />
-<action_requirement />
+<action_comment></action_comment>
 <action_dsl>Add "Must Provide Validation of Citizenship" to client.notes</action_dsl>
-<action_postfix>&quot;Must Provide Validation of Citizenship&quot; client.notes swap addto</action_postfix>
-<action_column column_value="X" column_number="12" />
-<action_column column_value="X" column_number="13" /></action_details>
+<action_postfix>
+"Must Provide Validation of Citizenship" client.notes swap addto
+</action_postfix>
+<action_column column_number="12" column_value="X" />
+<action_column column_number="13" column_value="X" />
+</action_details>
 <action_details>
 <action_number>7</action_number>
-<action_comment />
-<action_requirement />
+<action_comment></action_comment>
 <action_dsl>Add "Case must be within a KidAid County" to client.notes</action_dsl>
-<action_postfix>&quot;Case must be within a KidAid County&quot; client.notes swap addto</action_postfix>
-<action_column column_value="X" column_number="12" />
-<action_column column_value="X" column_number="14" /></action_details>
+<action_postfix>
+"Case must be within a KidAid County" client.notes swap addto
+</action_postfix>
+<action_column column_number="12" column_value="X" />
+<action_column column_number="14" column_value="X" />
+</action_details>
 <action_details>
 <action_number>8</action_number>
 <action_comment>Add "Must be 18 or younger to qualify for KidAid" to client.notes</action_comment>
-<action_requirement />
 <action_dsl />
-<action_postfix>
-"Must be 18 or younger to qualify for KidAid" client.notes swap addto 
-</action_postfix>
-<action_column column_value="X" column_number="15" /></action_details>
+<action_postfix></action_postfix>
+<action_column column_number="15" column_value="X" />
+</action_details>
 <action_details>
 <action_number>9</action_number>
-<action_comment />
-<action_requirement />
+<action_comment></action_comment>
 <action_dsl>set client_fpl = (100.0 * totalGroupIncome) / FPL</action_dsl>
-<action_postfix>100.0 totalGroupIncome fmul 0 local@ fdiv cvi /client_fpl xdef</action_postfix>
-<action_column column_value="X" column_number="1" />
-<action_column column_value="X" column_number="2" />
-<action_column column_value="X" column_number="3" />
-<action_column column_value="X" column_number="5" />
-<action_column column_value="X" column_number="6" />
-<action_column column_value="X" column_number="7" />
-<action_column column_value="X" column_number="9" />
-<action_column column_value="X" column_number="11" />
-<action_column column_value="X" column_number="12" />
-<action_column column_value="X" column_number="13" />
-<action_column column_value="X" column_number="14" />
-<action_column column_value="X" column_number="15" /></action_details></actions>
-<policy_statements /></decision_table>
+<action_postfix>
+100.0 totalGroupIncome fmul 0 local@ fdiv cvi /client_fpl xdef
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+<action_column column_number="2" column_value="X" />
+<action_column column_number="3" column_value="X" />
+<action_column column_number="5" column_value="X" />
+<action_column column_number="6" column_value="X" />
+<action_column column_number="7" column_value="X" />
+<action_column column_number="9" column_value="X" />
+<action_column column_number="11" column_value="X" />
+<action_column column_number="12" column_value="X" />
+<action_column column_number="13" column_value="X" />
+<action_column column_number="14" column_value="X" />
+<action_column column_number="15" column_value="X" />
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- TABLE 500: Evaluate_MEDICAID_Eligibility -->
 <decision_table>
+<source>
+<relative_path>KidAid_dt.xls</relative_path>
+<file_name>KidAid_dt.xls</file_name>
+<sheet_number>5</sheet_number>
+</source>
 <table_name>Evaluate_MEDICAID_Eligibility</table_name>
 <xls_file>KidAid_dt.xls</xls_file>
 <attribute_fields>
-<TYPE>FIRST</TYPE>
+<Type>FIRST</Type>
 <COMMENTS>At this time we are not evaluating Medicaid Clients</COMMENTS>
-<POLICY_REFERENCE /></attribute_fields>
+<TABLE_NUMBER>500</TABLE_NUMBER>
+</attribute_fields>
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_comment />
+<context_comment></context_comment>
 <context_dsl>for all clients</context_dsl>
-<context_postfix>dup clients forall pop</context_postfix></context_details></contexts>
-<initial_actions />
+<context_postfix>
+dup clients forall pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
 <conditions>
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
-<condition_requirement />
 <condition_dsl>client.applying == true</condition_dsl>
-<condition_postfix>client.applying true beq</condition_postfix>
-<condition_column column_value="Y" column_number="1" /></condition_details></conditions>
+<condition_postfix>
+client.applying true beq
+</condition_postfix>
+<condition_column column_number="1" column_value="Y" />
+</condition_details>
+</conditions>
 <actions>
 <action_details>
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
-<action_requirement />
 <action_dsl>set client.eligible = false</action_dsl>
-<action_postfix>false cvb /client.eligible xdef</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details>
+<action_postfix>
+false cvb /client.eligible xdef
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Medicaid Applications" to client.notes</action_comment>
-<action_requirement />
 <action_dsl />
-<action_postfix>
-"The System does not yet support Medicaid Applications" client.notes swap addto 
-</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details></actions>
-<policy_statements /></decision_table>
+<action_postfix></action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- TABLE 600: Evaluate_FOODSTAMPS_Eligibility -->
 <decision_table>
+<source>
+<relative_path>KidAid_dt.xls</relative_path>
+<file_name>KidAid_dt.xls</file_name>
+<sheet_number>6</sheet_number>
+</source>
 <table_name>Evaluate_FOODSTAMPS_Eligibility</table_name>
 <xls_file>KidAid_dt.xls</xls_file>
 <attribute_fields>
-<TYPE>FIRST</TYPE>
+<Type>FIRST</Type>
 <COMMENTS>At this time we are not evaluating Food Stamp Clients</COMMENTS>
-<POLICY_REFERENCE /></attribute_fields>
+<TABLE_NUMBER>600</TABLE_NUMBER>
+</attribute_fields>
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_comment />
+<context_comment></context_comment>
 <context_dsl>for all clients</context_dsl>
-<context_postfix>dup clients forall pop</context_postfix></context_details></contexts>
-<initial_actions />
+<context_postfix>
+dup clients forall pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
 <conditions>
 <condition_details>
 <condition_number>1</condition_number>
 <condition_comment>Is this client applying for this program?</condition_comment>
-<condition_requirement />
 <condition_dsl>client.applying == true</condition_dsl>
-<condition_postfix>client.applying true beq</condition_postfix>
-<condition_column column_value="Y" column_number="1" /></condition_details></conditions>
+<condition_postfix>
+client.applying true beq
+</condition_postfix>
+<condition_column column_number="1" column_value="Y" />
+</condition_details>
+</conditions>
 <actions>
 <action_details>
 <action_number>1</action_number>
 <action_comment>Reject the client</action_comment>
-<action_requirement />
 <action_dsl>set client.eligible = false</action_dsl>
-<action_postfix>false cvb /client.eligible xdef</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details>
+<action_postfix>
+false cvb /client.eligible xdef
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Food Stamp Applications" to client.notes</action_comment>
-<action_requirement />
 <action_dsl />
-<action_postfix>
-"The System does not yet support Food Stamp Applications" client.notes swap addto 
-</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details></actions>
-<policy_statements /></decision_table>
+<action_postfix></action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+
+<!-- TABLE 700: Evaluate_Results -->
 <decision_table>
+<source>
+<relative_path>KidAid_dt.xls</relative_path>
+<file_name>KidAid_dt.xls</file_name>
+<sheet_number>7</sheet_number>
+</source>
 <table_name>Evaluate_Results</table_name>
 <xls_file>KidAid_dt.xls</xls_file>
 <attribute_fields>
-<TYPE>FIRST</TYPE>
+<Type>FIRST</Type>
 <COMMENTS>This table is really unnecessarily complicated.  All the client information can be accessed by the calling code, 
 as we are including a reference to the client in the Result. An exercise for the reader would be to eliminate all the copying 
 of information from the client to the Result object.  Remove these fields from the Result object in the EDD, remove the logic 
 in this table, and update the test code to get the data from the client object.</COMMENTS>
-<POLICY_REFERENCE /></attribute_fields>
+<TABLE_NUMBER>700</TABLE_NUMBER>
+</attribute_fields>
 <contexts>
 <context_details>
 <context_number>1</context_number>
-<context_comment />
+<context_comment></context_comment>
 <context_dsl>for all clients whose applying == true</context_dsl>
-<context_postfix>{ { dup execute } applying true beq if } clients forall pop</context_postfix></context_details></contexts>
-<initial_actions />
+<context_postfix>
+{ { dup execute } applying true beq if } clients forall pop
+</context_postfix>
+</context_details>
+</contexts>
+<initial_actions></initial_actions>
 <conditions>
 <condition_details>
 <condition_number>1</condition_number>
-<condition_comment />
-<condition_requirement />
+<condition_comment></condition_comment>
 <condition_dsl>perform when called</condition_dsl>
-<condition_postfix>perform when called</condition_postfix>
-<condition_column column_value="*" column_number="1" /></condition_details></conditions>
+<condition_postfix>
+perform when called
+</condition_postfix>
+<condition_column column_number="1" column_value="*" />
+</condition_details>
+</conditions>
 <actions>
 <action_details>
 <action_number>1</action_number>
 <action_comment>Create a Result Record</action_comment>
-<action_requirement />
 <action_dsl>add a new Result entity to the context of this table</action_dsl>
-<action_postfix>/Result createentity entitypush</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details>
+<action_postfix>
+/Result createentity entitypush
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
 <action_details>
 <action_number>2</action_number>
 <action_comment>Add the record to the list on the job</action_comment>
-<action_requirement />
 <action_dsl>add the result to the job.results</action_dsl>
-<action_postfix>result job.results swap addto</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details>
+<action_postfix>
+result job.results swap addto
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
 <action_details>
 <action_number>3</action_number>
 <action_comment>Add the case notes to the result notes</action_comment>
-<action_requirement />
 <action_dsl>Add the case.notes to the Result.notes</action_dsl>
-<action_postfix>case.notes Result.notes true addarray</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details>
+<action_postfix>
+case.notes Result.notes true addarray
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
 <action_details>
 <action_number>4</action_number>
 <action_comment>Add the client notes to the result notes</action_comment>
-<action_requirement />
 <action_dsl>Add the client.notes to the Result.notes</action_dsl>
-<action_postfix>client.notes Result.notes true addarray</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details>
+<action_postfix>
+client.notes Result.notes true addarray
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
 <action_details>
 <action_number>5</action_number>
 <action_comment>Copy the client ID</action_comment>
-<action_requirement />
 <action_dsl>Set Result.client_id = client.client_id</action_dsl>
-<action_postfix>client.client_id cvi /Result.client_id xdef</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details>
+<action_postfix>
+client.client_id cvs /Result.client_id xdef
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
 <action_details>
 <action_number>6</action_number>
 <action_comment>Point the Result to the client</action_comment>
-<action_requirement />
 <action_dsl>Set Result.client = client.client</action_dsl>
-<action_postfix>client.client cve /Result.client xdef</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details>
+<action_postfix>
+client.client cve /Result.client xdef
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
 <action_details>
 <action_number>7</action_number>
 <action_comment>Set the Result to the program we processed</action_comment>
-<action_requirement />
 <action_dsl>Set Result.program = job.program</action_dsl>
-<action_postfix>job.program cvs /Result.program xdef</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details>
+<action_postfix>
+job.program cvs /Result.program xdef
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
 <action_details>
 <action_number>8</action_number>
 <action_comment>Set the Result programLevel to that recorded on the client</action_comment>
-<action_requirement />
 <action_dsl>Set Result.programLevel = client.programLevel</action_dsl>
-<action_postfix>client.programLevel cvi /Result.programLevel xdef</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details>
+<action_postfix>
+client.programLevel cvs /Result.programLevel xdef
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
 <action_details>
 <action_number>9</action_number>
 <action_comment>Set the Result eligible flag to that recorded on the client</action_comment>
-<action_requirement />
 <action_dsl>Set Result.eligible = client.eligible</action_dsl>
-<action_postfix>client.eligible cvb /Result.eligible xdef</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details>
+<action_postfix>
+client.eligible cvb /Result.eligible xdef
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
 <action_details>
 <action_number>10</action_number>
 <action_comment>Set the Result Federal Poverty Level to the client's</action_comment>
-<action_requirement />
 <action_dsl>Set Result.client_fpl = client.client_fpl</action_dsl>
-<action_postfix>client.client_fpl cvi /Result.client_fpl xdef</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details>
+<action_postfix>
+client.client_fpl cvi /Result.client_fpl xdef
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
 <action_details>
 <action_number>11</action_number>
 <action_comment>Set the Result's totalGroupIncome to the clients.</action_comment>
-<action_requirement />
 <action_dsl>Set Result.totalGroupIncome = client.totalGroupIncome</action_dsl>
-<action_postfix>client.totalGroupIncome cvi /Result.totalGroupIncome xdef</action_postfix>
-<action_column column_value="X" column_number="1" /></action_details></actions>
-<policy_statements /></decision_table></decision_tables>
+<action_postfix>
+client.totalGroupIncome cvi /Result.totalGroupIncome xdef
+</action_postfix>
+<action_column column_number="1" column_value="X" />
+</action_details>
+</actions>
+<policy_statements></policy_statements>
+</decision_table>
+</decision_tables>


### PR DESCRIPTION
## The defect

Real DTRules XML spells the table type three ways — `<Type>`, `<TYPE>`, `<type>` — and the runtime loader accepts all three. The **authoring model read only `<Type>`**, so a table written in the legacy uppercase form loaded with an empty type and was written back with an empty `<Type>`: whether the table is FIRST, ALL or BALANCED, silently erased.

I hit this by recompiling KidAid, whose seven tables are all `<TYPE>`. Every one came back typeless and the project stopped loading:

```
failed to build decision table Compute_Eligibility: condition table compile error at row 2, col 2
```

I caught it by diffing before committing — the `+<Type></Type>` lines in my own diff — so the sample is repaired here rather than shipped broken.

**Two places needed the fix.** `AttributeFieldsXML.EffectiveType()` resolves the three spellings, and the XML *writer* uses it. The writer matters as much as the reader: patching one table rewrites the whole file, and the tables nobody touched are written straight from the parsed model. Fixing only the reader left 6 of KidAid's 7 tables still typeless — one correct because it was the one with a Table view.

## KidAid

- Rows recompiled through the authoring API, so context locals resolve (#965) and `is the <R> of` compiles (#927).
- `<entry>Compute_Eligibility</entry>`; runs from the CLI leaving a trace with **11 fired columns**; joins `TestSampleProjectsProduceLoadableTraces`.
- `lib/*.jar` and `.classpath` removed per the campaign's scope decision.
- All 7 tables keep their types: 6 FIRST, 1 ALL.

**Seven samples now run from the CLI and leave editor-loadable traces:** TestProject, StateTax, SinusitisTherapy, CHIP, ChipApp, KidAid, Poker.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)