### PR TITLE
docs: show only syntax the compiler accepts, and gate it (#985, #1021)

### DIFF
--- a/cmd/dtrules/docs.go
+++ b/cmd/dtrules/docs.go
@@ -201,12 +201,14 @@ Built-in integer functions:
     long value of myOperator(args)        integer result from a custom operator
 
 Mutating integer operations (used in actions):
-    add to myLong 5                add 5 to variable
-    subtract from myLong 3         subtract 3 from variable
-    multiply myLong by 2           multiply variable in place
-    divide myLong by 4             divide variable in place
+    add 5 to myLong                add 5 to variable
+    subtract 3 from myLong         subtract 3 from variable
     increment myLong               add 1
     decrement myLong               subtract 1
+
+    There is no in-place multiply or divide shortcut; write the assignment:
+    set myLong = myLong * 2
+    set myLong = myLong / 4
 
 Cast to integer:
     (long) "42"                    parse string to integer
@@ -245,10 +247,10 @@ Min / max (also 'smaller of' / 'larger of'; 'the' is optional):
     the maximum of (result.agi - deduction) and 0.0
 
 Mutating double operations:
-    add to myDouble 1.5            add to variable in place
-    subtract from myDouble 0.5     subtract from variable in place
-    multiply myDouble by 1.1       multiply in place
-    divide myDouble by 2.0         divide in place
+    add 1.5 to myDouble            add to variable in place
+    subtract 0.5 from myDouble     subtract from variable in place
+    set myDouble = myDouble * 1.1  multiply in place (no shortcut form)
+    set myDouble = myDouble / 2.0  divide in place (no shortcut form)
 
 Cast to double:
     (double) "3.14"                parse string to double
@@ -1565,14 +1567,16 @@ Mutating shortcuts (action statements):
     decrement myLong                          (subtracts 1)
     increment myDouble
     decrement myDouble
-    add to myLong 5                           (myLong = myLong + 5)
-    subtract from myLong 3                    (myLong = myLong - 3)
-    multiply myLong by 2                      (myLong = myLong * 2)
-    divide myLong by 4                        (myLong = myLong / 4)
-    add to myDouble 1.5
-    subtract from myDouble 0.5
-    multiply myDouble by 1.1
-    divide myDouble by 2.0
+    add 5 to myLong                           (myLong = myLong + 5)
+    subtract 3 from myLong                    (myLong = myLong - 3)
+    add 1.5 to myDouble
+    subtract 0.5 from myDouble
+
+    No in-place multiply or divide shortcut exists — use the assignment form:
+    set myLong = myLong * 2                   (myLong = myLong * 2)
+    set myLong = myLong / 4                   (myLong = myLong / 4)
+    set myDouble = myDouble * 1.1
+    set myDouble = myDouble / 2.0
 
 
 Comparison Operators

--- a/cmd/dtrules/docs_examples_compile_test.go
+++ b/cmd/dtrules/docs_examples_compile_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	el "github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+)
+
+// mutatingShortcutExamples are the action forms `dtrules docs operators`
+// presents as mutating shortcuts. Every one must compile.
+//
+// The docs listed eight forms that do not parse (#985): `add to myLong 5` and
+// `subtract from myLong 3` have the operand and target the wrong way round,
+// and `multiply myLong by 2` / `divide myLong by 4` do not exist at all — in
+// any spelling. A rule author following the docs got
+// `no viable alternative at input 'addto'` and no hint that the docs were
+// wrong rather than their rule.
+//
+// This is the `dtrules docs` counterpart of the el-reference gate (#961,
+// extended in #1021): documentation that shows syntax the compiler rejects is
+// worse than no documentation, because the reader trusts it.
+var mutatingShortcutExamples = []string{
+	"add 5 to myLong",
+	"subtract 3 from myLong",
+	"increment myLong",
+	"decrement myLong",
+	"add 1.5 to myDouble",
+	"subtract 0.5 from myDouble",
+	"set myLong = myLong * 2",
+	"set myLong = myLong / 4",
+	"set myDouble = myDouble * 1.1",
+	"set myDouble = myDouble / 2.0",
+}
+
+func TestDocsMutatingShortcutsCompile(t *testing.T) {
+	for _, dsl := range mutatingShortcutExamples {
+		c := el.NewCompiler()
+		c.SetSymbols(map[string]string{"myLong": "long", "myDouble": "double"})
+		if _, err := c.CompileAction(dsl); err != nil {
+			t.Errorf("`dtrules docs` shows %q but it does not compile:\n  %v", dsl, err)
+		}
+	}
+}
+
+// TestDocsDoNotShowRejectedForms pins the specific forms that were wrong, so
+// they cannot come back. Listing them by name is deliberate: a reader who
+// remembers the old spelling should find it absent, not silently changed.
+func TestDocsDoNotShowRejectedForms(t *testing.T) {
+	body := docsOperatorsBody(t)
+	for _, dead := range []string{
+		"add to myLong",
+		"subtract from myLong",
+		"multiply myLong by",
+		"divide myLong by",
+		"add to myDouble",
+		"subtract from myDouble",
+		"multiply myDouble by",
+		"divide myDouble by",
+	} {
+		if strings.Contains(body, dead) {
+			t.Errorf("docs still show %q, which the compiler rejects (#985)", dead)
+		}
+	}
+}
+
+// docsOperatorsBody returns every docs page that carries the mutating
+// shortcuts. Both `dtrules docs el` and `dtrules docs operators` listed them,
+// and only one of the two was reported — fixing a page at a time is how the
+// other survives.
+func docsOperatorsBody(t *testing.T) string {
+	t.Helper()
+	body := docOperators + "\n" + docEL
+	if len(body) < 1000 {
+		t.Fatalf("docs body is %d bytes — the pages are not being read", len(body))
+	}
+	return body
+}

--- a/docs/el-reference.md
+++ b/docs/el-reference.md
@@ -636,6 +636,7 @@ Pure dates (midnight UTC) serialize back as `YYYY-MM-DD`; timestamps serialize a
 
 **Syntax**: `MAP arrayExpr THROUGH texpr`
 **Semantics**: Apply a decision table to each element and collect results. Postfix: `mapthrough`.
+**Status**: NOT IMPLEMENTED — the grammar accepts this, but the compiler emits a runtime-error stub. Do not use it in a rule.
 **Example (EL)**: `map brackets through Apply_Bracket`
 **Compiled postfix**: `"map ... through ... not yet implemented" elstmterror`
 
@@ -731,6 +732,7 @@ Pure dates (midnight UTC) serialize back as `YYYY-MM-DD`; timestamps serialize a
 
 **Syntax**: `EARLIEST OF arrayExpr AFTER dexpr`
 **Semantics**: Returns the earliest date in an array that is after a given date.
+**Status**: NOT IMPLEMENTED — the grammar accepts this, but the compiler emits a runtime-error stub. Do not use it in a rule.
 **Example (EL)**: `earliest of pending_dates after current date`
 **Compiled postfix**: `"earliest of <arr> after <d> not yet implemented (needs earliestafter runtime op)" elstmterror`
 
@@ -752,6 +754,7 @@ Pure dates (midnight UTC) serialize back as `YYYY-MM-DD`; timestamps serialize a
 
 **Syntax**: `(long) typedTable(key)` / `(double) typedTable(key)` / `(string) typedTable(key)`
 **Semantics**: Look up a value in a named decision table using a key string.
+**Status**: NOT IMPLEMENTED — the grammar accepts this, but the compiler emits a runtime-error stub. Do not use it in a rule.
 **Example (EL)**: `(double) bracket_table("0.22")`
 **Compiled postfix**: `"hash tables removed — (double) table-lookup unsupported" elstmterror 0.0`
 
@@ -773,6 +776,7 @@ Pure dates (midnight UTC) serialize back as `YYYY-MM-DD`; timestamps serialize a
 
 **Syntax**: `mapping key`
 **Semantics**: Returns the current key when iterating over a mapped structure.
+**Status**: NOT IMPLEMENTED — the grammar accepts this, but the compiler emits a runtime-error stub. Do not use it in a rule.
 **Example (EL)**: `mapping key == "CHIP"`
 **Compiled postfix**: `"mappingkey not yet implemented" elstmterror "CHIP" streq`
 
@@ -780,6 +784,7 @@ Pure dates (midnight UTC) serialize back as `YYYY-MM-DD`; timestamps serialize a
 
 **Syntax**: `RELATIONSHIP_BETWEEN eexpr AND eexpr`
 **Semantics**: Returns the relationship string between two entities.
+**Status**: NOT IMPLEMENTED — the grammar accepts this, but the compiler emits a runtime-error stub. Do not use it in a rule.
 **Example (EL)**: `relationship between person and household.head == "SPOUSE"`
 **Compiled postfix**: `"relationship between ... not yet implemented" elstmterror "SPOUSE" streq`
 
@@ -1045,9 +1050,11 @@ typedXmlValue : add attribute strexpr = xmlvalues
 ```
 
 **Semantics**: Set or add an XML attribute on an entity's backing XML element.
+**Status**: NOT IMPLEMENTED — the grammar accepts this, but the compiler emits a runtime-error stub. Do not use it in a rule.
 **Example (EL)**: `w2 : set attribute "wages" = w2.wages`
 **Compiled postfix**: `"xml mutation unsupported — xmlvaluestatements have no runtime" elstmterror`
 
+**Status**: NOT IMPLEMENTED — the grammar accepts this, but the compiler emits a runtime-error stub. Do not use it in a rule.
 **Example (EL)**: `w2 : add attribute "employer" = employer_name`
 **Compiled postfix**: `"xml mutation unsupported — xmlvaluestatements have no runtime" elstmterror`
 
@@ -1120,6 +1127,7 @@ See [Local Variables](#local-variables) section.
 
 **Syntax**: `MAP arrayExpr THROUGH texpr`
 **Semantics**: Apply a decision table to each element in an array and collect the results into a new array.
+**Status**: NOT IMPLEMENTED — the grammar accepts this, but the compiler emits a runtime-error stub. Do not use it in a rule.
 **Example (EL)**: `map brackets through Apply_Bracket`
 **Compiled postfix**: `"map ... through ... not yet implemented" elstmterror`
 
@@ -1174,6 +1182,7 @@ there is no eexpr in eexpr where bexpr
 
 **Syntax**: `FIRST eexpr IN arrayExpr WHERE bexpr`
 **Semantics**: Returns the first element in an array matching a condition, or null.
+**Status**: NOT IMPLEMENTED — the grammar accepts this, but the compiler emits a runtime-error stub. Do not use it in a rule.
 **Example (EL)**: `first person in household.members where person.is_adult`
 **Compiled postfix**: `"first <e> in <arr> where ... not yet implemented (needs firstwhere runtime op)" elstmterror`
 

--- a/docs/el_reference_postfix_test.go
+++ b/docs/el_reference_postfix_test.go
@@ -55,6 +55,13 @@ var probeTargets = []string{"probe.i", "probe.d", "probe.s", "probe.b", "probe.d
 //
 // Every **Example (EL)** is compiled here and its **Compiled postfix** line
 // must be exactly what came out.
+// notImplementedMarker labels an entry whose syntax the grammar accepts but
+// the compiler lowers to a runtime-error stub. Such entries are documented —
+// the grammar really does have them — but a rule author must be able to tell
+// them from working syntax at a glance, which `map ... through` claiming a
+// `mapthrough` postfix it never emitted did not allow (#1021).
+const notImplementedMarker = "**Status**: NOT IMPLEMENTED"
+
 func TestELReference_PostfixMatchesCompiler(t *testing.T) {
 	symbols := authoring.LoadEDDSymbols(elRefEDDDir)
 	if len(symbols) == 0 {
@@ -71,11 +78,20 @@ func TestELReference_PostfixMatchesCompiler(t *testing.T) {
 	scanner.Buffer(make([]byte, 1<<20), 1<<20)
 
 	var pendingEL string
-	var pendingLine, lineNo, checked int
+	var pendingLine, lineNo, checked, unlabelled int
+	var entryMarkedUnimplemented bool
 	for scanner.Scan() {
 		lineNo++
 		line := scanner.Text()
 
+		// A #### heading starts a new entry, so the NOT IMPLEMENTED label
+		// cannot leak from the entry above it.
+		if strings.HasPrefix(line, "####") {
+			entryMarkedUnimplemented = false
+		}
+		if strings.HasPrefix(line, notImplementedMarker) {
+			entryMarkedUnimplemented = true
+		}
 		if m := elExampleLine.FindStringSubmatch(line); m != nil {
 			pendingEL, pendingLine = m[1], lineNo
 			continue
@@ -85,6 +101,13 @@ func TestELReference_PostfixMatchesCompiler(t *testing.T) {
 			got, err := compileELExample(pendingEL, symbols)
 			if err != nil {
 				t.Errorf("%s:%d: EL does not compile: %s\n  %v", elRefFile, pendingLine, pendingEL, err)
+			} else if strings.Contains(got, "elstmterror") && !entryMarkedUnimplemented {
+				unlabelled++
+				t.Errorf("%s:%d: documented syntax compiles to a runtime-error stub but is not labelled\n"+
+					"  EL:     %s\n  emits:  %s\n"+
+					"Add a %q line to the entry, or remove the entry. Documenting dead syntax as usable\n"+
+					"is how `map ... through` sat in this reference claiming a `mapthrough` postfix it\n"+
+					"never emitted (#1021).", elRefFile, pendingLine, pendingEL, got, notImplementedMarker)
 			} else if got != normalizePostfix(m[1]) {
 				t.Errorf("%s:%d: documented postfix is not what the compiler emits\n  EL:       %s\n  document: %s\n  compiler: %s",
 					elRefFile, pendingLine, pendingEL, normalizePostfix(m[1]), got)
@@ -117,6 +140,7 @@ func TestELReference_PostfixMatchesCompiler(t *testing.T) {
 	// content count: if the example markup changes shape the extractor stops
 	// matching and silently checks nothing, which is the one way this test
 	// could pass while the page rots.
+	_ = unlabelled
 	if checked < 110 {
 		t.Errorf("only %d EL/postfix pairs checked in %s — the extractor has drifted from the page's example format",
 			checked, elRefFile)


### PR DESCRIPTION
Closes #985. Closes #1021.

Two documentation surfaces advertised syntax the grammar rejects. A reader following either got a parse error with no way to tell the docs were wrong rather than their rule.

## `dtrules docs` (#985)

**Eight of fourteen** documented mutating shortcuts do not parse:

| documented | reality |
|---|---|
| `add to myLong 5` | operand and target reversed — `add 5 to myLong` |
| `subtract from myLong 3` | `subtract 3 from myLong` |
| `multiply myLong by 2` | **does not exist in any spelling** — use `set myLong = myLong * 2` |
| `divide myLong by 4` | same |

…and the four `myDouble` twins. The issue named one form; probing the whole block found the rest, across **three sites in two pages**, only one of which had been reported.

## `docs/el-reference.md` (#1021)

Nine entries compile to an `elstmterror` runtime stub while presenting themselves as usable — `map … through` even documents a `mapthrough` postfix it never emits. They are now labelled:

```
**Status**: NOT IMPLEMENTED — the grammar accepts this, but the compiler
emits a runtime-error stub. Do not use it in a rule.
```

Kept rather than deleted: the grammar really does have them, and a reader who tries one deserves to find out why it fails *here* rather than by running it.

## The gates, which are the point

The el-reference test already failed on examples that do not compile — but passed one that compiles to an *error stub*, which is how `map … through` survived. It now requires such an entry to carry the label. **Verified by removing a label:** it fails with `documented syntax compiles to a runtime-error stub but is not labelled`.

`TestDocsMutatingShortcutsCompile` compiles every shortcut the docs show. `TestDocsDoNotShowRejectedForms` names the eight dead spellings so they cannot return — and it earned itself immediately by catching a third site I had missed after fixing the two the issue pointed at.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
