### PR TITLE
fix(authoring): --edd-file accepts the path form the caller has

### DIFF
--- a/pkg/dtrules/authoring/edd.go
+++ b/pkg/dtrules/authoring/edd.go
@@ -568,14 +568,26 @@ func (p *Project) EDDFiles() []string { return p.eddCandidates() }
 // written through the authoring API at all, and nothing said so. Naming the
 // file is how a caller reaches the others.
 func (p *Project) UseEDDFile(path string) error {
-	abs := path
-	if !filepath.IsAbs(abs) {
-		abs = filepath.Join(p.xmlDir, path)
+	// Accept the path however the caller naturally has it: absolute, relative
+	// to the rules directory (states/NV_corp_edd.xml), or relative to the
+	// project root (xml/states/NV_corp_edd.xml). Resolving only one of those
+	// and reporting "no such file" sends the caller looking for a missing file
+	// that is right there.
+	tried := []string{}
+	for _, cand := range []string{
+		path,
+		filepath.Join(p.xmlDir, path),
+		filepath.Join(p.projectRoot(), path),
+	} {
+		if cand == "" {
+			continue
+		}
+		tried = append(tried, cand)
+		if info, err := os.Stat(cand); err == nil && !info.IsDir() {
+			p.eddFile = cand
+			p.edd = nil // drop any EDD already loaded from a different file
+			return nil
+		}
 	}
-	if _, err := os.Stat(abs); err != nil {
-		return fmt.Errorf("EDD file %s: %w", path, err)
-	}
-	p.eddFile = abs
-	p.edd = nil // drop any EDD already loaded from a different file
-	return nil
+	return fmt.Errorf("EDD file %q not found; tried %s", path, strings.Join(tried, ", "))
 }

--- a/pkg/dtrules/authoring/edd_selection_test.go
+++ b/pkg/dtrules/authoring/edd_selection_test.go
@@ -17,6 +17,7 @@ package authoring
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -90,5 +91,41 @@ func TestEDDCandidateOrderIsStable(t *testing.T) {
 				t.Fatalf("order changed between calls: %v vs %v", first, got)
 			}
 		}
+	}
+}
+
+// A caller naturally has an EDD path in one of two relative forms: relative to
+// the rules directory (states/NV_edd.xml) or to the project root
+// (xml/states/NV_edd.xml). Resolving only the first and reporting "no such
+// file" sends them looking for a file that is right there -- which is exactly
+// what happened running 60 deletions across the state EDDs.
+func TestUseEDDFileAcceptsEitherRelativeForm(t *testing.T) {
+	p := projectWithEDDs(t, "Core_edd.xml", "states/NV_edd.xml")
+
+	for _, form := range []string{
+		"states/NV_edd.xml",     // relative to the rules directory
+		"xml/states/NV_edd.xml", // relative to the project root
+	} {
+		p.eddFile = ""
+		if err := p.UseEDDFile(form); err != nil {
+			t.Errorf("UseEDDFile(%q): %v", form, err)
+			continue
+		}
+		if filepath.Base(p.eddFile) != "NV_edd.xml" {
+			t.Errorf("UseEDDFile(%q) selected %q", form, p.eddFile)
+		}
+	}
+}
+
+// And when it genuinely is not there, say what was looked for.
+func TestUseEDDFileSaysWhereItLooked(t *testing.T) {
+	p := projectWithEDDs(t, "Core_edd.xml")
+
+	err := p.UseEDDFile("states/XX_edd.xml")
+	if err == nil {
+		t.Fatal("expected an error for a file that does not exist")
+	}
+	if !strings.Contains(err.Error(), "tried") {
+		t.Errorf("the error should name the paths tried, got: %v", err)
 	}
 }


### PR DESCRIPTION
Follow-up to #1099.

`UseEDDFile` resolved a relative path against the rules directory only, so
`states/NV_corp_edd.xml` worked and `xml/states/NV_corp_edd.xml` — the same
file, named from the project root — came back "no such file". It also did not
say where it had looked.

Found running 60 `delete-field` operations across CorporateTax's state EDDs:
**every one failed**, and the message gave no clue why.

It now tries the path as given, then against the rules directory, then against
the project root, and names all three when none exist.

`make check` passes; two tests cover both relative forms and the improved
error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)