### PR TITLE
fix(review,mcp): honour the project's declared xml_dir/excel_dir (#1031)

### DIFF
--- a/cmd/dtrules/mcp_tools.go
+++ b/cmd/dtrules/mcp_tools.go
@@ -240,7 +240,7 @@ func (s *mcpServer) toolEDDGet(project string) (map[string]interface{}, error) {
 }
 
 func (s *mcpServer) toolProjectValidate(project string) (map[string]interface{}, error) {
-	structRes, err := sync.ValidateProjectStructure(project, "", "")
+	structRes, err := validateStructure(project)
 	if err != nil {
 		return nil, newToolError("io_error", "structure validation failed", err.Error())
 	}

--- a/cmd/dtrules/project_config.go
+++ b/cmd/dtrules/project_config.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/sync"
 )
 
 // projectConfig holds optional project settings declared in DTRules.xml.
@@ -99,4 +101,26 @@ func checkDirWithHint(dir, flagName string) error {
 		"could not find directory\n  Tried: %s\n  Use %s <path> or declare the element in DTRules.xml.",
 		dir, flagName,
 	)
+}
+
+// validateStructure runs the project-structure check against the directories
+// the project actually declares.
+//
+// `sync.ValidateProjectStructure` falls back to the literal "excel" and "xml"
+// names when given no override, which is right for the function but wrong for
+// every caller that has a manifest available and does not pass it. `review`
+// and the MCP project tools both passed empty strings, so a project declaring
+// <excel_dir>source</excel_dir> was told `excel/ directory not found` — naming
+// a path it does not use — while `verify` on the same project resolved it
+// correctly. One layout, two answers (#1031).
+//
+// Callers with their own --xml-dir/--excel-dir flags should keep calling
+// resolveDirs themselves and pass the result; this is for the callers that
+// have no flags to honour.
+func validateStructure(projectRoot string) (*sync.StructureValidationResult, error) {
+	xmlDir, excelDir, err := resolveDirs(projectRoot, "", "")
+	if err != nil {
+		return nil, err
+	}
+	return sync.ValidateProjectStructure(projectRoot, xmlDir, excelDir)
 }

--- a/cmd/dtrules/review.go
+++ b/cmd/dtrules/review.go
@@ -103,7 +103,7 @@ func runFullReview(projectPath string) (*reviewReport, error) {
 	}
 
 	// 1. Structure validation.
