### PR TITLE
fix(excel): refuse to compile decision tables with no EDD symbols (#1029)

### DIFF
--- a/pkg/dtrules/excel/dt_importer.go
+++ b/pkg/dtrules/excel/dt_importer.go
@@ -1410,6 +1410,32 @@ func (i *DTImporter) compileTableEL(table *DecisionTableXML) error {
 		return nil
 	}
 
+	// Compiling with no symbol table is not a degraded mode, it is a wrong
+	// one: with no types, every field reference compiles as an integer. A
+	// `fixed` subtraction becomes `-` instead of `fp-` and the assignment
+	// stores `cvi` instead of `cvfp`, so a money calculation silently changes
+	// its arithmetic — and the build reports "no drops" and exits 0.
+	//
+	// This is reachable whenever the workbook set carries no EDD sheet and the
+	// output directory has no EDD either, which is exactly what
+	// `build --from-excel` into a fresh directory does: symbols come from the
+	// *output* dir (newWorkbookImporter → LoadEDDSymbols(xmlDir)). The
+	// Accumulate staking rules hit it — 35 tables, entities=0, every
+	// fixed-point operator downgraded (#1029).
+	//
+	// A table with no DSL has nothing to type, so it is unaffected.
+	if n := countDSLRows(table); len(i.symbols) == 0 && n > 0 {
+		if i.stats != nil {
+			i.stats.AddDrop(table.TableName, 0, "postfix",
+				fmt.Sprintf("no EDD symbols available: %d DSL row(s) would compile untyped, "+
+					"emitting integer operators for typed fields (fp- becomes -, cvfp becomes cvi). "+
+					"Import the EDD alongside the decision tables, or build into a directory that "+
+					"already holds the project's *_edd.xml", n))
+		}
+		return fmt.Errorf("%s: refusing to compile with no EDD symbols — "+
+			"every field would be typed as integer", table.TableName)
+	}
+
 	// Set symbols if available
 	if i.symbols != nil {
 		i.elCompiler.SetSymbols(i.symbols)

--- a/pkg/dtrules/excel/no_edd_symbols_test.go
+++ b/pkg/dtrules/excel/no_edd_symbols_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import (
+	"strings"
+	"testing"
+)
+
+// stubCompiler stands in for the EL compiler. The guard under test runs before
+// any compilation, so the returned postfix does not matter — what matters is
+// whether we get here at all.
+type stubCompiler struct{ symbols map[string]string }
+
+func (c *stubCompiler) SetSymbols(s map[string]string)          { c.symbols = s }
+func (c *stubCompiler) CompileCondition(string) (string, error) { return "x", nil }
+func (c *stubCompiler) CompileAction(string) (string, error)    { return "x", nil }
+func (c *stubCompiler) CompileContext(string) (string, error)   { return "x", nil }
+
+// TestNoEDDSymbolsIsRefused pins #1029.
+//
+// With no symbol table every field reference compiles as an integer: a `fixed`
+// subtraction emits `-` instead of `fp-` and the assignment stores `cvi`
+// instead of `cvfp`. A money calculation silently changes its arithmetic while
+// the build reports "no drops" and exits 0.
+//
+// The Accumulate staking rules hit this: their EDD workbook was deleted in
+// May 2026 as a supposed duplicate of the decision-table workbook — it was
+// not, it was the only Excel copy of the EDD — so an Excel-authored rebuild
+// imported 35 tables with entities=0 and downgraded every fixed-point
+// operator. It stayed invisible because the only path that regenerates
+// postfix was itself a no-op (#1010).
+//
+// Compiling untyped is not a degraded mode, it is a wrong one, so this is an
+// error rather than a warning.
+func TestNoEDDSymbolsIsRefused(t *testing.T) {
+	imp := NewDTImporter()
+	imp.SetELCompiler(&stubCompiler{})
+	stats := &ImportStats{}
+	imp.SetStats(stats)
+
+	err := imp.compileTableEL(tableWithDSL())
+	if err == nil {
+		t.Fatal("compiled a table with DSL and no EDD symbols — every field would be typed as integer")
+	}
+	if !strings.Contains(err.Error(), "no EDD symbols") {
+		t.Errorf("error should name the cause, got: %v", err)
+	}
+	if len(stats.Drops) != 1 {
+		t.Fatalf("want 1 drop, got %d: %+v", len(stats.Drops), stats.Drops)
+	}
+	// The drop has to be actionable: it must say what goes wrong, not just
+	// that something did.
+	reason := stats.Drops[0].Reason
+	for _, want := range []string{"4 DSL row(s)", "cvfp becomes cvi", "*_edd.xml"} {
+		if !strings.Contains(reason, want) {
+			t.Errorf("drop reason missing %q; got: %s", want, reason)
+		}
+	}
+}
+
+// TestSymbolsPresentCompilesNormally is the control: the guard must not fire
+// on the ordinary path, which is every project that has an EDD.
+func TestSymbolsPresentCompilesNormally(t *testing.T) {
+	imp := NewDTImporter()
+	imp.SetELCompiler(&stubCompiler{})
+	imp.SetSymbols(map[string]string{"client.age": "integer"})
+	stats := &ImportStats{}
+	imp.SetStats(stats)
+
+	if err := imp.compileTableEL(tableWithDSL()); err != nil {
+		t.Fatalf("refused a table that has symbols: %v", err)
+	}
+	if len(stats.Drops) != 0 {
+		t.Errorf("unexpected drops on the normal path: %+v", stats.Drops)
+	}
+}
+
+// TestNoSymbolsNoDSLIsFine keeps the guard narrow: a table with nothing to
+// compile has nothing to mistype.
+func TestNoSymbolsNoDSLIsFine(t *testing.T) {
+	imp := NewDTImporter()
+	imp.SetELCompiler(&stubCompiler{})
+	stats := &ImportStats{}
+	imp.SetStats(stats)
+
+	if err := imp.compileTableEL(&DecisionTableXML{TableName: "Empty"}); err != nil {
+		t.Errorf("refused a table with no DSL: %v", err)
+	}
+	if len(stats.Drops) != 0 {
+		t.Errorf("unexpected drops for a table with no DSL: %+v", stats.Drops)
+	}
+}


### PR DESCRIPTION
Closes #1029.

## It is not the type inference — there were no types

The issue offered two possibilities. It is the first, but not for the reason it suggests: the compiler is not choosing integer ops for fixed-point fields. It had **no symbol table at all**.

Symbols come from `LoadEDDSymbols(xmlDir)` — the *output* directory (`newWorkbookImporter`). The reproduction builds into an **empty** `xml/`, so there are no symbols, and every field reference compiles as an integer. Reproduced with your workbook:

```
tables=35  actions=101  conditions=56  entities=0
committed:  supply_limit acme_issued fp-  cvfp /unissued_supply xdef
rebuilt:    supply_limit acme_issued -    cvi  /unissued_supply xdef
drops: none      exit 0
```

`entities=0` is the tell.

**Your committed postfix is not hand-crafted.** Possibility 2 is ruled out — it is exactly what the compiler emits when the EDD is present.

## Why the EDD was not found

It is not in Excel. `pkg/dtrules/source/staking_edd.xlsx` was deleted in `3d8feb92` (2026-05-10, *"drop non-deployed Excel/XML artifacts"*) as one of the *"top-level workbooks duplicating staking.xlsx"*.

It was not a duplicate. I checked both sides:

- the deleted workbook had exactly one sheet: **`EDD`**
- `staking.xlsx` has 35 sheets, none an EDD — no EDD-ish sheet name, and no `EDD:` header cell anywhere in its shared strings

So the EDD has had no Excel system of record since May. Nothing surfaced it because the only path that regenerates postfix was itself a no-op (#1010) — as you noted, the reason this stayed invisible.

In fairness, that deletion cites a real DTRules defect as its motivation: *"eliminates the dual-source-of-truth in .sync-manifest.json where both staking.xlsx and staking_edd.xlsx mapped to staking_edd.xml, last-writer-wins."* Two workbooks colliding on one XML output is ours, and it is what pushed the EDD out of Excel. Filing separately.

## The fix here

Compiling with no symbol table is not a degraded mode, it is a wrong one, so it is an error rather than a warning: a drop naming the table and affected row count, and a refusal to write.

```
drops: 35
  table="Staking_Distribution"  item="postfix"
  reason=no EDD symbols available: 20 DSL row(s) would compile untyped,
  emitting integer operators for typed fields (fp- becomes -, cvfp becomes cvi).
  Import the EDD alongside the decision tables, or build into a directory that
  already holds the project's *_edd.xml
exit 1
```

A table with no DSL has nothing to mistype and is unaffected — the control test caught my first version firing on those, which would have broken any project holding tables without DSL.

Every sample still builds with `drops: none`; `make check` green.

## What this does not do

It makes the failure loud; it does not restore your EDD to Excel. That is recoverable from `3d8feb92^`, or by exporting `staking_edd.xml` back out. Until then, build into a directory that already holds `staking_edd.xml` — which is what your normal build does, and why this never bit in day-to-day use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
