### PR TITLE
Restore the 13 rows my recompiles deleted, and stop it happening again

### DIFF
--- a/docs/sample-repair-campaign.md
+++ b/docs/sample-repair-campaign.md
@@ -102,3 +102,21 @@ KidAid_Application → KidAid (partial; #927 items need Paul) → CorporateTax.
 - Task list: task #8 "Inventory all sample projects" created, in progress.
 - Nothing for this campaign has been committed yet; the only artifact is the
   scratchpad inventory scanner (broken, see above) and this plan.
+
+## Recompiling a project (learned the hard way, 2026-07-29)
+
+Re-applying a row's own DSL through `dtrules table patch update-condition-dsl`
+/ `update-action-dsl` recompiles the WHOLE table — that is how a project picks
+up compiler fixes. Two things to know before doing it:
+
+- **`set-policy` does not recompile.** It reports success and re-syncs
+  nothing; only the real mutators call `syncToXML`.
+- **It deletes hand-coded rows.** `syncToXML` regenerates every postfix from
+  its DSL, so a row whose only content IS postfix comes back empty. Check
+  `Table.HandCodedRows()` first and author the EL for anything it names —
+  read the stored postfix, write the DSL, confirm it compiles to the same
+  thing. CHIP, ChipApp, KidAid and KidAid_Application each lost rows this way
+  before anyone noticed, because the emptied rows were in no scenario.
+
+Always diff before committing a recompile. `+<Type></Type>` is what caught
+the type-erasure bug; missing `<*_postfix>` content is what catches this one.

--- a/pkg/dtrules/authoring/policy_statement_test.go
+++ b/pkg/dtrules/authoring/policy_statement_test.go
@@ -195,3 +195,41 @@ func TestLocalSlotsDoNotBleedBetweenTables(t *testing.T) {
 		t.Errorf("slot indices differ between tables that declare the same locals:\n  %s\n  %s", first, second)
 	}
 }
+
+// TestHandCodedRowsAreReportedBeforeARecompileEatsThem is the guard for the
+// one operation in this package that destroys content.
+//
+// syncToXML regenerates every postfix from its DSL, so a row whose only
+// content is postfix comes back empty — its logic gone, from an operation
+// that reads like normalization. Four sample projects lost rows that way
+// during the repair campaign, and no test caught it because the emptied rows
+// were not covered by any scenario. HandCodedRows names them first.
+func TestHandCodedRowsAreReportedBeforeARecompileEatsThem(t *testing.T) {
+	tbl := newTable(&excel.DecisionTableXML{
+		TableName: "Evaluate_MEDICAID_Eligibility",
+		Conditions: []excel.ConditionXML{
+			{Number: "1", DSL: "client.age > 18", Postfix: "client.age 18 >"},
+		},
+		Actions: []excel.ActionXML{
+			{Number: "1", DSL: "set client.eligible = false", Postfix: "false cvb /client.eligible xdef"},
+			// The shape that gets destroyed: postfix, no DSL.
+			{Number: "2", Postfix: `"not supported" client.notes swap addto`},
+		},
+	}, map[string]string{})
+
+	got := tbl.HandCodedRows()
+	if len(got) != 1 || got[0] != "action 2" {
+		t.Fatalf("HandCodedRows() = %v, want [\"action 2\"]", got)
+	}
+
+	// A table authored in EL throughout has nothing to report.
+	clean := newTable(&excel.DecisionTableXML{
+		TableName: "Clean",
+		Actions: []excel.ActionXML{
+			{Number: "1", DSL: "set client.eligible = true", Postfix: "true cvb /client.eligible xdef"},
+		},
+	}, map[string]string{})
+	if rows := clean.HandCodedRows(); len(rows) != 0 {
+		t.Errorf("a fully authored table reports %v, want nothing", rows)
+	}
+}

--- a/pkg/dtrules/authoring/table.go
+++ b/pkg/dtrules/authoring/table.go
@@ -89,6 +89,42 @@ type PolicyStatement struct {
 	Description string
 }
 
