### PR TITLE
fix(authoring): the Excel refresh must write a workbook only its own tables (#1077)

### DIFF
--- a/pkg/dtrules/authoring/excel_sync.go
+++ b/pkg/dtrules/authoring/excel_sync.go
@@ -123,8 +123,20 @@ func RefreshExcelIn(xmlDir, excelDir string) error {
 		if _, err := os.Stat(excelPath); err != nil {
 			continue
 		}
-		if err := exporter.ExportDecisionTables(excelPath); err != nil {
+		// Only this workbook's own tables. ExportDecisionTables writes the
+		// whole rule set, which run across a project's workbooks gives every
+		// one of them every table: a no-op `table put` on SinusitisTherapy
+		// took service1_medication.xlsx from 3 sheets to 6 and therapy.xlsx
+		// from 1 to 6, and turned a verified project red (#1077).
+		//
+		// A workbook no table claims is left alone rather than emptied --
+		// see ExportDecisionTablesOwnedBy.
+		n, err := exporter.ExportDecisionTablesOwnedBy(excelPath)
+		if err != nil {
 			return fmt.Errorf("excel refresh: export %s: %w", excelPath, err)
+		}
+		if n == 0 {
+			continue
 		}
 		if err := m.RecordExport(excelPath, entry.XMLFiles); err != nil {
 			return fmt.Errorf("excel refresh: record manifest for %s: %w", excelPath, err)

--- a/pkg/dtrules/excel/export_owned_test.go
+++ b/pkg/dtrules/excel/export_owned_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import (
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// Refreshing a project's workbooks used to call ExportDecisionTables once per
+// workbook, and that writes the whole rule set. Across N workbooks every one
+// ended up holding every table: a no-op `dtrules table put` on
+// SinusitisTherapy took service1_medication.xlsx from 3 sheets to 6 and
+// therapy.xlsx from 1 to 6 (#1077). Ownership is decided by workbookKey.
+
+func TestWorkbookKeyMatchesHowXlsFileIsActuallyRecorded(t *testing.T) {
+	cases := []struct {
+		a, b string
+		same bool
+	}{
+		// The recorded xls_file is historically inconsistent about extension.
+		{"/p/excel/Foo.xlsx", "Foo.xls", true},
+		{"/p/excel/Foo.xlsx", "Foo.xlsx", true},
+		{"/p/excel/Foo.xlsx", "Foo", true},
+		// And about being a path rather than a name.
+		{"/p/excel/states/NV_corp.xlsx", "NV_corp.xlsx", true},
+		{"/p/excel/Foo.xlsx", "other/Foo.xls", true},
+		// Case is display-only in DTRules; two spellings are one name.
+		{"/p/excel/Foo.xlsx", "foo.XLS", true},
+		// Different workbooks stay different.
+		{"/p/excel/Foo.xlsx", "Bar.xlsx", false},
+		{"/p/excel/CHIP.xlsx", "CHIP_map.xlsx", false},
+	}
+	for _, c := range cases {
+		got := workbookKey(c.a) == workbookKey(c.b)
+		if got != c.same {
+			t.Errorf("workbookKey(%q)==workbookKey(%q) = %v, want %v (%q vs %q)",
+				c.a, c.b, got, c.same, workbookKey(c.a), workbookKey(c.b))
+		}
+	}
+}
+
+// A workbook no table claims must be left alone. Overwriting it with an empty
+// file would destroy a workbook whose tables merely record a different
+// spelling than the one on disk -- which is the state CorporateTax and CHIP
+// were both in.
+func TestExportOwnedByLeavesAnUnclaimedWorkbookAlone(t *testing.T) {
+	e := NewExporter(session.NewRuleSet("empty")) // nothing can claim anything
+
+	n, err := e.ExportDecisionTablesOwnedBy("/nonexistent/dir/Unclaimed.xlsx")
+	if err != nil {
+		t.Fatalf("an unclaimed workbook should be a no-op, not an error: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("wrote %d tables to a workbook no table claims, want 0", n)
+	}
+	// The path does not exist; reaching SaveAs would have errored above. That
+	// it did not is the assertion.
+}

--- a/pkg/dtrules/excel/exporter.go
+++ b/pkg/dtrules/excel/exporter.go
@@ -18,6 +18,7 @@ package excel
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -31,7 +32,7 @@ import (
 
 const (
 	maxCol         = 16
-	narrowColWidth = 5.0  // Decision columns (Y/N/X values)
+	narrowColWidth = 5.0 // Decision columns (Y/N/X values)
 	wideColWidth   = 40.0
 
 	colorEDDEntityHeader = "D0D8E8"
@@ -75,6 +76,65 @@ func (e *Exporter) ExportDecisionTables(filename string) error {
 	}
 
 	return f.SaveAs(filename)
+}
+
+// ExportDecisionTablesOwnedBy writes only the tables that belong in filename,
+// judged by each table's xls_file, and reports how many it wrote.
+//
+// ExportDecisionTables writes every table in the rule set, which is right for
+// a caller producing one workbook from a whole project and destructive for one
+// refreshing a project's existing workbooks in place: run over N workbooks it
+// writes the rule set N times and every workbook ends up holding every table.
+// A no-op `dtrules table put` on SinusitisTherapy took service1_medication.xlsx
+// from 3 sheets to 6 and therapy.xlsx from 1 to 6, turning a verified project
+// red without any rule being edited (#1077).
+//
+// Matching is on base name with the extension dropped, because the recorded
+// xls_file is historically inconsistent about it -- the same table may be
+// recorded as Foo.xls, Foo.xlsx or a path -- and case-insensitively, because
+// nothing about a name in DTRules is case-sensitive.
+//
+// Returns 0 when no table claims the workbook. Callers should treat that as
+// "leave the file alone": overwriting it with nothing would empty a workbook
+// whose tables merely record a different spelling.
+func (e *Exporter) ExportDecisionTablesOwnedBy(filename string) (int, error) {
+	want := workbookKey(filename)
+
+	var owned []*decisiontable.RDecisionTable
+	for _, dt := range e.getAllDecisionTables() {
+		if workbookKey(dt.GetFilePath()) == want {
+			owned = append(owned, dt)
+		}
+	}
+	if len(owned) == 0 {
+		return 0, nil
+	}
+	sortTablesByTableNumber(owned)
+
+	f := excelize.NewFile()
+	defer f.Close()
+	defaultSheet := f.GetSheetName(0)
+
+	styler, err := NewStyler(f)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create styles: %w", err)
+	}
+	for _, dt := range owned {
+		if err := e.writeDecisionTable(f, dt, styler); err != nil {
+			return 0, fmt.Errorf("failed to write table %s: %w", dt.GetName(), err)
+		}
+	}
+	if len(f.GetSheetList()) > 1 {
+		f.DeleteSheet(defaultSheet)
+	}
+	return len(owned), f.SaveAs(filename)
+}
+
+// workbookKey reduces a workbook reference to something comparable: base name,
+// no extension, lowercased.
+func workbookKey(ref string) string {
+	base := filepath.Base(strings.TrimSpace(ref))
+	return strings.ToLower(strings.TrimSuffix(base, filepath.Ext(base)))
 }
 
 // getAllDecisionTables returns all decision tables from the ruleset.


### PR DESCRIPTION
Addresses #1077.

`RefreshExcelIn` called `ExportDecisionTables` once per workbook in the sync
manifest — and that method writes **every** decision table in the rule set.
Across N workbooks it wrote the rule set N times, destroying the
workbook↔table mapping.

A `table put` that changed nothing was enough to trigger it:

```
$ dtrules verify
verified: ... is consistent with its Excel source
$ dtrules table put Determine_Therapy < unchanged.json
$ dtrules verify
verify FAILED
[build] xml/service1_medication_dt.xml: content differs from build output
```

| workbook | before | after (old) | after (fixed) |
|---|---|---|---|
| `service1_medication.xlsx` | 3 sheets | 6 | **3** |
| `therapy.xlsx` | 1 sheet | 6 | **1** |

Any project with more than one workbook, on every authoring write. Single-
workbook projects are unaffected, which is why the CHIP-based authoring tests
never caught it.

## The fix

`ExportDecisionTablesOwnedBy` selects by the table's own `xls_file`. Matching
is on base name without extension — what gets recorded there is historically
inconsistent (`Foo.xls`, `Foo.xlsx`, or a path) — and case-insensitively, since
two spellings of a name in DTRules are one name.

A workbook no table claims is **left alone rather than emptied**. Overwriting
it with nothing would destroy a workbook whose tables merely record a different
spelling, which is the state CHIP and CorporateTax are both in.

## Honest limit

This does not yet make the no-op put a no-op. Two findings remain on
SinusitisTherapy from a separate round-trip asymmetry — the exporter writes `-`
into condition cells the XML left blank, and the importer reads those back as
explicit entries. Same meaning, different bytes. Filed separately; sheet
routing is what this PR fixes.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)