### PR TITLE
feat(build): say so when a recompile weakens the arithmetic (#1019)

### DIFF
--- a/pkg/dtrules/excel/dt_importer.go
+++ b/pkg/dtrules/excel/dt_importer.go
@@ -1500,6 +1500,8 @@ func (i *DTImporter) compileTableEL(table *DecisionTableXML) error {
 				}
 				continue
 			}
+			i.warnNumericDowngrade(table.TableName,
+				fmt.Sprintf("initial action %d", idx+1), action.Postfix, postfix)
 			action.Postfix = postfix
 			if i.stats != nil {
 				i.stats.Compiled++
@@ -1522,6 +1524,8 @@ func (i *DTImporter) compileTableEL(table *DecisionTableXML) error {
 					ctx.DSL, ctx.Comment, err)
 				continue
 			}
+			i.warnNumericDowngrade(table.TableName,
+				fmt.Sprintf("context %d", idx+1), ctx.Postfix, postfix)
 			ctx.Postfix = postfix
 			if i.stats != nil {
 				i.stats.Compiled++
@@ -1541,6 +1545,8 @@ func (i *DTImporter) compileTableEL(table *DecisionTableXML) error {
 					cond.DSL, cond.Comment, err)
 				continue
 			}
+			i.warnNumericDowngrade(table.TableName,
+				"condition "+cond.Number, cond.Postfix, postfix)
 			cond.Postfix = postfix
 			if i.stats != nil {
 				i.stats.Compiled++
@@ -1560,6 +1566,8 @@ func (i *DTImporter) compileTableEL(table *DecisionTableXML) error {
 					action.DSL, action.Comment, err)
 				continue
 			}
+			i.warnNumericDowngrade(table.TableName,
+				"action "+action.Number, action.Postfix, postfix)
 			action.Postfix = postfix
 			if i.stats != nil {
 				i.stats.Compiled++
@@ -1627,6 +1635,67 @@ func countDSLRows(table *DecisionTableXML) int {
 	}
 	for _, a := range table.Actions {
 		count(a.DSL)
+	}
+	return n
+}
+
+// numericDowngrades are the operator substitutions that quietly change what a
+// number means. Key is what the committed postfix had; value is what the
+// recompile produced and why it matters.
+//
+// Only losses are listed. Compiling `fp/` where the old artifact had `/` is an
+// upgrade and says nothing worrying, so it is not here.
+var numericDowngrades = map[string]struct{ to, meaning string }{
+	"fphalfup/": {"fp/", "round-half-up division became truncating"},
+	"fp/":       {"/", "fixed-point division became integer"},
+	"fp*":       {"*", "fixed-point multiply became integer"},
+	"fp+":       {"+", "fixed-point add became integer"},
+	"fp-":       {"-", "fixed-point subtract became integer"},
+	"cvfp":      {"cvi", "value stored as integer instead of fixed-point"},
+}
+
+// warnNumericDowngrade reports a recompile that silently weakens arithmetic.
+//
+// A committed artifact can carry postfix an older compiler produced from DSL
+// the current one reads differently. The staking rules are the case in point
+// (#1019): the DSL says `weighted_balance * staker_budget / total_weighted`,
+// plain `/`, which compiles to truncating `fp/` — but the committed postfix
+// says `fphalfup/`, because an older compiler conflated the two forms. The
+// spec requires round-half-up and their own test asserts it, so the correct
+// behaviour was being held up by a stale artifact. The first Excel-authored
+// rebuild would have switched that division to truncation with no drops
+// reported and exit 0.
+//
+// This is deliberately a warning, not a drop. Recompiling legitimately changes
+// postfix — #1015's associativity fix rewrote multiply chains across the
+// samples — so refusing would block real work. What must not happen is the
+// change going unmentioned.
+//
+// Only whole tokens count: postfix is space-separated, and matching on
+// substrings would see `fp/` inside `fphalfup/` and report every correct
+// round-half-up row as a downgrade.
+func (i *DTImporter) warnNumericDowngrade(tableName, item, before, after string) {
+	if i.stats == nil || before == "" || before == after {
+		return
+	}
+	old, recompiled := countOps(before), countOps(after)
+	for lost, d := range numericDowngrades {
+		// The operator has to actually disappear, and its weaker form has to
+		// actually appear, before this is a downgrade rather than an edit.
+		if old[lost] > recompiled[lost] && recompiled[d.to] > old[d.to] {
+			i.stats.AddWarning(tableName, 0, item,
+				fmt.Sprintf("recompiling changed %s to %s: %s. The DSL and the committed "+
+					"postfix disagree — say what you mean in the DSL (for round-half-up, "+
+					"`divide X by Y rounding by 0.5fp`) and rebuild", lost, d.to, d.meaning))
+		}
+	}
+}
+
+// countOps tallies whole-token occurrences in a postfix string.
+func countOps(postfix string) map[string]int {
+	n := make(map[string]int)
+	for _, tok := range strings.Fields(postfix) {
+		n[tok]++
 	}
 	return n
 }

