### PR TITLE
fix(excel): write the authored table name, not the interned one (#1040)

### DIFF
--- a/pkg/dtrules/decisiontable/authored_name_test.go
+++ b/pkg/dtrules/decisiontable/authored_name_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package decisiontable
+
+import (
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+)
+
+// TestAuthoredNameSurvivesInterning pins #1040.
+//
+// RNames are interned case-insensitively and the cache keeps the first
+// spelling it sees, process-wide and across namespaces. So an EDD field named
+// `matches_onchain`, loaded before the decision tables, made GetName() report
+// a table authored as `Matches_Onchain` under the field's casing — and the
+// exporter, which named the sheet from GetName(), silently renamed the table.
+// The next import read the new name back, so the name could never round-trip.
+//
+// Resolution stays case-insensitive. Only what gets written back out changes.
+func TestAuthoredNameSurvivesInterning(t *testing.T) {
+	// Intern the lower-case spelling first, the way an EDD field would.
+	if rn := dtrules.GetRName("matches_onchain"); rn == nil {
+		t.Fatal("could not intern the lower-case name")
+	}
+
+	b := NewBuilder("Matches_Onchain", nil)
+	if b == nil {
+		t.Fatal("NewBuilder returned nil")
+	}
+	dt, err := b.Build(nil)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if got := dt.AuthoredName(); got != "Matches_Onchain" {
+		t.Errorf("AuthoredName() = %q, want the spelling the author wrote", got)
+	}
+	// GetName is allowed to report the interned spelling — that is what makes
+	// lookup case-insensitive, and it is not the bug.
+	t.Logf("GetName() reports %q (interned); AuthoredName() reports %q", dt.GetName(), dt.AuthoredName())
+}
+
+// TestAuthoredNameFallsBack keeps the accessor safe for tables built by paths
+// that never record a source spelling.
+func TestAuthoredNameFallsBack(t *testing.T) {
+	rn := dtrules.GetRName("Some_Table")
+	if rn == nil {
+		t.Fatal("intern failed")
+	}
+	dt := NewRDecisionTable(rn, nil)
+	if got := dt.AuthoredName(); got != dt.GetName() {
+		t.Errorf("AuthoredName() = %q, want it to fall back to GetName() = %q", got, dt.GetName())
+	}
+}

--- a/pkg/dtrules/decisiontable/builder.go
+++ b/pkg/dtrules/decisiontable/builder.go
@@ -33,9 +33,9 @@ func NewBuilder(name string, session dtrules.Session) *Builder {
 	if rname == nil {
 		return nil
 	}
-	return &Builder{
-		dt: NewRDecisionTable(rname, session),
-	}
+	dt := NewRDecisionTable(rname, session)
+	dt.SetAuthoredName(name)
+	return &Builder{dt: dt}
 }
 
 // SetType sets the table type (BALANCED, FIRST, or ALL).

--- a/pkg/dtrules/decisiontable/table.go
+++ b/pkg/dtrules/decisiontable/table.go
@@ -59,6 +59,13 @@ type RDecisionTable struct {
 	dtrules.BaseObject
 
 	name      *dtrules.RName // The decision table's name
+	// authoredName is the name exactly as written in the source, before
+	// interning. RNames are case-insensitive and the intern cache keeps the
+	// first spelling it sees across the whole process — so an EDD field named
+	// matches_onchain, loaded before the tables, makes GetName() report a
+	// table authored as Matches_Onchain under the field's casing. Resolution
+	// should ignore case; writing the name back out should not (#1040).
+	authoredName string
 	filename  string         // Filename where the table is defined
 	filePath  string         // FILE_PATH: canonical path for Excel generation
 	tableType TableType      // Type of decision table
@@ -160,6 +167,22 @@ func (dt *RDecisionTable) Type() *dtrules.RType {
 // GetName returns the decision table's name as a string
 func (dt *RDecisionTable) GetName() string {
 	return dt.name.StringValue()
+}
+
+// AuthoredName returns the table name as written in the source, falling back
+// to the interned name when the source spelling was not recorded. Use it when
+// writing the name back out — to Excel, to XML, to a report — so a round trip
+// preserves what the author wrote. Use GetName for lookup and comparison.
+func (dt *RDecisionTable) AuthoredName() string {
+	if dt.authoredName != "" {
+		return dt.authoredName
+	}
+	return dt.GetName()
+}
+
+// SetAuthoredName records the source spelling of the table name.
+func (dt *RDecisionTable) SetAuthoredName(name string) {
+	dt.authoredName = name
 }
 
 // GetRName returns the decision table's name

--- a/pkg/dtrules/excel/exporter.go
+++ b/pkg/dtrules/excel/exporter.go
@@ -728,7 +728,10 @@ func (e *Exporter) writeEDDEntities(f *excelize.File, sheet string, entities []*
 }
 
 func (e *Exporter) writeDecisionTable(f *excelize.File, dt *decisiontable.RDecisionTable, styler *Styler) error {
-	name := dt.GetName()
+	// AuthoredName, not GetName: the interned name carries whatever casing was
+	// seen first anywhere in the project, so writing it back renames the
+	// author's table (#1040).
+	name := dt.AuthoredName()
 	sheetName := sanitizeSheetName(name)
 
 	for i := 1; ; i++ {
@@ -774,7 +777,7 @@ func (e *Exporter) writeDecisionTable(f *excelize.File, dt *decisiontable.RDecis
 }
 
 func (e *Exporter) writeName(f *excelize.File, sheet string, dt *decisiontable.RDecisionTable, row, numCols int, styler *Styler) int {
-	displayName := strings.ReplaceAll(dt.GetName(), "_", " ")
+	displayName := strings.ReplaceAll(dt.AuthoredName(), "_", " ")
 	startCell := cellName(1, row)
 	endCell := cellName(3+numCols, row)
 	f.MergeCell(sheet, startCell, endCell)

--- a/pkg/dtrules/loader/dt.go
+++ b/pkg/dtrules/loader/dt.go
@@ -403,8 +403,14 @@ func (l *DTLoader) processTable(table *DTTable) error {
 		return fmt.Errorf("invalid decision table name syntax: %s", tableName)
 	}
 
-	// Create the decision table using the builder
-	builder := decisiontable.NewBuilder(name.StringValue(), l.session)
+	// Create the decision table using the builder.
+	//
+	// tableName, not name.StringValue(): the RName is interned
+	// case-insensitively and keeps whatever spelling was seen first anywhere
+	// in the project, so passing it through would hand the builder some other
+	// declaration's casing. The exporter writes the sheet from this, and an
+	// EDD field sharing the name was silently renaming the table (#1040).
+	builder := decisiontable.NewBuilder(tableName, l.session)
 
 	// Set table type
 	builder.SetTypeFromString(table.AttributeFields.GetType())


### PR DESCRIPTION
Closes #1040.

## An EDD field could silently rename a decision table

The staking rules declare a table `Matches_Onchain` and, separately, a field `period_state.matches_onchain`. RNames are interned case-insensitively and the cache keeps the **first spelling it sees**, process-wide and across namespaces. The EDD loads before the tables, so the field's casing won, `GetName()` reported the table under it, and the exporter named the sheet from that. The next import read the new name back.

```
XML in:   <table_name>Matches_Onchain</table_name>
sheet:    "matches onchain"   A1: "DT: matches onchain"
XML out:  <table_name>matches_onchain</table_name>
```

So the name could never round-trip, `verify` could never go green, and the only workaround was to spell the table the way some unrelated declaration happened to spell it — which is what that project had adopted.

## The fix

Resolution stays case-insensitive; that is deliberate and correct. Only the name written back out changes.

`RDecisionTable` now carries the source spelling, and **the loader passes the XML's `table_name` rather than `name.StringValue()`** — which had already been through the intern cache. That was the actual leak: recording the name in the builder alone did nothing, because the builder was already being handed the interned string.

The exporter uses `AuthoredName()` for the sheet name and the `DT:` header, falling back to `GetName()` for tables built by paths that record no spelling.

## Verified against the reporting project

With its original spelling restored:

```
export        sheet "Matches Onchain"
round trip    <table_name>Matches_Onchain</table_name>
their suite   0 failures
build→build   byte-identical
verify        exit 0
```

The test log makes the distinction visible:

```
GetName() reports "matches_onchain" (interned); AuthoredName() reports "Matches_Onchain"
```

`make check` green.

## Follow-up worth checking

EDD entity and field names are exported through the same accessor and may lose their case the same way. I have not tested that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
