### PR TITLE
fix(build): stop a stale map workbook from deleting createentity list= (#993)

### DIFF
--- a/cmd/dtrules/build.go
+++ b/cmd/dtrules/build.go
@@ -177,6 +177,14 @@ func (c *CLI) runBuild(args []string) int {
 	case "xml":
 		code = c.runXMLAuthoredBuild(xmlDir, excelDir, opts)
 	default:
+		// MAP files sit outside the main sync pipeline, whose "nothing to
+		// sync" verdict only considers DT/EDD workbooks. Without this, a map
+		// sheet stale enough to be missing createentity `list=` could never
+		// be refreshed by `dtrules build` at all — and the #993 guard's
+		// advice to re-export would be advice the tool could not take.
+		if err := c.syncMAPFiles(xmlDir, excelDir, "xml-to-excel", opts.verbose); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: MAP sync error: %v\n", err)
+		}
 		code = runNoSyncAdvisory(xmlDir)
 	}
 	if code != 0 {
@@ -617,6 +625,56 @@ func (c *CLI) runBuildDryRun(xmlDir, excelDir, authoringPath string, opts *build
 	return 0
 }
 
+// createEntityKey identifies a createentity row across a round trip. Entity
+// plus tag is what the mapping loader keys on; `list` is the attribute at
+// risk, so it is deliberately not part of the identity.
+func createEntityKey(ce excel.MapCreateEntity) string {
+	return ce.Entity + "\x00" + ce.Tag + "\x00" + ce.ID
+}
+
+// listsLost reports whether the imported rows dropped a `list=` that the
+// existing XML carried. A sheet predating the list column reads back with
+// every List empty (#993).
+func listsLost(imported, existing []excel.MapCreateEntity) bool {
+	have := map[string]string{}
+	for _, ce := range existing {
+		if ce.List != "" {
+			have[createEntityKey(ce)] = ce.List
+		}
+	}
+	if len(have) == 0 {
+		return false
+	}
+	for _, ce := range imported {
+		if ce.List == "" && have[createEntityKey(ce)] != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// mergeCreateEntityLists restores a `list=` the sheet could not carry,
+// leaving every other imported value alone — an edit made in Excel still
+// wins, only the unrepresentable attribute is recovered.
+func mergeCreateEntityLists(imported, existing []excel.MapCreateEntity) []excel.MapCreateEntity {
+	have := map[string]string{}
+	for _, ce := range existing {
+		if ce.List != "" {
+			have[createEntityKey(ce)] = ce.List
+		}
+	}
+	out := make([]excel.MapCreateEntity, len(imported))
+	copy(out, imported)
+	for i := range out {
+		if out[i].List == "" {
+			if l, ok := have[createEntityKey(out[i])]; ok {
+				out[i].List = l
+			}
+		}
+	}
+	return out
+}
+
 // syncMAPFiles handles _map.xml ↔ _map.xlsx synchronization which the main
 // sync pipeline skips. direction is "xml-to-excel" or "excel-to-xml".
 func (c *CLI) syncMAPFiles(xmlDir, excelDir, direction string, verbose bool) error {
@@ -681,20 +739,43 @@ func (c *CLI) syncMAPFiles(xmlDir, excelDir, direction string, verbose bool) err
 		if mapXML == nil || len(mapXML.Entries) == 0 {
 			return nil
 		}
-		// Clobber guard: a sheet written before the structural-section
-		// round-trip fix carries no createentity / cardinality /
-		// initialization rows. Overwriting an XML that HAS them with a
-		// model that has none would silently break the project's data
-		// loading — carry the existing sections forward and warn.
-		if len(mapXML.CreateEntities)+len(mapXML.EntityDecls)+len(mapXML.InitialEntities) == 0 {
-			if existing, lerr := excel.LoadMapXMLFromFile(xmlPath); lerr == nil {
-				if len(existing.CreateEntities)+len(existing.EntityDecls)+len(existing.InitialEntities) > 0 {
-					mapXML.CreateEntities = existing.CreateEntities
-					mapXML.EntityDecls = existing.EntityDecls
-					mapXML.InitialEntities = existing.InitialEntities
-					fmt.Printf("  Warning: %s has no structural sections (pre-fix sheet); kept the sections from %s — re-export to refresh the sheet\n",
-						filepath.Base(path), filepath.Base(xmlPath))
-				}
+		// Clobber guard. A workbook written by an older DTRules can be
+		// missing structure the XML has, and importing it would quietly
+		// delete that structure from a working ruleset. Two shapes, both
+		// seen in the wild:
+		//
+		//   1. No structural rows at all (pre-#938 sheet).
+		//   2. createentity rows present but their `list` column empty,
+		//      because the sheet predates that column (#993). This one is
+		//      nastier: the section is non-empty, so a count-based guard
+		//      passes it through, and `list=` is what appends each parsed
+		//      entity onto the collection the tables iterate. Losing it
+		//      leaves every `for all` running over an empty array — the
+		//      Accumulate staking ruleset silently returned 0 for every
+		//      staked balance while the build printed "OK — no drops".
+		//
+		// The rule: never let an import *remove* structure. Compare
+		// against the XML being replaced and carry forward anything the
+		// sheet cannot account for.
+		if existing, lerr := excel.LoadMapXMLFromFile(xmlPath); lerr == nil {
+			warn := func(what string) {
+				fmt.Printf("  Warning: %s is missing %s that %s has; kept the existing values — re-export to refresh the sheet\n",
+					filepath.Base(path), what, filepath.Base(xmlPath))
+			}
+			if len(mapXML.CreateEntities) == 0 && len(existing.CreateEntities) > 0 {
+				mapXML.CreateEntities = existing.CreateEntities
+				warn("createentity rows")
+			} else if listsLost(mapXML.CreateEntities, existing.CreateEntities) {
+				mapXML.CreateEntities = mergeCreateEntityLists(mapXML.CreateEntities, existing.CreateEntities)
+				warn("createentity list= attributes")
+			}
+			if len(mapXML.EntityDecls) == 0 && len(existing.EntityDecls) > 0 {
+				mapXML.EntityDecls = existing.EntityDecls
+				warn("entity cardinality declarations")
+			}
+			if len(mapXML.InitialEntities) == 0 && len(existing.InitialEntities) > 0 {
+				mapXML.InitialEntities = existing.InitialEntities
+				warn("the initialization stack")
 			}
 		}
 		if err := os.MkdirAll(filepath.Dir(xmlPath), 0755); err != nil {

--- a/cmd/dtrules/map_roundtrip_test.go
+++ b/cmd/dtrules/map_roundtrip_test.go
@@ -1,0 +1,90 @@
+// Copyright 2024 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/excel"
+)
+
+// #993: a workbook written before the `list` column existed reads back with
+// createentity rows present but every List empty. The old guard counted rows,
+// so it passed that through and the rewritten map lost `list=` on every
+// createentity — which is what appends each parsed entity onto the collection
+// the tables iterate. Every `for all` then ran over an empty array and the
+// Accumulate staking ruleset returned 0 for every staked balance, while the
+// build printed "Result: OK — no drops" and exited 0.
+func TestListsLostDetectsPreListSheet(t *testing.T) {
+	existing := []excel.MapCreateEntity{
+		{Entity: "staking_account", Tag: "staking_account", ID: "account_url", List: "accounts"},
+		{Entity: "balance_tx", Tag: "balance_tx", ID: "btx_seq", List: "balance_history"},
+		{Entity: "job", Tag: "job", ID: "id"}, // legitimately has no list
+	}
+
+	preList := []excel.MapCreateEntity{
+		{Entity: "staking_account", Tag: "staking_account", ID: "account_url"},
+		{Entity: "balance_tx", Tag: "balance_tx", ID: "btx_seq"},
+		{Entity: "job", Tag: "job", ID: "id"},
+	}
+	if !listsLost(preList, existing) {
+		t.Fatal("a sheet that dropped every list= was not detected as lossy")
+	}
+
+	merged := mergeCreateEntityLists(preList, existing)
+	if merged[0].List != "accounts" || merged[1].List != "balance_history" {
+		t.Errorf("lists not restored: %+v", merged)
+	}
+	if merged[2].List != "" {
+		t.Errorf("invented a list for a row that never had one: %+v", merged[2])
+	}
+
+	// A current sheet round-trips intact and must not be flagged.
+	if listsLost(existing, existing) {
+		t.Error("an intact sheet was reported as lossy")
+	}
+
+	// An author who deliberately removes a list in Excel is indistinguishable
+	// from a lossy sheet, so the conservative choice is to keep the value and
+	// warn — losing a production ruleset's data loading is the worse failure.
+	// This pins that choice so a change to it is deliberate.
+	oneRemoved := []excel.MapCreateEntity{
+		{Entity: "staking_account", Tag: "staking_account", ID: "account_url"},
+		{Entity: "balance_tx", Tag: "balance_tx", ID: "btx_seq", List: "balance_history"},
+		{Entity: "job", Tag: "job", ID: "id"},
+	}
+	if !listsLost(oneRemoved, existing) {
+		t.Error("a single dropped list= should still be caught")
+	}
+	if got := mergeCreateEntityLists(oneRemoved, existing)[0].List; got != "accounts" {
+		t.Errorf("kept value = %q, want the existing \"accounts\"", got)
+	}
+}
+
+// A renamed row is a different row: nothing should be carried onto it.
+func TestMergeCreateEntityListsKeysOnIdentity(t *testing.T) {
+	existing := []excel.MapCreateEntity{
+		{Entity: "staking_account", Tag: "staking_account", ID: "account_url", List: "accounts"},
+	}
+	renamed := []excel.MapCreateEntity{
+		{Entity: "staking_account", Tag: "renamed_tag", ID: "account_url"},
+	}
+	if listsLost(renamed, existing) {
+		t.Error("a renamed tag must not look like a lost list")
+	}
+	if got := mergeCreateEntityLists(renamed, existing)[0].List; got != "" {
+		t.Errorf("carried %q onto a renamed row", got)
+	}
+}


### PR DESCRIPTION
Closes #993.

## What it actually was

Not the Excel columns. The exporter writes `list` and the importer reads it —
which is exactly why a freshly generated workbook round-trips intact and the
minimal repro in the issue would not fail.

The trigger is a workbook written **before that column existed**. It reads
back with its createentity rows *present* but every `List` empty, and the
clobber guard only fired when the section was entirely empty:

```go
if len(CreateEntities)+len(EntityDecls)+len(InitialEntities) == 0
```

Non-empty section → passed straight through → the rewrite dropped every
`list=`. Reproduced deterministically by clearing column D of a generated
sheet: five `list=` gone, exit 0, `Result: OK — no drops`.

That also explains the shape you noticed — `id=` surviving while `list=`
vanished, and only the map file affected while `_dt.xml` and `_edd.xml` come
back byte-identical.

## The fix

The guard now compares against the XML it is about to replace and refuses to
let an import **remove** structure — per section, and per createentity `list`
keyed on entity+tag+id. An edit you make in Excel still wins; only an
attribute the sheet cannot represent is carried forward, with a warning that
names the file and what to do:

```
Warning: stk_map.xlsx is missing createentity list= attributes that
stk_map.xml has; kept the existing values — re-export to refresh the sheet
```

## A second defect, found while verifying the first

MAP files sync outside the main pipeline, whose "nothing to sync" verdict
considers only DT/EDD workbooks — and that path returned *before* the map
export ran. So a sheet stale enough to be missing `list=` could never be
refreshed by `dtrules build` at all, and the warning above would have been
advice the tool could not take. The export now runs on that path too;
verified end to end: stale sheet → `build .` refreshes it → round-trip is
silent and lossless.

## On your suggestion 2

An import that would remove structure is now loud, and the structure
survives. I left it a warning rather than a hard build failure because the
same shape is produced by an author legitimately deleting a createentity row
in Excel — and the failure worth preventing is the silent one you hit, which
it now prevents outright.

Tests in `cmd/dtrules/map_roundtrip_test.go` cover the pre-list sheet, a
single dropped `list=`, an intact sheet (must not warn), and a renamed row
(must not have a value carried onto it). `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)