### PR TITLE
fix(excel): an entity belongs in the workbook its EDD file pairs with (#1094)

### DIFF
--- a/pkg/dtrules/excel/edd_importer.go
+++ b/pkg/dtrules/excel/edd_importer.go
@@ -29,14 +29,14 @@ import (
 
 // EDDXML represents the root EDD structure for XML output
 type EDDXML struct {
-	XMLName  xml.Name       `xml:"entity_data_dictionary"`
-	Version  string         `xml:"version,attr"`
+	XMLName xml.Name `xml:"entity_data_dictionary"`
+	Version string   `xml:"version,attr"`
 	// FileMetadata carries the <file_path> marker the directory loader
 	// uses to distinguish a real multi-entity EDD from a legacy merged
 	// artifact (which it skips). Losing it on an Excel round-trip made
 	// the loader silently skip the regenerated EDD.
 	FileMetadata *EDDFileMetadata `xml:"file_metadata,omitempty"`
-	Entities []*EDDXMLEntity `xml:"entity"`
+	Entities     []*EDDXMLEntity  `xml:"entity"`
 }
 
 // EDDFileMetadata mirrors the loader's <file_metadata> block.
@@ -46,16 +46,16 @@ type EDDFileMetadata struct {
 
 // EDDXMLEntity represents an entity in the EDD XML
 type EDDXMLEntity struct {
-	Name    string          `xml:"name,attr"`
+	Name string `xml:"name,attr"`
 	// Number orders entities like TABLE_NUMBER orders decision tables.
 	// Optional in authored XML; WriteXML backfills missing numbers in
 	// increments of 100 so every emitted EDD is fully numbered.
-	Number  string          `xml:"number,attr,omitempty"`
-	XlsFile string          `xml:"xls_file,attr,omitempty"`
-	Access  string          `xml:"access,attr"`
-	Comment string          `xml:"comment,attr,omitempty"`
-	Source  *SourceXML      `xml:"source,omitempty"`
-	Fields  []*EDDXMLField  `xml:"field"`
+	Number  string         `xml:"number,attr,omitempty"`
+	XlsFile string         `xml:"xls_file,attr,omitempty"`
+	Access  string         `xml:"access,attr"`
+	Comment string         `xml:"comment,attr,omitempty"`
+	Source  *SourceXML     `xml:"source,omitempty"`
+	Fields  []*EDDXMLField `xml:"field"`
 }
 
 // EDDXMLField represents a field in the EDD XML
@@ -359,6 +359,15 @@ func (i *EDDImporter) WriteXML(edd *EDDXML, filename string) error {
 		base := strings.TrimSuffix(filepath.Base(filename), filepath.Ext(filename))
 		edd.FileMetadata = &EDDFileMetadata{FilePath: base}
 	}
+	// An entity declared in X_edd.xml belongs in X.xlsx unless it says
+	// otherwise. That pairing is not a guess -- it is the one the sync layer
+	// already uses to match an EDD file to its workbook.
+	//
+	// Without it, an entity created through the authoring API has no xls_file,
+	// so nothing claims its workbook and the refresh writes no EDD sheet for
+	// it. The definitions then live only in XML, which is the wrong way round:
+	// Excel is the system of record (#1094).
+	backfillEntityWorkbook(edd, filename)
 	normalizeEntityNumbers(edd)
 
 	output, err := xml.MarshalIndent(edd, "", "\t")
@@ -649,4 +658,23 @@ func MergeEDD(edds ...*EDDXML) *EDDXML {
 	}
 
 	return result
+}
+
+// backfillEntityWorkbook gives every entity without an xls_file the workbook
+// paired with the EDD file it is being written to: X_edd.xml -> X.xlsx.
+//
+// Entities that already name a workbook keep it, so a project that
+// deliberately groups entities elsewhere is untouched.
+func backfillEntityWorkbook(edd *EDDXML, filename string) {
+	base := strings.TrimSuffix(filepath.Base(filename), filepath.Ext(filename))
+	base = strings.TrimSuffix(base, "_edd")
+	if base == "" {
+		return
+	}
+	workbook := base + ".xlsx"
+	for _, ent := range edd.Entities {
+		if ent != nil && strings.TrimSpace(ent.XlsFile) == "" {
+			ent.XlsFile = workbook
+		}
+	}
 }

--- a/pkg/dtrules/excel/entity_workbook_test.go
+++ b/pkg/dtrules/excel/entity_workbook_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import "testing"
+
+// An entity declared in X_edd.xml belongs in X.xlsx unless it says otherwise.
+// That is the pairing the sync layer already uses to match an EDD file to its
+// workbook, and without it an entity created through the authoring API has no
+// xls_file at all -- so nothing claims its workbook, the refresh writes no EDD
+// sheet, and the definitions live only in XML (#1094).
+
+func TestEntitiesInheritTheirEDDFilesWorkbook(t *testing.T) {
+	edd := &EDDXML{Entities: []*EDDXMLEntity{
+		{Name: "nv_result"},
+		{Name: "nv_apportionment"},
+	}}
+
+	backfillEntityWorkbook(edd, "/p/xml/states/NV_corp_edd.xml")
+
+	for _, e := range edd.Entities {
+		if e.XlsFile != "NV_corp.xlsx" {
+			t.Errorf("%s got xls_file %q, want NV_corp.xlsx", e.Name, e.XlsFile)
+		}
+	}
+}
+
+// An entity that already names a workbook keeps it, so a project that
+// deliberately groups entities elsewhere is untouched.
+func TestAnExplicitWorkbookIsNotOverwritten(t *testing.T) {
+	edd := &EDDXML{Entities: []*EDDXMLEntity{
+		{Name: "shared", XlsFile: "CorporateTax_core.xlsx"},
+		{Name: "nv_result"},
+	}}
+
+	backfillEntityWorkbook(edd, "/p/xml/states/NV_corp_edd.xml")
+
+	if edd.Entities[0].XlsFile != "CorporateTax_core.xlsx" {
+		t.Errorf("an explicit workbook was overwritten: %q", edd.Entities[0].XlsFile)
+	}
+	if edd.Entities[1].XlsFile != "NV_corp.xlsx" {
+		t.Errorf("the unset one should be filled: %q", edd.Entities[1].XlsFile)
+	}
+}
+
+// The _edd suffix is dropped, not just the extension -- otherwise the entity
+// would claim NV_corp_edd.xlsx, which is not a workbook any project has.
+func TestTheEDDSuffixIsNotPartOfTheWorkbookName(t *testing.T) {
+	edd := &EDDXML{Entities: []*EDDXMLEntity{{Name: "job"}}}
+
+	backfillEntityWorkbook(edd, "CHIP_edd.xml")
+
+	if edd.Entities[0].XlsFile != "CHIP.xlsx" {
+		t.Errorf("got %q, want CHIP.xlsx", edd.Entities[0].XlsFile)
+	}
+}


### PR DESCRIPTION
Part of #1094, and the precondition for converting states to their own
entities.

An entity created through the authoring API has no `xls_file`, because
`add-entity` does not take one. Nothing then claims its workbook, the refresh
writes no EDD sheet, and the entity's definition lives only in XML — backwards,
since Excel is the system of record.

The pairing is not a guess: `X_edd.xml` goes with `X.xlsx`, the same
association the sync layer uses. So an entity written to `NV_corp_edd.xml` with
no workbook of its own takes `NV_corp.xlsx`. One that already names a workbook
keeps it.

## Found converting Nevada

| | before | after |
|---|---|---|
| `NV_corp.xlsx` | 5 sheets, no EDD | **6 sheets, EDD present** |
| entities in that sheet | — | `nv_apportionment`, `nv_result`, no foreign fields |
| second rebuild | — | **stable** (the first adds `<source>` and renumbers) |
| `verify` | — | 8 findings, all `[external]`, **zero `[build]`** |

The suffix matters: dropping only the extension would have the entity claim
`NV_corp_edd.xlsx`, which no project has. Pinned by a test.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)