### PR TITLE
fix(cli): requiring --edd-file broke every table command on CorporateTax

### DIFF
--- a/cmd/dtrules/edd_ambiguity_scope_test.go
+++ b/cmd/dtrules/edd_ambiguity_scope_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Requiring --edd-file is the EDD commands' business. `table get` works on
+// decision tables and does not care which EDD is loaded; demanding a choice
+// from it broke `dtrules table` outright on the one project that has several
+// EDD files, and no test caught it because every other sample has one.
+
+func multiEDDProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	xmlDir := filepath.Join(root, "xml")
+	states := filepath.Join(xmlDir, "states")
+	if err := os.MkdirAll(states, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	edd := `<entity_data_dictionary version="2"><entity name="job" number="100">` +
+		`<field name="age" type="integer" subtype="" access="rw" input="" default_value="" comment=""></field>` +
+		`</entity></entity_data_dictionary>`
+	dt := `<decision_tables><decision_table><table_name>Only</table_name>` +
+		`<attribute_fields><Type>FIRST</Type><TABLE_NUMBER>100</TABLE_NUMBER></attribute_fields>` +
+		`<contexts></contexts><initial_actions></initial_actions>` +
+		`<conditions></conditions><actions></actions></decision_table></decision_tables>`
+	for p, body := range map[string]string{
+		filepath.Join(xmlDir, "Core_edd.xml"): edd,
+		filepath.Join(states, "NV_edd.xml"):   edd,
+		filepath.Join(xmlDir, "Core_dt.xml"):  dt,
+	} {
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestTableCommandsDoNotRequireAnEDDChoice(t *testing.T) {
+	root := multiEDDProject(t)
+	ctx := &tableCmdCtx{stdin: strings.NewReader(""), stdout: &strings.Builder{},
+		stderr: &strings.Builder{}, projectPath: root}
+
+	if _, code := ctx.openProject(); code != 0 {
+		t.Fatalf("a table command must open a multi-EDD project without --edd-file; got exit %d", code)
+	}
+}
+
+func TestEDDCommandsDoRequireAChoice(t *testing.T) {
+	root := multiEDDProject(t)
+	var errOut strings.Builder
+	ctx := &tableCmdCtx{stdin: strings.NewReader(""), stdout: &strings.Builder{},
+		stderr: &errOut, projectPath: root}
+
+	if _, code := ctx.openProjectForEDD(); code == 0 {
+		t.Fatal("an EDD command on a project with several EDD files must ask " +
+			"which one, not serve the first")
+	}
+	if !strings.Contains(errOut.String(), "--edd-file") {
+		t.Errorf("the error should name the way out, got: %s", errOut.String())
+	}
+}
+
+func TestEDDCommandsAcceptTheChoice(t *testing.T) {
+	root := multiEDDProject(t)
+	ctx := &tableCmdCtx{stdin: strings.NewReader(""), stdout: &strings.Builder{},
+		stderr: &strings.Builder{}, projectPath: root, eddFile: "states/NV_edd.xml"}
+
+	if _, code := ctx.openProjectForEDD(); code != 0 {
+		t.Fatalf("naming the EDD file should be enough; got exit %d", code)
+	}
+}

--- a/cmd/dtrules/table_cmd.go
+++ b/cmd/dtrules/table_cmd.go
@@ -286,11 +286,31 @@ func (ctx *tableCmdCtx) openProject() (*authoring.Project, int) {
 	// know whether to bypass the Excel-mtime guard for this command.
 	p.OverwriteExcel = ctx.forceOverwriteExcel
 
-	// A project may hold many EDD files; the Project works on one. Naming it
-	// is the caller's job, and a project with several refuses rather than
-	// silently taking the first (#1099).
-	if err := selectEDD(p, ctx.eddFile); err != nil {
-		return nil, emitErr(ctx.stderr, 1, "ambiguous_edd", "", "pass --edd-file <name>", err.Error())
+	// Honour --edd-file when given. Requiring a choice is the EDD commands'
+	// business, not every command's: `table get` works on decision tables and
+	// does not care which EDD is loaded, and demanding --edd-file from it
+	// broke `dtrules table` outright on the one project with several.
+	if ctx.eddFile != "" {
+		if err := p.UseEDDFile(ctx.eddFile); err != nil {
+			return nil, emitErr(ctx.stderr, 1, "io_error", "", "check the path", err.Error())
+		}
+	}
+	return p, 0
+}
+
+// openProjectForEDD is openProject for the commands that read or write the
+// EDD, where which file is being operated on is the whole question. A project
+// with several and no --edd-file is refused rather than silently served the
+// first (#1099).
+func (ctx *tableCmdCtx) openProjectForEDD() (*authoring.Project, int) {
+	p, code := ctx.openProject()
+	if code != 0 {
+		return nil, code
+	}
+	if ctx.eddFile == "" {
+		if err := selectEDD(p, ""); err != nil {
+			return nil, emitErr(ctx.stderr, 1, "ambiguous_edd", "", "pass --edd-file <name>", err.Error())
+		}
 	}
 	return p, 0
 }
@@ -528,7 +548,7 @@ func (ctx *tableCmdCtx) tableSchema(rest []string) int {
 // --- EDD handlers ---
 
 func (ctx *tableCmdCtx) eddGet() int {
-	p, code := ctx.openProject()
+	p, code := ctx.openProjectForEDD()
 	if code != 0 {
 		return code
 	}
@@ -539,7 +559,7 @@ func (ctx *tableCmdCtx) eddGet() int {
 }
 
 func (ctx *tableCmdCtx) eddPut() int {
-	p, code := ctx.openProject()
+	p, code := ctx.openProjectForEDD()
 	if code != 0 {
 		return code
 	}
@@ -557,7 +577,7 @@ func (ctx *tableCmdCtx) eddPut() int {
 }
 
 func (ctx *tableCmdCtx) eddPatch() int {
-	p, code := ctx.openProject()
+	p, code := ctx.openProjectForEDD()
 	if code != 0 {
 		return code
 	}


### PR DESCRIPTION
Regression from #1099, found two commands into using the feature.

That PR put the "which EDD file?" refusal in `openProject`, which every command
goes through. So `dtrules table get` on CorporateTax came back `ambiguous_edd`
and asked for `--edd-file` — a flag with nothing to do with reading a decision
table.

`make check` passed because CorporateTax is the only project with more than one
EDD file, and no test drives a table command against it.

## The split

The refusal belongs to the commands whose subject *is* the EDD. `table`
commands honour `--edd-file` when given and otherwise do not care which EDD is
loaded; `edd get`, `put` and `patch` go through an opener that insists on a
choice.

```
$ dtrules table get Determine_NV_Filing_Requirement     # works, no flag
$ dtrules edd get                                        # ambiguous_edd
$ dtrules edd get --edd-file states/NV_corp_edd.xml      # works
```

Three tests pin it against a two-EDD fixture. `make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)