### PR TITLE
fix(excel): an authoring write must not delete the workbook's EDD sheet (#1094)

### DIFF
--- a/pkg/dtrules/authoring/excel_sync.go
+++ b/pkg/dtrules/authoring/excel_sync.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/DTRules/DTRules/pkg/dtrules/excel"
 	"github.com/DTRules/DTRules/pkg/dtrules/session"
@@ -219,8 +221,29 @@ func loadRuleSetForExportInDir(xmlDir string) (*session.RuleSet, error) {
 	if rs == nil {
 		return nil, fmt.Errorf("failed to create ruleset")
 	}
-	eddMatches, _ := filepath.Glob(filepath.Join(xmlDir, "*_edd.xml"))
-	for _, eddPath := range eddMatches {
+	// EDD files are loaded recursively, for the same reason the DT files
+	// below are: a nested layout puts them under states/ and the runtime
+	// loader finds them there.
+	//
+	// This globbed the top level only, so CorporateTax's 51 state EDDs were
+	// never loaded while their decision tables were. Two consequences, both
+	// silent. The export wrote every state workbook without its EDD sheet,
+	// because no entity claimed the workbook -- the entities were not in the
+	// rule set at all. And the tables compiled against a symbol table missing
+	// their own fields, so `f<` on two doubles came out as `<`: fixed-point
+	// amounts compared as integers (#1094).
+	var eddPaths []string
+	_ = filepath.WalkDir(xmlDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(d.Name(), "_edd.xml") {
+			eddPaths = append(eddPaths, p)
+		}
+		return nil
+	})
+	sort.Strings(eddPaths)
+	for _, eddPath := range eddPaths {
 		if err := rs.LoadEDDFile(eddPath); err != nil {
 			return nil, fmt.Errorf("load edd %s: %w", eddPath, err)
 		}

--- a/pkg/dtrules/excel/dt_importer.go
+++ b/pkg/dtrules/excel/dt_importer.go
@@ -1704,6 +1704,18 @@ var numericDowngrades = map[string]struct{ to, meaning string }{
 	"fp+":       {"+", "fixed-point add became integer"},
 	"fp-":       {"-", "fixed-point subtract became integer"},
 	"cvfp":      {"cvi", "value stored as integer instead of fixed-point"},
+
+	// Comparisons were missing from this table, and a rebuild of
+	// CorporateTax's NV rules quietly turned `f<` into `<`: two fixed-point
+	// amounts compared as integers, so the scaled and unscaled values are
+	// read as the same magnitude. A wrong comparison decides which column
+	// fires, which is a wrong answer rather than a rounded one.
+	"f<":  {"<", "fixed-point comparison became integer"},
+	"f>":  {">", "fixed-point comparison became integer"},
+	"f<=": {"<=", "fixed-point comparison became integer"},
+	"f>=": {">=", "fixed-point comparison became integer"},
+	"f==": {"==", "fixed-point equality became integer"},
+	"f!=": {"!=", "fixed-point inequality became integer"},
 }
 
 // warnNumericDowngrade reports a recompile that silently weakens arithmetic.

--- a/pkg/dtrules/excel/exporter.go
+++ b/pkg/dtrules/excel/exporter.go
@@ -124,6 +124,19 @@ func (e *Exporter) ExportDecisionTablesOwnedBy(filename string) (int, error) {
 			return 0, fmt.Errorf("failed to write table %s: %w", dt.GetName(), err)
 		}
 	}
+
+	// The workbook's own entities go back with its tables. Writing decision
+	// tables alone deleted the EDD sheet from every workbook that carried one,
+	// on every authoring write -- and Excel is the system of record, so that
+	// deleted the dictionary from the record. The next build then imported a
+	// workbook with no types and compiled the DSL untyped, turning `f<` into
+	// `<`: two fixed-point amounts compared as integers (#1094).
+	if ents := e.entitiesOwnedBy(filename); len(ents) > 0 {
+		if err := e.writeEDDSheet(f, styler, "EDD", ents); err != nil {
+			return 0, fmt.Errorf("failed to write EDD sheet: %w", err)
+		}
+	}
+
 	if len(f.GetSheetList()) > 1 {
 		f.DeleteSheet(defaultSheet)
 	}
@@ -362,9 +375,8 @@ func (e *Exporter) ExportCombinedWorkbook(filename string) error {
 		}
 	}
 
