### PR TITLE
fix(excel): an export that cannot carry every table must refuse (#1081)

### DIFF
--- a/pkg/dtrules/authoring/excel_sync.go
+++ b/pkg/dtrules/authoring/excel_sync.go
@@ -251,6 +251,12 @@ func loadRuleSetForExportInDir(xmlDir string) (*session.RuleSet, error) {
 			return nil, fmt.Errorf("load dt %s: %w", dtPath, err)
 		}
 	}
+	// Tolerance is for partially-compiled DSL, not for losing tables. An
+	// export that quietly omits one writes a workbook that cannot regenerate
+	// the project it came from (#1081).
+	if err := excel.AssertRuleSetCovers(rs, dtPaths...); err != nil {
+		return nil, err
+	}
 	return rs, nil
 }
 

--- a/pkg/dtrules/excel/coverage.go
+++ b/pkg/dtrules/excel/coverage.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+var tableNameRE = regexp.MustCompile(`<table_name>([^<]*)</table_name>`)
+
+// AssertRuleSetCovers refuses an export whose rule set is missing tables the
+// XML declares.
+//
+// Exports build from a tolerantly-loaded rule set, deliberately: the export
+// has to work while an operator has DSL written and postfix not yet compiled.
+// The cost is that a table which will not load is skipped, and the workbook is
+// written without it -- bootstrapping Cribbage produced a six-sheet workbook
+// for an eleven-table project and reported success (#1081).
+//
+// While Excel merely sat beside the XML that was an incomplete artifact. Once
+// Excel is the system of record and the XML is generated from it, the same
+// skip deletes rules: the next build regenerates the XML from a workbook that
+// never received them.
+//
+// So this is a refusal, not a warning. If Excel cannot represent every table
+// the XML declares, that is a defect in DTRules -- the system of record has to
+// be able to hold the system -- and the right response is to stop and say
+// which tables, not to write a lossy workbook quietly.
+func AssertRuleSetCovers(rs *session.RuleSet, xmlPaths ...string) error {
+	declared := map[string]bool{}
+	for _, p := range xmlPaths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue // a path that is not there declares nothing
+		}
+		for _, m := range tableNameRE.FindAllStringSubmatch(string(data), -1) {
+			if name := strings.TrimSpace(m[1]); name != "" {
+				declared[strings.ToLower(name)] = true
+			}
+		}
+	}
+	if len(declared) == 0 {
+		return nil
+	}
+
+	for _, rn := range rs.GetDecisionTableNames() {
+		delete(declared, strings.ToLower(rn.StringValue()))
+	}
+	if len(declared) == 0 {
+		return nil
+	}
+
+	missing := make([]string, 0, len(declared))
+	for name := range declared {
+		missing = append(missing, name)
+	}
+	sort.Strings(missing)
+
+	return fmt.Errorf(
+		"refusing to export: %d table(s) declared in the XML did not load, so the "+
+			"workbook would be written without them: %s\n"+
+			"  Excel is the system of record, so a workbook that cannot hold every "+
+			"table is a defect, not a partial success. Fix the load errors "+
+			"(dtrules verify names them) and export again",
+		len(missing), strings.Join(missing, ", "))
+}

