### PR TITLE
feat(sync): say when an export wrote a workbook missing tables (#1081)

### DIFF
--- a/cmd/dtrules/cli.go
+++ b/cmd/dtrules/cli.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/xuri/excelize/v2"
 	"os"
 	"path/filepath"
 	"strings"
@@ -553,6 +554,7 @@ func (c *CLI) syncExport() int {
 
 	if result.XMLToExcelCount > 0 {
 		fmt.Printf("✓ Exported %d file(s) from XML to Excel.\n", result.XMLToExcelCount)
+		c.warnIncompleteExport()
 	} else {
 		fmt.Println("No files needed export (Excel is up to date).")
 	}
@@ -873,4 +875,70 @@ func (c *CLI) runVersion() int {
 	fmt.Println("Decision Table Rules Engine")
 	fmt.Println("https://github.com/DTRules/DTRules")
 	return 0
+}
+
+// warnIncompleteExport reports workbooks that came out with fewer sheets than
+// their XML has tables.
+//
+// The export builds from a tolerantly-loaded rule set -- deliberately, so it
+// still works while an operator has DSL written and postfix not yet compiled.
+// A table that will not load is skipped, and the workbook is written without
+// it. That is the right tolerance and the wrong silence: bootstrapping
+// Cribbage produced a six-sheet workbook for an eleven-table project, reported
+// "Exported 2 file(s)", exited 0, and the five tables it left out were only
+// noticed after they had been committed (#1081).
+//
+// verify cannot catch it either: it compares the XML against a rebuild from
+// that same workbook, so both sides agree on the tables that survived and the
+// missing ones are never part of the comparison.
+//
+// Checking the outcome rather than instrumenting the loader keeps this honest
+// whichever stage does the dropping.
+func (c *CLI) warnIncompleteExport() {
+	for _, msg := range c.incompleteExports() {
+		fmt.Fprint(os.Stderr, msg)
+	}
+}
+
+// incompleteExports returns one message per workbook that has fewer sheets
+// than its XML has tables. Separated from the printing so it can be tested.
+func (c *CLI) incompleteExports() []string {
+	var found []string
+	dtFiles, _ := filepath.Glob(filepath.Join(c.xmlDir, "*_dt.xml"))
+	nested, _ := filepath.Glob(filepath.Join(c.xmlDir, "*", "*_dt.xml"))
+	dtFiles = append(dtFiles, nested...)
+
+	for _, dtPath := range dtFiles {
+		data, err := os.ReadFile(dtPath)
+		if err != nil {
+			continue
+		}
+		declared := strings.Count(string(data), "<table_name>")
+		if declared == 0 {
+			continue
+		}
+
+		base := strings.TrimSuffix(filepath.Base(dtPath), "_dt.xml")
+		rel, err := filepath.Rel(c.xmlDir, filepath.Dir(dtPath))
+		if err != nil {
+			rel = "."
+		}
+		excelPath := filepath.Join(c.excelDir, rel, base+".xlsx")
+
+		f, err := excelize.OpenFile(excelPath)
+		if err != nil {
+			continue // no paired workbook; verify reports that separately
+		}
+		written := len(f.GetSheetList())
+		_ = f.Close()
+
+		if written < declared {
+			found = append(found, fmt.Sprintf(
+				"WARNING: %s has %d sheet(s) for %d table(s) in %s.\n"+
+					"  Tables that fail to load are skipped by the export. Fix the load\n"+
+					"  errors and re-export, or the workbook is missing rules.\n",
+				filepath.Base(excelPath), written, declared, filepath.Base(dtPath)))
+		}
+	}
+	return found
 }

--- a/cmd/dtrules/incomplete_export_test.go
+++ b/cmd/dtrules/incomplete_export_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xuri/excelize/v2"
+)
+
+// The export builds from a tolerantly-loaded rule set, so a table that will
+// not load is skipped and the workbook is written without it -- reporting
+// success. Bootstrapping Cribbage produced a six-sheet workbook for an
+// eleven-table project and the five missing tables were only noticed after
+// being committed (#1081). verify cannot catch it: it compares the XML against
+// a rebuild from that same workbook, so the missing tables are never part of
+// the comparison.
+
+// exportedProject writes a _dt.xml declaring tables and a workbook holding
+// sheets, in whatever numbers the caller asks for.
+func exportedProject(t *testing.T, tables, sheets int) *CLI {
+	t.Helper()
+	root := t.TempDir()
+	xmlDir := filepath.Join(root, "xml")
+	excelDir := filepath.Join(root, "excel")
+	for _, d := range []string{xmlDir, excelDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<decision_tables>")
+	for i := 0; i < tables; i++ {
+		sb.WriteString("<decision_table><table_name>T")
+		sb.WriteByte(byte('A' + i))
+		sb.WriteString("</table_name></decision_table>")
+	}
+	sb.WriteString("</decision_tables>")
+	if err := os.WriteFile(filepath.Join(xmlDir, "Proj_dt.xml"), []byte(sb.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := excelize.NewFile()
+	defer f.Close()
+	for i := 1; i < sheets; i++ { // NewFile already has one sheet
+		if _, err := f.NewSheet("S" + string(rune('A'+i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := f.SaveAs(filepath.Join(excelDir, "Proj.xlsx")); err != nil {
+		t.Fatal(err)
+	}
+
+	return &CLI{xmlDir: xmlDir, excelDir: excelDir}
+}
+
+func TestIncompleteExportIsReported(t *testing.T) {
+	c := exportedProject(t, 11, 6) // the Cribbage shape
+
+	found := c.incompleteExports()
+	if len(found) != 1 {
+		t.Fatalf("want 1 warning for a 6-sheet workbook covering 11 tables, got %d: %v",
+			len(found), found)
+	}
+	// The counts are what make it actionable -- "something is wrong" is not
+	// enough to act on before committing.
+	for _, want := range []string{"6 sheet", "11 table", "Proj.xlsx", "Proj_dt.xml"} {
+		if !strings.Contains(found[0], want) {
+			t.Errorf("warning should mention %q, got: %s", want, found[0])
+		}
+	}
+}
+
+func TestCompleteExportIsSilent(t *testing.T) {
+	c := exportedProject(t, 6, 6)
+
+	if found := c.incompleteExports(); len(found) != 0 {
+		t.Errorf("a workbook covering every table must be silent, got: %v", found)
+	}
+}
+
+// More sheets than tables is normal -- a workbook can carry an EDD sheet or
+// other content alongside. Only a shortfall means rules went missing.
+func TestExtraSheetsAreNotAShortfall(t *testing.T) {
+	c := exportedProject(t, 3, 8)
+
+	if found := c.incompleteExports(); len(found) != 0 {
+		t.Errorf("extra sheets are not missing rules, got: %v", found)
+	}
+}
+
+// No workbook at all is verify's business, not this check's; reporting it here
+// too would double up on every project mid-bootstrap.
+func TestMissingWorkbookIsNotReportedHere(t *testing.T) {
+	c := exportedProject(t, 4, 4)
+	if err := os.Remove(filepath.Join(c.excelDir, "Proj.xlsx")); err != nil {
+		t.Fatal(err)
+	}
+
+	if found := c.incompleteExports(); len(found) != 0 {
+		t.Errorf("a missing workbook is reported by verify, not here, got: %v", found)
+	}
+}


### PR DESCRIPTION
Closes #1081.

The export builds from a tolerantly-loaded rule set. That tolerance is right —
it has to work while an operator has DSL written and postfix not yet compiled —
but a table that will not load is skipped, the workbook is written without it,
and the command reports success.

Bootstrapping Cribbage produced a **six-sheet workbook for an eleven-table
project**: `✓ Exported 2 file(s) from XML to Excel.`, exit 0, no warning. The
five missing tables were noticed only after being committed (#1080).

Nothing downstream catches it — `verify` compares the XML against a rebuild
from that same workbook, so both sides agree on the tables that survived and
the missing ones are never part of the comparison.

## The check

On the **outcome**, not the loader: for each `*_dt.xml`, compare the tables it
declares against the sheets in its workbook. That stays honest whichever stage
does the dropping, and needs no plumbing through the export path.

```
WARNING: Cribbage.xlsx has 6 sheet(s) for 11 table(s) in Cribbage_dt.xml.
  Tables that fail to load are skipped by the export. Fix the load
  errors and re-export, or the workbook is missing rules.
```

The counts are the point — "something is wrong" is not enough to act on before
committing; six-of-eleven is.

## Deliberately quiet

More sheets than tables is normal (a workbook can carry an EDD sheet alongside),
and a missing workbook is `verify`'s business rather than a second report here.
Both pinned by tests.

Verified silent on Cribbage, SinusitisTherapy and CHIP. `make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)