### PR TITLE
fix(authoring): refresh the workbooks that exist, not the ones the manifest remembers (#1062)

### DIFF
--- a/pkg/dtrules/authoring/excel_sync.go
+++ b/pkg/dtrules/authoring/excel_sync.go
@@ -106,6 +106,23 @@ func RefreshExcelIn(xmlDir, excelDir string) error {
 	exporter := excel.NewExporter(rs)
 	for excelRel, entry := range m.Files {
 		excelPath := filepath.Join(manifestDir, excelRel)
+		// Refresh what exists; do not resurrect what does not.
+		//
+		// The manifest outlives the files it names. TaxReturn's committed
+		// manifest still lists 114 per-table workbooks that the samples
+		// consolidation replaced with a single TaxReturn.xlsx, so every
+		// `dtrules table put` re-created all 114 beside the real one and
+		// turned a one-action edit into a 244-file diff (#1062).
+		//
+		// A missing workbook is not something an export should invent. Excel
+		// is the system of record, and a file that is not there is not a
+		// source of truth; `verify` already reports tables whose declared
+		// workbook is absent, which is where that belongs. Bootstrapping a
+		// project with no Excel at all is a different path — no manifest,
+		// handled above.
+		if _, err := os.Stat(excelPath); err != nil {
+			continue
+		}
 		if err := exporter.ExportDecisionTables(excelPath); err != nil {
 			return fmt.Errorf("excel refresh: export %s: %w", excelPath, err)
 		}

--- a/pkg/dtrules/authoring/refresh_skips_missing_test.go
+++ b/pkg/dtrules/authoring/refresh_skips_missing_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/sync"
+)
+
+// A sync manifest outlives the files it names. TaxReturn's committed manifest
+// still listed 114 per-table workbooks that the samples consolidation had
+// replaced with a single TaxReturn.xlsx, and RefreshExcelIn re-created every
+// one of them on each authoring write -- turning a one-action edit into a
+// 244-file diff with 172 binary workbooks (#1062).
+
+// staleManifestProject writes a project whose manifest names two workbooks:
+// one that exists and one that does not.
+func staleManifestProject(t *testing.T) (xmlDir, excelDir, live, ghost string) {
+	t.Helper()
+	root := t.TempDir()
+	xmlDir = filepath.Join(root, "xml")
+	excelDir = filepath.Join(root, "excel")
+	for _, d := range []string{xmlDir, excelDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(p, s string) {
+		t.Helper()
+		if err := os.WriteFile(p, []byte(s), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(xmlDir, "P_edd.xml"), declaredEDD)
+	write(filepath.Join(xmlDir, "P_dt.xml"), declaredDT)
+
+	live = filepath.Join(excelDir, "P.xlsx")
+	ghost = filepath.Join(excelDir, "001_Only_dt.xlsx")
+	write(live, "") // presence is what matters; the exporter rewrites it
+
+	m := sync.NewManifest()
+	m.SetPath(filepath.Join(excelDir, ".sync-manifest.json"))
+	for _, p := range []string{live, ghost} {
+		if err := m.RecordExport(p, []string{filepath.Join(xmlDir, "P_dt.xml")}); err != nil {
+			t.Fatalf("RecordExport %s: %v", p, err)
+		}
+	}
+	// RecordExport stats the file, so the ghost entry exists with a zero
+	// mod time -- exactly the shape a deleted workbook leaves behind.
+	if err := os.Remove(ghost); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	return xmlDir, excelDir, live, ghost
+}
+
+func TestRefreshExcelDoesNotResurrectDeletedWorkbooks(t *testing.T) {
+	xmlDir, excelDir, live, ghost := staleManifestProject(t)
+
+	if err := RefreshExcelIn(xmlDir, excelDir); err != nil {
+		t.Fatalf("RefreshExcelIn: %v", err)
+	}
+
+	if _, err := os.Stat(ghost); err == nil {
+		t.Errorf("%s was re-created; a workbook that is not there is not a "+
+			"source of truth and an export must not invent it",
+			filepath.Base(ghost))
+	}
+	if _, err := os.Stat(live); err != nil {
+		t.Errorf("the workbook that does exist should still be refreshed: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #1062. Unblocks #1000.

`RefreshExcelIn` re-exports every entry in the sync manifest after an authoring
write, whether or not the workbook is still on disk — and
`ExportDecisionTables` creates the file it is pointed at. So an entry for a
deleted workbook resurrected it on every edit.

TaxReturn's committed manifest lists **172 workbooks; only 59 exist.** The
samples consolidation replaced 114 per-table files with a single
`TaxReturn.xlsx` and left the manifest naming them.

| | before | after |
|---|---|---|
| `excel/*.xlsx` after one `table put` | 173 | 59 |
| files in the resulting diff | 244 (172 binary) | 130 |

That made the authoring API unusable on the largest sample, and the only
alternative — hand-editing XML — is exactly what the authoring contract exists
to prevent.

## Why skipping is the right answer

A missing workbook is not something an export should invent. Excel is the
system of record; a file that is not there is not a source of truth. `verify`
already reports tables whose declared workbook is absent, which is where that
reporting belongs.

Bootstrapping a project with no Excel at all is a different path — it returns
early above this loop when there is no manifest — so it is unaffected.

## Verification

- Test asserts a manifest-named-but-deleted workbook is not re-created while
  the one that does exist still is. Fails without the change.
- TaxReturn: `build --from-excel` then `table put` now leaves `excel/` at 59
  workbooks and reports `status: updated`.
- SinusitisTherapy, which has no stale entries, is unchanged (6 → 6).
- `make check` passes; `go test -tags archive ./pkg/dtrules/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)