-	entities := e.ruleSet.GetEntityFactory().GetRefEntities()
-	if len(entities) > 0 {
-		if err := e.writeEDDSheet(f, styler, "EDD"); err != nil {
+	if entities := e.allEntities(); len(entities) > 0 {
+		if err := e.writeEDDSheet(f, styler, "EDD", entities); err != nil {
 			return fmt.Errorf("failed to write EDD sheet: %w", err)
 		}
 	}
@@ -380,7 +392,9 @@ func (e *Exporter) ExportCombinedWorkbook(filename string) error {
 // writeEDDSheet writes the EDD data to a sheet in an existing workbook.
 // Row 1 carries the "EDD: EDD" type marker so mixed-workbook importers can
 // detect sheet type from A1 without relying on the sheet name.
-func (e *Exporter) writeEDDSheet(f *excelize.File, styler *Styler, sheetName string) error {
+// writeEDDSheet adds an EDD sheet holding the given entities. Callers that
+// want the whole dictionary pass e.allEntities().
+func (e *Exporter) writeEDDSheet(f *excelize.File, styler *Styler, sheetName string, entities []*entity.REntity) error {
 	_, err := f.NewSheet(sheetName)
 	if err != nil {
 		return err
@@ -400,14 +414,37 @@ func (e *Exporter) writeEDDSheet(f *excelize.File, styler *Styler, sheetName str
 	e.writeEDDHeaders(f, sheetName, styler, 2)
 	FreezePaneAtRow3(f, sheetName)
 
+	e.writeEDDEntities(f, sheetName, entities, styler, eddStyles, 3)
+
+	return nil
+}
+
+// allEntities is every entity in the rule set, in name order.
+func (e *Exporter) allEntities() []*entity.REntity {
 	entities := e.ruleSet.GetEntityFactory().GetRefEntities()
 	sort.Slice(entities, func(i, j int) bool {
 		return entities[i].GetName().StringValue() < entities[j].GetName().StringValue()
 	})
+	return entities
+}
 
-	e.writeEDDEntities(f, sheetName, entities, styler, eddStyles, 3)
-
-	return nil
+// entitiesOwnedBy is the entities whose workbook is filename, in name order.
+//
+// Deliberately GetXlsFile and not GetFilePath: the latter prefers the EDD's
+// own file identity ("CHIP_edd", from <file_metadata><file_path>) and falls
+// back to the workbook only when that is absent. That is the right answer for
+// ExportEDDToDir, which names output files after the EDD, and the wrong one
+// here, where the question is which workbook an entity belongs in. Matching on
+// it silently found nothing and the EDD sheet went on being dropped.
+func (e *Exporter) entitiesOwnedBy(filename string) []*entity.REntity {
+	want := workbookKey(filename)
+	var owned []*entity.REntity
+	for _, ent := range e.allEntities() {
+		if workbookKey(ent.GetXlsFile()) == want {
+			owned = append(owned, ent)
+		}
+	}
+	return owned
 }
 
 // ExportEDDToDir exports entities grouped by xls_file to a directory.

--- a/pkg/dtrules/excel/numeric_downgrade_test.go
+++ b/pkg/dtrules/excel/numeric_downgrade_test.go
@@ -99,3 +99,33 @@ func TestOperatorRemovedWithoutAWeakerReplacementIsSilent(t *testing.T) {
 		t.Errorf("deleting an operation is an edit, not a downgrade: %v", got)
 	}
 }
+
+// Comparisons were missing from the table. A rebuild of CorporateTax's NV
+// rules turned `f<` into `<` -- two fixed-point amounts compared as integers,
+// so a scaled value and an unscaled one read as the same magnitude. That
+// decides which column fires, which is a wrong answer rather than a rounded
+// one, and nothing said a word.
+func TestWarnsWhenAFixedPointComparisonBecomesInteger(t *testing.T) {
+	got := warningsFor(t,
+		"result.nv_gross_revenue result.nv_commerce_tax_threshold f<",
+		"result.nv_gross_revenue result.nv_commerce_tax_threshold <")
+
+	if len(got) != 1 {
+		t.Fatalf("want one warning for f< becoming <, got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0], "comparison became integer") {
+		t.Errorf("the warning should say what was lost, got: %s", got[0])
+	}
+}
+
+func TestEveryFixedPointComparisonIsCovered(t *testing.T) {
+	for _, pair := range [][2]string{
+		{"f<", "<"}, {"f>", ">"}, {"f<=", "<="},
+		{"f>=", ">="}, {"f==", "=="}, {"f!=", "!="},
+	} {
+		got := warningsFor(t, "a b "+pair[0], "a b "+pair[1])
+		if len(got) != 1 {
+			t.Errorf("%s -> %s produced %d warnings, want 1", pair[0], pair[1], len(got))
+		}
+	}
+}


### PR DESCRIPTION
Part of #1094.

The Excel refresh wrote decision tables and nothing else, so a workbook carrying
an EDD sheet lost it on **every authoring write**. A `table put` feeding back
exactly what `table get` returned took `CHIP.xlsx` from 8 sheets to 7, EDD gone.
Excel is the system of record, so that deleted the entity dictionary from the
record.

It did not stop there. The next `build --from-excel` read a workbook with no
EDD, so fields had no types and the DSL recompiled untyped:

```
before:  result.nv_gross_revenue result.nv_commerce_tax_threshold f<
after:   result.nv_gross_revenue result.nv_commerce_tax_threshold <
```

Both are `type="double"`. Comparing a scaled value against an unscaled one reads
them as the same magnitude — a wrong answer, not a rounded one.

## Three changes

**The owned-tables export writes the workbook's own entities.** Matching on
`GetXlsFile`, not `GetFilePath` — the latter prefers the EDD's own file identity
(`CHIP_edd`) and falls back to the workbook only when absent. Right for
`ExportEDDToDir`, wrong here; matching on it found nothing, silently.

**EDD files load recursively**, as the DT files beside them already did. A
nested layout puts them under `states/`, and globbing the top level meant the
export never saw them.

**The numeric-downgrade guard covers comparisons.** It had the arithmetic
operators and `cvfp` but not `f<`, `f>`, `f<=`, `f>=`, `f==`, `f!=` — which is
why the downgrade that led here went unreported.

## Verification

A no-op authoring write across seven samples, total sheet count before → after:

| CHIP | ChipApp | KidAid | Poker | Sinusitis | StateTax | Cribbage |
|---|---|---|---|---|---|---|
| 9 → 9 | 9 → 9 | 9 → 9 | 8 → 8 | 8 → 8 | 11 → 11 | 12 → 12 |

All seven still verify. Before this, CHIP lost a sheet on any write. `make
check` passes.

## Not fixed, and worth stating

CorporateTax's 51 state EDDs each declare entities named `result` and
`apportionment`, so they collapse to 19 shared entities and none claims a
particular state workbook. "Entities owned by `NV_corp.xlsx`" has no answer for
that shape, so its workbooks still lose their EDD sheet. Left on #1094.

🤖 Generated with [Claude Code](https://claude.com/claude-code)