### PR TITLE
fix(build): the no-sync line said more than it knew (#1051)

### DIFF
--- a/cmd/dtrules/build.go
+++ b/cmd/dtrules/build.go
@@ -242,7 +242,22 @@ func dupGate(xmlDir string) int {
 // a copyProject is unreliable because mtimes and hashes drift on
 // copy. Direct invocation pins the behavior end-to-end.
 func runNoSyncAdvisory(xmlDir string) int {
-	fmt.Println("Nothing to sync — normalizing XML and running the advisory pass.")
+	// "Nothing to sync" used to be the whole message, and it was read as
+	// "Excel and XML agree". It means only that no workbook is newer than its
+	// XML. Content can still differ -- an XML written by an older exporter has
+	// the same mtimes and different bytes -- and that is exactly the state
+	// `verify` fails on, so a user could see this line and a red gate in the
+	// same minute with nothing connecting them (#1051).
+	//
+	// Saying which question was answered, and naming the one that was not, is
+	// as far as this branch can honestly go. Actually comparing content means
+	// rebuilding into a temp tree, which is what verify does and what takes
+	// minutes on TaxReturn -- too much for every build. And resolving a
+	// difference automatically would be worse than useless: on CHIP the XML is
+	// ahead of its workbook, so taking Excel silently reverts working rules
+	// (#1058).
+	fmt.Println("No workbook is newer than its XML — normalizing and running the advisory pass.")
+	fmt.Println("  (this compares timestamps, not content; `dtrules verify` checks the bytes)")
 	// Normalization (section renumbering, entity-number backfill) is
 	// idempotent — run it even when Excel and XML are in sync, so a plain
 	// `dtrules build` always leaves normalized files.

--- a/cmd/dtrules/build_test.go
+++ b/cmd/dtrules/build_test.go
@@ -474,8 +474,12 @@ func TestStaticAnalysis_UnusedEDDField(t *testing.T) {
 // branch (taken when sync detection returns "none") used to print
 // "Nothing to do: all files are in sync." and exit without running
 // the advisory pass. The fix routes through `runNoSyncAdvisory`,
-// which prints "Nothing to sync — running advisory pass…" and calls
-// `runStaticAnalysis`.
+// which prints a no-sync header and calls `runStaticAnalysis`.
+//
+// The header wording changed with #1051: "Nothing to sync" read as "Excel and
+// XML agree", when all it means is that no workbook is newer. What this test
+// exists for is the advisory pass running at all, so it asserts the header
+// names the comparison it actually made rather than pinning a phrase.
 //
 // We exercise `runNoSyncAdvisory` directly rather than going through
 // the full CLI dispatch because reaching the "none" sync state from
@@ -495,8 +499,8 @@ func TestRunNoSyncAdvisory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Capture stdout: runNoSyncAdvisory writes the "Nothing to sync"
-	// header + the per-warning lines there.
+	// Capture stdout: runNoSyncAdvisory writes the no-sync header + the
+	// per-warning lines there.
 	stdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
@@ -510,8 +514,13 @@ func TestRunNoSyncAdvisory(t *testing.T) {
 	if code != 0 {
 		t.Errorf("runNoSyncAdvisory exit=%d; want 0", code)
 	}
-	if !strings.Contains(out, "Nothing to sync") {
-		t.Errorf("expected 'Nothing to sync' marker; got:\n%s", out)
+	if !strings.Contains(out, "newer than its XML") {
+		t.Errorf("expected the no-sync header; got:\n%s", out)
+	}
+	// The header must not leave the reader thinking content was compared --
+	// that is the confusion #1051 was reported as.
+	if !strings.Contains(out, "not content") {
+		t.Errorf("the header should say timestamps were compared, not content; got:\n%s", out)
 	}
 	// The fixture's no-op column finding must show up.
 	if !strings.Contains(out, "no-op column") && !strings.Contains(out, "no actions") {


### PR DESCRIPTION
The remaining half of #1051.

`Nothing to sync` reads as "Excel and XML agree". It means only that no
workbook is newer than its XML. Content can differ with identical mtimes — an
XML written by an older exporter is exactly that — and that is the state
`verify` fails on. A user could see this line and a red gate in the same minute
with nothing connecting them.

```
No workbook is newer than its XML — normalizing and running the advisory pass.
  (this compares timestamps, not content; `dtrules verify` checks the bytes)
```

## Why not actually reconcile here

Both alternatives are worse:

**Comparing content** means rebuilding into a temp tree — what `verify` does,
and what takes over ten minutes on TaxReturn. Not a cost to pay on every build.

**Resolving automatically** would be harmful. Excel is the system of record, so
the resolution is to take Excel — but on CHIP, ChipApp, KidAid and StateTax the
XML is *ahead* of its workbook (#1058), so a plain build would silently revert
working rules and report success. This branch must not become destructive.

A cheap content check would need something the manifest does not record today
(per-file hashes). Worth its own issue if the timestamps-only answer proves
insufficient.

## Test

The #787 test pinned the old phrase. Its subject is that the advisory pass runs
at all, so it now asserts the header names the comparison it made, plus that
the header must not leave a reader thinking content was checked.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)