### PR TITLE
docs: state plainly that case is display only, not a conflict

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -102,6 +102,31 @@ Hard rules:
 
 See `dtrules docs workflow` for the build pipeline.
 
+## EL is case-insensitive (CRITICAL)
+
+`Status` and `status` are **one name**, not two that clash. There is no
+ambiguity to resolve and nothing to disambiguate — "collision" is a
+case-sensitive-language idea and does not apply here. If you catch yourself
+reasoning about the *risk* of two spellings meeting, the model is wrong: they
+were always the same thing.
+
+Case is for people — readability and project conventions (`Compute_Tax_Return`
+for a table, `taxpayer.gross_income` for a field). It means nothing to
+execution, and no rule ever behaves differently because of it.
+
+It must still be **preserved**, for two reasons, neither of them correctness:
+the author's chosen spelling is theirs to keep, and the XML must round-trip
+byte-identically because that is what `dtrules verify` compares.
+
+- Matching a name — regex, map key, comparison — must normalise
+  (`strings.EqualFold`, `/i`, lowercased keys).
+- Writing a name back out — Excel, XML, a report — must use the **authored**
+  spelling, never the interned one. `RDecisionTable.AuthoredName()` and
+  `EntityEntry.AuthoredName` exist for exactly this (#1040).
+- Do not describe differing case as a conflict in issues, commits or docs. It
+  teaches the wrong model to whoever reads next.
+
+
 ## State Tax Implementation
 
 ### CRITICAL: Use Separate Files Per State

--- a/cmd/dtrules/docs.go
+++ b/cmd/dtrules/docs.go
@@ -124,6 +124,20 @@ EL is the REQUIRED format for writing decision table conditions and actions.
 EL is case-insensitive. Articles (a, an, the) are ignored by the parser.
 Statements are separated by semicolons. Comments use // or /* ... */.
 
+What case-insensitive means here:
+    taxpayer.filing_status and Taxpayer.Filing_Status are the SAME name.
+    Not two names that clash — one name, written two ways. There is no
+    ambiguity to resolve and nothing to disambiguate.
+
+    Case is for you, not the engine. Use it to make a name readable, or to
+    follow your project's conventions: Compute_Tax_Return for a table,
+    taxpayer.gross_income for a field. The engine ignores it entirely when
+    resolving a name, and always will.
+
+    DTRules preserves the spelling you write when it writes your rules back
+    out to Excel or XML, so your conventions survive a build. It does not
+    treat a different spelling as a different thing.
+
 Always use EL in *_dsl tags
 (e.g., condition_dsl, action_dsl, context_dsl, initial_action_dsl).
 

--- a/pkg/dtrules/decisiontable/authored_name_test.go
+++ b/pkg/dtrules/decisiontable/authored_name_test.go
@@ -22,16 +22,22 @@ import (
 
 // TestAuthoredNameSurvivesInterning pins #1040.
 //
-// RNames are interned case-insensitively and the cache keeps the first
-// spelling it sees, process-wide and across namespaces. So an EDD field named
-// `matches_onchain`, loaded before the decision tables, made GetName() report
-// a table authored as `Matches_Onchain` under the field's casing — and the
-// exporter, which named the sheet from GetName(), silently renamed the table.
-// The next import read the new name back, so the name could never round-trip.
+// EL names are case-insensitive: `Matches_Onchain` and `matches_onchain` are
+// ONE name, and always resolved to the same table. Case is display only — it
+// exists so people can read a name, not so the engine can tell two apart.
+//
+// The intern cache keeps the first spelling seen process-wide, so an EDD field
+// written `matches_onchain` and loaded before the tables made GetName() report
+// the table under the field's spelling, and the exporter wrote that to the
+// sheet. Nothing executed differently. What broke is that the XML stopped
+// matching what building from Excel produced, and byte-equality is what
+// `dtrules verify` compares.
 //
 // Resolution stays case-insensitive. Only what gets written back out changes.
 func TestAuthoredNameSurvivesInterning(t *testing.T) {
-	// Intern the lower-case spelling first, the way an EDD field would.
+	// Intern the lower-case spelling first, the way an EDD field declared
+	// earlier in the project would. Same name either way — this only decides
+	// which styling the cache hands back.
 	if rn := dtrules.GetRName("matches_onchain"); rn == nil {
 		t.Fatal("could not intern the lower-case name")
 	}

--- a/pkg/dtrules/decisiontable/table.go
+++ b/pkg/dtrules/decisiontable/table.go
@@ -58,17 +58,25 @@ func (t TableType) String() string {
 type RDecisionTable struct {
 	dtrules.BaseObject
 
-	name      *dtrules.RName // The decision table's name
-	// authoredName is the name exactly as written in the source, before
-	// interning. RNames are case-insensitive and the intern cache keeps the
-	// first spelling it sees across the whole process — so an EDD field named
-	// matches_onchain, loaded before the tables, makes GetName() report a
-	// table authored as Matches_Onchain under the field's casing. Resolution
-	// should ignore case; writing the name back out should not (#1040).
+	name *dtrules.RName // The decision table's name
+	// authoredName is the name exactly as written in the source.
+	//
+	// EL names are case-insensitive, so Matches_Onchain and matches_onchain are
+	// ONE name. Case means nothing to execution — it is for people, to make a
+	// table readable and to follow a project's conventions. Resolution ignores
+	// it deliberately.
+	//
+	// It still has to survive a write. The intern cache keeps the first
+	// spelling seen process-wide, so an EDD field written matches_onchain and
+	// loaded before the tables made GetName() report a table authored as
+	// Matches_Onchain under the field's spelling — and the exporter wrote that
+	// to the sheet. Nothing ran differently; the XML simply stopped matching
+	// what building from Excel produced, which is what `dtrules verify`
+	// compares (#1040).
 	authoredName string
-	filename  string         // Filename where the table is defined
-	filePath  string         // FILE_PATH: canonical path for Excel generation
-	tableType TableType      // Type of decision table
+	filename     string    // Filename where the table is defined
+	filePath     string    // FILE_PATH: canonical path for Excel generation
+	tableType    TableType // Type of decision table
 
 	maxCol int // Number of columns in this decision table
 

--- a/pkg/dtrules/entity/entry.go
+++ b/pkg/dtrules/entity/entry.go
@@ -25,14 +25,24 @@ import (
 // EntityEntry holds attribute type and metadata for an entity attribute.
 // Each attribute has an index into the entity's values slice.
 type EntityEntry struct {
-	Entity       *REntity       // The owning entity
-	Attribute    *dtrules.RName // The name of this attribute
-	// AuthoredName is the field name exactly as written in the EDD, before
-	// interning. RNames are case-insensitive and the intern cache keeps the
-	// first spelling seen across the whole process, so a field `Status` on one
-	// entity is reported as `status` when another entity declared `status`
-	// first — and the exporter wrote that back, renaming the author's field
-	// (#1040). Empty for entries created by paths that record no spelling.
+	Entity    *REntity       // The owning entity
+	Attribute *dtrules.RName // The name of this attribute
+	// AuthoredName is the field name exactly as written in the EDD.
+	//
+	// EL names are case-insensitive, so `Status` and `status` are ONE name —
+	// not two that clash. Case carries no meaning to the engine at all; it is
+	// for people, to make a field readable and to follow a project's naming
+	// conventions. Resolution ignores it and always will.
+	//
+	// It still has to survive a write. The intern cache keeps the first
+	// spelling it sees process-wide, so without this the exporter wrote back
+	// whichever spelling happened to be interned first and silently restyled
+	// the author's field. Nothing computed differently — but the XML no longer
+	// matched what building from Excel produced, and byte-equality is what
+	// `dtrules verify` compares (#1040).
+	//
+	// Empty for entries created by paths that record no spelling; callers fall
+	// back to the interned name.
 	AuthoredName string
 	DefaultTxt   string         // Text representation of default value
 	DefaultValue dtrules.Object // Default value (may be nil)

--- a/pkg/dtrules/loader/dt.go
+++ b/pkg/dtrules/loader/dt.go
@@ -108,7 +108,7 @@ type DTSource struct {
 type DTTable struct {
 	// NameAttr captures the 'name' attribute on <decision_table name="...">
 	// Used by the EL XML format (e.g., CorporateTax, staking)
-	NameAttr         string             `xml:"name,attr" json:"-"`
+	NameAttr string `xml:"name,attr" json:"-"`
 	// NumberAttr captures the 'number' attribute on <decision_table number="...">
 	NumberAttr       string             `xml:"number,attr" json:"-"`
 	Source           *DTSource          `xml:"source,omitempty" json:"-"`
@@ -216,14 +216,14 @@ func (a DTInitialActions) All() []DTInitialAction {
 // (action_dsl/action_postfix on <initial_action>) and the EL-aware
 // authoring SDK form (initial_action_dsl/initial_action_postfix).
 type DTInitialAction struct {
-	Number             int    `xml:"action_number" json:"action_number"`
-	Comment            string `xml:"action_comment" json:"action_comment,omitempty"`
-	InitialComment     string `xml:"initial_action_comment" json:"initial_action_comment,omitempty"`
-	DSL                string `xml:"initial_action_dsl" json:"initial_action_dsl,omitempty"`
-	ActionDSL          string `xml:"action_dsl" json:"action_dsl,omitempty"`
-	Description        string `xml:"action_description" json:"action_description"`
-	Postfix            string `xml:"action_postfix" json:"action_postfix"`
-	InitialActPostfix  string `xml:"initial_action_postfix" json:"initial_action_postfix,omitempty"`
+	Number            int    `xml:"action_number" json:"action_number"`
+	Comment           string `xml:"action_comment" json:"action_comment,omitempty"`
+	InitialComment    string `xml:"initial_action_comment" json:"initial_action_comment,omitempty"`
+	DSL               string `xml:"initial_action_dsl" json:"initial_action_dsl,omitempty"`
+	ActionDSL         string `xml:"action_dsl" json:"action_dsl,omitempty"`
+	Description       string `xml:"action_description" json:"action_description"`
+	Postfix           string `xml:"action_postfix" json:"action_postfix"`
+	InitialActPostfix string `xml:"initial_action_postfix" json:"initial_action_postfix,omitempty"`
 }
 
 // GetDSL returns the first non-empty DSL field, preferring initial_action_dsl
@@ -405,11 +405,11 @@ func (l *DTLoader) processTable(table *DTTable) error {
 
 	// Create the decision table using the builder.
 	//
-	// tableName, not name.StringValue(): the RName is interned
-	// case-insensitively and keeps whatever spelling was seen first anywhere
-	// in the project, so passing it through would hand the builder some other
-	// declaration's casing. The exporter writes the sheet from this, and an
-	// EDD field sharing the name was silently renaming the table (#1040).
+	// tableName, not name.StringValue(): the RName has already been through the
+	// intern cache, which keeps the first spelling seen anywhere in the
+	// project. Case is display only — it never changes which table this is —
+	// but passing the interned string here hands the builder some other
+	// declaration's styling, and the exporter writes the sheet from it (#1040).
 	builder := decisiontable.NewBuilder(tableName, l.session)
 
 	// Set table type

--- a/pkg/dtrules/loader/edd.go
+++ b/pkg/dtrules/loader/edd.go
@@ -329,8 +329,9 @@ func (l *EDDLoader) processField(refEntity *entity.REntity, field *EDDField) err
 		return fmt.Errorf("failed to add field %s: %s", field.Name, errStr)
 	}
 
-	// Record the spelling the author used, so writing the EDD back out does
-	// not rename the field to whatever casing was interned first (#1040).
+	// Record the spelling the author used. Case is display only — it never
+	// changes which field this is — but writing the EDD back out must not
+	// restyle it to whatever spelling was interned first (#1040).
 	if entry := refEntity.GetEntry(attributeName); entry != nil {
 		entry.AuthoredName = strings.TrimSpace(field.Name)
 	}

--- a/pkg/dtrules/loader/edd_authored_name_test.go
+++ b/pkg/dtrules/loader/edd_authored_name_test.go
@@ -25,11 +25,14 @@ import (
 // TestEDDFieldKeepsAuthoredCase is the EDD half of #1040.
 //
 // Decision-table names were fixed first; EDD fields go out through the same
-// accessor and had the same defect. RNames intern case-insensitively and the
-// cache keeps the first spelling seen process-wide, so a field `Status`
-// declared on one entity reported as `status` once another entity had declared
-// `status` earlier — and the exporter wrote that back, renaming the author's
-// field on every build.
+// accessor and had the same defect.
+//
+// `Status` and `status` are ONE name — EL is case-insensitive, and no rule ever
+// behaved differently. Case is display only, for readability and a project's
+// conventions. But the intern cache keeps the first spelling seen process-wide,
+// so a field declared `Status` was written back as `status` once another entity
+// had declared `status` earlier, and the XML stopped matching what building
+// from Excel produced.
 //
 // The entities are ordered so the lower-case spelling interns first. Reverse
 // them and the bug hides, which is why this fixture is written the way it is.


### PR DESCRIPTION
I described differing case as a **collision** — in #1040, in the commits, and in the code comments — and then reasoned from it: risk, exposure, odds of a future clash. That is a case-sensitive-language idea and it does not apply here.

`Status` and `status` are **one name**. No second identifier, no ambiguity, nothing to disambiguate. No rule ever behaved differently.

The wrong model was spreading into places future readers would pick it up, so it is corrected in all of them:

- **`.claude/CLAUDE.md`** — a CRITICAL section. This is the file every session in this repo reads and it said nothing about case at all, which is presumably why I got it wrong.
- **`dtrules docs el`** — in users' terms: the two spellings are the same name, case is yours for readability and conventions, and DTRules preserves what you write.
- The comments on `authoredName`/`AuthoredName` and both loaders.
- The two tests, which explained the defect the same wrong way.

It also states the part that is easy to lose once collision is gone: case must still be **preserved**, for two reasons, neither of them correctness of execution — the author's spelling is theirs to keep, and the XML must round-trip byte-identically because that is what `verify` compares.

Behaviour unchanged. Comments, docs, and one CLAUDE.md section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)