### PR TITLE
fix(excel): keep the authored case of EDD field names too (#1040)

### DIFF
--- a/pkg/dtrules/entity/entry.go
+++ b/pkg/dtrules/entity/entry.go
@@ -27,6 +27,13 @@ import (
 type EntityEntry struct {
 	Entity       *REntity       // The owning entity
 	Attribute    *dtrules.RName // The name of this attribute
+	// AuthoredName is the field name exactly as written in the EDD, before
+	// interning. RNames are case-insensitive and the intern cache keeps the
+	// first spelling seen across the whole process, so a field `Status` on one
+	// entity is reported as `status` when another entity declared `status`
+	// first — and the exporter wrote that back, renaming the author's field
+	// (#1040). Empty for entries created by paths that record no spelling.
+	AuthoredName string
 	DefaultTxt   string         // Text representation of default value
 	DefaultValue dtrules.Object // Default value (may be nil)
 	Writable     bool           // Whether attribute is writable by decision tables

--- a/pkg/dtrules/excel/exporter.go
+++ b/pkg/dtrules/excel/exporter.go
@@ -669,7 +669,13 @@ func (e *Exporter) writeEDDEntities(f *excelize.File, sheet string, entities []*
 			f.SetCellValue(sheet, cellName(1, row), "")
 			f.SetCellStyle(sheet, cellName(1, row), cellName(1, row), rowStyle)
 
-			f.SetCellValue(sheet, cellName(2, row), attrName.StringValue())
+			// The authored spelling, not the interned one — see
+			// EntityEntry.AuthoredName (#1040).
+			fieldName := attrName.StringValue()
+			if entry.AuthoredName != "" {
+				fieldName = entry.AuthoredName
+			}
+			f.SetCellValue(sheet, cellName(2, row), fieldName)
 			f.SetCellStyle(sheet, cellName(2, row), cellName(2, row), s.attribute)
 
 			typeStyle := e.getTypeStyle(s, entry.Type.String())

--- a/pkg/dtrules/loader/edd.go
+++ b/pkg/dtrules/loader/edd.go
@@ -329,6 +329,12 @@ func (l *EDDLoader) processField(refEntity *entity.REntity, field *EDDField) err
 		return fmt.Errorf("failed to add field %s: %s", field.Name, errStr)
 	}
 
+	// Record the spelling the author used, so writing the EDD back out does
+	// not rename the field to whatever casing was interned first (#1040).
+	if entry := refEntity.GetEntry(attributeName); entry != nil {
+		entry.AuthoredName = strings.TrimSpace(field.Name)
+	}
+
 	// Carry collect/question metadata onto the entity entry (#850) so the
 	// runtime read-point and the Excel exporter can see it.
 	if strings.EqualFold(field.Collect, "true") {

--- a/pkg/dtrules/loader/edd_authored_name_test.go
+++ b/pkg/dtrules/loader/edd_authored_name_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loader
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/entity"
+)
+
+// TestEDDFieldKeepsAuthoredCase is the EDD half of #1040.
+//
+// Decision-table names were fixed first; EDD fields go out through the same
+// accessor and had the same defect. RNames intern case-insensitively and the
+// cache keeps the first spelling seen process-wide, so a field `Status`
+// declared on one entity reported as `status` once another entity had declared
+// `status` earlier — and the exporter wrote that back, renaming the author's
+// field on every build.
+//
+// The entities are ordered so the lower-case spelling interns first. Reverse
+// them and the bug hides, which is why this fixture is written the way it is.
+func TestEDDFieldKeepsAuthoredCase(t *testing.T) {
+	factory := entity.NewFactory(nil)
+	l := NewEDDLoader(tzTestSession{}, factory)
+
+	xml := `<?xml version="1.0" encoding="UTF-8"?>
+<entity_data_dictionary version="1.0">
+  <entity name="alpha" access="rw">
+    <field name="status" type="string" access="rw"/>
+  </entity>
+  <entity name="Bravo" access="rw">
+    <field name="Status" type="string" access="rw"/>
+  </entity>
+</entity_data_dictionary>`
+
+	if err := l.Load(strings.NewReader(xml)); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	ent := factory.FindRefEntity(dtrules.GetRName("Bravo"))
+	if ent == nil {
+		t.Fatal("Bravo entity not found")
+	}
+	attr := dtrules.GetRName("Status")
+	entry := ent.GetEntry(attr)
+	if entry == nil {
+		t.Fatal("Bravo.Status entry not found")
+	}
+
+	if entry.AuthoredName != "Status" {
+		t.Errorf("AuthoredName = %q, want %q — the author's case was replaced by the spelling "+
+			"interned first on another entity", entry.AuthoredName, "Status")
+	}
+	// The interned name is allowed to differ; that is what makes lookup
+	// case-insensitive and is not the bug.
+	t.Logf("interned = %q, authored = %q", entry.Attribute.StringValue(), entry.AuthoredName)
+}


### PR DESCRIPTION
The follow-up I flagged when table names were fixed — EDD fields go out through the same accessor and had the same defect.

Reproduced before fixing. Two entities, `alpha.status` then `Bravo.Status`, through a full export/import:

```
before   <field name="status">   <- Bravo's Status, lower-cased
after    <field name="Status">
```

Entity names were already unaffected.

`EntityEntry` now carries `AuthoredName`, the EDD loader records it from the XML, and the exporter writes that rather than the interned RName, falling back when no spelling was recorded. Resolution stays case-insensitive — only what is written back changes.

The test fixture orders the entities so the lower-case spelling interns first; reversed, the bug hides. Worth knowing before anyone simplifies it.

`make check` green, and the staking project still passes 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)