### PR TITLE
fix(testdata): regenerate the custom_layout fixture from its workbook (#1013)

### DIFF
--- a/cmd/dtrules/path_flags_test.go
+++ b/cmd/dtrules/path_flags_test.go
@@ -41,27 +41,27 @@ func TestVerifyCustomLayoutViaFlags(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var code int
 	stderr := captureStderr(t, func() {
 		cli := NewCLI()
-		cli.runVerify([]string{
+		code = cli.runVerify([]string{
 			"--xml-dir", "rules",
 			"--excel-dir", "workbooks",
 			absFixture,
 		})
 	})
 
-	// What this test is for is path resolution: --xml-dir and --excel-dir
-	// must be honoured. It is not a statement about the fixture being
-	// contract-clean.
+	// Path resolution is the subject, but the fixture is now contract-clean
+	// (its XML is what building from its workbook produces), so this asserts
+	// the stronger thing: verify passes end to end.
 	//
-	// It used to assert exit 0, on the stated premise that "workbooks/ is
-	// absent ... all checks are skipped due to missing excel dir". The
-	// workbook was added later, so that premise stopped holding — and the
-	// assertion kept passing anyway, because the build-idempotency gate was
-	// itself inert (#1010). With the gate working, the fixture does not
-	// round-trip: importing its workbook yields no tables at all, which is a
-	// real defect in its own right and tracked separately.
+	// It briefly asserted only resolution, on my mistaken reading that the
+	// fixture could not round-trip. It can — regenerating its XML from the
+	// workbook was all it needed (#1013).
 	assertDirsResolved(t, stderr)
+	if code != 0 {
+		t.Errorf("expected exit 0 on a clean custom-layout project, got %d\n%s", code, stderr)
+	}
 }
 
 // TestVerifyCustomLayoutViaDTRulesXML verifies that DTRules.xml declaring
@@ -78,13 +78,16 @@ func TestVerifyCustomLayoutViaDTRulesXML(t *testing.T) {
 	}
 
 	// No --xml-dir / --excel-dir flags; resolution should come from
-	// DTRules.xml. As above, the subject is resolution, not the fixture's
-	// consistency (#1010).
+	// DTRules.xml.
+	var code int
 	stderr := captureStderr(t, func() {
 		cli := NewCLI()
-		cli.runVerify([]string{absFixture})
+		code = cli.runVerify([]string{absFixture})
 	})
 	assertDirsResolved(t, stderr)
+	if code != 0 {
+		t.Errorf("expected exit 0 when DTRules.xml declares the dirs, got %d\n%s", code, stderr)
+	}
 }
 
 // assertDirsResolved fails if verify could not locate the project's xml or

--- a/cmd/dtrules/testdata/custom_layout/rules/Simple_dt.xml
+++ b/cmd/dtrules/testdata/custom_layout/rules/Simple_dt.xml
@@ -1,14 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <decision_tables>
-<decision_table>
+
+<!-- TABLE 100: SimpleRule -->
+<decision_table el_compiled="true">
+<source>
+<relative_path>Simple.xlsx</relative_path>
+<file_name>Simple.xlsx</file_name>
+<sheet_number>1</sheet_number>
+</source>
 <table_name>SimpleRule</table_name>
+<xls_file>Simple.xlsx</xls_file>
 <attribute_fields>
 <Type>FIRST</Type>
 <COMMENTS>A simple test rule</COMMENTS>
+<TABLE_NUMBER>100</TABLE_NUMBER>
 </attribute_fields>
 <contexts></contexts>
 <initial_actions></initial_actions>
 <conditions></conditions>
 <actions></actions>
+<policy_statements></policy_statements>
 </decision_table>
 </decision_tables>

--- a/cmd/dtrules/testdata/custom_layout/rules/Simple_edd.xml
+++ b/cmd/dtrules/testdata/custom_layout/rules/Simple_edd.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<entity_data_dictionary version='2' xmlns:xs='http://www.w3.org/2001/XMLSchema'>
-  <entity name="test" access="rw" comment="Test entity">
-    <field name="value" type="integer" subtype="" access="rw" input="" default_value="" comment="A test value" />
-  </entity>
+<entity_data_dictionary version="2">
+	<file_metadata>
+		<file_path>Simple_edd</file_path>
+	</file_metadata>
+	<entity name="test" number="100" xls_file="Simple.xlsx" access="rw">
+		<source>
+			<relative_path>Simple.xlsx</relative_path>
+			<file_name>Simple.xlsx</file_name>
+			<sheet_number>2</sheet_number>
+		</source>
+		<field name="value" type="integer" subtype="" access="rw" input="" default_value="" comment="A test value"></field>
+	</entity>
 </entity_data_dictionary>


### PR DESCRIPTION
Closes #1013 — by correcting it.

I filed that issue claiming the fixture's workbook **"imports zero tables"**. That was wrong. Rebuilding imports it fine:

```
tables=1  actions=0  conditions=0  entities=1  drops: none
```

The `tables=0` I reported was a **staleness artifact** — the import had been skipped because the XML was newer, and I read the skip as a failure to parse. The real issue was narrower and duller: the committed XML was simply not what building from the workbook produces, so the idempotency check reported a difference.

Regenerated from the workbook, so the fixture is genuinely contract-clean and `verify` exits 0 on it. Nothing was lost — the committed table already had no conditions or actions; the diff is the `el_compiled` marker, `<source>` provenance, and EDD attribute normalisation.

## The part that matters

This lets the two path-flag tests go back to asserting `exit 0`. I **weakened them** in #1010 to assert only that the directories resolve, on the mistaken premise that the fixture could not round-trip. They now assert both — resolution, and that a clean custom-layout project passes — which is the stronger check and the one that was there originally.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
