### PR TITLE
Bring the campaign plan of record up to date (#948)

### DIFF
--- a/docs/sample-repair-campaign.md
+++ b/docs/sample-repair-campaign.md
@@ -1,122 +1,190 @@
 # Sample Repair Campaign — Plan of Record
 
-*Written 2026-07-28, at the start of the work. Paul's directive: "Fix all the
-sample projects; remove all hand crafted postfix, and flush out all stubbed
-tables. All this work should be done using the authoring API of DTRules."
-Sub-issues per project, with progress documented in each issue.*
+*Started 2026-07-28. Paul's directive: "Fix all the sample projects; remove all
+hand crafted postfix, and flush out all stubbed tables. All this work should be
+done using the authoring API of DTRules." Later: "goal is to make all sample
+projects work, demonstrate DTRules, with traces that can be loaded into an
+editor."*
 
-## Goal
+Parent issue: **#948**. One sub-issue per project, one PR per project, merged
+only via `scripts/merge-pr.sh`. `make check` green is the definition of done.
 
-Every sample project loads clean, executes, and satisfies the authoring
-contract: **no hand-coded postfix anywhere** (every row's postfix is compiled
-from its EL DSL), **no stub tables** (every table has real, executable
-content), and **Excel/XML in agreement** (all edits through the authoring
-API / build funnel — never direct XML edits; see the 2026-07-26 lesson where
-direct edits nearly got clobbered by a stale-workbook mtime race).
+## Definition of done
 
-## Non-negotiable method (Paul's correction, twice)
+A sample is repaired when all four hold:
 
-- Rule edits go through **`dtrules table put/patch` / `dtrules edd put`**
-  (writes XML + compiles postfix + updates Excel atomically), or through
-  **`dtrules build`** (XML-authored path exports Excel; run `--dry-run`
-  first and READ THE DIRECTION LINE — conflicts now fail loudly per #938/#946).
-- For bulk work, **script against the authoring API**, not against the XML.
-- Before any risky build: everything committed + tarball outside the repo.
-- Branch per project, PR per project ("Closes #<sub-issue>"), merge only via
-  `scripts/merge-pr.sh`. `make check` green is the definition of done.
+1. **No hand-coded postfix** — every row's postfix compiles from its EL DSL.
+2. **No stub tables** — every table has real, executable content.
+3. **Excel and XML agree** — all edits through `dtrules table put/patch`,
+   `dtrules edd put`, or the `dtrules build` funnel. Never hand-edit rule XML.
+4. **It runs and leaves a trace** — `dtrules run --entry <t> --input <scenario>
+   --trace <file>` succeeds, the trace loads, and it records real fired
+   columns. Enforced by `TestSampleProjectsProduceLoadableTraces`.
 
-## Worklist (from `apiserver.DiscoverProjects` — 13 projects + TaxReturn done)
+Point 4 was added late and matters most. See "The pattern".
 
-| Project | Marker | Known state (pre-inventory) |
-|---|---|---|
-| sampleprojects/TaxReturn | DTRules.xml | ✅ DONE (#520 campaign, PRs #933–#938): 0 hand rows, Excel regenerated |
-| sampleprojects/CHIP | DTRules.xml | Known hand-postfix warnings (Evaluate_MEDICAID/FOODSTAMPS_Eligibility); CHIP_dt_strip.xml is unparseable junk |
-| sampleprojects/ChipApp | DTRules.xml | Unknown; likely CHIP sibling |
-| sampleprojects/CorporateTax | xml/ | WORST: EDD uses wrong root element `<entity_dictionary>` (loader expects `entity_data_dictionary`); "condition table isn't balanced" load errors; `*_dt_core.xml` has XML syntax errors; state files carry test-first ifelse hand postfix (#947) |
-| sampleprojects/KidAid | DTRules.xml | #927: findmatch-era rules (`relationship-is-of` uses REMOVED op) — migration needs Paul's semantics call; map Excel round-trip formerly lossy; checked-in postfix predates numeric-add fix |
-| sampleprojects/KidAid_Application/repository | DTRules.xml | Unknown; nested project |
-| sampleprojects/Poker | xml/ | Unknown; no DTRules.xml |
-| sampleprojects/SinusitisTherapy | xml/ | Unknown; no DTRules.xml |
-| sampleprojects/StateTax | DTRules.xml | Unknown |
-| sampleprojects/SyntaxTests | DTRules.xml (+ nested repository/) | Test-first ifelse hand postfix (#947); `syntaxexample_edd.xml` has type conflict (totalIncome integer vs double) |
-| sampleprojects/TestProject | DTRules.xml | Unknown; probably small |
-| cmd/sinusitis-web/rules | xml/ | Embedded project; also a candidate to relocate under sampleprojects/ |
+## Status
 
-Projects without DTRules.xml get one created (one per project — it is the
-project marker; #941/#942 established this model).
+| Project | State |
+|---|---|
+| TaxReturn | done before this campaign (#520, PRs #933–#938) |
+| TestProject | done — #950 / #951 |
+| StateTax | done — #952 / #953, all 51 state scenarios compute correct tax |
+| Poker | done — #954 / #955, #958, 12 documented decisions checked |
+| SinusitisTherapy | done — #963 / #964 |
+| CHIP | done — #962 / #969, #970, one open data-model question below |
+| ChipApp | done — #971 |
+| KidAid | done — #972 |
+| KidAid_Application | done — #973 |
+| DTEligibility | deleted — #959 / #960 |
+| **SyntaxTests** | **remaining** — #975 |
+| **CorporateTax** | **remaining** — never scoped |
 
-## Execution order
+DTEligibility was deleted rather than repaired. It arrived on 2026-02-05 inside
+a commit titled "docs: Consolidate documentation into /docs directory", unnamed
+in that commit message, and had never worked: its map used a format the Go
+loader has never supported and its postfix a calling convention predating the
+Go compiler. Nothing executed it. **Check provenance
+(`git log --diff-filter=A -- <path>`) before assuming a sample was intended.**
 
-Small/easy first to bed the workflow in, hardest last:
-TestProject → StateTax → Poker → SinusitisTherapy (+
-cmd/sinusitis-web/rules) → SyntaxTests → CHIP → ChipApp →
-KidAid_Application → KidAid (partial; #927 items need Paul) → CorporateTax.
+## The pattern
 
-## Per-project procedure
+**Every project examined had a test that passed while executing nothing.** Six
+for six, a different cause each time:
 
-1. **Inventory** (read-only scanner, scratchpad `inventory/main.go` — has a
-   syntax error at line 36 to fix: `if d := ...; st, err := os.Stat(d)` is
-   illegal Go; restructure): classify every row as ok / stale (DSL compiles,
-   differs from stored postfix) / prose (DSL doesn't compile) / hand
-   (postfix without DSL) / empty; list stub tables and load errors.
-2. **File the sub-issue** with the findings table ("Part of the sample repair
-   campaign; parent #947 for ifelse rows"). Keep updating it as work lands.
-3. **Repair via authoring API**:
-   - stale rows → `dtrules build` recompiles (its import step compiles all DSL);
-   - prose/hand rows → author EL from the stored postfix (reverse index in
-     `dtrules docs operators` maps postfix ops → EL phrases), applied with
-     `dtrules table put/patch`;
-   - stub tables → implement real logic (domain judgment — document the
-     chosen semantics in the sub-issue);
-   - broken EDDs (CorporateTax root element, SyntaxTests type conflict) →
-     fix via `dtrules edd put` where possible;
-   - create DTRules.xml for the xml/-convention projects.
-4. **Verify**: project's own tests if any (`sampleprojects_test.go`,
-   corporate_tax_test etc. — some behind `-tags archive`), then `make check`.
-5. **PR** ("Closes #<sub-issue>"), merge via `scripts/merge-pr.sh`, post the
-   outcome summary as a final issue comment.
+| project | why it executed nothing |
+|---|---|
+| TestProject | test read a stale `repository/` mirror whose map lacked its `createentity` lines |
+| StateTax | test logged its own runtime failure as "may be expected" |
+| Poker | map never attached players to `game.players` |
+| SinusitisTherapy | map never declared the `<patient>` root, so the singleton loaded empty |
+| CHIP | same as SinusitisTherapy |
+| KidAid | tables loaded typeless after a recompile erased `<TYPE>` |
 
-## Landmines (learned the hard way this session)
+A run that does nothing still exits 0 and still writes a well-formed trace. The
+**fired-column floor** in `TestSampleProjectsProduceLoadableTraces` is the only
+check that catches all six. Every sample added to that test gets one.
 
-- `ifelse`/`if` pop the TEST from the TOP; legacy test-first postfix fails at
-  runtime (#943). Recompiling from DSL fixes it — that's the point.
-- A multi-entity EDD without `<file_metadata><file_path>` is SKIPPED by the
-  directory loader (#946) — regenerated EDDs must carry it (fixed in the
-  writer, but watch for it in hand-repairs).
-- Map workbooks have no sync support (#929) — sync skips `*_map.xlsx`.
-- Comment-only `/* ... */` DSL rows are valid no-ops (since #933/#944).
-- The excel package's `EffectiveDSL()` does NOT fall back to
-  `action_description` but the runtime loader's `GetDSL()` DOES — a scanner
-  must check all three fields or it under-reports prose rows (this bit the
-  TaxReturn campaign: ~20 rows hid until the build's drop report).
-- KidAid: do the mechanical parts; `relationship-is-of`/findmatch semantics
-  are Paul's call (#927) — document, don't guess.
+## Method
 
-## State at handoff
+Rule edits go through the authoring API — `dtrules table put/patch`,
+`dtrules edd put` — or the `dtrules build` funnel. For bulk work, script
+against the API, not the XML.
 
-- Everything through PR #941 is merged; main = `ef7dca44`; installed
-  `~/go/bin/dtrules` = v1.21.0-7. Working tree clean.
-- Issues: #942–#946 filed+closed (retrospective); #947 OPEN (ifelse legacy
-  samples — this campaign supersedes/absorbs it); #935 OPEN (Family_2025
-  expected values — Paul's decision); #927–#931 open backlog.
-- Task list: task #8 "Inventory all sample projects" created, in progress.
-- Nothing for this campaign has been committed yet; the only artifact is the
-  scratchpad inventory scanner (broken, see above) and this plan.
+**Authoring a hand-coded row.** Read the stored postfix, write the EL you
+believe produces it, compile it, diff against what was there, and apply only on
+a match. `dtrules docs operators` carries a postfix→EL reverse index. This is
+how StateTax's and Poker's rows were done, and it is the only safe way — #974
+is what happens without it.
 
-## Recompiling a project (learned the hard way, 2026-07-29)
-
-Re-applying a row's own DSL through `dtrules table patch update-condition-dsl`
-/ `update-action-dsl` recompiles the WHOLE table — that is how a project picks
-up compiler fixes. Two things to know before doing it:
+**Recompiling a project** (how a project picks up compiler fixes): re-apply a
+row's own DSL through `update-condition-dsl` / `update-action-dsl`, which
+re-syncs the whole table. Two hazards:
 
 - **`set-policy` does not recompile.** It reports success and re-syncs
   nothing; only the real mutators call `syncToXML`.
 - **It deletes hand-coded rows.** `syncToXML` regenerates every postfix from
-  its DSL, so a row whose only content IS postfix comes back empty. Check
-  `Table.HandCodedRows()` first and author the EL for anything it names —
-  read the stored postfix, write the DSL, confirm it compiles to the same
-  thing. CHIP, ChipApp, KidAid and KidAid_Application each lost rows this way
-  before anyone noticed, because the emptied rows were in no scenario.
+  its DSL, so a row whose only content *is* postfix comes back empty. Check
+  `Table.HandCodedRows()` first and author the EL for anything it names.
 
-Always diff before committing a recompile. `+<Type></Type>` is what caught
-the type-erasure bug; missing `<*_postfix>` content is what catches this one.
+**Always diff before committing a recompile.** `+<Type></Type>` caught the
+type-erasure bug (#972); missing `<*_postfix>` content caught the row deletion
+(#974). Both were mine.
+
+## Scope decisions (Paul, 2026-07-28)
+
+- Legacy `repository/xml/` mirrors get deleted; each project single-sources on
+  `xml/` and tests reading the mirror are repointed. **Exception:**
+  `KidAid_Application/repository` *is* the project.
+- `lib/*.jar` and `.classpath` get deleted. `DecisionTables/*.xls` and
+  `edd/*.xls` stay as the historical authoring source.
+
+## Engine defects this campaign uncovered
+
+All fixed unless noted.
+
+**Policy statements.** No runtime implementation at all (#949) — the compiler
+emitted `policystatements`, ten samples authored it, nothing implemented it.
+Column 1's statement was eaten on every Excel→XML build. `{expr}` interpolation
+was emitted as literal braces. They were not authorable, because `syncToXML`
+preserved their hand-written postfix, so #817 stopped at the table's last
+section. Then, to Paul's design (#956): statements collect automatically, drain
+with `add the policy statements to <array>`, reset with `clear the policy
+statements` — and that add was appending the whole accumulator as one blob.
+
+**Sync and round-trip.** `<createentity list='…'>` dropped on every map round
+trip, which emptied StateTax's bracket schedules so 29 states computed zero.
+Context comments erased one build at a time. Column elements written in Go map
+order. The legacy `<TYPE>` spelling erased on write, leaving tables typeless
+and unloadable (#972).
+
+**Loading.** `Initialize`+`LoadData` built a second instance of any
+cardinality-1 entity that also had a `createentity`, so loaded values landed on
+a copy nobody held.
+
+**Compiler and EL.** Rows compiled blind to their own table's context locals
+(#965). `is the <R> of` emitted a runtime error stub after findmatch was removed
+(#927) — it means only "the entity is held by that field of the other entity",
+which `getrelationship` already did. `allowing array to be removed` emitted the
+forward iteration that makes removal unsafe. `forallr` had no EL surface at
+all, in context cells (#977) or action cells (#978). `CompileAction` reported
+the wrong parse error, pointing at the entry rule instead of the real mistake.
+
+**Tooling and docs.** `dtrules verify` rejected `{}`, so every table containing
+a bare `if` failed. `docs/el-reference.md` documented postfix the compiler does
+not emit in 70 of its 116 examples (#961) — now regenerated from the compiler
+and gated by `docs/el_reference_postfix_test.go` against a fixture EDD the
+reference owns.
+
+## Remaining work
+
+### SyntaxTests (#975)
+
+23 tables: 48 hand rows, 30 prose rows, 3 stub tables, plus an EDD type
+conflict (#783).
+
+The 48 are mostly reverse iteration, and since #978 they have an authorable
+form producing byte-identical postfix:
+
+```
+for all clients in reverse { set eligible = true; }
+  ->  { true cvb /eligible xdef } clients forallr
+```
+
+Transcribing them is mechanical: compile, diff, apply on exact match. The 30
+prose rows need reading individually. **Do not run the recompile recipe here** —
+those 48 rows are exactly what it deletes.
+
+Two gotchas: statements inside a block need their own semicolons
+(`{ set x = 1; }`), and the inventory scanner reports rows referencing context
+locals as "stale" because it compiles each row independently. Those are false
+positives.
+
+### CorporateTax
+
+Never scoped. From the initial inventory: 26 stub tables; the EDD uses root
+element `<entity_dictionary>` where the loader expects
+`<entity_data_dictionary>`; `*_dt_core.xml` and `states/DC_corp_dt.xml` have
+XML syntax errors; `CorporateTax_edd.xml` has an unescaped `<` inside a quoted
+string. Its `PHASE1_COMPLETE.md`-style status files come from a real feature
+effort (#316–#320), not an accident.
+
+### CHIP's open question (#962)
+
+CHIP executes, but its EDD models relationships as a separate `relationship`
+entity — `source` / `target` / `type`, its own field comment reading *"Source
+is the &lt;relationship type&gt; of the target"* — not as `client.parent`
+fields. Its three `is the <R> of` rows compile and execute correctly under the
+stated semantics but evaluate false against that data shape. Either the EDD
+grows the fields or those rows are re-authored to search the relationship
+entities. Paul's call.
+
+## Tools
+
+The read-only inventory scanner and the EL probe used throughout live in the
+session scratchpad, not the repo. Rebuild as needed:
+
+- **inventory** — walks a project and classifies every row as ok / stale /
+  prose / hand / comment / empty; lists stub tables and load errors.
+- **elc** — compiles candidate EL against a project's EDD symbols and diffs it
+  against an expected postfix. This is the verification loop for authoring.


### PR DESCRIPTION
`docs/sample-repair-campaign.md` was written on day one and had drifted badly: it still listed DTEligibility as work to do, still carried the original 13-project worklist and execution order, and its "state at handoff" section described a session that ended eleven PRs ago.

Rewritten around what's now known:

- **A four-point definition of done**, with *"it runs and leaves a loadable trace"* as the fourth — added late, and the one that matters most.
- **Status of all twelve projects**, with issue and PR numbers.
- **The pattern that has held six for six**: every project examined had a test passing while executing nothing, with a different cause each time. That table is the most useful thing in the document.
- **The method** for authoring a hand-coded row — compile the candidate, diff against the stored postfix, apply only on an exact match — and the two hazards of the recompile recipe.
- **The engine defects** the campaign uncovered, grouped by area rather than as a bare count.
- **What's actually left**: SyntaxTests (mechanical now that #978 landed), CorporateTax (never scoped), and CHIP's open data-model question.

It also records two things that cost real time and aren't obvious from the code:

- **Check a sample's provenance** before assuming it was ever intended. DTEligibility was added by accident inside a docs commit and had never worked; `git log --diff-filter=A` would have said so in seconds.
- **Always diff before committing a recompile.** `+<Type></Type>` caught the type erasure in #972; missing `<*_postfix>` content caught the 13 deleted rows in #974. Both were defects I introduced, and the diff is what caught them.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)