### PR TITLE
fix(build): --from-excel forces the Excel→XML direction (#1051)

### DIFF
--- a/cmd/dtrules/build.go
+++ b/cmd/dtrules/build.go
@@ -433,6 +433,21 @@ func (c *CLI) runExcelAuthoredBuild(xmlDir, excelDir string, opts *buildOptions)
 
 	syncOpts := dtrsync.DefaultOptions()
 	syncOpts.Verbose = opts.verbose
+	// --from-excel means Excel-authored, so say so instead of leaving the
+	// per-workbook timestamp check to decide. Selecting this branch only
+	// chose the code path; SyncAll still detected direction per workbook
+	// and answered NoSync whenever the XML was not older, so the import
+	// never ran: "XML is already up to date", tables=0, files-written=0.
+	//
+	// The visible cost was that a table could never acquire el_compiled.
+	// The attribute is written from the in-memory flag, which is set when
+	// the postfix is compiled from EL — and with the import skipped
+	// nothing was compiled, so an XML predating the attribute could not
+	// gain it through build, while verify's rebuild (into an empty
+	// directory, always written) always had it. verify then reported
+	// `content differs from build output` forever, on a project that was
+	// otherwise byte-identical (#1051).
+	syncOpts.ForceDirection = dtrsync.ExcelToXML
 
 	syncer := dtrsync.NewSyncerWithOptions(xmlDir, excelDir, syncOpts)
 	syncer.SetUseCombinedWorkbooks(true)


### PR DESCRIPTION
Closes #1051.

`--from-excel` selected the Excel-authored code path but did not set a direction. `SyncAll` still ran its per-workbook timestamp detection and answered `NoSync` whenever the XML was not older, so the import never happened:

```
XML is already up to date.
tables=0  actions=0  conditions=0  entities=0  mappings=0
files-written=0
```

The flag asked for a direction and got a timestamp comparison.

### The reported symptom (#1051)

A table could never acquire `el_compiled` through `build`. The attribute is written from the in-memory flag, which is set when the postfix is compiled from EL — and with the import skipped, nothing is compiled. `verify` rebuilds into an empty directory, which is always written, so its output always carried the attribute. `verify` therefore reported `content differs from build output` **permanently**, on a project that was otherwise byte-identical.

### The quieter and worse symptom

For a project where Excel is the system of record, an edit made in Excel is **silently discarded** whenever the XML happens not to be older — with a zero exit and a line stating the XML is already up to date. There is no signal that the edit was dropped.

### Fix

```go
syncOpts.ForceDirection = dtrsync.ExcelToXML
```

`ForceDirection` already exists; `--from-excel` simply never used it.

### Verification

Against the Accumulate staking ruleset (35 tables), built from this branch vs. committed `main`:

| | `main` | this branch |
|---|---|---|
| `build --from-excel` | `tables=0 … files-written=0` | `tables=35 actions=101 conditions=56 entities=18 files-written=2` |
| rebuilt XML | (unchanged — nothing ran) | **byte-identical** to committed |
| `el_compiled` | 35 | 35 |
| `fphalfup/` divisions | 10 | 10 |
| `verify` | pass | pass |

So the import now actually runs and reproduces the ruleset exactly — including every round-half-up division, which is the money path.