### PR TITLE
fix(excel): point the no-EDD error at the fix that works (#1029)

### DIFF
--- a/pkg/dtrules/excel/dt_importer.go
+++ b/pkg/dtrules/excel/dt_importer.go
@@ -1427,10 +1427,9 @@ func (i *DTImporter) compileTableEL(table *DecisionTableXML) error {
 	if n := countDSLRows(table); len(i.symbols) == 0 && n > 0 {
 		if i.stats != nil {
 			i.stats.AddDrop(table.TableName, 0, "postfix",
-				fmt.Sprintf("no EDD symbols available: %d DSL row(s) would compile untyped, "+
-					"emitting integer operators for typed fields (fp- becomes -, cvfp becomes cvi). "+
-					"Import the EDD alongside the decision tables, or build into a directory that "+
-					"already holds the project's *_edd.xml", n))
+				fmt.Sprintf("no EDD in the Excel source: %d DSL row(s) would compile untyped, "+
+					"turning fp- into - and cvfp into cvi. Export your EDD into the workbook "+
+					"(dtrules sync export --force), then rebuild", n))
 		}
 		return fmt.Errorf("%s: refusing to compile with no EDD symbols — "+
 			"every field would be typed as integer", table.TableName)

--- a/pkg/dtrules/excel/no_edd_symbols_test.go
+++ b/pkg/dtrules/excel/no_edd_symbols_test.go
@@ -64,7 +64,7 @@ func TestNoEDDSymbolsIsRefused(t *testing.T) {
 	// The drop has to be actionable: it must say what goes wrong, not just
 	// that something did.
 	reason := stats.Drops[0].Reason
-	for _, want := range []string{"4 DSL row(s)", "cvfp becomes cvi", "*_edd.xml"} {
+	for _, want := range []string{"4 DSL row(s)", "cvfp into cvi", "sync export"} {
 		if !strings.Contains(reason, want) {
 			t.Errorf("drop reason missing %q; got: %s", want, reason)
 		}


### PR DESCRIPTION
Follow-up to #1033.

The error offered two remedies and led with the weaker one — *"import the EDD alongside the decision tables, or build into a directory that already holds the project's `*_edd.xml`"*. The second is a workaround for a gap rather than a way to close it, and it is what I wrongly recommended to the reporter before finding that the export path bootstraps the EDD into the workbook.

Now one action:

```
no EDD in the Excel source: 20 DSL row(s) would compile untyped, turning
fp- into - and cvfp into cvi. Export your EDD into the workbook
(dtrules sync export --force), then rebuild
```

Verified that path end to end on the reporting project: the export adds an `EDD` sheet (35 → 36), the rebuild reports `entities=18` instead of 0 with no drops, `fp-` and `cvfp` survive, and `verify` exits 0.

## On whether the guard is needed at all

It is, and I checked rather than assumed. It fires only when there is **no EDD anywhere** — not in the workbook, not in the output directory. In that state there is nothing to infer types from, so the alternative is not "make it work", it is the silent wrong arithmetic this replaced.

The case worth worrying about was a false positive on a project whose EDD lives in a *separate* workbook from its decision tables. Tested: builds into an empty directory with `entities=1` and `fp-` intact, no drop. And every sample still builds with `drops: none`.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
