### PR TITLE
fix(el): group multiply chains left in `divide … by … rounding by` (#1015)

### DIFF
--- a/pkg/dtrules/compiler/el/divide_rounding_assoc_test.go
+++ b/pkg/dtrules/compiler/el/divide_rounding_assoc_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package el
+
+import (
+	"strings"
+	"testing"
+)
+
+func compileFixed(t *testing.T, dsl string) string {
+	t.Helper()
+	c := NewCompiler()
+	c.SetSymbols(map[string]string{
+		"tot": "fixed", "n": "fixed", "x": "fixed", "y": "fixed", "z": "fixed",
+		"weekly_budget": "fixed", "unissued_supply": "fixed", "days_per_year": "fixed",
+		"days_per_period_num": "long", "days_per_period_den": "long",
+		"token_issuance_rate_num": "long", "token_issuance_rate_den": "long",
+	})
+	pf, err := c.CompileAction(dsl)
+	if err != nil {
+		t.Fatalf("compile %q: %v", dsl, err)
+	}
+	return strings.Join(strings.Fields(pf), " ")
+}
+
+// TestDivideRoundingByGroupsLeft pins #1015.
+//
+// A bare `x * y * z` groups left everywhere in the language except the two
+// operands of `divide … by … rounding by`, where it grouped right: `iexpr
+// TIMES fexpr` is not a left-recursive alternative of fexpr, so ANTLR tries it
+// as a primary here and its right operand swallows the rest of the chain.
+//
+// This is not a cosmetic difference. fp* rounds, so moving the grouping moves
+// the rounding point. On the Accumulate staking rules the right-nested form
+// shifted a payout by 1 nanoACME (3410864457 vs 3410864458) and broke their
+// on-chain period reproduction — from a recompile of unchanged DSL, with
+// nothing in the authored source to show why.
+func TestDivideRoundingByGroupsLeft(t *testing.T) {
+	tests := []struct {
+		name string
+		dsl  string
+		want string
+	}{
+		{
+			"divisor chain groups left",
+			"set tot = divide n by x * y * z rounding by 0.5fp",
+			"n x y fp* z fp* fphalfup/ cvfp /tot xdef",
+		},
+		{
+			"numerator chain groups left",
+			"set tot = divide n * x * y by z rounding by 0.5fp",
+			"n x fp* y fp* z fphalfup/ cvfp /tot xdef",
+		},
+		{
+			"explicit left grouping is unchanged",
+			"set tot = divide n by (x * y) * z rounding by 0.5fp",
+			"n x y fp* z fp* fphalfup/ cvfp /tot xdef",
+		},
+		{
+			// The author asked for right grouping, so they get it. This is the
+			// case that makes the fix a re-association of bare chains rather
+			// than a blanket rewrite.
+			"explicit right grouping is honoured",
+			"set tot = divide n by x * (y * z) rounding by 0.5fp",
+			"n x y z fp* fp* fphalfup/ cvfp /tot xdef",
+		},
+		{
+			// Two operands have nothing to re-associate; guards the len<3 path.
+			"two-operand divisor is unchanged",
+			"set tot = divide n by x * y rounding by 0.5fp",
+			"n x y fp* fphalfup/ cvfp /tot xdef",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := compileFixed(t, tc.dsl); got != tc.want {
+				t.Errorf("\n dsl:  %s\n got:  %s\n want: %s", tc.dsl, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOtherContextsStillGroupLeft is the control: every other construct was
+// already correct, and the fix must not have touched them.
+func TestOtherContextsStillGroupLeft(t *testing.T) {
+	for dsl, want := range map[string]string{
+		"set tot = x * y * z":       "x y fp* z fp* cvfp /tot xdef",
+		"set tot = x - y - z":       "x y fp- z fp- cvfp /tot xdef",
+		"set tot = x / y / z":       "x y fp/ z fp/ cvfp /tot xdef",
+		"set tot = n + x * y * z":   "n x y fp* z fp* fp+ cvfp /tot xdef",
+		"set tot = (x * y * z) + n": "x y fp* z fp* n fp+ cvfp /tot xdef",
+	} {
+		if got := compileFixed(t, dsl); got != want {
+			t.Errorf("\n dsl:  %s\n got:  %s\n want: %s", dsl, got, want)
+		}
+	}
+}
+
+// TestStakingWeeklyBudgetPostfix pins the exact production expression that
+// exposed this, against the postfix its repository has committed — which was
+// compiled correctly before the regression. Reproducing it byte for byte is
+// what makes an Excel-authored rebuild of that ruleset behaviour-neutral.
+func TestStakingWeeklyBudgetPostfix(t *testing.T) {
+	const dsl = "set weekly_budget = divide unissued_supply * (fixed) days_per_period_num * " +
+		"(fixed) token_issuance_rate_num by (fixed) token_issuance_rate_den * days_per_year * " +
+		"(fixed) days_per_period_den rounding by 0.5fp"
+	const want = "unissued_supply days_per_period_num cvfp token_issuance_rate_num cvfp fp* fp* " +
+		"token_issuance_rate_den cvfp days_per_year fp* days_per_period_den cvfp fp* " +
+		"fphalfup/ cvfp /weekly_budget xdef"
+
+	if got := compileFixed(t, dsl); got != want {
+		t.Errorf("\n got:  %s\n want: %s", got, want)
+	}
+}

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -1859,8 +1859,22 @@ func (e *PostfixEmitter) VisitDivideRoundingBy(ctx *DivideRoundingByContext) int
 			return nil
 		}
 	}
-	e.emitWithTypeConversion(ctx.Fexpr(0), TypeFixed)
-	e.emitWithTypeConversion(ctx.Fexpr(1), TypeFixed)
+	// Emit both operands left-associated. Everywhere else in the language a
+	// bare `x * y * z` groups left, but the two operands of this rule parse
+	// right-nested: `iexpr TIMES fexpr` is not a left-recursive alternative of
+	// fexpr, so ANTLR tries it as a primary here and its right operand
+	// swallows the rest of the chain.
+	//
+	// That matters because fp* rounds. Regrouping a product moves the rounding
+	// point, so the two forms are not interchangeable: on the Accumulate
+	// staking rules the right-nested form shifts a payout by 1 nanoACME and
+	// breaks their on-chain period reproduction. Their committed postfix is
+	// left-associated, compiled before this regressed (#1015).
+	//
+	// Only unparenthesised chains are re-associated — a parenthesised
+	// subexpression is its own node and is emitted as the author grouped it.
+	e.emitFixedProductLeftAssoc(ctx.Fexpr(0))
+	e.emitFixedProductLeftAssoc(ctx.Fexpr(1))
 
 	rText := ctx.FP_LITERAL().GetText()
 	rMantissa, err := parseFpLiteralToMantissa(rText)
@@ -7533,4 +7547,43 @@ func (e *PostfixEmitter) VisitDateEarliestAfter(ctx *DateEarliestAfterContext) i
 	e.emit(`"earliest of <arr> after <d> not yet implemented (needs earliestafter runtime op)"`)
 	e.emit("elstmterror")
 	return nil
+}
+
+// emitFixedProductLeftAssoc emits an fexpr as fixed, forcing a bare
+// multiplication chain to group left-to-right.
+//
+// See VisitDivideRoundingBy for why: fp* rounds, so `(x*y)*z` and `x*(y*z)`
+// are different numbers, and every other context in the language groups left.
+// A chain of fewer than three operands has nothing to re-associate and takes
+// the ordinary path.
+func (e *PostfixEmitter) emitFixedProductLeftAssoc(ctx antlr.ParseTree) {
+	operands := flattenMulChain(ctx)
+	if len(operands) < 3 {
+		e.emitWithTypeConversion(ctx, TypeFixed)
+		return
+	}
+	e.emitWithTypeConversion(operands[0], TypeFixed)
+	for _, operand := range operands[1:] {
+		e.emitWithTypeConversion(operand, TypeFixed)
+		e.emit("fp*")
+	}
+}
+
+// flattenMulChain returns the operands of a multiplication chain in source
+// order, whatever shape the parse gave it.
+//
+// It descends only through the three multiply alternatives. A parenthesised
+// subexpression is a FloatParen node, not a multiply node, so it is returned
+// whole — explicit grouping by the author survives, which is what makes
+// `divide n by x * (y * z) rounding by 0.5fp` still mean what it says.
+func flattenMulChain(t antlr.ParseTree) []antlr.ParseTree {
+	switch c := t.(type) {
+	case *FloatMulFloatContext:
+		return append(flattenMulChain(c.Fexpr(0)), flattenMulChain(c.Fexpr(1))...)
+	case *FloatMulIntContext:
+		return append(flattenMulChain(c.Fexpr()), c.Iexpr())
+	case *IntMulFloatContext:
+		return append([]antlr.ParseTree{c.Iexpr()}, flattenMulChain(c.Fexpr())...)
+	}
+	return []antlr.ParseTree{t}
 }


### PR DESCRIPTION
Closes #1015.

## The defect

A bare `x * y * z` groups left everywhere in the language except the two operands of `divide … by … rounding by`, where it grouped right. `iexpr TIMES fexpr` is not a left-recursive alternative of `fexpr`, so ANTLR tries it as a primary in that position and its right operand swallows the rest of the chain.

```
divisor:  x y z fp* fp*     x * (y * z)   before
          x y fp* z fp*     (x * y) * z   after
```

`fp*` rounds, so moving the grouping moves the rounding point. Recompiling unchanged DSL shifted an Accumulate staking payout by 1 nanoACME with nothing in the authored source to explain it.

## Verified

The staking `weekly_budget` expression now compiles **byte for byte** to the postfix their repository has committed — which was produced before this regressed:

```
unissued_supply days_per_period_num cvfp token_issuance_rate_num cvfp fp* fp*
token_issuance_rate_den cvfp days_per_year fp* days_per_period_den cvfp fp*
fphalfup/ cvfp /weekly_budget xdef
```

`make check` green. Scope was measured rather than assumed — `+`, `-`, `/`, plain multiply chains and chains inside other constructs were already correct, and a control test pins that they stay that way.

## Why the emitter and not the grammar

There is no ANTLR toolchain in this environment, and regenerating a grammar this size to change precedence would put every other construct’s postfix at risk to fix one rule. `flattenMulChain` descends only through the three multiply alternatives, so a parenthesised subexpression is its own node and survives — `divide n by x * (y * z) rounding by 0.5fp` still means what it says. That is pinned by a test, because it is what makes this a re-association of bare chains rather than a blanket rewrite.

## What this does NOT fix

I rebuilt the staking rules with this and ran their suite: still 6 failures against a baseline of 1. **#1015 was one of four divergences, not the only one.** The others are separate and I will file them:

- `set reward = weighted_balance * staker_budget / total_weighted` compiles to truncating `fp/`, but their spec and `TestRoundHalfUp_PerAccountReward` require round-half-up. Their committed postfix has `fphalfup/` from an older compiler that conflated the two. Today’s distinction is correct — `/` truncates, `divide … rounding by 0.5fp` rounds — so **their DSL does not say what their spec requires**. That is a rule change on their side, not ours.
- Table-name case is not preserved through the Excel round trip: `Matches_Onchain` comes back `matches_onchain`.
- Ten `<condition_column column_value="-"/>` entries are dropped on the round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)