--- a/pkg/dtrules/excel/coverage_test.go
+++ b/pkg/dtrules/excel/coverage_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// Exports build from a tolerantly-loaded rule set, so a table that will not
+// load is skipped and the workbook written without it. While Excel merely sat
+// beside the XML that was an incomplete artifact; once Excel is the system of
+// record and the XML is generated from it, the same skip deletes rules
+// (#1081).
+
+const twoTableDT = `<decision_tables>
+<decision_table><table_name>Alpha</table_name>
+<attribute_fields><Type>FIRST</Type><TABLE_NUMBER>1</TABLE_NUMBER></attribute_fields>
+<contexts></contexts><initial_actions></initial_actions>
+<conditions></conditions><actions></actions>
+</decision_table>
+<decision_table><table_name>Beta</table_name>
+<attribute_fields><Type>FIRST</Type><TABLE_NUMBER>2</TABLE_NUMBER></attribute_fields>
+<contexts></contexts><initial_actions></initial_actions>
+<conditions></conditions><actions></actions>
+</decision_table>
+</decision_tables>`
+
+func writeDT(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "P_dt.xml")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestExportRefusedWhenATableDidNotLoad(t *testing.T) {
+	path := writeDT(t, twoTableDT)
+
+	// A rule set that got only one of the two -- the shape a tolerant load
+	// leaves behind when a table fails.
+	rs := session.NewRuleSet("partial")
+	if err := rs.LoadDecisionTablesTolerant(strings.NewReader(
+		strings.Replace(twoTableDT, `<decision_table><table_name>Beta</table_name>
+<attribute_fields><Type>FIRST</Type><TABLE_NUMBER>2</TABLE_NUMBER></attribute_fields>
+<contexts></contexts><initial_actions></initial_actions>
+<conditions></conditions><actions></actions>
+</decision_table>
+`, "", 1))); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	err := AssertRuleSetCovers(rs, path)
+	if err == nil {
+		t.Fatal("a rule set missing a table the XML declares must refuse the " +
+			"export; writing the workbook without it deletes the rule on the " +
+			"next build")
+	}
+	if !strings.Contains(err.Error(), "beta") {
+		t.Errorf("the error must name what is missing, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "system of record") {
+		t.Errorf("the error should say why this is fatal, got: %v", err)
+	}
+}
+
+func TestExportProceedsWhenEveryTableLoaded(t *testing.T) {
+	path := writeDT(t, twoTableDT)
+
+	rs := session.NewRuleSet("full")
+	if err := rs.LoadDecisionTablesTolerant(strings.NewReader(twoTableDT)); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if err := AssertRuleSetCovers(rs, path); err != nil {
+		t.Fatalf("every declared table loaded, so the export should proceed: %v", err)
+	}
+}
+
+// Case is display-only in DTRules: two spellings are one name, so a rule set
+// holding "alpha" covers an XML declaring "Alpha".
+func TestCoverageIsCaseInsensitive(t *testing.T) {
+	path := writeDT(t, strings.ReplaceAll(twoTableDT, "Alpha", "ALPHA"))
+
+	rs := session.NewRuleSet("mixed")
+	if err := rs.LoadDecisionTablesTolerant(strings.NewReader(twoTableDT)); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if err := AssertRuleSetCovers(rs, path); err != nil {
+		t.Errorf("ALPHA and Alpha are one name; coverage must not depend on "+
+			"spelling: %v", err)
+	}
+}
+
+// A path that is not there declares nothing, and an empty project is not a
+// failure -- otherwise bootstrapping a project with no XML yet would refuse.
+func TestNoDeclaredTablesIsNotAFailure(t *testing.T) {
+	rs := session.NewRuleSet("empty")
+	if err := AssertRuleSetCovers(rs, "/nonexistent/P_dt.xml"); err != nil {
+		t.Errorf("nothing declared means nothing to lose: %v", err)
+	}
+}

--- a/pkg/dtrules/excel/workbook_exporter.go
+++ b/pkg/dtrules/excel/workbook_exporter.go
@@ -98,6 +98,11 @@ func (w *WorkbookExporter) ExportDecisionTable(xmlPath, excelPath string) error 
 	if err := rs.LoadDecisionTablesTolerantFile(xmlPath); err != nil {
 		return fmt.Errorf("failed to load decision table: %w", err)
 	}
+	// Tolerance is for partially-compiled DSL, not for losing tables. See
+	// AssertRuleSetCovers (#1081).
+	if err := AssertRuleSetCovers(rs, xmlPath); err != nil {
+		return err
+	}
 
 	// Ensure parent directory exists
 	if err := os.MkdirAll(filepath.Dir(excelPath), 0755); err != nil {
@@ -198,6 +203,11 @@ func (w *WorkbookExporter) ExportCombined(dtPath, eddPath, excelPath string) err
 		if _, err := os.Stat(dtPath); err == nil {
 			if err := rs.LoadDecisionTablesTolerantFile(dtPath); err != nil {
 				return fmt.Errorf("failed to load decision table: %w", err)
+			}
+			// Tolerance is for partially-compiled DSL, not for losing
+			// tables (#1081).
+			if err := AssertRuleSetCovers(rs, dtPath); err != nil {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
Reopens and hardens #1081.

Exports build from a tolerantly-loaded rule set, and that tolerance is right —
the export has to work while an operator has DSL written and postfix not yet
compiled. The cost was that a table which would not load was skipped, the
workbook written without it, and success reported. Bootstrapping Cribbage
produced a **six-sheet workbook for an eleven-table project** that way.

While Excel merely sat beside the XML, that was an incomplete artifact and a
warning was a reasonable answer (#1082). It stops being reasonable the moment
**Excel is the system of record and the XML is generated from it**: the same
skip then *deletes* rules, because the next build regenerates the XML from a
workbook that never received them.

So it refuses, and names the tables:

```
refusing to export: 1 table(s) declared in the XML did not load, so the
workbook would be written without them: beta
  Excel is the system of record, so a workbook that cannot hold every table
  is a defect, not a partial success.
```

## Why a refusal rather than a fix-up

If Excel cannot represent every table the XML declares, that is a defect in
DTRules — a system of record has to be able to hold the system. The useful
response is to stop and say which tables, not to write a lossy workbook
quietly and let it be discovered later.

## Where the check sits

On the **outcome**: compare the tables the XML declares against the tables the
rule set actually loaded. That stays honest wherever the drop happens, which
matters because the tolerance lives several layers down in the loader. Both
export paths call it — the workbook exporter `sync export` uses, and the
authoring refresh.

Matching is case-insensitive, since two spellings of a name in DTRules are one
name. An XML path that is not there declares nothing, so bootstrapping a
project with no XML yet is unaffected.

## Verification

- Four tests: refusal names the missing table and says why; a complete load
  proceeds; case does not affect coverage; nothing declared is not a failure.
- Verified quiet on SinusitisTherapy, CHIP, Cribbage, Poker, StateTax and
  SyntaxTests — all export with no refusal.
- `make check` passes.

This is a precondition for making the XML fully derived from Excel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)