### PR TITLE
`allowing array to be removed` must iterate in reverse (#975)

### DIFF
--- a/pkg/dtrules/compiler/el/compiler_test.go
+++ b/pkg/dtrules/compiler/el/compiler_test.go
@@ -990,3 +990,35 @@ func TestRelationshipIsOf(t *testing.T) {
 		})
 	}
 }
+
+// TestForallAllowingRemovalIteratesInReverse: the `allowing array to be
+// removed` phrase must emit forallr.
+//
+// Walking an array forward while the body removes elements skips entries —
+// the iterator's index and the array's contents move against each other.
+// That is precisely why `remove each ... where ...` has always compiled to
+// forallr. The three `allowing array to be removed` variants emitted plain
+// `forall`, so a rule that announced it was going to remove elements got the
+// iteration order that makes removal unsafe.
+func TestForallAllowingRemovalIteratesInReverse(t *testing.T) {
+	symbols := map[string]string{"clients": "array", "age": "integer"}
+	tests := []struct{ name, el, want string }{
+		{"plain forall stays forward", "for all clients", "dup clients forall pop"},
+		{"allowing removal goes in reverse", "for all clients allowing array to be removed", "dup clients forallr pop"},
+		{"where + allowing removal", "for all clients where age > 18 allowing array to be removed",
+			"{ { dup execute } age 18 > if } clients forallr pop"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCompiler()
+			c.SetSymbols(symbols)
+			got, err := c.CompileContext(tt.el)
+			if err != nil {
+				t.Fatalf("CompileContext(%q): %v", tt.el, err)
+			}
+			if n := strings.Join(strings.Fields(got), " "); n != tt.want {
+				t.Errorf("CompileContext(%q)\n got %s\nwant %s", tt.el, n, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -3314,10 +3314,17 @@ func (e *PostfixEmitter) VisitForallSimple(ctx *ForallSimpleContext) interface{}
 }
 
 // VisitForallAllowRemove: `for all <array> allowing array to be removed`.
+// The `allowing array to be removed` variants iterate in REVERSE. That is
+// the whole point of the phrase: walking forward while the body removes
+// elements skips entries, because the iterator's index and the array's
+// contents move against each other. VisitRemoveEachWhere has always used
+// forallr for exactly this reason. These three emitted plain `forall`, so a
+// rule that said it was going to remove elements got the iteration order
+// that makes removal unsafe.
 func (e *PostfixEmitter) VisitForallAllowRemove(ctx *ForallAllowRemoveContext) interface{} {
 	e.emit("dup")
 	e.Visit(ctx.ArrayExpr())
-	e.emit("forall")
+	e.emit("forallr")
 	e.emit("pop")
 	return nil
 }
@@ -3350,7 +3357,7 @@ func (e *PostfixEmitter) VisitForallWhereAllowRemove(ctx *ForallWhereAllowRemove
 	e.emit("if")
 	e.emit("}")
 	e.Visit(ctx.ArrayExpr())
-	e.emit("forall")
+	e.emit("forallr")
 	e.emit("pop")
 	return nil
 }
@@ -3518,7 +3525,7 @@ func (e *PostfixEmitter) VisitForallInEntityAllowRemove(ctx *ForallInEntityAllow
 	e.emit("entitypush")
 	e.emit("dup")
 	e.Visit(ctx.ArrayExpr())
-	e.emit("forall")
+	e.emit("forallr")
 	e.emit("pop")
 	e.emit("entitypop")
 	e.emit("pop")


### PR DESCRIPTION
Walking an array forward while the body removes elements **skips entries** — the iterator's index and the array's contents move against each other. That is exactly why `remove each … from … where …` has always compiled to `forallr`; its emitter says so in a comment.

The three `allowing array to be removed` variants emitted plain `forall`. So a rule that announced it was going to remove elements got the one iteration order that makes removal unsafe, and the phrase documented a guarantee the compiler didn't provide.

```
for all clients allowing array to be removed
  before:  dup clients forall pop
  after:   dup clients forallr pop
```

Plain `for all` is untouched and stays forward.

## How it surfaced

Scoping SyntaxTests (#975), whose 48 hand-coded rows are mostly `{ … } <array> forallr` — reverse iteration with no EL surface at all. This gives the runtime operator a surface for the removal case.

**It does not close #975.** The general "iterate backwards for its own sake" case still has no EL form, and using the removal phrase for rows that remove nothing would be writing a lie into the sample. That decision — add `for all <array> in reverse`, author the rows forward where order doesn't matter, or drop them — is still open on that issue.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)