+// HandCodedRows reports rows that carry postfix but no DSL, as
+// "<kind> <number>" strings.
+//
+// These rows are the one thing a recompile destroys. syncToXML regenerates
+// every postfix from its DSL (#817), so a row whose only content IS postfix
+// comes back empty — its logic deleted, silently, by an operation that looks
+// like normalization. Four sample projects lost rows that way before anyone
+// noticed, because the emptied rows were not covered by any scenario.
+//
+// Author the EL first (read the stored postfix, write the DSL that compiles
+// to it, check they match), then recompile.
+func (t *Table) HandCodedRows() []string {
+	var out []string
+	for i, c := range t.xml.Contexts.Details {
+		if strings.TrimSpace(c.Postfix) != "" && strings.TrimSpace(c.DSL) == "" {
+			out = append(out, fmt.Sprintf("context %d", i+1))
+		}
+	}
+	for i, ia := range t.xml.InitialActions {
+		if strings.TrimSpace(ia.EffectivePostfix()) != "" && strings.TrimSpace(ia.EffectiveDSL()) == "" {
+			out = append(out, fmt.Sprintf("initial action %d", i+1))
+		}
+	}
+	for _, c := range t.xml.Conditions {
+		if strings.TrimSpace(c.Postfix) != "" && strings.TrimSpace(c.DSL) == "" {
+			out = append(out, "condition "+c.Number)
+		}
+	}
+	for _, a := range t.xml.Actions {
+		if strings.TrimSpace(a.Postfix) != "" && strings.TrimSpace(a.DSL) == "" {
+			out = append(out, "action "+a.Number)
+		}
+	}
+	return out
+}
+
 // newTable builds a Table view from an underlying XML struct.
 func newTable(x *excel.DecisionTableXML, symbols map[string]string) *Table {
 	t := &Table{

--- a/sampleprojects/CHIP/xml/CHIP_dt.xml
+++ b/sampleprojects/CHIP/xml/CHIP_dt.xml
@@ -653,8 +653,10 @@ false cvb /client.eligible xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Medicaid Applications" to client.notes</action_comment>
-<action_dsl />
-<action_postfix></action_postfix>
+<action_dsl>add "The System does not yet support Medicaid Applications" to the client.notes</action_dsl>
+<action_postfix>
+"The System does not yet support Medicaid Applications" client.notes swap addto
+</action_postfix>
 <action_column column_number="1" column_value="X" />
 </action_details>
 </actions>
@@ -710,8 +712,10 @@ false cvb /client.eligible xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Food Stamp Applications" to client.notes</action_comment>
-<action_dsl />
-<action_postfix></action_postfix>
+<action_dsl>add "The System does not yet support Food Stamp Applications" to the client.notes</action_dsl>
+<action_postfix>
+"The System does not yet support Food Stamp Applications" client.notes swap addto
+</action_postfix>
 <action_column column_number="1" column_value="X" />
 </action_details>
 </actions>

--- a/sampleprojects/ChipApp/xml/CHIP_dt.xml
+++ b/sampleprojects/ChipApp/xml/CHIP_dt.xml
@@ -653,8 +653,10 @@ false cvb /client.eligible xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Medicaid Applications" to client.notes</action_comment>
-<action_dsl />
-<action_postfix></action_postfix>
+<action_dsl>add "The System does not yet support Medicaid Applications" to the client.notes</action_dsl>
+<action_postfix>
+"The System does not yet support Medicaid Applications" client.notes swap addto
+</action_postfix>
 <action_column column_number="1" column_value="X" />
 </action_details>
 </actions>
@@ -710,8 +712,10 @@ false cvb /client.eligible xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Food Stamp Applications" to client.notes</action_comment>
-<action_dsl />
-<action_postfix></action_postfix>
+<action_dsl>add "The System does not yet support Food Stamp Applications" to the client.notes</action_dsl>
+<action_postfix>
+"The System does not yet support Food Stamp Applications" client.notes swap addto
+</action_postfix>
 <action_column column_number="1" column_value="X" />
 </action_details>
 </actions>

--- a/sampleprojects/KidAid/xml/kidaid_dt.xml
+++ b/sampleprojects/KidAid/xml/kidaid_dt.xml
@@ -751,8 +751,10 @@ false cvb /client.eligible xdef
 <action_details>
 <action_number>8</action_number>
 <action_comment>Add "Must be 18 or younger to qualify for KidAid" to client.notes</action_comment>
-<action_dsl />
-<action_postfix></action_postfix>
+<action_dsl>add "Must be 18 or younger to qualify for KidAid" to the client.notes</action_dsl>
+<action_postfix>
+"Must be 18 or younger to qualify for KidAid" client.notes swap addto
+</action_postfix>
 <action_column column_number="15" column_value="X" />
 </action_details>
 <action_details>
@@ -828,8 +830,10 @@ false cvb /client.eligible xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Medicaid Applications" to client.notes</action_comment>
-<action_dsl />
-<action_postfix></action_postfix>
+<action_dsl>add "The System does not yet support Medicaid Applications" to the client.notes</action_dsl>
+<action_postfix>
+"The System does not yet support Medicaid Applications" client.notes swap addto
+</action_postfix>
 <action_column column_number="1" column_value="X" />
 </action_details>
 </actions>
@@ -885,8 +889,10 @@ false cvb /client.eligible xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Food Stamp Applications" to client.notes</action_comment>
-<action_dsl />
-<action_postfix></action_postfix>
+<action_dsl>add "The System does not yet support Food Stamp Applications" to the client.notes</action_dsl>
+<action_postfix>
+"The System does not yet support Food Stamp Applications" client.notes swap addto
+</action_postfix>
 <action_column column_number="1" column_value="X" />
 </action_details>
 </actions>

--- a/sampleprojects/KidAid_Application/repository/xml/kidaid_dt.xml
+++ b/sampleprojects/KidAid_Application/repository/xml/kidaid_dt.xml
@@ -751,8 +751,10 @@ false cvb /client.eligible xdef
 <action_details>
 <action_number>8</action_number>
 <action_comment>Add "Must be 18 or younger to qualify for KidAid" to client.notes</action_comment>
-<action_dsl />
-<action_postfix></action_postfix>
+<action_dsl>add "Must be 18 or younger to qualify for KidAid" to the client.notes</action_dsl>
+<action_postfix>
+"Must be 18 or younger to qualify for KidAid" client.notes swap addto
+</action_postfix>
 <action_column column_number="15" column_value="X" />
 </action_details>
 <action_details>
@@ -828,8 +830,10 @@ false cvb /client.eligible xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Medicaid Applications" to client.notes</action_comment>
-<action_dsl />
-<action_postfix></action_postfix>
+<action_dsl>add "The System does not yet support Medicaid Applications" to the client.notes</action_dsl>
+<action_postfix>
+"The System does not yet support Medicaid Applications" client.notes swap addto
+</action_postfix>
 <action_column column_number="1" column_value="X" />
 </action_details>
 </actions>
@@ -885,8 +889,10 @@ false cvb /client.eligible xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Food Stamp Applications" to client.notes</action_comment>
-<action_dsl />
-<action_postfix></action_postfix>
+<action_dsl>add "The System does not yet support Food Stamp Applications" to the client.notes</action_dsl>
+<action_postfix>
+"The System does not yet support Food Stamp Applications" client.notes swap addto
+</action_postfix>
 <action_column column_number="1" column_value="X" />
 </action_details>
 </actions>

--- a/sampleprojects/KidAid_Application/repository/xml/sp2_dt.xml
+++ b/sampleprojects/KidAid_Application/repository/xml/sp2_dt.xml
@@ -1028,8 +1028,10 @@ false cvb /client.eligible xdef
 <action_details>
 <action_number>8</action_number>
 <action_comment>Add "Must be 18 or younger to qualify for KidAid" to client.notes</action_comment>
-<action_dsl />
-<action_postfix></action_postfix>
+<action_dsl>add "Must be 18 or younger to qualify for KidAid" to the client.notes</action_dsl>
+<action_postfix>
+"Must be 18 or younger to qualify for KidAid" client.notes swap addto
+</action_postfix>
 <action_column column_number="15" column_value="X" />
 </action_details>
 <action_details>
@@ -1120,8 +1122,10 @@ false cvb /client.eligible xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Medicaid Applications" to client.notes</action_comment>
-<action_dsl />
-<action_postfix></action_postfix>
+<action_dsl>add "The System does not yet support Medicaid Applications" to the client.notes</action_dsl>
+<action_postfix>
+"The System does not yet support Medicaid Applications" client.notes swap addto
+</action_postfix>
 <action_column column_number="1" column_value="X" />
 </action_details>
 </actions>
@@ -1192,8 +1196,10 @@ false cvb /client.eligible xdef
 <action_details>
 <action_number>2</action_number>
 <action_comment>Note rejection reason; add "The System does not yet support Food Stamp Applications" to client.notes</action_comment>
-<action_dsl />
-<action_postfix></action_postfix>
+<action_dsl>add "The System does not yet support Food Stamp Applications" to the client.notes</action_dsl>
+<action_postfix>
+"The System does not yet support Food Stamp Applications" client.notes swap addto
+</action_postfix>
 <action_column column_number="1" column_value="X" />
 </action_details>
 </actions>


### PR DESCRIPTION
## What I broke

The "recompile every table" recipe I used on CHIP, ChipApp, KidAid and KidAid_Application **deletes hand-coded rows**. `syncToXML` regenerates every postfix from its DSL (#817), so a row whose only content *is* postfix comes back empty — its logic gone, from an operation that reads like normalization.

CHIP went from 65 non-empty postfix elements to 63, and I called it progress: the inventory's `hand=2 → empty=2` looked like the campaign's no-hand-postfix goal being met. It was the rows being gutted.

**No test caught it.** The emptied rows were in no scenario — the exact failure mode this campaign has documented five times, walked into from the other side. I found it only when SyntaxTests would have lost 48 rows at once and the number was too big to misread.

## Restored

All 13, recovered from the pre-merge commits and checked against the postfix they replace:

```
"The System does not yet support Medicaid Applications" client.notes swap addto
  →  add "The System does not yet support Medicaid Applications" to the client.notes
```

Every one compiles to its original postfix **exactly** — verified with the same compile-and-compare used for StateTax and Poker. CHIP, ChipApp and KidAid now report zero empty rows; KidAid_Application's last two were in `sp2_dt.xml` under the duplicate-renamed table names (`Evaluate_KidAid_Eligibility-1`).

## So it can't recur

`Table.HandCodedRows()` names the rows a recompile would eat, so the check comes before the damage rather than after. Test included.

`docs/sample-repair-campaign.md` now records both hazards of the recipe:
- it deletes hand-coded rows — check `HandCodedRows()` and author their EL first;
- `set-policy` reports success while recompiling nothing.

And: **always diff before committing a recompile.** `+<Type></Type>` is what caught the type-erasure bug in #972; missing `<*_postfix>` content is what catches this one.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)