### PR TITLE
fix(sync): an EDD-only workbook wrote its XML into the working directory (#1056)

### DIFF
--- a/pkg/dtrules/sync/output_dir_test.go
+++ b/pkg/dtrules/sync/output_dir_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import "testing"
+
+// A workbook produces a DT file, an EDD file, or both, and the unused path is
+// left empty. Deriving the output directory from DTXMLPath alone answers "."
+// for an EDD-only workbook, so the import landed in the process's working
+// directory instead of the project (#1056).
+
+func TestOutputDirUsesWhicheverPathIsSet(t *testing.T) {
+	cases := []struct {
+		name     string
+		wb       CombinedWorkbook
+		fallback string
+		want     string
+	}{
+		{
+			name: "mixed workbook uses the DT path",
+			wb:   CombinedWorkbook{DTXMLPath: "/p/xml/Foo_dt.xml", EDDXMLPath: "/p/xml/Foo_edd.xml"},
+			want: "/p/xml",
+		},
+		{
+			name: "DT-only workbook",
+			wb:   CombinedWorkbook{DTXMLPath: "/p/xml/Foo_dt.xml"},
+			want: "/p/xml",
+		},
+		{
+			// The regression. Before the fix this answered "." and the EDD
+			// was written wherever the process happened to be running.
+			name: "EDD-only workbook falls through to the EDD path",
+			wb:   CombinedWorkbook{EDDXMLPath: "/p/xml/Foo_edd.xml"},
+			want: "/p/xml",
+		},
+		{
+			name: "nested workbook keeps its subdirectory",
+			wb:   CombinedWorkbook{EDDXMLPath: "/p/xml/states/CO_edd.xml"},
+			want: "/p/xml/states",
+		},
+		{
+			name:     "neither path set falls back to the syncer's xml dir",
+			wb:       CombinedWorkbook{},
+			fallback: "/p/xml",
+			want:     "/p/xml",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.wb.outputDir(tc.fallback); got != tc.want {
+				t.Errorf("outputDir(%q) = %q, want %q", tc.fallback, got, tc.want)
+			}
+		})
+	}
+}
+
+// The specific shape that bit us: never answer the working directory when the
+// workbook names a real destination.
+func TestOutputDirNeverAnswersWorkingDirectory(t *testing.T) {
+	wb := CombinedWorkbook{EDDXMLPath: "/project/xml/TaxReturn_edd.xml"}
+	if got := wb.outputDir("/project/xml"); got == "." {
+		t.Fatal(`outputDir answered "." — the import would write into the caller's cwd`)
+	}
+}

--- a/pkg/dtrules/sync/sync.go
+++ b/pkg/dtrules/sync/sync.go
@@ -100,6 +100,25 @@ type CombinedWorkbook struct {
 	Direction SyncDirection
 }
 
+// outputDir is the directory this workbook's XML belongs in.
+//
+// A workbook produces a DT file, an EDD file, or both, and the unused path is
+// left empty — so taking filepath.Dir of DTXMLPath alone answers "." for an
+// EDD-only workbook, and the import lands in the process's working directory
+// instead of the project. That is how `dtrules verify` came to leave a
+// TaxReturn_edd.xml at the root of any project holding a *_edd.xlsx (#1056);
+// verify is a read-only gate and should not write into the tree at all.
+//
+// fallback is the syncer's own xml directory, used when neither path is set.
+func (wb *CombinedWorkbook) outputDir(fallback string) string {
+	for _, p := range []string{wb.DTXMLPath, wb.EDDXMLPath} {
+		if p != "" {
+			return filepath.Dir(p)
+		}
+	}
+	return fallback
+}
+
 // SyncResult holds the result of a sync operation.
 type SyncResult struct {
 	// Pairs contains all file pairs discovered.
@@ -1229,7 +1248,7 @@ func (s *Syncer) importCombinedWorkbook(wb *CombinedWorkbook) error {
 	if s.workbookImporter != nil {
 		// Use the combined workbook importer
 		// Ensure parent directory exists
-		xmlDir := filepath.Dir(wb.DTXMLPath)
+		xmlDir := wb.outputDir(s.xmlDir)
 		if err := os.MkdirAll(xmlDir, 0755); err != nil {
 			return fmt.Errorf("failed to create directory: %w", err)
 		}
@@ -1244,7 +1263,7 @@ func (s *Syncer) importCombinedWorkbook(wb *CombinedWorkbook) error {
 	}
 
 	// Ensure parent directory exists
-	if err := os.MkdirAll(filepath.Dir(wb.DTXMLPath), 0755); err != nil {
+	if err := os.MkdirAll(wb.outputDir(s.xmlDir), 0755); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 


### PR DESCRIPTION
Closes #1056.

`CombinedWorkbook` carries a DT path, an EDD path, or both, leaving the unused
one empty. `importCombinedWorkbook` derived the output directory from
`filepath.Dir(wb.DTXMLPath)` — which for a `*_edd.xlsx` workbook is
`filepath.Dir("")`, i.e. `"."`. The import wrote relative to the process's
working directory.

TaxReturn ships `excel/TaxReturn_edd.xlsx`, so `dtrules verify` there left a
178 KB `TaxReturn_edd.xml` at the project root — a read-only CI gate writing
into the tree, under the one filename `.claude/CLAUDE.md` says must never be
committed.

## It was also hiding real drift

Because the rebuild wrote that EDD outside the rebuild directory, verify had
nothing to compare and never checked it:

| | findings | stray file |
|---|---|---|
| before | 114 | `TaxReturn_edd.xml` at project root |
| after | 115 | none |

The one added finding is `[build] xml/TaxReturn_edd.xml: content differs from
build output` — genuine drift the gate could not see. Every project with a
`*_edd.xlsx` workbook had the same blind spot.

## How it was found

Instrumented `EDDImporter.WriteXML` to panic on a filename containing no path
separator. The stack pointed at `sync.go` calling `ImportWorkbookToDir` with
`"."`.

## Fix

`CombinedWorkbook.outputDir(fallback)` — DT path, then EDD path, then the
syncer's own xml dir. Applied to both the workbook-importer path and the
separate-importer fallback, which had the same flaw.

Unit tests cover all five shapes including the regression. `make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)