-	structRes, err := sync.ValidateProjectStructure(projectPath, "", "")
+	structRes, err := validateStructure(projectPath)
 	if err != nil {
 		rep.Errors = append(rep.Errors, reviewError{
 			Category: reviewCategoryStructure,

--- a/cmd/dtrules/structure_layout_test.go
+++ b/cmd/dtrules/structure_layout_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// customLayoutProject writes a project whose DTRules.xml declares directories
+// that are not the `xml/` + `excel/` defaults.
+func customLayoutProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, sub := range []string{"xml", "source"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manifest := `<DTRules>
+  <xml_dir>xml</xml_dir>
+  <excel_dir>source</excel_dir>
+</DTRules>`
+	if err := os.WriteFile(filepath.Join(dir, "DTRules.xml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// TestStructureHonoursDeclaredDirs pins #1031.
+//
+// `sync.ValidateProjectStructure` falls back to the literal "excel" and "xml"
+// names when given no override. `review` and the MCP project tools both passed
+// empty strings, so a project declaring <excel_dir>source</excel_dir> was told
+// `excel/ directory not found` — naming a path it does not use — while
+// `verify` on the same project resolved it correctly. One layout, two answers.
+//
+// The assertion is on the resolved directories rather than on an error string,
+// because the failure mode is resolution: getting the paths right is the thing
+// that makes every downstream check look in the right place.
+func TestStructureHonoursDeclaredDirs(t *testing.T) {
+	dir := customLayoutProject(t)
+
+	res, err := validateStructure(dir)
+	if err != nil {
+		t.Fatalf("validateStructure: %v", err)
+	}
+
+	wantExcel := filepath.Join(dir, "source")
+	wantXML := filepath.Join(dir, "xml")
+	if res.Structure.ExcelDir != wantExcel {
+		t.Errorf("ExcelDir = %s, want %s (the declared <excel_dir>)", res.Structure.ExcelDir, wantExcel)
+	}
+	if res.Structure.XMLDir != wantXML {
+		t.Errorf("XMLDir = %s, want %s", res.Structure.XMLDir, wantXML)
+	}
+	for _, e := range res.Errors {
+		if e != nil && filepath.Base(e.Path) == "excel" {
+			t.Errorf("reported a missing `excel/` the project never declared: %s", e.Message)
+		}
+	}
+}
+
+// TestStructureAndVerifyAgreeOnLayout is the property the issue is really
+// about: every command must answer the same question the same way. Before the
+// fix `verify` resolved `source/` and `review` did not.
+func TestStructureAndVerifyAgreeOnLayout(t *testing.T) {
+	dir := customLayoutProject(t)
+
+	verifyXML, verifyExcel, err := resolveDirs(dir, "", "")
+	if err != nil {
+		t.Fatalf("resolveDirs: %v", err)
+	}
+	res, err := validateStructure(dir)
+	if err != nil {
+		t.Fatalf("validateStructure: %v", err)
+	}
+
+	if res.Structure.XMLDir != verifyXML {
+		t.Errorf("structure check and verify disagree on the XML dir:\n  structure: %s\n  verify:    %s",
+			res.Structure.XMLDir, verifyXML)
+	}
+	if res.Structure.ExcelDir != verifyExcel {
+		t.Errorf("structure check and verify disagree on the Excel dir:\n  structure: %s\n  verify:    %s",
+			res.Structure.ExcelDir, verifyExcel)
+	}
+}
+
+// TestStructureStillDefaultsWithoutManifest keeps the fix narrow: a project
+// with no DTRules.xml must still get the conventional layout.
+func TestStructureStillDefaultsWithoutManifest(t *testing.T) {
+	dir := t.TempDir()
+	for _, sub := range []string{"xml", "excel"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	res, err := validateStructure(dir)
+	if err != nil {
+		t.Fatalf("validateStructure: %v", err)
+	}
+	if res.Structure.ExcelDir != filepath.Join(dir, "excel") {
+		t.Errorf("ExcelDir = %s, want the default excel/", res.Structure.ExcelDir)
+	}
+}


### PR DESCRIPTION
Closes #1031.

## The fix

`review` and the MCP project tools now resolve `<xml_dir>` / `<excel_dir>` from `DTRules.xml`, the way `verify` already did. Both go through a shared `validateStructure` helper; callers that have their own `--xml-dir` / `--excel-dir` flags keep resolving themselves and passing the result, which is where the pattern was already correct.

Reproduced your exact case first — a project laid out `xml/` + `source/` with the manifest declaring it:

```
v1.22.4   "message": "/tmp/srcdir/excel: excel/ directory not found"
fixed     "valid": true
```

## On the tests

They assert on the **resolved directories** rather than on an error string, because resolution is the actual failure — getting the paths right is what makes every downstream check look in the right place. One of them pins the property the issue is really about, that the structure check and `verify` must agree; before this they did not. A third keeps the fix narrow: a project with no `DTRules.xml` still gets the conventional layout.

Verified they catch the regression by reverting the helper:

```
ExcelDir = .../excel, want .../source (the declared <excel_dir>)
reported a missing `excel/` the project never declared
structure check and verify disagree on the Excel dir
```

## The part worth keeping in mind

Your note that this pattern used to make `verify` silently **pass** is the important half, and I can confirm it from the other side: that is exactly what #1010 turned out to be. `checkBuildIdempotency` joined the literal `"excel"` onto its temp copy, the directory did not exist, the rebuild was skipped, and the comparison then ran the XML against an unmodified copy of itself — always equal, on **every** project, not only custom layouts. This change removes the last caller of that pattern.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
