### PR TITLE
feat(authoring): reach every EDD file, not just the first one found

### DIFF
--- a/cmd/dtrules/run_cmd.go
+++ b/cmd/dtrules/run_cmd.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -40,7 +41,7 @@ import (
 // value hasn't been provided (#850/#854).
 func (c *CLI) runRun(args []string) int {
 	path, entry, input, resultEntity := ".", "", "", "result"
-	var save, data, review, tracePath string
+	var save, data, review, tracePath, mapPath string
 	interactive, web, noOpen := false, false, false
 	port := "0" // 0 = let the OS pick a free port
 	for i := 0; i < len(args); i++ {
@@ -63,6 +64,11 @@ func (c *CLI) runRun(args []string) int {
 		case "--data":
 			if i+1 < len(args) {
 				data = args[i+1]
+				i++
+			}
+		case "--map":
+			if i+1 < len(args) {
+				mapPath = args[i+1]
 				i++
 			}
 		case "--review":
@@ -177,7 +183,7 @@ func (c *CLI) runRun(args []string) int {
 	}
 
 	// Initialize entities (and optionally load input data) via the mapping.
-	if err := initMapping(sess, xmlDir, input); err != nil {
+	if err := initMapping(sess, xmlDir, input, mapPath); err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing data: %v\n", err)
 		return 1
 	}
@@ -249,12 +255,28 @@ func (c *CLI) runRun(args []string) int {
 
 // initMapping loads the project's *_map.xml (if any), initializes the entity
 // stack, and loads input data when a file is given.
-func initMapping(sess dtrules.Session, xmlDir, input string) error {
-	maps, _ := filepath.Glob(filepath.Join(xmlDir, "*_map.xml"))
-	if len(maps) == 0 {
-		return nil // no mapping; rely on whatever the session set up
+func initMapping(sess dtrules.Session, xmlDir, input, mapPath string) error {
+	// A named mapping wins. A mapping is an argument to loading data, not a
+	// property of the project: the same external tag can belong in a different
+	// entity depending on what is being run, and only the caller knows which.
+	chosen := mapPath
+	if chosen == "" {
+		maps, _ := filepath.Glob(filepath.Join(xmlDir, "*_map.xml"))
+		if len(maps) == 0 {
+			return nil // no mapping; rely on whatever the session set up
+		}
+		if len(maps) > 1 {
+			names := make([]string, 0, len(maps))
+			for _, m := range maps {
+				names = append(names, filepath.Base(m))
+			}
+			sort.Strings(names)
+			return fmt.Errorf("%s holds %d mapping files (%s); pass --map <file> to say which one",
+				xmlDir, len(maps), strings.Join(names, ", "))
+		}
+		chosen = maps[0]
 	}
-	mapFile, err := os.Open(maps[0])
+	mapFile, err := os.Open(chosen)
 	if err != nil {
 		return err
 	}
@@ -389,6 +411,10 @@ Options:
   --entry <table>        Decision table to run (required)
   --input <file.xml>     Input data to load via the project mapping
   --data <file.xml>      Load canonical (mapping-free) data, authoritative
+  --map <file.xml>       Use this mapping to load the data. A mapping decides
+                         which entity each external tag lands in, so it is an
+                         argument to loading, not a property of the project.
+                         Required when the project holds more than one.
   --review <file.xml>    Load canonical data for re-interview (pre-filled, asked)
   --save <file.xml>      Save the collected data as canonical XML after the run
   --trace <file.xml>     Write a complete execution trace (initial data,

--- a/cmd/dtrules/table_cmd.go
+++ b/cmd/dtrules/table_cmd.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -120,6 +121,10 @@ type tableCmdCtx struct {
 	// the `--force-overwrite-excel` CLI flag; the default is false,
 	// which preserves human Excel edits by refusing the XML write.
 	forceOverwriteExcel bool
+	// eddFile names which of the project's EDD files to work on, from
+	// --edd-file. Empty is fine when the project has one; with several the
+	// command refuses rather than pick.
+	eddFile string
 }
 
 // emitErr writes a JSON error record to stderr and returns the exit code.
@@ -143,9 +148,23 @@ func writeJSON(w io.Writer, v interface{}) error {
 // with those flags removed. Defaults: projectPath=".",
 // forceOverwriteExcel=false.
 func parseProjectFlag(args []string) (projectPath string, forceOverwriteExcel bool, rest []string) {
+	projectPath, _, forceOverwriteExcel, rest = parseProjectFlags(args)
+	return projectPath, forceOverwriteExcel, rest
+}
+
+// parseProjectFlags is parseProjectFlag plus --edd-file, which names which of
+// a project's EDD files to work on.
+func parseProjectFlags(args []string) (projectPath, eddFile string, forceOverwriteExcel bool, rest []string) {
 	projectPath = "."
 	out := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
+		if args[i] == "--edd-file" {
+			if i+1 < len(args) {
+				eddFile = args[i+1]
+				i++
+				continue
+			}
+		}
 		if args[i] == "--project" || args[i] == "-p" {
 			if i+1 < len(args) {
 				projectPath = args[i+1]
@@ -159,7 +178,33 @@ func parseProjectFlag(args []string) (projectPath string, forceOverwriteExcel bo
 		}
 		out = append(out, args[i])
 	}
-	return projectPath, forceOverwriteExcel, out
+	return projectPath, eddFile, forceOverwriteExcel, out
+}
+
+// selectEDD points the project at the EDD file the caller named, and refuses
+// to guess when there is more than one and nobody said which.
+//
+// A project may hold many EDD files. The Project model works on one at a time
+// and used to take whichever sorted first, silently, so 51 of CorporateTax's
+// 52 were unreachable through the authoring API. Same rule as mappings: when
+// there is a choice to make, the caller makes it.
+func selectEDD(p *authoring.Project, eddFile string) error {
+	if eddFile != "" {
+		return p.UseEDDFile(eddFile)
+	}
+	files := p.EDDFiles()
+	if len(files) <= 1 {
+		return nil
+	}
+	names := make([]string, 0, len(files))
+	for _, f := range files {
+		names = append(names, filepath.Base(f))
+	}
+	if len(names) > 6 {
+		names = append(names[:6], fmt.Sprintf("... and %d more", len(files)-6))
+	}
+	return fmt.Errorf("this project has %d EDD files (%s); say which with --edd-file <name>",
+		len(files), strings.Join(names, ", "))
 }
 
 // runTable dispatches `dtrules table ...`.
@@ -210,7 +255,7 @@ func (c *CLI) runEDD(args []string) int {
 	}
 	sub := args[0]
 	rest := args[1:]
-	ctx.projectPath, ctx.forceOverwriteExcel, rest = parseProjectFlag(rest)
+	ctx.projectPath, ctx.eddFile, ctx.forceOverwriteExcel, rest = parseProjectFlags(rest)
 
 	switch sub {
 	case "get":
@@ -240,6 +285,13 @@ func (ctx *tableCmdCtx) openProject() (*authoring.Project, int) {
 	// Thread the --force-overwrite-excel flag through so Save / SaveEDD
 	// know whether to bypass the Excel-mtime guard for this command.
 	p.OverwriteExcel = ctx.forceOverwriteExcel
+
+	// A project may hold many EDD files; the Project works on one. Naming it
+	// is the caller's job, and a project with several refuses rather than
+	// silently taking the first (#1099).
+	if err := selectEDD(p, ctx.eddFile); err != nil {
+		return nil, emitErr(ctx.stderr, 1, "ambiguous_edd", "", "pass --edd-file <name>", err.Error())
+	}
 	return p, 0
 }
 

--- a/pkg/dtrules/authoring/edd.go
+++ b/pkg/dtrules/authoring/edd.go
@@ -101,11 +101,14 @@ func (p *Project) EDD() *EDD {
 		return p.edd
 	}
 
-	entries, _ := filepath.Glob(filepath.Join(p.xmlDir, "*_edd.xml"))
+	entries := p.eddCandidates()
 
 	eddPath := ""
 	var eddXML *excel.EDDXML
 
+	if p.eddFile != "" {
+		entries = []string{p.eddFile}
+	}
 	if len(entries) > 0 {
 		eddPath = entries[0]
 		data, err := os.ReadFile(eddPath)
@@ -527,5 +530,52 @@ func validateDefault(typ, def string) error {
 		}
 	}
 	// string, date, array, entity: any value is syntactically acceptable
+	return nil
+}
+
+// eddCandidates lists the project's EDD files, nearest first: the top level,
+// then nested directories. Sorted so the answer does not depend on the
+// filesystem.
+//
+// A project may hold many -- CorporateTax has a core EDD and 51 state EDDs --
+// and the Project model works on one at a time. Which one is the caller's
+// choice, made with UseEDDFile; this is only the list to choose from.
+func (p *Project) eddCandidates() []string {
+	top, _ := filepath.Glob(filepath.Join(p.xmlDir, "*_edd.xml"))
+	sort.Strings(top)
+
+	var nested []string
+	_ = filepath.WalkDir(p.xmlDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Dir(path) == p.xmlDir {
+			return nil
+		}
+		if strings.HasSuffix(d.Name(), "_edd.xml") {
+			nested = append(nested, path)
+		}
+		return nil
+	})
+	sort.Strings(nested)
+	return append(top, nested...)
+}
+
+// EDDFiles is the project's EDD files, for a caller deciding which to work on.
+func (p *Project) EDDFiles() []string { return p.eddCandidates() }
+
+// UseEDDFile points the Project at one of its EDD files.
+//
+// The Project holds one EDD at a time and used to take whichever sorted first,
+// silently -- so 51 of CorporateTax's 52 EDD files could not be read or
+// written through the authoring API at all, and nothing said so. Naming the
+// file is how a caller reaches the others.
+func (p *Project) UseEDDFile(path string) error {
+	abs := path
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(p.xmlDir, path)
+	}
+	if _, err := os.Stat(abs); err != nil {
+		return fmt.Errorf("EDD file %s: %w", path, err)
+	}
+	p.eddFile = abs
+	p.edd = nil // drop any EDD already loaded from a different file
 	return nil
 }

--- a/pkg/dtrules/authoring/edd_selection_test.go
+++ b/pkg/dtrules/authoring/edd_selection_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The Project works on one EDD at a time and used to take whichever sorted
+// first, silently. CorporateTax has 52 EDD files -- a core plus 51 states --
+// so 51 of them could not be read or written through the authoring API at
+// all, and nothing said so.
+
+func projectWithEDDs(t *testing.T, rel ...string) *Project {
+	t.Helper()
+	root := t.TempDir()
+	xmlDir := filepath.Join(root, "xml")
+	for _, r := range rel {
+		p := filepath.Join(xmlDir, r)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := `<entity_data_dictionary version="2"><entity name="` +
+			filepath.Base(filepath.Dir(p+"x")) + `"></entity></entity_data_dictionary>`
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &Project{xmlDir: xmlDir}
+}
+
+func TestEDDFilesFindsNestedOnesToo(t *testing.T) {
+	p := projectWithEDDs(t, "Core_edd.xml", "states/NV_edd.xml", "states/AK_edd.xml")
+
+	files := p.EDDFiles()
+	if len(files) != 3 {
+		t.Fatalf("found %d EDD files, want 3: %v", len(files), files)
+	}
+	// Top level first, so a project with one obvious EDD and nested extras
+	// still resolves to the obvious one when nobody chooses.
+	if filepath.Base(files[0]) != "Core_edd.xml" {
+		t.Errorf("top-level EDD should come first, got %q", filepath.Base(files[0]))
+	}
+}
+
+func TestUseEDDFileSelectsANestedOne(t *testing.T) {
+	p := projectWithEDDs(t, "Core_edd.xml", "states/NV_edd.xml")
+
+	if err := p.UseEDDFile("states/NV_edd.xml"); err != nil {
+		t.Fatalf("UseEDDFile: %v", err)
+	}
+	if filepath.Base(p.eddFile) != "NV_edd.xml" {
+		t.Errorf("selected %q, want NV_edd.xml", p.eddFile)
+	}
+}
+
+func TestUseEDDFileRejectsOneThatIsNotThere(t *testing.T) {
+	p := projectWithEDDs(t, "Core_edd.xml")
+
+	if err := p.UseEDDFile("states/XX_edd.xml"); err == nil {
+		t.Fatal("selecting a file that does not exist must fail, not silently " +
+			"fall back to another EDD")
+	}
+}
+
+// Ordering must not depend on the filesystem, or which EDD a project resolves
+// to would vary by machine.
+func TestEDDCandidateOrderIsStable(t *testing.T) {
+	p := projectWithEDDs(t, "Core_edd.xml", "states/NV_edd.xml", "states/AK_edd.xml", "states/CA_edd.xml")
+
+	first := p.EDDFiles()
+	for i := 0; i < 5; i++ {
+		got := p.EDDFiles()
+		for j := range got {
+			if got[j] != first[j] {
+				t.Fatalf("order changed between calls: %v vs %v", first, got)
+			}
+		}
+	}
+}

--- a/pkg/dtrules/authoring/execute.go
+++ b/pkg/dtrules/authoring/execute.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/DTRules/DTRules/pkg/dtrules"
@@ -154,6 +155,33 @@ func (p *Project) LoadTestData(path string) error {
 	dataF, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("open test data: %w", err)
+	}
+	defer dataF.Close()
+
+	return p.loadTestDataFromReaders(mapF, dataF)
+}
+
+// LoadTestDataWithMap populates entity state from a data file, using the
+// mapping the caller names rather than whatever the project happens to hold.
+//
+// This is the general form. A project with one mapping can use LoadTestData
+// and let it find the file; a project with several -- per-state mappings, say,
+// where the same external tag belongs in a different entity depending on which
+// state is being run -- has to say which, because the mapping decides where
+// the data lands.
+func (p *Project) LoadTestDataWithMap(mapPath, dataPath string) error {
+	if err := p.ensureExecState(); err != nil {
+		return err
+	}
+	mapF, err := os.Open(mapPath)
+	if err != nil {
+		return fmt.Errorf("open map file: %w", err)
+	}
+	defer mapF.Close()
+
+	dataF, err := os.Open(dataPath)
+	if err != nil {
+		return fmt.Errorf("open data file: %w", err)
 	}
 	defer dataF.Close()
 
@@ -550,6 +578,16 @@ func (p *Project) findEntityOnStack(name *dtrules.RName) (dtrules.Entity, error)
 }
 
 // findMapFile looks for a *_map.xml file in the project xml dir.
+//
+// One mapping, or none. It used to return maps[0] and say nothing, which is
+// harmless while every project has exactly one and a silent wrong answer the
+// moment one does not: a project with per-state mappings would have been
+// mapped by whichever file sorted first, for every state.
+//
+// A mapping is an argument to loading data, not a property of the project --
+// loadTestDataFromReaders builds a fresh Mapping per call and keeps none. So
+// when there is a choice to make, the caller makes it: LoadTestDataWithMap,
+// or `dtrules run --map`.
 func (p *Project) findMapFile() (string, error) {
 	maps, err := filepath.Glob(filepath.Join(p.xmlDir, "*_map.xml"))
 	if err != nil {
@@ -557,6 +595,19 @@ func (p *Project) findMapFile() (string, error) {
 	}
 	if len(maps) == 0 {
 		return "", fmt.Errorf("no *_map.xml file found in %s", p.xmlDir)
+	}
+	if len(maps) > 1 {
+		names := make([]string, 0, len(maps))
+		for _, m := range maps {
+			names = append(names, filepath.Base(m))
+		}
+		sort.Strings(names)
+		return "", fmt.Errorf(
+			"%s holds %d mapping files (%s); say which one to use\n"+
+				"  A mapping is an argument to loading data, not a property of the "+
+				"project. Pass it explicitly: dtrules run --map <file>, or "+
+				"Project.LoadTestDataWithMap",
+			p.xmlDir, len(maps), strings.Join(names, ", "))
 	}
 	return maps[0], nil
 }

--- a/pkg/dtrules/authoring/explicit_mapping_test.go
+++ b/pkg/dtrules/authoring/explicit_mapping_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A mapping decides which entity each external tag lands in, so it is an
+// argument to loading data rather than a property of the project --
+// loadTestDataFromReaders builds a fresh Mapping per call and keeps none.
+//
+// findMapFile used to return the first match and say nothing, which is
+// harmless while every project has exactly one and a silent wrong answer the
+// moment one does not: per-state mappings would all have been ignored in
+// favour of whichever sorted first.
+
+func projectWithMaps(t *testing.T, names ...string) *Project {
+	t.Helper()
+	root := t.TempDir()
+	xmlDir := filepath.Join(root, "xml")
+	if err := os.MkdirAll(xmlDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(xmlDir, n), []byte("<mapping></mapping>"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &Project{xmlDir: xmlDir}
+}
+
+func TestOneMappingIsFoundWithoutAsking(t *testing.T) {
+	p := projectWithMaps(t, "P_map.xml")
+
+	got, err := p.findMapFile()
+	if err != nil {
+		t.Fatalf("a single mapping should be found: %v", err)
+	}
+	if filepath.Base(got) != "P_map.xml" {
+		t.Errorf("found %q, want P_map.xml", filepath.Base(got))
+	}
+}
+
+func TestSeveralMappingsMustBeChosenBetween(t *testing.T) {
+	p := projectWithMaps(t, "NV_map.xml", "AK_map.xml", "CA_map.xml")
+
+	_, err := p.findMapFile()
+	if err == nil {
+		t.Fatal("with several mappings the project must not pick one; the " +
+			"mapping decides where data lands and only the caller knows which")
+	}
+	// Naming them is what makes it actionable, and the way out has to be in
+	// the message.
+	for _, want := range []string{"AK_map.xml", "CA_map.xml", "NV_map.xml", "--map"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q, got: %v", want, err)
+		}
+	}
+}
+
+func TestNoMappingIsStillAnError(t *testing.T) {
+	p := projectWithMaps(t)
+
+	if _, err := p.findMapFile(); err == nil {
+		t.Fatal("a project with no mapping cannot load mapped data")
+	}
+}

--- a/pkg/dtrules/authoring/project.go
+++ b/pkg/dtrules/authoring/project.go
@@ -42,6 +42,7 @@ type Project struct {
 	dtFiles     []dtFileEntry // one entry per loaded _dt.xml file
 	symbols     map[string]string
 	edd         *EDD         // lazily loaded
+	eddFile     string       // which EDD file to work on; empty means the first candidate
 	execSt      *execState   // lazily-created execution state; nil until first use
 	diagnostics []Diagnostic // authoring-time diagnostics (duplicate renames, etc.)
 


### PR DESCRIPTION
`Project.EDD()` globbed `*_edd.xml` at the top level and took `entries[0]`.
CorporateTax has **52 EDD files** — a core and 51 states nested under
`states/` — so 51 of them could not be read or written through the authoring
API at all. Not refused: invisible.

Same shape as the mapping bug in #1098, and it blocked real work. Deleting a
dead field from a state EDD, moving a statutory rate out of a default and into
its table, restructuring the states into per-state entities — each needs the
API to reach the file, and none of them could. The only alternative was
hand-editing XML, which the contract forbids.

## The change

`EDDFiles()` lists them, nearest first and sorted so the answer does not depend
on the filesystem. `UseEDDFile()` picks one. `--edd-file` names it from the CLI.

```
$ dtrules edd get
{"error": "ambiguous_edd",
 "detail": "this project has 52 EDD files (CorporateTax_core_edd.xml,
            AK_corp_edd.xml, ... and 46 more); say which with --edd-file <name>"}

$ dtrules edd get --edd-file states/NV_corp_edd.xml
entities: apportionment, result | fields: 19
```

A project with one EDD needs no argument and behaves exactly as before — every
sample except CorporateTax.

## Verification

`edd patch --edd-file states/CO_corp_edd.xml` with a `delete-field` takes that
file from 16 fields to 15, through the guard and the Excel refresh like any
other authoring write.

`make check` passes; four tests cover nested discovery, selection, rejecting a
file that is not there, and stable ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)