### PR TITLE
fix(sync): importing Excel must clear the export guard it tells you to clear

### DIFF
--- a/pkg/dtrules/sync/import_records_manifest_test.go
+++ b/pkg/dtrules/sync/import_records_manifest_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The export guard refuses to write when a workbook is newer than the last
+// recorded export, and tells the caller to "Import Excel to XML first, then
+// re-apply your changes". The manifest was only ever written on export, so
+// doing exactly that changed nothing and the guard blocked forever -- which is
+// every fresh clone, since checkout stamps each file with the checkout time.
+// The tool's own instructions have to work.
+
+// guardedProject builds a syncer over a workbook that is newer than the
+// manifest's recorded export, i.e. one the guard will refuse.
+func guardedProject(t *testing.T) (*Syncer, *CombinedWorkbook) {
+	t.Helper()
+	root := t.TempDir()
+	xmlDir := filepath.Join(root, "xml")
+	excelDir := filepath.Join(root, "excel")
+	for _, d := range []string{xmlDir, excelDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	excelPath := filepath.Join(excelDir, "Thing.xlsx")
+	if err := os.WriteFile(excelPath, []byte("workbook"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewSyncerWithOptions(xmlDir, excelDir, DefaultOptions())
+	wb := &CombinedWorkbook{
+		ExcelPath:  excelPath,
+		DTXMLPath:  filepath.Join(xmlDir, "Thing_dt.xml"),
+		EDDXMLPath: filepath.Join(xmlDir, "Thing_edd.xml"),
+		RelPath:    "Thing",
+	}
+
+	// Put the pair in the state a checkout leaves behind: the workbook was
+	// touched after the recorded export, but both are in the past, so a
+	// fresh RecordExport (stamped now) will clear it. Backdating rather than
+	// pushing the workbook into the future matters -- a future mtime is
+	// genuinely unresolvable and the guard should keep refusing it.
+	m, err := s.GetManifest()
+	if err != nil {
+		t.Fatalf("GetManifest: %v", err)
+	}
+	if err := m.RecordExport(excelPath, []string{wb.DTXMLPath}); err != nil {
+		t.Fatalf("RecordExport: %v", err)
+	}
+	touched := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(excelPath, touched, touched); err != nil {
+		t.Fatal(err)
+	}
+	entry := m.GetEntry(excelPath)
+	if entry == nil {
+		t.Fatal("RecordExport left no entry")
+	}
+	entry.LastExportTime = touched.Add(-time.Hour)
+	entry.ExcelModTimeAtExport = entry.LastExportTime
+	if err := m.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := m.ExportGuard(excelPath); err == nil {
+		t.Fatal("setup is wrong: the guard should be blocking before the import")
+	}
+	return s, wb
+}
+
+func TestImportClearsTheExportGuard(t *testing.T) {
+	s, wb := guardedProject(t)
+
+	// The separate-importer path, reached with no workbook importer set: the
+	// imports themselves no-op on a stub workbook, which is fine -- what is
+	// under test is whether the manifest gets written.
+	s.importer = stubImporter{}
+	if err := s.importCombinedWorkbook(wb); err != nil {
+		t.Fatalf("importCombinedWorkbook: %v", err)
+	}
+
+	m, err := s.GetManifest()
+	if err != nil {
+		t.Fatalf("GetManifest: %v", err)
+	}
+	if err := m.ExportGuard(wb.ExcelPath); err != nil {
+		t.Fatalf("the guard still blocks after an import, so its own advice "+
+			"cannot be followed: %v", err)
+	}
+}
+
+// recordSynced must not lose the EDD when a workbook has no DT half, or the
+// guard stays armed for EDD-only workbooks.
+func TestRecordSyncedCoversEDDOnlyWorkbooks(t *testing.T) {
+	s, wb := guardedProject(t)
+	wb.DTXMLPath = ""
+
+	s.recordSynced(wb)
+
+	m, err := s.GetManifest()
+	if err != nil {
+		t.Fatalf("GetManifest: %v", err)
+	}
+	if err := m.ExportGuard(wb.ExcelPath); err != nil {
+		t.Fatalf("EDD-only workbook left the guard armed: %v", err)
+	}
+}
+
+// stubImporter satisfies the separate-importer interface without touching
+// Excel; the import result is not what these tests are about.
+type stubImporter struct{}
+
+func (stubImporter) ImportDecisionTable(_, _ string) error { return nil }
+func (stubImporter) ImportEDD(_, _ string) error           { return nil }

--- a/pkg/dtrules/sync/sync.go
+++ b/pkg/dtrules/sync/sync.go
@@ -1253,8 +1253,11 @@ func (s *Syncer) importCombinedWorkbook(wb *CombinedWorkbook) error {
 			return fmt.Errorf("failed to create directory: %w", err)
 		}
 
-		_, _, err := s.workbookImporter.ImportWorkbook(wb.ExcelPath, xmlDir)
-		return err
+		if _, _, err := s.workbookImporter.ImportWorkbook(wb.ExcelPath, xmlDir); err != nil {
+			return err
+		}
+		s.recordSynced(wb)
+		return nil
 	}
 
 	// Fallback to separate importers if workbook importer not available
@@ -1283,7 +1286,41 @@ func (s *Syncer) importCombinedWorkbook(wb *CombinedWorkbook) error {
 		}
 	}
 
+	s.recordSynced(wb)
 	return nil
+}
+
+// recordSynced marks a workbook and its XML as agreeing as of now.
+//
+// The manifest used to be written only when exporting, so an import left the
+// old export timestamp in place. The authoring guard compares that timestamp
+// against the workbook's mtime and refuses to write when the workbook is
+// newer -- advising "Import Excel to XML first, then re-apply your changes".
+// Doing exactly that changed nothing, because the import did not touch the
+// manifest, so the guard blocked forever on any project whose workbooks were
+// merely touched (a fresh clone stamps every file with the checkout time).
+// The tool's own instructions have to work (#1000).
+//
+// A failure here is not worth failing the import over -- the files are
+// already written -- so it is reported only under Verbose, matching the
+// export path.
+func (s *Syncer) recordSynced(wb *CombinedWorkbook) {
+	m, err := s.GetManifest()
+	if err != nil {
+		if s.options.Verbose {
+			fmt.Printf("Warning: could not load manifest to record import: %v\n", err)
+		}
+		return
+	}
+	var xmlFiles []string
+	for _, p := range []string{wb.DTXMLPath, wb.EDDXMLPath} {
+		if p != "" {
+			xmlFiles = append(xmlFiles, p)
+		}
+	}
+	if err := m.RecordExport(wb.ExcelPath, xmlFiles); err != nil && s.options.Verbose {
+		fmt.Printf("Warning: failed to update manifest after import: %v\n", err)
+	}
 }
 
 // exportCombinedWorkbook exports XML files to a combined Excel workbook.


### PR DESCRIPTION
Blocker found while working #1000.

The authoring guard refuses a write when a workbook is newer than the recorded
export, and instructs:

> Import Excel to XML first, then re-apply your changes.

The manifest was only written on **export**. Importing changed nothing, so the
guard blocked again with the same message and the same timestamp — the advice
was unfollowable, and `dtrules table put` on TaxReturn was unreachable by any
sequence of commands.

Not an exotic state: a checkout stamps every file with the checkout time, which
is later than whatever the committed manifest records. Any fresh clone of a
project that ships a manifest starts out locked.

## Fix

The import path records the pair as agreeing, exactly as the export path
already does. A manifest write is not worth failing an import over — the XML is
already written — so failures are reported under `Verbose`, matching export.

## Verification

- `build --from-excel` followed by `table put` now succeeds on TaxReturn, where
  before it failed on `excel/states/NJ.xlsx` no matter how many times the
  import ran.
- Two tests, both failing without the change. They backdate the manifest rather
  than pushing the workbook into the future — deliberately, since a future
  mtime is genuinely unresolvable and the guard should keep refusing it. The
  second covers EDD-only workbooks, which would otherwise stay armed.
- `make check` passes.

The #1000 rule change itself is not in this PR — see the issue for why that one
needs more care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)