### PR TITLE
fix(sync): export may create the excel directory it is asked to write

### DIFF
--- a/cmd/dtrules/cli.go
+++ b/cmd/dtrules/cli.go
@@ -280,8 +280,11 @@ func (c *CLI) runSync(args []string) int {
 		return 1
 	}
 
-	// Initialize syncer
-	if err := c.initSyncer(); err != nil {
+	// Initialize syncer. Export is the one direction that may legitimately
+	// run against a project with no excel/ yet -- that is bootstrapping, and
+	// refusing it is what left Cribbage, CorporateTax and SyntaxTests with no
+	// authoring surface at all (#1026, #1012).
+	if err := c.initSyncerFor(subcmd); err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing syncer: %v\n", err)
 		return 1
 	}
@@ -328,12 +331,30 @@ Examples:
 }
 
 func (c *CLI) initSyncer() error {
+	return c.initSyncerFor("")
+}
+
+// initSyncerFor is initSyncer knowing which subcommand asked.
+//
+// A missing excel/ is an error for every direction but one. Importing from a
+// directory that is not there, or reporting status on it, means the caller is
+// pointed at the wrong project and should hear so. Exporting into it is
+// bootstrapping -- the authoring contract says a project with no Excel yet
+// gets one built from its XML -- so the directory is created rather than
+// refused.
+func (c *CLI) initSyncerFor(subcmd string) error {
 	// Check directories exist
 	if _, err := os.Stat(c.xmlDir); os.IsNotExist(err) {
 		return fmt.Errorf("XML directory not found: %s", c.xmlDir)
 	}
 	if _, err := os.Stat(c.excelDir); os.IsNotExist(err) {
-		return fmt.Errorf("Excel directory not found: %s", c.excelDir)
+		if subcmd != "export" {
+			return fmt.Errorf("Excel directory not found: %s", c.excelDir)
+		}
+		if err := os.MkdirAll(c.excelDir, 0o755); err != nil {
+			return fmt.Errorf("creating Excel directory %s: %w", c.excelDir, err)
+		}
+		fmt.Printf("Created %s (bootstrapping Excel from XML).\n", c.excelDir)
 	}
 
 	// Create syncer

--- a/cmd/dtrules/sync_bootstrap_test.go
+++ b/cmd/dtrules/sync_bootstrap_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A missing excel/ is an error for every sync direction but one. Importing
+// from a directory that is not there, or reporting status on it, means the
+// caller is pointed at the wrong project. Exporting into it is bootstrapping,
+// which the authoring contract provides for -- and refusing it is what left
+// Cribbage, CorporateTax and SyntaxTests with no authoring surface at all
+// (#1026, #1012).
+
+func syncCLIWithoutExcelDir(t *testing.T) (*CLI, string) {
+	t.Helper()
+	root := t.TempDir()
+	xmlDir := filepath.Join(root, "xml")
+	if err := os.MkdirAll(xmlDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	excelDir := filepath.Join(root, "excel") // deliberately not created
+	return &CLI{xmlDir: xmlDir, excelDir: excelDir}, excelDir
+}
+
+func TestSyncExportCreatesTheExcelDirectory(t *testing.T) {
+	c, excelDir := syncCLIWithoutExcelDir(t)
+
+	if err := c.initSyncerFor("export"); err != nil {
+		t.Fatalf("export should bootstrap a missing excel dir, got: %v", err)
+	}
+	if _, err := os.Stat(excelDir); err != nil {
+		t.Errorf("excel dir was not created: %v", err)
+	}
+}
+
+func TestSyncImportAndStatusStillRefuseAMissingExcelDirectory(t *testing.T) {
+	for _, subcmd := range []string{"import", "status", "check", "auto", ""} {
+		t.Run("subcmd="+subcmd, func(t *testing.T) {
+			c, excelDir := syncCLIWithoutExcelDir(t)
+
+			if err := c.initSyncerFor(subcmd); err == nil {
+				t.Fatalf("%q should refuse a missing excel dir rather than "+
+					"create one — the caller is pointed at the wrong project", subcmd)
+			}
+			if _, err := os.Stat(excelDir); err == nil {
+				t.Errorf("%q created the excel dir; only export may do that", subcmd)
+			}
+		})
+	}
+}
+
+// A missing xml/ is always an error: there is nothing to export from.
+func TestSyncExportStillRefusesAMissingXMLDirectory(t *testing.T) {
+	root := t.TempDir()
+	c := &CLI{
+		xmlDir:   filepath.Join(root, "xml"), // not created
+		excelDir: filepath.Join(root, "excel"),
+	}
+	if err := c.initSyncerFor("export"); err == nil {
+		t.Fatal("export with no XML directory should be an error")
+	}
+}


### PR DESCRIPTION
Advances #1026 and #1012.

`dtrules sync export` refused outright when `excel/` did not exist:

```
Error initializing syncer: Excel directory not found: .../excel
```

A missing `excel/` is an error for every direction but this one. Importing from
a directory that is not there, or reporting status on it, means the caller is
pointed at the wrong project. Exporting into it is **bootstrapping**, which the
authoring contract provides for — *"if the project has no Excel yet, the API
bootstraps it from the XML"* — so the directory is created rather than refused.

## What it unblocks

Cribbage, CorporateTax and SyntaxTests each carry XML whose tables name
workbooks that do not exist, and the one command that could have produced them
would not run. Cribbage had an empty `excel/` so it only needed #1069; the
other two had no directory at all.

| sample | workbooks bootstrapped | `references workbook X` findings | verify |
|---|---|---|---|
| Cribbage | 2 | gone | **verified** |
| CorporateTax | 3 | gone | still fails — undefined operators in the NV tables |
| SyntaxTests | 2 | gone | still fails — undefined `Error_handling_table` |

The two remaining failures are rule content, not plumbing, and were there all
along behind the workbook errors.

## Tests

Pin the asymmetry: export creates it; `import`, `status`, `check`, `auto` and
the unnamed default still refuse and must not create it; and a missing `xml/`
is still an error in every direction, since there is nothing to export from.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)