### PR TITLE
fix(authoring): honour the project's declared xml_dir and excel_dir (#1049)

### DIFF
--- a/pkg/dtrules/authoring/batch_test.go
+++ b/pkg/dtrules/authoring/batch_test.go
@@ -221,9 +221,9 @@ func TestBatchResult_Summary(t *testing.T) {
 // TestBatchResult_AllPassed checks AllPassed logic.
 func TestBatchResult_AllPassed(t *testing.T) {
 	tests := []struct {
-		name    string
-		batch   authoring.BatchResult
-		want    bool
+		name  string
+		batch authoring.BatchResult
+		want  bool
 	}{
 		{"all pass", authoring.BatchResult{Passed: 3}, true},
 		{"has failure", authoring.BatchResult{Passed: 2, Failed: 1}, false},

--- a/pkg/dtrules/authoring/debug_session.go
+++ b/pkg/dtrules/authoring/debug_session.go
@@ -55,9 +55,9 @@ type EntityView struct {
 // DebugSession is a live session paused before a specific invocation.
 type DebugSession struct {
 	project    *Project
-	trace      *RunTrace     // Original trace from which we replayed
-	pauseIndex int           // The index we are paused before
-	execSt     *execState    // Dedicated exec state for this session
+	trace      *RunTrace  // Original trace from which we replayed
+	pauseIndex int        // The index we are paused before
+	execSt     *execState // Dedicated exec state for this session
 }
 
 // traceBuilder accumulates TableInvocation records during ExecuteEntry.
@@ -65,7 +65,7 @@ type traceBuilder struct {
 	invocations  []*TableInvocation
 	project      *Project
 	currentDepth int
-	stopAt       int  // if > 0, stop (via sentinel error) after this many invocations
+	stopAt       int        // if > 0, stop (via sentinel error) after this many invocations
 	execSt       *execState // if set, used instead of project.execSt for snapshots
 }
 
@@ -217,11 +217,11 @@ func (w *depthAwareWrapper) StringValue() string { return w.name.StringValue() }
 func (w *depthAwareWrapper) PostFix() string     { return w.name.StringValue() + " performaliased " }
 
 func (w *depthAwareWrapper) Clone(s dtrules.Session) (dtrules.Object, error) { return w, nil }
-func (w *depthAwareWrapper) RClone() dtrules.Object                           { return w }
-func (w *depthAwareWrapper) IntValue() (int, error)                           { return 0, unsupported("IntValue") }
-func (w *depthAwareWrapper) LongValue() (int64, error)                        { return 0, unsupported("LongValue") }
-func (w *depthAwareWrapper) DoubleValue() (float64, error)                    { return 0, unsupported("DoubleValue") }
-func (w *depthAwareWrapper) BooleanValue() (bool, error)                      { return false, unsupported("BooleanValue") }
+func (w *depthAwareWrapper) RClone() dtrules.Object                          { return w }
+func (w *depthAwareWrapper) IntValue() (int, error)                          { return 0, unsupported("IntValue") }
+func (w *depthAwareWrapper) LongValue() (int64, error)                       { return 0, unsupported("LongValue") }
+func (w *depthAwareWrapper) DoubleValue() (float64, error)                   { return 0, unsupported("DoubleValue") }
+func (w *depthAwareWrapper) BooleanValue() (bool, error)                     { return false, unsupported("BooleanValue") }
 func (w *depthAwareWrapper) TimeValue() (time.Time, error) {
 	return time.Time{}, unsupported("TimeValue")
 }

--- a/pkg/dtrules/authoring/declared_layout_test.go
+++ b/pkg/dtrules/authoring/declared_layout_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const declaredEDD = `<entity_data_dictionary>
+	<entity name="job" number="100" access="rw">
+		<field name="age" type="integer" subtype="" access="rw" input="" default_value="" comment=""></field>
+	</entity>
+</entity_data_dictionary>`
+
+const declaredDT = `<decision_tables><decision_table>
+<table_name>Only</table_name>
+<attribute_fields><Type>FIRST</Type><TABLE_NUMBER>100</TABLE_NUMBER></attribute_fields>
+<conditions></conditions><actions></actions>
+</decision_table></decision_tables>`
+
+// declaredLayoutProject writes a project whose DTRules.xml points somewhere
+// other than the conventional xml/ + excel/, and puts a decoy workbook
+// directory next to the rules — the shape that made this silently wrong.
+func declaredLayoutProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	rules := filepath.Join(root, "pkg", "rules")
+	books := filepath.Join(root, "books")
+	decoy := filepath.Join(root, "pkg", "excel") // adjacent to the rules
+	for _, d := range []string{rules, books, decoy} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(p, s string) {
+		if err := os.WriteFile(p, []byte(s), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(rules, "P_edd.xml"), declaredEDD)
+	write(filepath.Join(rules, "P_dt.xml"), declaredDT)
+	write(filepath.Join(root, "DTRules.xml"),
+		"<DTRules><xml_dir>pkg/rules</xml_dir><excel_dir>books</excel_dir></DTRules>")
+	return root
+}
+
+// TestOpenProjectHonoursDeclaredLayout pins #1049.
+//
+// OpenProject hardcoded `<path>/xml` and never read DTRules.xml, so the
+// authoring API — the sanctioned way to change a rule without hand-editing XML
+// — could not open a project that declares its own layout at all. The obvious
+// workaround, pointing --project at whatever directory happens to contain an
+// xml/, silently retargets the Excel side too.
+func TestOpenProjectHonoursDeclaredLayout(t *testing.T) {
+	root := declaredLayoutProject(t)
+
+	p, err := OpenProject(root)
+	if err != nil {
+		t.Fatalf("OpenProject on a project that declares its layout: %v", err)
+	}
+	if want := filepath.Join(root, "pkg", "rules"); p.xmlDir != want {
+		t.Errorf("xmlDir = %s, want the declared %s", p.xmlDir, want)
+	}
+	if got, want := p.projectRoot(), root; got != want {
+		t.Errorf("projectRoot() = %s, want %s — inferring it by stripping \"xml\" is wrong here", got, want)
+	}
+	if got, want := p.excelDirectory(), filepath.Join(root, "books"); got != want {
+		t.Errorf("excelDirectory() = %s, want the declared %s", got, want)
+	}
+	// The decoy sits beside the rules and is what adjacency-based search finds.
+	if p.excelDirectory() == filepath.Join(root, "pkg", "excel") {
+		t.Error("resolved the workbook directory next to the rules rather than the declared one")
+	}
+}
+
+// TestOpenProjectStillAcceptsConventionalLayout keeps the fix narrow: a project
+// with no DTRules.xml must still open by convention.
+func TestOpenProjectStillAcceptsConventionalLayout(t *testing.T) {
+	root := t.TempDir()
+	xmlDir := filepath.Join(root, "xml")
+	if err := os.MkdirAll(xmlDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(xmlDir, "P_dt.xml"), []byte(declaredDT), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p, err := OpenProject(root)
+	if err != nil {
+		t.Fatalf("OpenProject on a conventional project: %v", err)
+	}
+	if p.xmlDir != xmlDir {
+		t.Errorf("xmlDir = %s, want %s", p.xmlDir, xmlDir)
+	}
+	if got, want := p.excelDirectory(), filepath.Join(root, "excel"); got != want {
+		t.Errorf("excelDirectory() = %s, want the conventional %s", got, want)
+	}
+}

--- a/pkg/dtrules/authoring/edd_symbols_test.go
+++ b/pkg/dtrules/authoring/edd_symbols_test.go
@@ -56,8 +56,8 @@ func TestLoadEDDSymbols(t *testing.T) {
 	syms := authoring.LoadEDDSymbols(xmlDir)
 
 	want := map[string]string{
-		"supply_limit":        "fixed", // top-level, bare
-		"budget.supply_limit": "fixed", // top-level, qualified
+		"supply_limit":        "fixed",  // top-level, bare
+		"budget.supply_limit": "fixed",  // top-level, qualified
 		"rate":                "double", // nested, bare (recursive discovery)
 		"state.rate":          "double", // nested, qualified
 	}

--- a/pkg/dtrules/authoring/excel_sync.go
+++ b/pkg/dtrules/authoring/excel_sync.go
@@ -46,7 +46,18 @@ import (
 //
 // Returns nil on no-manifest projects.
 func GuardExcelInDir(xmlDir string, overwrite bool) error {
-	m, manifestDir := LoadSyncManifestForXMLDir(xmlDir)
+	return GuardExcelIn(xmlDir, "", overwrite)
+}
+
+// GuardExcelIn is GuardExcelInDir with the project's declared Excel directory.
+// Pass "" to fall back to searching the conventional layouts.
+//
+// The search is adjacency-based, so a project whose rules sit beside a second,
+// unused workbook directory guards — and writes — the wrong one. Staking has
+// exactly that shape: excel/ is declared and used by build and verify, while a
+// stale pkg/dtrules/excel/ sits next to the rules and won the search (#1049).
+func GuardExcelIn(xmlDir, excelDir string, overwrite bool) error {
+	m, manifestDir := loadSyncManifest(xmlDir, excelDir)
 	if m == nil {
 		return nil
 	}
@@ -78,7 +89,13 @@ func GuardExcelInDir(xmlDir string, overwrite bool) error {
 //
 // Returns nil on no-manifest projects.
 func RefreshExcelInDir(xmlDir string) error {
-	m, manifestDir := LoadSyncManifestForXMLDir(xmlDir)
+	return RefreshExcelIn(xmlDir, "")
+}
+
+// RefreshExcelIn is RefreshExcelInDir with the project's declared Excel
+// directory. Pass "" to search the conventional layouts (#1049).
+func RefreshExcelIn(xmlDir, excelDir string) error {
+	m, manifestDir := loadSyncManifest(xmlDir, excelDir)
 	if m == nil {
 		return nil
 	}
@@ -206,4 +223,23 @@ func loadRuleSetForExportInDir(xmlDir string) (*session.RuleSet, error) {
 		}
 	}
 	return rs, nil
+}
+
+// loadSyncManifest prefers an explicitly declared Excel directory over the
+// adjacency search, so a project that says where its workbooks live is
+// believed (#1049).
+func loadSyncManifest(xmlDir, excelDir string) (*sync.Manifest, string) {
+	if excelDir != "" {
+		path := filepath.Join(excelDir, ".sync-manifest.json")
+		if _, err := os.Stat(path); err == nil {
+			if m, err := sync.LoadManifest(path); err == nil {
+				return m, excelDir
+			}
+		}
+		// Declared but with no manifest: that is a project whose Excel has
+		// never been exported, not an invitation to guard a different
+		// directory's workbooks.
+		return nil, ""
+	}
+	return LoadSyncManifestForXMLDir(xmlDir)
 }

--- a/pkg/dtrules/authoring/files.go
+++ b/pkg/dtrules/authoring/files.go
@@ -44,10 +44,27 @@ func (e *dtFileEntry) ranged() bool { return e.lo > 0 && e.hi >= e.lo }
 // ---- path helpers ---------------------------------------------------------
 
 func (p *Project) projectRoot() string {
+	// Prefer the root the project was opened at. Inferring it by stripping a
+	// trailing "xml" is right only for the conventional layout; a project whose
+	// DTRules.xml declares something else got a root one level too deep, and
+	// everything derived from it — notes file, Excel directory — followed
+	// (#1049).
+	if p.root != "" {
+		return p.root
+	}
 	if filepath.Base(p.xmlDir) == "xml" {
 		return filepath.Dir(p.xmlDir)
 	}
 	return p.xmlDir
+}
+
+// excelDirectory is where this project's workbooks live: what DTRules.xml
+// declares, or `excel/` beside the rules.
+func (p *Project) excelDirectory() string {
+	if p.excelDir != "" {
+		return p.excelDir
+	}
+	return filepath.Join(p.projectRoot(), "excel")
 }
 
 func (p *Project) notesFile() string {
@@ -584,7 +601,7 @@ func (p *Project) removeOrphans() {
 		// Best-effort: remove the combined Excel workbook (CO_dt.xml -> CO.xlsx).
 		rel := p.relPathOf(abs)
 		stem := strings.TrimSuffix(rel, "_dt.xml")
-		excelDir := filepath.Join(p.projectRoot(), "excel")
+		excelDir := p.excelDirectory()
 		_ = os.Remove(filepath.Join(excelDir, filepath.FromSlash(stem)+".xlsx"))
 	}
 	p.orphans = nil

--- a/pkg/dtrules/authoring/forall_as_runtime_test.go
+++ b/pkg/dtrules/authoring/forall_as_runtime_test.go
@@ -196,7 +196,9 @@ func TestForallAs_WhereClauseReadsAliasField(t *testing.T) {
 // TestForallAs_NestedNonShadowing: nested iteration with distinct aliases.
 // Inner filters by inner_a.balance > outer_a.balance. With balances 100,200,300
 // and labels A,B,C, the pairs emitted (outer<inner) are:
-//   A<B, A<C, B<C
+//
+//	A<B, A<C, B<C
+//
 // joined by ";" with a trailing ";".
 func TestForallAs_NestedNonShadowing(t *testing.T) {
 	state := runForallAs(t, "FA_Nested")

--- a/pkg/dtrules/authoring/generator_parity_test.go
+++ b/pkg/dtrules/authoring/generator_parity_test.go
@@ -42,9 +42,9 @@ const parityEDD = `<entity_data_dictionary version='2'>
 var parityCorpus = []string{
 	"supply_limit >= acme_issued",               // fixed comparison -> fp>=
 	"budget.supply_limit >= budget.acme_issued", // entity-qualified keys
-	"rate > 1.0",                                // double comparison -> f>
-	"count > 1",                                 // integer comparison
-	"supply_limit != acme_issued",               // fixed inequality -> fp!=
+	"rate > 1.0",                  // double comparison -> f>
+	"count > 1",                   // integer comparison
+	"supply_limit != acme_issued", // fixed inequality -> fp!=
 }
 
 // TestGeneratorParity (#898) pins that the two independent EDD→symbol builders

--- a/pkg/dtrules/authoring/mapping.go
+++ b/pkg/dtrules/authoring/mapping.go
@@ -24,9 +24,9 @@ import (
 
 // Mapping is a view over a project's _map.xml file, supporting read and mutate operations.
 type Mapping struct {
-	project  *Project
-	path     string
-	mapXML   *excel.MapXML
+	project *Project
+	path    string
+	mapXML  *excel.MapXML
 }
 
 // SetAttribute is a single non-section entry in the mapping.

--- a/pkg/dtrules/authoring/project.go
+++ b/pkg/dtrules/authoring/project.go
@@ -29,7 +29,15 @@ import (
 // Project holds all loaded decision tables for a DTRules project. It provides
 // a typed Go API for reading and mutating tables without touching XML directly.
 type Project struct {
-	xmlDir      string
+	xmlDir string
+	// root and excelDir come from the project's DTRules.xml when it declares
+	// them. Both used to be inferred — root by stripping a trailing "xml" from
+	// xmlDir, excel by joining "excel" onto that — which is wrong for any
+	// project that declares a different layout, and silently wrong rather than
+	// loudly: writes landed in a workbook the rest of the toolchain ignores
+	// (#1049). Empty means "infer", which keeps the conventional layout working.
+	root        string
+	excelDir    string
 	dtFiles     []dtFileEntry // one entry per loaded _dt.xml file
 	symbols     map[string]string
 	edd         *EDD         // lazily loaded
@@ -84,14 +92,24 @@ type dtFileEntry struct {
 //
 // If neither layout matches, returns an error explaining both options.
 func OpenProject(path string) (*Project, error) {
-	xmlDir, err := resolveProjectXMLDir(path)
-	if err != nil {
-		return nil, err
+	declaredXML, declaredExcel := readProjectManifest(path)
+
+	xmlDir := declaredXML
+	if xmlDir == "" {
+		var err error
+		xmlDir, err = resolveProjectXMLDir(path)
+		if err != nil {
+			return nil, err
+		}
+	} else if info, err := os.Stat(xmlDir); err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("DTRules.xml declares <xml_dir> %s, which is not a directory", xmlDir)
 	}
 
 	p := &Project{
-		xmlDir:  xmlDir,
-		symbols: make(map[string]string),
+		xmlDir:   xmlDir,
+		root:     path,
+		excelDir: declaredExcel,
+		symbols:  make(map[string]string),
 	}
 
 	if err := p.loadEDD(xmlDir); err != nil {
@@ -299,7 +317,7 @@ func (p *Project) Save() error {
 // path runs whether the caller is Project.Save or a non-Project
 // surface like dtrules compile.
 func (p *Project) preWriteExcelGuard() error {
-	return GuardExcelInDir(p.xmlDir, p.OverwriteExcel)
+	return GuardExcelIn(p.xmlDir, p.excelDir, p.OverwriteExcel)
 }
 
 // refreshExcelFromXML re-exports every Excel file the sync manifest
@@ -325,7 +343,7 @@ func (p *Project) preWriteExcelGuard() error {
 // the package-level helper so the same code path runs from any caller
 // (Save, SaveEDD, dtrules compile).
 func (p *Project) refreshExcelFromXML() error {
-	return RefreshExcelInDir(p.xmlDir)
+	return RefreshExcelIn(p.xmlDir, p.excelDir)
 }
 
 // RenameTable renames a decision table in place.
@@ -439,4 +457,44 @@ func (p *Project) DeleteTable(name, reason string) error {
 	p.logChange("delete table `%s` from `%s` — %q", name, rel, strings.TrimSpace(reason))
 	p.dropIfEmpty(fi, fmt.Sprintf("last table removed: %s", strings.TrimSpace(reason)))
 	return nil
+}
+
+// projectManifest is the subset of DTRules.xml the authoring layer needs.
+type projectManifest struct {
+	XMLDir   string `xml:"xml_dir"`
+	ExcelDir string `xml:"excel_dir"`
+}
+
+// readProjectManifest returns the directories a project declares, resolved
+// against its root. Empty strings mean "not declared" and the caller falls back
+// to the conventional layout.
+//
+// The authoring API used to hardcode `<path>/xml` and `<path>/excel`, so a
+// project laid out per its own manifest could not be opened at all — and the
+// obvious workaround, pointing --project at whatever directory happened to
+// contain an xml/, silently retargeted writes at a different workbook (#1049).
+// build and verify have read the manifest since #1031; this closes the gap.
+func readProjectManifest(root string) (xmlDir, excelDir string) {
+	data, err := os.ReadFile(filepath.Join(root, "DTRules.xml"))
+	if err != nil {
+		return "", ""
+	}
+	var m projectManifest
+	if err := xml.Unmarshal(data, &m); err != nil {
+		// A malformed manifest is not the authoring layer's to report; the
+		// conventional layout is a reasonable answer and `verify` says so
+		// properly.
+		return "", ""
+	}
+	resolve := func(rel string) string {
+		rel = strings.TrimSpace(rel)
+		if rel == "" {
+			return ""
+		}
+		if filepath.IsAbs(rel) {
+			return rel
+		}
+		return filepath.Join(root, rel)
+	}
+	return resolve(m.XMLDir), resolve(m.ExcelDir)
 }


### PR DESCRIPTION
Closes #1049.

The authoring API is the sanctioned way to change a rule without hand-editing XML, and it could not open a project that declares its own layout.

`OpenProject` resolved the rules directory with `resolveProjectXMLDir`, which hardcodes `<path>/xml`, and never read `DTRules.xml`:

```
$ dtrules table get Calculate_Budget
{"error":"io_error","hint":"project must contain an xml/ subdirectory ..."}
```

`dtrules table` takes only `--project`, so flags could not compensate.

**And the workaround was worse than the failure.** `--project pkg/dtrules` finds an `xml/` and reads fine, but it also relocates the Excel side onto a stale `pkg/dtrules/excel/` sitting beside the rules — so a write went to a workbook the rest of the toolchain ignores:

```
"detail":"Excel file \"pkg/dtrules/excel/staking.xlsx\" was modified after last export ..."
```

The contract's premise is that a write updates XML **and** Excel together. That updated XML and the wrong Excel.

## The fix

Three inferences replaced by what the project declares — the rules directory, the project root (was: strip a trailing `"xml"` from `xmlDir`), and the workbook directory (was: join `"excel"` onto that, or an adjacency search that found the decoy first). Undeclared means infer, so conventional projects are unaffected; pinned by a test that also plants a decoy `pkg/excel/` next to the rules.

## Verified on staking

```
table get / edd get / table list    work from the project root, no flags
a write                             lands in the declared excel/
pkg/dtrules/excel/                  untouched
```

## The thing I should have said sooner

This is a pattern, not an incident. **DTRules has a manifest that much of DTRules ignores** — 14 sites across four packages hardcode the layout. #1031 fixed `review` and the MCP project tools, this fixes authoring, and `pkg/dtrules/apiserver` still has two (`discover.go:73`, `debug.go:67`). The remainder are legitimate defaults inside resolvers.

I fixed the first two as isolated bugs without naming the shape, which is why this one was still open. Worth a follow-up to give the resolver a single home both `cmd` and `pkg` can reach.

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
