### PR TITLE
fix: compile DSL on every path that writes postfix (#928, #929)

### DIFF
--- a/cmd/dtrules/cli.go
+++ b/cmd/dtrules/cli.go
@@ -330,9 +330,15 @@ func (c *CLI) initSyncer() error {
 	}
 	c.syncer = sync.NewSyncerWithOptions(c.xmlDir, c.excelDir, opts)
 
-	// Set up importer (combined workbook mode)
+	// Set up importer (combined workbook mode).
+	//
+	// This must be the same constructor `build` uses. A bare
+	// excel.NewWorkbookImporter() has no EL compiler, and an importer without
+	// one writes every postfix element empty — `sync import` produced a
+	// 490-line degradation of KidAid's decision table against the same
+	// workbook `build` compiled correctly, and reported success (#929).
 	c.syncer.SetUseCombinedWorkbooks(true)
-	c.importer = excel.NewWorkbookImporter()
+	c.importer = newWorkbookImporter(c.xmlDir)
 	c.importer.SetVerbose(c.verbose)
 	c.syncer.SetWorkbookImporter(&workbookImporterAdapter{impl: c.importer})
 

--- a/cmd/dtrules/verify.go
+++ b/cmd/dtrules/verify.go
@@ -194,7 +194,10 @@ func checkBuildIdempotency(projectDir, xmlDir, excelDir string, opts *verifyOpti
 		syncer := sync.NewSyncerWithOptions(tmpXML, tmpExcel, syncOpts)
 		syncer.SetUseCombinedWorkbooks(true)
 
-		importer := excel.NewWorkbookImporter()
+		// Same constructor as `build`: verify runs the build pipeline on a
+		// copy, so an importer without the EL compiler would have it
+		// verifying a pipeline nobody runs, and passing (#929).
+		importer := newWorkbookImporter(tmpXML)
 		syncer.SetWorkbookImporter(&workbookImporterAdapter{impl: importer})
 
 		exporter := excel.NewWorkbookExporter()

--- a/pkg/dtrules/apiserver/debug_speculate.go
+++ b/pkg/dtrules/apiserver/debug_speculate.go
@@ -256,13 +256,42 @@ func applySpeculativeEdit(overlay string, table *DecisionTableData) error {
 	return fmt.Errorf("table %q not found in the rules", table.TableName)
 }
 
-// compileTableDSL recompiles every condition/action row of one table from
-// its DSL, with the overlay's EDD symbols for type-aware dispatch. Rows
-// with no DSL keep their existing postfix.
+// compileTableDSL recompiles every row of one table from its DSL, with the
+// overlay's EDD symbols for type-aware dispatch. Rows with no DSL keep their
+// existing postfix — that is how a hand-coded row survives, and it is the only
+// case where keeping the stored postfix is correct.
+//
+// All four sections are covered. Contexts and initial actions were not, which
+// was survivable while this only served speculation but is not once a save
+// depends on it (#928): a table whose iteration lives in a context would have
+// been written with its edited context DSL against the previous postfix.
 func compileTableDSL(overlay string, x *excel.DecisionTableXML) error {
 	c := el.NewCompiler()
 	if syms := authoring.LoadEDDSymbols(overlay); len(syms) > 0 {
 		c.SetSymbols(syms)
+	}
+	for i := range x.Contexts.Details {
+		dsl := strings.TrimSpace(x.Contexts.Details[i].DSL)
+		if dsl == "" {
+			continue
+		}
+		pf, err := c.CompileContext(dsl)
+		if err != nil {
+			return fmt.Errorf("context %d: %v", i+1, err)
+		}
+		x.Contexts.Details[i].Postfix = pf
+	}
+	initial := x.EffectiveInitialActions()
+	for i := range initial {
+		dsl := strings.TrimSpace(initial[i].DSL)
+		if dsl == "" {
+			continue
+		}
+		pf, err := c.CompileAction(dsl)
+		if err != nil {
+			return fmt.Errorf("initial action %d: %v", i+1, err)
+		}
+		initial[i].Postfix = pf
 	}
 	for i := range x.Conditions {
 		dsl := strings.TrimSpace(x.Conditions[i].DSL)
@@ -323,3 +352,14 @@ func firstDecisionTable(n *trace.TraceNode) *trace.TraceNode {
 	}
 	return nil
 }
+
+// compileError marks a save that failed because the author's DSL would not
+// compile, as opposed to an I/O or parse failure. The distinction is what lets
+// the editor answer "fix your rule" rather than "the server broke" (#928).
+type compileError struct {
+	Table string
+	Err   error
+}
+
+func (e *compileError) Error() string { return e.Table + ": " + e.Err.Error() }
+func (e *compileError) Unwrap() error { return e.Err }

--- a/pkg/dtrules/apiserver/save_recompiles_test.go
+++ b/pkg/dtrules/apiserver/save_recompiles_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/excel"
+)
+
+const saveTestEDD = `<entity_data_dictionary>
+  <entity name="client" number="100" access="rw">
+    <field name="age" type="integer" access="rw"></field>
+    <field name="eligible" type="boolean" access="rw"></field>
+  </entity>
+</entity_data_dictionary>`
+
+// The stored postfix is deliberately WRONG for the DSL below (18 vs 21): it
+// stands in for the postfix left over from a previous edit, which is exactly
+// what a save used to preserve.
+const saveTestDT = `<decision_tables>
+<decision_table>
+  <table_name>Decide</table_name>
+  <attribute_fields><Type>FIRST</Type><TABLE_NUMBER>100</TABLE_NUMBER></attribute_fields>
+  <conditions><condition_details>
+    <condition_number>1</condition_number>
+    <condition_dsl>client.age &gt;= 21</condition_dsl>
+    <condition_postfix>client.age 18 i&gt;=</condition_postfix>
+    <condition_column column_number="1" column_value="Y" />
+  </condition_details></conditions>
+  <actions><action_details>
+    <action_number>1</action_number>
+    <action_dsl>set client.eligible = true</action_dsl>
+    <action_postfix>false client.eligible bset</action_postfix>
+    <action_column column_number="1" column_value="X" />
+  </action_details></actions>
+</decision_table>
+</decision_tables>`
+
+// saveTestServer writes a tiny project to a temp dir and returns a Server
+// wired to it, plus the DT file's path.
+func saveTestServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	dir := t.TempDir()
+	xmlDir := filepath.Join(dir, "xml")
+	if err := os.MkdirAll(xmlDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dtPath := filepath.Join(xmlDir, "p_dt.xml")
+	if err := os.WriteFile(filepath.Join(xmlDir, "p_edd.xml"), []byte(saveTestEDD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dtPath, []byte(saveTestDT), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return &Server{projectPath: dir, modified: map[string]bool{}}, dtPath
+}
+
+// tableFromFile reads back the one table a save wrote.
+func tableFromFile(t *testing.T, path string) excel.DecisionTableXML {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := excel.UnmarshalDecisionTablesXML(data)
+	if err != nil {
+		t.Fatalf("saved file does not parse: %v", err)
+	}
+	if len(doc.Tables) != 1 {
+		t.Fatalf("want 1 table in the saved file, got %d", len(doc.Tables))
+	}
+	return doc.Tables[0]
+}
+
+// TestSaveRecompilesDSL pins #928.
+//
+// saveDTFile merged edited DSL into the XML and wrote it without recompiling,
+// so a saved table carried the new DSL against the postfix from before the
+// edit. That is worse than writing none: the file stays well-formed and loads,
+// so the rule goes on executing the old logic while displaying the new. The
+// editor's "Run speculation" disagreed with its own Save, because speculation
+// has always compiled.
+func TestSaveRecompilesDSL(t *testing.T) {
+	s, dtPath := saveTestServer(t)
+	s.tables = []*DecisionTableData{{
+		TableName:  "Decide",
+		Source:     "xml/p_dt.xml",
+		Type:       "FIRST",
+		Conditions: []ConditionData{{Number: 1, Description: "client.age >= 21", Columns: map[string]string{"1": "Y"}}},
+		Actions:    []ActionData{{Number: 1, Description: "set client.eligible = true", Columns: map[string]string{"1": "X"}}},
+	}}
+
+	if err := s.saveDTFile(dtPath, "xml/p_dt.xml"); err != nil {
+		t.Fatalf("saveDTFile: %v", err)
+	}
+
+	got := tableFromFile(t, dtPath)
+	if len(got.Conditions) == 0 {
+		t.Fatal("saved table has no conditions")
+	}
+	pf := got.Conditions[0].Postfix
+	if strings.Contains(pf, "18") {
+		t.Errorf("condition postfix still holds the pre-edit constant 18: %q", pf)
+	}
+	if !strings.Contains(pf, "21") {
+		t.Errorf("condition postfix was not recompiled from the edited DSL, got %q", pf)
+	}
+	if apf := got.Actions[0].Postfix; strings.Contains(apf, "false") {
+		t.Errorf("action postfix still holds the pre-edit value: %q", apf)
+	}
+	if !got.ELCompiled {
+		t.Error("saved table should be marked el_compiled")
+	}
+}
+
+// TestSaveRejectsUncompilableDSL: a save that cannot compile must fail loudly
+// rather than write the stale postfix it was going to replace. Refusing to
+// save is a problem the author can see and fix; a silent stale write is not.
+func TestSaveRejectsUncompilableDSL(t *testing.T) {
+	s, dtPath := saveTestServer(t)
+	before, err := os.ReadFile(dtPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.tables = []*DecisionTableData{{
+		TableName:  "Decide",
+		Source:     "xml/p_dt.xml",
+		Type:       "FIRST",
+		Conditions: []ConditionData{{Number: 1, Description: "client.age >= >= and and", Columns: map[string]string{"1": "Y"}}},
+	}}
+
+	err = s.saveDTFile(dtPath, "xml/p_dt.xml")
+	if err == nil {
+		t.Fatal("save accepted DSL that does not compile")
+	}
+	// The editor needs to tell "fix your rule" from "the server broke".
+	var ce *compileError
+	if !errors.As(err, &ce) {
+		t.Errorf("error should be a *compileError so the handler can answer 400, got %T: %v", err, err)
+	}
+	if ce != nil && ce.Table != "Decide" {
+		t.Errorf("compileError names table %q, want Decide", ce.Table)
+	}
+
+	after, err := os.ReadFile(dtPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Error("a failed save must not modify the file on disk")
+	}
+}

--- a/pkg/dtrules/apiserver/server.go
+++ b/pkg/dtrules/apiserver/server.go
@@ -27,6 +27,7 @@ package apiserver
 import (
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -932,7 +933,15 @@ func (s *Server) handleProjectSave(w http.ResponseWriter, r *http.Request) {
 		if s.modified[dtFile] {
 			path := filepath.Join(s.projectPath, dtFile)
 			if err := s.saveDTFile(path, dtFile); err != nil {
-				jsonError(w, fmt.Sprintf("Failed to save %s: %v", dtFile, err), http.StatusInternalServerError)
+				// A compile error is the author's DSL, not a server fault, so
+				// it comes back 400. The editor can tell "fix your rule" from
+				// "the server broke" only if we make that distinction here.
+				status := http.StatusInternalServerError
+				var ce *compileError
+				if errors.As(err, &ce) {
+					status = http.StatusBadRequest
+				}
+				jsonError(w, fmt.Sprintf("Failed to save %s: %v", dtFile, err), status)
 				return
 			}
 			savedFiles = append(savedFiles, dtFile)
@@ -2473,9 +2482,25 @@ func (s *Server) saveDTFile(path, relPath string) error {
 		}
 	}
 
-	// Apply the API-editable fields onto the canonical model.
+	// Apply the API-editable fields onto the canonical model, then recompile
+	// each table's DSL to postfix.
+	//
+	// Without the recompile a save wrote the edited DSL against the postfix
+	// from before the edit (#928). That is worse than writing none: the file
+	// stays well-formed and loads, so the table goes on executing the old
+	// logic while displaying the new — and the editor's own "Run speculation"
+	// disagreed with it, because that path has always compiled.
+	//
+	// A compile error fails the save rather than being written past. Refusing
+	// to save is a visible problem the author can fix; a save that silently
+	// keeps stale postfix is not.
+	xmlDir := projectXMLDir(s.projectPath)
 	for i := range doc.Tables {
 		applyTableEdits(&doc.Tables[i], keep[doc.Tables[i].TableName])
+		if err := compileTableDSL(xmlDir, &doc.Tables[i]); err != nil {
+			return &compileError{Table: doc.Tables[i].TableName, Err: err}
+		}
+		doc.Tables[i].ELCompiled = true
 	}
 
 	importer := excel.NewDTImporter()

--- a/pkg/dtrules/excel/dt_importer.go
+++ b/pkg/dtrules/excel/dt_importer.go
@@ -1382,6 +1382,21 @@ func safeGet(row []string, idx int) string {
 // If no EL compiler is set, this method does nothing.
 func (i *DTImporter) compileTableEL(table *DecisionTableXML) error {
 	if !i.compileEL || i.elCompiler == nil {
+		// Skipping compilation is only harmless when there is no DSL to
+		// compile. With DSL present it means every postfix element in this
+		// table is about to be written empty, producing a rule set that loads
+		// and decides nothing.
+		//
+		// This was silent, and it is exactly how `dtrules sync import` shipped
+		// a 490-line degradation of KidAid while reporting success — two
+		// import pipelines, only one of which wired a compiler (#929). A
+		// caller that legitimately wants no compilation passes no DSL or
+		// collects no stats, so this costs them nothing.
+		if n := countDSLRows(table); n > 0 && i.stats != nil {
+			i.stats.AddDrop(table.TableName, 0, "postfix",
+				fmt.Sprintf("no EL compiler wired: %d DSL row(s) would be written with empty postfix — "+
+					"construct the importer with SetELCompiler (see newWorkbookImporter in cmd/dtrules)", n))
+		}
 		return nil
 	}
 
@@ -1531,4 +1546,30 @@ func SortTablesByNumber(tables *DecisionTablesXML) {
 		}
 		return numI < numJ
 	})
+}
+
+// countDSLRows reports how many rows of a table carry EL DSL that would need
+// compiling. Used to tell "nothing to compile" apart from "a compiler was
+// needed and none was wired" — the two cases look identical at the point
+// compilation is skipped, and conflating them is what made #929 silent.
+func countDSLRows(table *DecisionTableXML) int {
+	n := 0
+	count := func(dsl string) {
+		if strings.TrimSpace(dsl) != "" {
+			n++
+		}
+	}
+	for _, c := range table.Contexts.Details {
+		count(c.DSL)
+	}
+	for _, a := range table.EffectiveInitialActions() {
+		count(a.DSL)
+	}
+	for _, c := range table.Conditions {
+		count(c.DSL)
+	}
+	for _, a := range table.Actions {
+		count(a.DSL)
+	}
+	return n
 }

--- a/pkg/dtrules/excel/dt_importer_nocompiler_test.go
+++ b/pkg/dtrules/excel/dt_importer_nocompiler_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import (
+	"strings"
+	"testing"
+)
+
+// tableWithDSL is a minimal table carrying one DSL row in each section.
+func tableWithDSL() *DecisionTableXML {
+	t := &DecisionTableXML{TableName: "Decide"}
+	t.Contexts.Details = []ContextDetailXML{{Number: 1, DSL: "for all job.clients"}}
+	t.InitialActions = []InitialActionXML{{DSL: "set result.total = 0"}}
+	t.Conditions = []ConditionXML{{DSL: "client.age >= 18"}}
+	t.Actions = []ActionXML{{DSL: "set result.total = 1"}}
+	return t
+}
+
+// TestNoCompilerWithDSLIsRecorded pins the guard added for #929.
+//
+// An importer with no EL compiler writes every postfix element empty. That is
+// correct when there is no DSL and catastrophic when there is: `dtrules sync
+// import` built its importer without a compiler and produced a 490-line
+// degradation of KidAid's decision table — every postfix emptied, the rule set
+// reduced to one that loads and decides nothing — while reporting success.
+//
+// Skipping compilation must therefore be distinguishable from having nothing
+// to compile. It is recorded as a drop, which build and sync already surface.
+func TestNoCompilerWithDSLIsRecorded(t *testing.T) {
+	imp := NewDTImporter()
+	stats := &ImportStats{}
+	imp.SetStats(stats)
+
+	if err := imp.compileTableEL(tableWithDSL()); err != nil {
+		t.Fatalf("compileTableEL: %v", err)
+	}
+
+	if len(stats.Drops) != 1 {
+		t.Fatalf("want 1 drop for a table with DSL and no compiler, got %d: %+v",
+			len(stats.Drops), stats.Drops)
+	}
+	drop := stats.Drops[0]
+	if drop.Table != "Decide" {
+		t.Errorf("drop names table %q, want %q", drop.Table, "Decide")
+	}
+	// The count matters: it is what tells a reader this was not a no-op.
+	if !strings.Contains(drop.Reason, "4 DSL row(s)") {
+		t.Errorf("drop should say how many rows were affected, got: %s", drop.Reason)
+	}
+	if !strings.Contains(drop.Reason, "no EL compiler wired") {
+		t.Errorf("drop should name the cause, got: %s", drop.Reason)
+	}
+}
+
+// TestNoCompilerWithoutDSLIsSilent keeps the guard from crying wolf. Plenty of
+// callers construct an importer purely to inspect a workbook's shape; a table
+// with no DSL has nothing to compile and must not be reported as a drop.
+func TestNoCompilerWithoutDSLIsSilent(t *testing.T) {
+	imp := NewDTImporter()
+	stats := &ImportStats{}
+	imp.SetStats(stats)
+
+	bare := &DecisionTableXML{TableName: "Empty"}
+	bare.Conditions = []ConditionXML{{DSL: "   "}} // whitespace is not DSL
+	if err := imp.compileTableEL(bare); err != nil {
+		t.Fatalf("compileTableEL: %v", err)
+	}
+	if len(stats.Drops) != 0 {
+		t.Errorf("a table with no DSL must not be reported: %+v", stats.Drops)
+	}
+}
+
+// TestCountDSLRowsSeesBothInitialActionSpellings guards the interaction with
+// the `<initial_action_details>` fix: a table whose initial actions use the
+// legacy spelling must still be counted, or a project spelling them that way
+// would silently fall back into the case this guard exists to catch.
+func TestCountDSLRowsSeesBothInitialActionSpellings(t *testing.T) {
+	legacy := &DecisionTableXML{TableName: "Legacy"}
+	legacy.InitialActionsLegacy = []InitialActionXML{{DSL: "set result.total = 0"}}
+	if n := countDSLRows(legacy); n != 1 {
+		t.Errorf("countDSLRows sees %d rows in the legacy spelling, want 1", n)
+	}
+}


### PR DESCRIPTION
Closes #928. Closes #929.

Two write paths skipped the EL compiler. Same defect, opposite failure mode, and both reported success.

## `dtrules sync import` wrote every postfix empty (#929)

It constructed a bare `excel.NewWorkbookImporter()`; only `build` used the constructor that wires a compiler. Against the same KidAid workbook `build` compiles correctly:

```
$ dtrules sync import
✓ Imported 1 file(s) from Excel to XML.

$ diff build/xml/kidaid_dt.xml sync/xml/kidaid_dt.xml | wc -l
490
```

```diff
-<decision_table el_compiled="true">
+<decision_table>
-<context_postfix>
-{ { dup execute } applying true beq if } clients forall pop
-</context_postfix>
+<context_postfix></context_postfix>
```

Every postfix emptied. The result loads fine and decides nothing. Both paths now use `newWorkbookImporter` — **490 diff lines to 0**, the two pipelines byte-identical.

`dtrules verify` had the same bare importer, which meant it ran the build pipeline on a copy using an importer `build` never uses — verifying a pipeline nobody runs, and passing.

## The editor Save kept the postfix from before the edit (#928)

`saveDTFile` merged edited DSL into the XML and wrote it without recompiling. Worse than writing none: the file stays well-formed and loads, so the table goes on **executing the old logic while displaying the new**. And the editor disagreed with itself — "Run speculation" has always compiled, so it showed the edit taking effect while Save did not.

Save now runs the same compile. A compile failure **fails the save** rather than being written past, and comes back `400` rather than `500` via a typed `compileError` — the editor can only say "fix your rule" instead of "the server broke" if that distinction is made server-side.

`compileTableDSL` also grew contexts and initial actions. It covered only conditions and actions, which was survivable while it served speculation alone, but a save depending on it would have written a table’s edited *context* DSL against stale postfix.

## Making the next one non-silent

Both issues named the same underlying smell: two pipelines that disagree. So skipping compilation is no longer indistinguishable from having nothing to compile — an importer with DSL and no compiler records a drop naming the table and the row count, which `build` and `sync` already surface. Callers with nothing to compile are unaffected, so read-only inspection paths stay quiet.

## Verification

`make check` green. Each fix reverted in turn to confirm the new tests fail with exactly the reported symptom:

```
--- FAIL: TestSaveRecompilesDSL
    condition postfix still holds the pre-edit constant 18: "client.age 18 i>="
    action postfix still holds the pre-edit value: "false client.eligible bset"
--- FAIL: TestSaveRejectsUncompilableDSL
    save accepted DSL that does not compile
```

A failed save is also asserted to leave the file on disk untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)