### PR TITLE
fix(sync): import and export must go the way the command says (#1069)

### DIFF
--- a/cmd/dtrules/cli.go
+++ b/cmd/dtrules/cli.go
@@ -461,6 +461,9 @@ func (c *CLI) syncCheck() int {
 func (c *CLI) syncImport() int {
 	fmt.Println("Importing Excel to XML...")
 
+	// The command names the direction; detection must not overrule it (#1069).
+	c.syncer.SetForceDirection(sync.ExcelToXML)
+
 	result, err := c.syncer.SyncAll()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error during import: %v\n", err)
@@ -517,8 +520,10 @@ func (c *CLI) syncExport() int {
 
 	fmt.Println("Exporting XML to Excel...")
 
-	// For export, we need to load rules to create the exporter
-	// This is a simplified version - full implementation would load rules
+	// The command names the direction; detection must not overrule it (#1069).
+	// --force above only waives the pending-edits check.
+	c.syncer.SetForceDirection(sync.XMLToExcel)
+
 	result, err := c.syncer.SyncAll()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error during export: %v\n", err)

--- a/pkg/dtrules/sync/force_direction_test.go
+++ b/pkg/dtrules/sync/force_direction_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import "testing"
+
+// `dtrules sync import` and `dtrules sync export` name a direction in the
+// command itself, but both called SyncAll and let per-workbook timestamp
+// detection decide. So each silently did nothing whenever the timestamps
+// disagreed with the request -- "No files needed export (Excel is up to
+// date)", exit 0 -- and --force did not help, because it waives the
+// pending-user-edits check rather than direction detection (#1069).
+
+func TestSetForceDirectionOverridesDetection(t *testing.T) {
+	s := NewSyncerWithOptions("xml", "excel", DefaultOptions())
+
+	if got := s.options.ForceDirection; got != NoSync {
+		t.Fatalf("a fresh syncer should detect, not force; got %v", got)
+	}
+
+	s.SetForceDirection(XMLToExcel)
+	if got := s.options.ForceDirection; got != XMLToExcel {
+		t.Errorf("ForceDirection = %v, want XMLToExcel — `sync export` would "+
+			"fall back to detection and export nothing", got)
+	}
+
+	s.SetForceDirection(ExcelToXML)
+	if got := s.options.ForceDirection; got != ExcelToXML {
+		t.Errorf("ForceDirection = %v, want ExcelToXML — `sync import` would "+
+			"fall back to detection and import nothing", got)
+	}
+}
+
+// NoSync is the "detect" value, so setting it back has to restore detection
+// rather than pin some third behaviour.
+func TestSetForceDirectionBackToNoSyncRestoresDetection(t *testing.T) {
+	s := NewSyncerWithOptions("xml", "excel", DefaultOptions())
+	s.SetForceDirection(XMLToExcel)
+	s.SetForceDirection(NoSync)
+
+	if got := s.options.ForceDirection; got != NoSync {
+		t.Errorf("ForceDirection = %v, want NoSync (detect)", got)
+	}
+}

--- a/pkg/dtrules/sync/sync.go
+++ b/pkg/dtrules/sync/sync.go
@@ -1487,3 +1487,16 @@ func GetRelativeBase(filePath, baseDir string) string {
 
 	return base
 }
+
+// SetForceDirection pins the sync direction, overriding the per-workbook
+// timestamp detection.
+//
+// `dtrules sync import` and `dtrules sync export` name a direction in the
+// command itself, but both called SyncAll and let detection decide, so each
+// silently did nothing whenever the timestamps disagreed with the request --
+// "No files needed export (Excel is up to date)", exit 0. `--force` did not
+// help: it bypasses the pending-user-edits check, not direction detection
+// (#1069). This is the same defect #1051 fixed for `build --from-excel`.
+func (s *Syncer) SetForceDirection(d SyncDirection) {
+	s.options.ForceDirection = d
+}


### PR DESCRIPTION
Closes #1069. Unblocks #1058.

The export-side twin of #1051. Both subcommands called `SyncAll()` without
pinning a direction, so timestamp detection decided — and when it disagreed
with the command, the command did nothing and reported success:

```
$ dtrules sync export --force
Exporting XML to Excel...
No files needed export (Excel is up to date).
$ echo $?
0
```

Workbook byte-identical afterwards. `--force` waives the *pending user edits*
check, not direction detection, so the flag that reads like "do it anyway" did
not make it happen.

A command whose name is the direction should not have detection overrule it.
Detection is for plain `build`, which is not told which way to go.

## What it unblocks

CHIP, ChipApp, KidAid and StateTax have XML ahead of their workbooks (#1058),
so reconciliation must go XML → Excel — a push no command could make. With the
direction pinned, CHIP reconciles end to end:

```
$ dtrules sync export --force
✓ Exported 1 file(s) from XML to Excel.
$ dtrules build --from-excel
$ dtrules verify
verified: ... is consistent with its Excel source
```

and the rules survive the round trip — the older `getrelationship` condition
form does not come back, and the actions that were empty in the workbook are
still there.

The setter is on `Syncer` rather than the constructor because one syncer serves
every sync subcommand: the direction belongs to the command, not the session.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)