--- a/pkg/dtrules/excel/numeric_downgrade_test.go
+++ b/pkg/dtrules/excel/numeric_downgrade_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import (
+	"strings"
+	"testing"
+)
+
+// A committed artifact can carry postfix an older compiler produced from DSL
+// the current one reads differently, and a rebuild then changes the arithmetic
+// with nothing reported. The staking rules are the case: DSL says `/`, which
+// truncates, while the committed postfix says `fphalfup/`, which their spec
+// requires and their own test asserts (#1019).
+
+func warningsFor(t *testing.T, before, after string) []string {
+	t.Helper()
+	imp := &DTImporter{stats: &ImportStats{}}
+	imp.warnNumericDowngrade("T", "action 1", before, after)
+	msgs := make([]string, 0, len(imp.stats.Warnings))
+	for _, w := range imp.stats.Warnings {
+		msgs = append(msgs, w.Reason)
+	}
+	return msgs
+}
+
+func TestWarnsWhenRoundHalfUpBecomesTruncating(t *testing.T) {
+	got := warningsFor(t,
+		"weighted_balance staker_budget fp* total_weighted fphalfup/",
+		"weighted_balance staker_budget fp* total_weighted fp/")
+
+	if len(got) != 1 {
+		t.Fatalf("want exactly one warning, got %d: %v", len(got), got)
+	}
+	for _, want := range []string{"fphalfup/", "fp/", "round-half-up", "0.5fp"} {
+		if !strings.Contains(got[0], want) {
+			t.Errorf("warning should mention %q, got: %s", want, got[0])
+		}
+	}
+}
+
+func TestWarnsWhenFixedPointBecomesInteger(t *testing.T) {
+	got := warningsFor(t, "a b fp- amount cvfp", "a b - amount cvi")
+	if len(got) != 2 {
+		t.Fatalf("want a warning for each of fp- and cvfp, got %d: %v", len(got), got)
+	}
+}
+
+// fp/ is a substring of fphalfup/. Matching on substrings would report every
+// correct round-half-up row as having lost a fixed-point division.
+func TestRoundHalfUpIsNotReadAsLosingFixedDivide(t *testing.T) {
+	if got := warningsFor(t,
+		"a b fp/", "a b fphalfup/"); len(got) != 0 {
+		t.Errorf("gaining rounding is an upgrade, not a downgrade: %v", got)
+	}
+}
+
+func TestNoWarningWhenPostfixIsUnchanged(t *testing.T) {
+	p := "a b fphalfup/"
+	if got := warningsFor(t, p, p); len(got) != 0 {
+		t.Errorf("identical postfix must be silent: %v", got)
+	}
+}
+
+// A first compile has nothing to compare against, and must not be reported as
+// a loss just because the new postfix contains the weaker operator.
+func TestNoWarningWhenThereWasNoPriorPostfix(t *testing.T) {
+	if got := warningsFor(t, "", "a b fp/"); len(got) != 0 {
+		t.Errorf("a first compile has nothing to downgrade from: %v", got)
+	}
+}
+
+// #1015 rewrote multiply chains across the samples. Reordering operands must
+// stay silent -- the operator set is untouched.
+func TestReorderingOperandsIsNotADowngrade(t *testing.T) {
+	if got := warningsFor(t,
+		"a b fp* c fp* d fphalfup/",
+		"b c fp* a fp* d fphalfup/"); len(got) != 0 {
+		t.Errorf("same operators in a different order is not a downgrade: %v", got)
+	}
+}
+
+// Losing one fp* of several still matters, but only when a plain * appears in
+// its place -- otherwise the row was simply edited.
+func TestOperatorRemovedWithoutAWeakerReplacementIsSilent(t *testing.T) {
+	if got := warningsFor(t, "a b fp* c fp*", "a b fp*"); len(got) != 0 {
+		t.Errorf("deleting an operation is an edit, not a downgrade: %v", got)
+	}
+}


### PR DESCRIPTION
Addresses the DTRules-side risk in #1019. The staking rule change itself stays
with staking, as that issue says.

A committed artifact can carry postfix an older compiler produced from DSL the
current one reads differently. Nothing compared them, so the first
Excel-authored rebuild could change what a number means, report no drops, and
exit 0.

In #1019: the staking per-account reward is authored with a plain `/`, which
compiles to truncating `fp/`, while the committed postfix says `fphalfup/`.
Their spec requires round-half-up and their own test asserts it — so the
correct behaviour was being held up by a stale artifact rather than by the
rules. A rebuild would have switched it to truncation, silently.

## What it catches

| committed had | recompile produced | meaning |
|---|---|---|
| `fphalfup/` | `fp/` | round-half-up became truncating |
| `fp/` `fp*` `fp+` `fp-` | `/` `*` `+` `-` | fixed-point became integer |
| `cvfp` | `cvi` | stored as integer instead of fixed-point |

Losses only — compiling `fp/` where the artifact had `/` is an upgrade.

## Warning, not a drop

Recompiling legitimately changes postfix; #1015's associativity fix rewrote
multiply chains across the samples. Refusing those would block real work. What
must not happen is the change going unmentioned.

## Two ways to get this wrong, both pinned by tests

- `fp/` is a substring of `fphalfup/`. Substring matching reports every correct
  round-half-up row as a downgrade, so comparison is on whole space-separated
  tokens.
- An operator merely disappearing is an edit. The weaker form has to appear in
  its place, which keeps reordering and deletion silent.

## Noise check

CHIP, Poker, SinusitisTherapy, StateTax and KidAid all rebuild from Excel with
**zero** warnings. `make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)