### PR TITLE
feat: a mapping is an argument to loading data, not project state

### DIFF
--- a/cmd/dtrules/run_cmd.go
+++ b/cmd/dtrules/run_cmd.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -40,7 +41,7 @@ import (
 // value hasn't been provided (#850/#854).
 func (c *CLI) runRun(args []string) int {
 	path, entry, input, resultEntity := ".", "", "", "result"
-	var save, data, review, tracePath string
+	var save, data, review, tracePath, mapPath string
 	interactive, web, noOpen := false, false, false
 	port := "0" // 0 = let the OS pick a free port
 	for i := 0; i < len(args); i++ {
@@ -63,6 +64,11 @@ func (c *CLI) runRun(args []string) int {
 		case "--data":
 			if i+1 < len(args) {
 				data = args[i+1]
+				i++
+			}
+		case "--map":
+			if i+1 < len(args) {
+				mapPath = args[i+1]
 				i++
 			}
 		case "--review":
@@ -177,7 +183,7 @@ func (c *CLI) runRun(args []string) int {
 	}
 
 	// Initialize entities (and optionally load input data) via the mapping.
-	if err := initMapping(sess, xmlDir, input); err != nil {
+	if err := initMapping(sess, xmlDir, input, mapPath); err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing data: %v\n", err)
 		return 1
 	}
@@ -249,12 +255,28 @@ func (c *CLI) runRun(args []string) int {
 
 // initMapping loads the project's *_map.xml (if any), initializes the entity
 // stack, and loads input data when a file is given.
-func initMapping(sess dtrules.Session, xmlDir, input string) error {
-	maps, _ := filepath.Glob(filepath.Join(xmlDir, "*_map.xml"))
-	if len(maps) == 0 {
-		return nil // no mapping; rely on whatever the session set up
+func initMapping(sess dtrules.Session, xmlDir, input, mapPath string) error {
+	// A named mapping wins. A mapping is an argument to loading data, not a
+	// property of the project: the same external tag can belong in a different
+	// entity depending on what is being run, and only the caller knows which.
+	chosen := mapPath
+	if chosen == "" {
+		maps, _ := filepath.Glob(filepath.Join(xmlDir, "*_map.xml"))
+		if len(maps) == 0 {
+			return nil // no mapping; rely on whatever the session set up
+		}
+		if len(maps) > 1 {
+			names := make([]string, 0, len(maps))
+			for _, m := range maps {
+				names = append(names, filepath.Base(m))
+			}
+			sort.Strings(names)
+			return fmt.Errorf("%s holds %d mapping files (%s); pass --map <file> to say which one",
+				xmlDir, len(maps), strings.Join(names, ", "))
+		}
+		chosen = maps[0]
 	}
-	mapFile, err := os.Open(maps[0])
+	mapFile, err := os.Open(chosen)
 	if err != nil {
 		return err
 	}
@@ -389,6 +411,10 @@ Options:
   --entry <table>        Decision table to run (required)
   --input <file.xml>     Input data to load via the project mapping
   --data <file.xml>      Load canonical (mapping-free) data, authoritative
+  --map <file.xml>       Use this mapping to load the data. A mapping decides
+                         which entity each external tag lands in, so it is an
+                         argument to loading, not a property of the project.
+                         Required when the project holds more than one.
   --review <file.xml>    Load canonical data for re-interview (pre-filled, asked)
   --save <file.xml>      Save the collected data as canonical XML after the run
   --trace <file.xml>     Write a complete execution trace (initial data,

--- a/pkg/dtrules/authoring/execute.go
+++ b/pkg/dtrules/authoring/execute.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/DTRules/DTRules/pkg/dtrules"
@@ -154,6 +155,33 @@ func (p *Project) LoadTestData(path string) error {
 	dataF, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("open test data: %w", err)
+	}
+	defer dataF.Close()
+
+	return p.loadTestDataFromReaders(mapF, dataF)
+}
+
+// LoadTestDataWithMap populates entity state from a data file, using the
+// mapping the caller names rather than whatever the project happens to hold.
+//
+// This is the general form. A project with one mapping can use LoadTestData
+// and let it find the file; a project with several -- per-state mappings, say,
+// where the same external tag belongs in a different entity depending on which
+// state is being run -- has to say which, because the mapping decides where
+// the data lands.
+func (p *Project) LoadTestDataWithMap(mapPath, dataPath string) error {
+	if err := p.ensureExecState(); err != nil {
+		return err
+	}
+	mapF, err := os.Open(mapPath)
+	if err != nil {
+		return fmt.Errorf("open map file: %w", err)
+	}
+	defer mapF.Close()
+
+	dataF, err := os.Open(dataPath)
+	if err != nil {
+		return fmt.Errorf("open data file: %w", err)
 	}
 	defer dataF.Close()
 
@@ -550,6 +578,16 @@ func (p *Project) findEntityOnStack(name *dtrules.RName) (dtrules.Entity, error)
 }
 
 // findMapFile looks for a *_map.xml file in the project xml dir.
+//
+// One mapping, or none. It used to return maps[0] and say nothing, which is
+// harmless while every project has exactly one and a silent wrong answer the
+// moment one does not: a project with per-state mappings would have been
+// mapped by whichever file sorted first, for every state.
+//
+// A mapping is an argument to loading data, not a property of the project --
+// loadTestDataFromReaders builds a fresh Mapping per call and keeps none. So
+// when there is a choice to make, the caller makes it: LoadTestDataWithMap,
+// or `dtrules run --map`.
 func (p *Project) findMapFile() (string, error) {
 	maps, err := filepath.Glob(filepath.Join(p.xmlDir, "*_map.xml"))
 	if err != nil {
@@ -557,6 +595,19 @@ func (p *Project) findMapFile() (string, error) {
 	}
 	if len(maps) == 0 {
 		return "", fmt.Errorf("no *_map.xml file found in %s", p.xmlDir)
+	}
+	if len(maps) > 1 {
+		names := make([]string, 0, len(maps))
+		for _, m := range maps {
+			names = append(names, filepath.Base(m))
+		}
+		sort.Strings(names)
+		return "", fmt.Errorf(
+			"%s holds %d mapping files (%s); say which one to use\n"+
+				"  A mapping is an argument to loading data, not a property of the "+
+				"project. Pass it explicitly: dtrules run --map <file>, or "+
+				"Project.LoadTestDataWithMap",
+			p.xmlDir, len(maps), strings.Join(names, ", "))
 	}
 	return maps[0], nil
 }

--- a/pkg/dtrules/authoring/explicit_mapping_test.go
+++ b/pkg/dtrules/authoring/explicit_mapping_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A mapping decides which entity each external tag lands in, so it is an
+// argument to loading data rather than a property of the project --
+// loadTestDataFromReaders builds a fresh Mapping per call and keeps none.
+//
+// findMapFile used to return the first match and say nothing, which is
+// harmless while every project has exactly one and a silent wrong answer the
+// moment one does not: per-state mappings would all have been ignored in
+// favour of whichever sorted first.
+
+func projectWithMaps(t *testing.T, names ...string) *Project {
+	t.Helper()
+	root := t.TempDir()
+	xmlDir := filepath.Join(root, "xml")
+	if err := os.MkdirAll(xmlDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(xmlDir, n), []byte("<mapping></mapping>"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &Project{xmlDir: xmlDir}
+}
+
+func TestOneMappingIsFoundWithoutAsking(t *testing.T) {
+	p := projectWithMaps(t, "P_map.xml")
+
+	got, err := p.findMapFile()
+	if err != nil {
+		t.Fatalf("a single mapping should be found: %v", err)
+	}
+	if filepath.Base(got) != "P_map.xml" {
+		t.Errorf("found %q, want P_map.xml", filepath.Base(got))
+	}
+}
+
+func TestSeveralMappingsMustBeChosenBetween(t *testing.T) {
+	p := projectWithMaps(t, "NV_map.xml", "AK_map.xml", "CA_map.xml")
+
+	_, err := p.findMapFile()
+	if err == nil {
+		t.Fatal("with several mappings the project must not pick one; the " +
+			"mapping decides where data lands and only the caller knows which")
+	}
+	// Naming them is what makes it actionable, and the way out has to be in
+	// the message.
+	for _, want := range []string{"AK_map.xml", "CA_map.xml", "NV_map.xml", "--map"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q, got: %v", want, err)
+		}
+	}
+}
+
+func TestNoMappingIsStillAnError(t *testing.T) {
+	p := projectWithMaps(t)
+
+	if _, err := p.findMapFile(); err == nil {
+		t.Fatal("a project with no mapping cannot load mapped data")
+	}
+}


### PR DESCRIPTION
Groundwork for per-state entities.

The model was already right and the discovery was not.
`loadTestDataFromReaders` builds a fresh `mapping.NewMapping` per call and keeps
none — nothing about a mapping is persistent. But both entry points that *find*
one did this:

```go
maps, _ := filepath.Glob(filepath.Join(xmlDir, "*_map.xml"))
return maps[0], nil            // authoring/execute.go
mapFile, err := os.Open(maps[0])   // cmd/dtrules/run_cmd.go
```

First alphabetically, the rest ignored without a word. Harmless while every
project has exactly one, and a silent wrong answer the moment one does not — a
project with per-state mappings would have had **every** state mapped by
whichever file sorted first.

## The caller says which

```
Project.LoadTestDataWithMap(mapPath, dataPath)
dtrules run --map <file.xml> --data <file.xml>
```

When a project holds more than one mapping and nobody said which, both paths
stop and name the candidates rather than guessing. One mapping still needs no
argument, so nothing existing changes.

## Why it matters

This is what makes external data independent of internal structure. The mapping
decides which entity a tag lands in, so the same input can feed per-state
entities (`nv_result`, `ak_result`) without the caller knowing they exist — and
that only works if the mapping is chosen per load, which it now is.

`make check` passes and all 11 sample projects still pass the verify gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)