### PR TITLE
fix(excel): an EDD-only workbook was never refreshed, so every EDD edit reverted on the next build (#1094)

### DIFF
--- a/pkg/dtrules/excel/exporter.go
+++ b/pkg/dtrules/excel/exporter.go
@@ -94,9 +94,18 @@ func (e *Exporter) ExportDecisionTables(filename string) error {
 // recorded as Foo.xls, Foo.xlsx or a path -- and case-insensitively, because
 // nothing about a name in DTRules is case-sensitive.
 //
-// Returns 0 when no table claims the workbook. Callers should treat that as
-// "leave the file alone": overwriting it with nothing would empty a workbook
-// whose tables merely record a different spelling.
+// Returns 0 when nothing claims the workbook -- neither a table nor an entity.
+// Callers should treat that as "leave the file alone": overwriting it with
+// nothing would empty a workbook whose contents merely record a different
+// spelling.
+//
+// A workbook may hold entities and no tables, and that case has to be written
+// too. Returning early on "no tables" meant an EDD-only workbook was never
+// refreshed at all, so every `dtrules edd` edit updated the XML and left the
+// workbook stale -- and the next `build --from-excel` restored the XML from
+// that stale workbook, silently reverting the edit. Folding 401 fields into
+// CorporateTax's master EDD survived until the next build and then vanished
+// (#1094).
 func (e *Exporter) ExportDecisionTablesOwnedBy(filename string) (int, error) {
 	want := workbookKey(filename)
 
@@ -106,7 +115,8 @@ func (e *Exporter) ExportDecisionTablesOwnedBy(filename string) (int, error) {
 			owned = append(owned, dt)
 		}
 	}
-	if len(owned) == 0 {
+	ents := e.entitiesOwnedBy(filename)
+	if len(owned) == 0 && len(ents) == 0 {
 		return 0, nil
 	}
 	sortTablesByTableNumber(owned)
@@ -131,7 +141,7 @@ func (e *Exporter) ExportDecisionTablesOwnedBy(filename string) (int, error) {
 	// deleted the dictionary from the record. The next build then imported a
 	// workbook with no types and compiled the DSL untyped, turning `f<` into
 	// `<`: two fixed-point amounts compared as integers (#1094).
-	if ents := e.entitiesOwnedBy(filename); len(ents) > 0 {
+	if len(ents) > 0 {
 		if err := e.writeEDDSheet(f, styler, "EDD", ents); err != nil {
 			return 0, fmt.Errorf("failed to write EDD sheet: %w", err)
 		}
@@ -140,7 +150,9 @@ func (e *Exporter) ExportDecisionTablesOwnedBy(filename string) (int, error) {
 	if len(f.GetSheetList()) > 1 {
 		f.DeleteSheet(defaultSheet)
 	}
-	return len(owned), f.SaveAs(filename)
+	// Count both: the caller uses this to decide whether anything was
+	// written, and an EDD-only workbook writes no tables.
+	return len(owned) + len(ents), f.SaveAs(filename)
 }
 
 // workbookKey reduces a workbook reference to something comparable: base name,


### PR DESCRIPTION
Part of #1094.

`ExportDecisionTablesOwnedBy` returned early when no decision table claimed the
workbook, and the refresh skips a workbook that reports nothing written. So a
workbook holding **entities and no tables** was never written at all.

`CorporateTax_core.xlsx` is exactly that — `CorporateTax_core_edd.xml` has no
matching `_dt.xml`. So `dtrules edd patch` updated the XML, left the workbook
untouched, and the next `build --from-excel` restored the XML from that stale
workbook. **The edit disappeared, having reported success both times.**

## Measured

Adding one field through the authoring API:

| | workbook after |
|---|---|
| main | byte-identical |
| with fix | updated |

The early return now considers entities as well as tables, and the returned
count covers both — an EDD-only workbook writes no tables, so counting only
those told the caller nothing had happened.

Found while folding CorporateTax's 51 state EDDs into a master, where 401 field
additions survived until the next build and then vanished.

`make check` passes and all 11 sample projects still pass the verify gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)