### PR TITLE
fix(verify): accept integer-form fp and hex literals in the operator check (#1006)

### DIFF
--- a/pkg/dtrules/analysis/external_refs.go
+++ b/pkg/dtrules/analysis/external_refs.go
@@ -430,6 +430,9 @@ func operatorCandidate(tok string) bool {
 	if isNumericLiteral(tok) {
 		return false
 	}
+	if isTypedNumericLiteral(tok) {
+		return false
+	}
 	if strings.Contains(tok, ".") { // dotted field reference
 		return false
 	}
@@ -437,6 +440,57 @@ func operatorCandidate(tok string) bool {
 		return false
 	}
 	return true
+}
+
+// isTypedNumericLiteral reports whether tok is a numeric literal carrying a
+// type marker: a fixed-point literal (`0fp`, `0.5fp`, `.5fp`) or a hex-bytes
+// literal (`0x1f`). These are literals the compiler emits verbatim into
+// postfix, not operators.
+//
+// isNumericLiteral cannot see them because it rejects any token containing a
+// letter, so `0fp` was reported as an undefined operator and `dtrules verify`
+// failed on a rule set that builds, loads and executes correctly (#1006). On
+// the Accumulate staking rules that was 44 uses across 8 tables — enough to
+// stop verify being usable as the authoring-contract gate in CI, which is the
+// point of the check.
+//
+// `0.5fp` appeared to work, but only by accident: it contains a `.`, so the
+// dotted-field-reference branch below let it through. Both forms are now
+// recognised for the right reason, and the hex form — which had the identical
+// defect and simply had not been hit yet — with them.
+//
+// The accepted shapes mirror the grammar exactly (EL.g4, FP_LITERAL and
+// HEX_BYTES_LITERAL):
+//
+//	FP_LITERAL        : DIGIT+ '.' DIGIT* 'fp' | DIGIT* '.' DIGIT+ 'fp' | DIGIT+ 'fp'
+//	HEX_BYTES_LITERAL : '0x' HEX_DIGIT*
+func isTypedNumericLiteral(tok string) bool {
+	if tok == "" {
+		return false
+	}
+	// Hex bytes: 0x followed by hex digits (the grammar permits none). No
+	// sign — it is a bytes literal, not an arithmetic one.
+	if len(tok) >= 2 && tok[0] == '0' && (tok[1] == 'x' || tok[1] == 'X') {
+		for _, r := range tok[2:] {
+			if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Fixed point: a numeric body followed by the fp suffix, matched
+	// case-insensitively because EL names and keywords are. The sign is left
+	// to isNumericLiteral, which permits exactly one; stripping it here as
+	// well would have accepted "--3fp".
+	if len(tok) < 3 {
+		return false
+	}
+	suffix := tok[len(tok)-2:]
+	if suffix != "fp" && suffix != "FP" && suffix != "Fp" && suffix != "fP" {
+		return false
+	}
+	return isNumericLiteral(tok[:len(tok)-2])
 }
 
 // isNumericLiteral reports whether tok is an integer or decimal numeric

--- a/pkg/dtrules/analysis/typed_literals_test.go
+++ b/pkg/dtrules/analysis/typed_literals_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import "testing"
+
+// TestTypedNumericLiteralsAreNotOperators pins #1006.
+//
+// `dtrules verify` reported the integer-form fixed-point literal `0fp` as an
+// undefined operator while accepting `0.5fp` two lines below it in the same
+// file. Both are valid — EL.g4's FP_LITERAL has three alternatives and
+// `DIGIT+ 'fp'` is one of them — and the engine builds, loads and executes
+// them correctly. On the Accumulate staking rules this was 44 uses across 8
+// tables, which stopped verify being usable as the CI authoring-contract gate.
+//
+// `0.5fp` only appeared to work: it contains a `.`, so it fell through the
+// dotted-field-reference branch. Right answer, wrong reason — which is why the
+// decimal forms are pinned here too, and why the hex-bytes literal is, having
+// had the identical defect without anyone having hit it yet.
+func TestTypedNumericLiteralsAreNotOperators(t *testing.T) {
+	literals := []string{
+		// FP_LITERAL: DIGIT+ 'fp'
+		"0fp", "12fp", "-3fp", "+3fp",
+		// FP_LITERAL: DIGIT+ '.' DIGIT* 'fp'
+		"0.5fp", "1.3fp", "2.fp",
+		// FP_LITERAL: DIGIT* '.' DIGIT+ 'fp'
+		".5fp",
+		// EL is case-insensitive.
+		"0FP", "0Fp",
+		// HEX_BYTES_LITERAL: '0x' HEX_DIGIT*
+		"0x1f", "0xdeadbeef", "0xDEADBEEF", "0x",
+	}
+	for _, tok := range literals {
+		if operatorCandidate(tok) {
+			t.Errorf("%q treated as an operator; it is a literal the compiler emits verbatim", tok)
+		}
+	}
+}
+
+// TestTypedLiteralFixIsNotOverPermissive keeps the #1006 fix from swallowing
+// real findings. An undefined operator is a hard gate failure, so widening the
+// literal class must not turn identifiers into literals.
+func TestTypedLiteralFixIsNotOverPermissive(t *testing.T) {
+	operators := []string{
+		"addto",  // a real operator
+		"fp",     // the suffix alone is an identifier, not a literal
+		"0fpx",   // suffix must end the token
+		"x0fp",   // and must follow digits
+		"0xg",    // g is not a hex digit
+		"12fp34", // trailing junk
+		"--3fp",  // one sign only
+		"cvfp",   // the conversion operator, which is genuinely an operator
+	}
+	for _, tok := range operators {
+		if !operatorCandidate(tok) {
+			t.Errorf("%q exempted from the operator check; it is not a numeric literal", tok)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1006. Unblocks wiring `dtrules verify` into CI for the Accumulate staking rules.

## The defect

`operatorCandidate` exempts numeric literals via `isNumericLiteral`, which rejects any token containing a letter. So every *typed* literal fell through to "must be a registered operator", and `0fp` was reported as undefined.

The literal is valid. `EL.g4` FP_LITERAL has three alternatives and the integer form is one of them:

```
FP_LITERAL : DIGIT+ . DIGIT* 'fp' | DIGIT* '.' DIGIT+ 'fp' | DIGIT+ 'fp' ;
```

**`0.5fp` only appeared to work.** It contains a `.`, so it fell through the *dotted-field-reference* branch — right answer, wrong reason. Both forms are now recognised as literals deliberately.

**Hex had the same bug, latent.** `HEX_BYTES_LITERAL : '0x' HEX_DIGIT*` — `0x1f` was equally rejected; nobody had hit it. Fixed with the same change.

## Verification

Against the reporter’s exact minimal reproduction:

```
# released v1.22.1
[external] Lit uses undefined operator "0fp" (Lit_dt.xml)

# this build
(no external findings)
```

And the gate still bites — swapping in a name that really is undefined:

```
[external] Lit uses undefined operator "notarealoperator" (Lit_dt.xml)
```

Sample projects’ verify output is unchanged **byte for byte** (diffed old vs new on CHIP and KidAid; their 7 pre-existing findings each are identical and untouched). `make check` green.

## On the choice of fix

The issue offered two options and asked which. Option 1 — teach the checker the literal — is right: the grammar defines the form, the compiler emits it, the runtime executes it, and the reporter’s ruleset reproduces a production period to the nanoACME using it. Normalising 44 correct sites to satisfy a checker would have been fixing the wrong end.

## Note

The negative test earned its place immediately: it caught `--3fp` being accepted, because the sign was stripped both in the new helper and in `isNumericLiteral`. Widening an exemption on a hard gate is exactly where over-permissiveness costs you findings, so the over-permissive cases are pinned alongside the valid ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)