### PR TITLE
fix(excel): type decision-table fields from every EDD, not one workbook's (#1094)

### DIFF
--- a/pkg/dtrules/excel/dt_importer.go
+++ b/pkg/dtrules/excel/dt_importer.go
@@ -1716,6 +1716,20 @@ var numericDowngrades = map[string]struct{ to, meaning string }{
 	"f>=": {">=", "fixed-point comparison became integer"},
 	"f==": {"==", "fixed-point equality became integer"},
 	"f!=": {"!=", "fixed-point inequality became integer"},
+
+	// Doubles, the other numeric family. The fixed-point rows above were added
+	// when `f<` turned into `<`; the arithmetic on the same values was left
+	// out, so a rebuild that turned `apportionment.state_credits f-` into `-`
+	// and `cvd` into `cvi` -- money subtracted and stored as whole units --
+	// reported nothing at all and exited 0. CorporateTax has five state files
+	// carrying that form today and 26 carrying the correct one, which is what
+	// a silent downgrade looks like after a few rebuilds (#1094).
+	"f+":   {"+", "double add became integer"},
+	"f-":   {"-", "double subtract became integer"},
+	"fmul": {"*", "double multiply became integer"},
+	"f/":   {"/", "double division became integer"},
+	"fdiv": {"/", "double division became integer"},
+	"cvd":  {"cvi", "value stored as integer instead of double"},
 }
 
 // warnNumericDowngrade reports a recompile that silently weakens arithmetic.

--- a/pkg/dtrules/excel/workbook_importer.go
+++ b/pkg/dtrules/excel/workbook_importer.go
@@ -37,6 +37,10 @@ type WorkbookImporter struct {
 	eddImporter *EDDImporter
 	verbose     bool
 	stats       *ImportStats // accumulated stats across all ImportWorkbookToDir calls
+	// projectSymbols is every EDD in the project, field→type. Held so each
+	// workbook's own EDD can be layered over a clean copy of it rather than
+	// replacing it for the rest of the run.
+	projectSymbols map[string]string
 }
 
 // NewWorkbookImporter creates a new workbook importer.
@@ -77,10 +81,42 @@ func (w *WorkbookImporter) SetELCompiler(c ELCompiler) {
 // SetSymbols seeds the inner DT importer with a project-wide EDD field→type
 // map so the EL compiler types operands correctly even when a decision table
 // lives in a different workbook than its EDD (multi-file projects). A workbook
-// that carries its own EDD still overrides these per-workbook during import;
-// DT-only workbooks fall back to this project-wide map.
+// that carries its own EDD layers its entities over these during import;
+// DT-only workbooks use this project-wide map as-is.
+//
+// The map is kept here as well as handed down, because the per-workbook layer
+// is rebuilt from it for each workbook rather than written over it.
 func (w *WorkbookImporter) SetSymbols(symbols map[string]string) {
+	w.projectSymbols = symbols
 	w.dtImporter.SetSymbols(symbols)
+}
+
+// symbolsFor layers one workbook's own EDD over the project-wide map.
+//
+// This used to replace the project map outright, which broke multi-file
+// projects in both directions. A workbook's tables could only see the entities
+// declared in that same workbook, so a state table reading the shared
+// `apportionment` entity -- declared in the core workbook -- found no type for
+// it and compiled money as integers: `f-` became `-` and `cvd` became `cvi`,
+// silently. And because one importer is reused for every workbook in the
+// build loop with no save/restore, the replacement leaked forward: a DT-only
+// workbook inherited whichever EDD happened to be imported before it.
+//
+// The workbook's own declarations still win, which is what "overrides" was
+// reaching for -- an entity is defined by the EDD it ships with.
+func (w *WorkbookImporter) symbolsFor(edd *EDDXML) map[string]string {
+	own := EDDSymbols(edd)
+	if len(own) == 0 {
+		return w.projectSymbols
+	}
+	merged := make(map[string]string, len(w.projectSymbols)+len(own))
+	for k, v := range w.projectSymbols {
+		merged[k] = v
+	}
+	for k, v := range own {
+		merged[k] = v
+	}
+	return merged
 }
 
 // ImportWorkbook reads a single Excel file and extracts both DT and EDD sheets.
@@ -192,8 +228,9 @@ func (w *WorkbookImporter) importWorkbookWithSource(excelPath, xlsFile, relPath 
 	// Without this, double/fixed fields compile as integers — e.g. a Cockcroft
 	// -Gault "(140 - age) * weight / (pcr * 72)" emits integer ops and cvi,
 	// silently truncating the result to 0. Combined workbooks carry their EDD
-	// in the same file (parsed above), so the symbols are available here.
-	if symbols := EDDSymbols(result.EDD); len(symbols) > 0 {
+	// in the same file (parsed above), so the symbols are available here; the
+	// rest of the project's entities come from the project-wide map.
+	if symbols := w.symbolsFor(result.EDD); len(symbols) > 0 {
 		w.dtImporter.SetSymbols(symbols)
 	}
 

--- a/pkg/dtrules/excel/workbook_symbols_test.go
+++ b/pkg/dtrules/excel/workbook_symbols_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import "testing"
+
+// A multi-file project's decision tables read entities declared in other
+// workbooks. CorporateTax is the shape: 51 state workbooks whose tables all
+// read the shared `apportionment` entity, which is declared once in the core
+// workbook.
+//
+// The symbol table decides the arithmetic. A field the compiler cannot type is
+// assumed to be an integer, so `apportionment.state_credits f-` compiles to
+// `-` and `cvd` to `cvi`: money subtracted and stored as whole units, with no
+// error and no warning. That is a wrong answer, not a rounded one (#1094).
+
+func ownEDD() *EDDXML {
+	return &EDDXML{Entities: []*EDDXMLEntity{{
+		Name:   "sc_apportionment",
+		Fields: []*EDDXMLField{{Name: "state_tax_rate", Type: "double"}},
+	}}}
+}
+
+// The project-wide types must survive a workbook that carries its own EDD.
+func TestWorkbookSymbolsKeepTheRestOfTheProject(t *testing.T) {
+	w := NewWorkbookImporter()
+	w.SetSymbols(map[string]string{
+		"apportionment.state_credits": "double",
+		"state_credits":               "double",
+	})
+
+	got := w.symbolsFor(ownEDD())
+
+	if got["apportionment.state_credits"] != "double" {
+		t.Errorf("a shared entity from another workbook lost its type (got %q); "+
+			"its arithmetic compiles as integer", got["apportionment.state_credits"])
+	}
+	if got["sc_apportionment.state_tax_rate"] != "double" {
+		t.Error("the workbook's own EDD is missing from the symbol table")
+	}
+}
+
+// The workbook that ships an entity is the authority on it.
+func TestWorkbookOwnEDDWinsOnConflict(t *testing.T) {
+	w := NewWorkbookImporter()
+	w.SetSymbols(map[string]string{"sc_apportionment.state_tax_rate": "integer"})
+
+	if got := w.symbolsFor(ownEDD())["sc_apportionment.state_tax_rate"]; got != "double" {
+		t.Errorf("own EDD did not win: got %q, want double", got)
+	}
+}
+
+// One importer is reused for every workbook in the build loop, with no
+// save/restore around the per-workbook layer. When that layer was written over
+// the project map, it leaked forward: a DT-only workbook compiled against
+// whichever EDD happened to be imported before it.
+func TestWorkbookSymbolsDoNotLeakToTheNextWorkbook(t *testing.T) {
+	w := NewWorkbookImporter()
+	w.SetSymbols(map[string]string{"apportionment.state_credits": "double"})
+
+	w.symbolsFor(ownEDD()) // a workbook with its own EDD
+
+	// The next workbook has no EDD sheet of its own and falls back.
+	next := w.symbolsFor(&EDDXML{})
+	if next["apportionment.state_credits"] != "double" {
+		t.Error("the project-wide map was consumed by the previous workbook")
+	}
+	if _, leaked := next["sc_apportionment.state_tax_rate"]; leaked {
+		t.Error("the previous workbook's entities leaked into this one")
+	}
+}

--- a/sampleprojects/TaxReturn/xml/states/AL_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/AL_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Alabama Tax Calculation (top marginal 5%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Alabama Tax Calculation (top marginal 5%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Alabama Tax Calculation (top marginal 5%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $7,500 std ded, 5%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 7500.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.05</action_dsl>
 <action_postfix>
-result.agi 7500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.05 fmul cvi /result.computed_state_tax xdef
+result.agi 7500.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.05 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 7500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>HOH: $4,700 std ded, 5%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 4700.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.05</action_dsl>
 <action_postfix>
-result.agi 4700.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.05 fmul cvi /result.computed_state_tax xdef
+result.agi 4700.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.05 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 4700.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>Default (Single/MFS): $2,500 std ded, 5%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 2500.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.05</action_dsl>
 <action_postfix>
-result.agi 2500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.05 fmul cvi /result.computed_state_tax xdef
+result.agi 2500.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.05 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/AZ_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/AZ_dt.xml
@@ -77,7 +77,7 @@ result.agi 15750.0 f- 0.0 fmax cvd /result.az_taxable_income xdef result.az_taxa
 <action_comment>Publish state result to the generic computed_state_tax fields</action_comment>
 <action_dsl>set result.computed_state_taxable_income = result.az_taxable_income; set result.computed_state_tax = result.az_state_tax</action_dsl>
 <action_postfix>
-result.az_taxable_income cvi /result.computed_state_taxable_income xdef result.az_state_tax cvi /result.computed_state_tax xdef
+result.az_taxable_income cvd /result.computed_state_taxable_income xdef result.az_state_tax cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>XXX</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/CA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/CA_dt.xml
@@ -59,7 +59,7 @@ result.agi ca_standard_deduction_single f- 0.0 fmax cvd /result.ca_taxable_incom
 <action_comment>Publish state result to the generic computed_state_tax fields</action_comment>
 <action_dsl>set result.computed_state_taxable_income = result.ca_taxable_income; set result.computed_state_tax = result.ca_state_tax</action_dsl>
 <action_postfix>
-result.ca_taxable_income cvi /result.computed_state_taxable_income xdef result.ca_state_tax cvi /result.computed_state_tax xdef
+result.ca_taxable_income cvd /result.computed_state_taxable_income xdef result.ca_state_tax cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>XX</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/CO_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/CO_dt.xml
@@ -121,7 +121,7 @@ result.agi 0.0 fmax cvd /result.co_taxable_income xdef result.co_taxable_income 
 <action_comment>Publish state result to the generic computed_state_tax fields</action_comment>
 <action_dsl>set result.computed_state_taxable_income = result.co_taxable_income; set result.computed_state_tax = result.co_tax</action_dsl>
 <action_postfix>
-result.co_taxable_income cvi /result.computed_state_taxable_income xdef result.co_tax cvi /result.computed_state_tax xdef
+result.co_taxable_income cvd /result.computed_state_taxable_income xdef result.co_tax cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/CT_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/CT_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Connecticut Tax Calculation (top marginal 6.99%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Connecticut Tax Calculation (top marginal 6.99%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Connecticut Tax Calculation (top marginal 6.99%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $24,000 std ded, 6.99%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 24000.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0699</action_dsl>
 <action_postfix>
-result.agi 24000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0699 fmul cvi /result.computed_state_tax xdef
+result.agi 24000.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0699 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 24000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $19,000 std ded, 6.99%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 19000.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0699</action_dsl>
 <action_postfix>
-result.agi 19000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0699 fmul cvi /result.computed_state_tax xdef
+result.agi 19000.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0699 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 19000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>Default (Single/MFS): $0 std ded, 6.99%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 0.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0699</action_dsl>
 <action_postfix>
-result.agi 0.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0699 fmul cvi /result.computed_state_tax xdef
+result.agi 0.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0699 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/DC_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/DC_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Washington DC Tax Calculation (top marginal 10.75%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Washington DC Tax Calculation (top marginal 10.75%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Washington DC Tax Calculation (top marginal 10.75%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $30,000 std ded, 10.75%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 30000.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.1075</action_dsl>
 <action_postfix>
-result.agi 30000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.1075 fmul cvi /result.computed_state_tax xdef
+result.agi 30000.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.1075 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 30000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $22,500 std ded, 10.75%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 22500.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.1075</action_dsl>
 <action_postfix>
-result.agi 22500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.1075 fmul cvi /result.computed_state_tax xdef
+result.agi 22500.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.1075 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 22500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>Default (Single/MFS): $15,000 std ded, 10.75%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 15000.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.1075</action_dsl>
 <action_postfix>
-result.agi 15000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.1075 fmul cvi /result.computed_state_tax xdef
+result.agi 15000.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.1075 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/DE_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/DE_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Delaware Tax Calculation (top marginal 6.6%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Delaware Tax Calculation (top marginal 6.6%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Delaware Tax Calculation (top marginal 6.6%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $6,500 std ded, 6.6%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 6500.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.066</action_dsl>
 <action_postfix>
-result.agi 6500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.066 fmul cvi /result.computed_state_tax xdef
+result.agi 6500.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.066 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 6500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>HOH: $3,250 std ded, 6.6%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 3250.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.066</action_dsl>
 <action_postfix>
-result.agi 3250.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.066 fmul cvi /result.computed_state_tax xdef
+result.agi 3250.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.066 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 3250.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>Default (Single/MFS): $3,250 std ded, 6.6%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 3250.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.066</action_dsl>
 <action_postfix>
-result.agi 3250.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.066 fmul cvi /result.computed_state_tax xdef
+result.agi 3250.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.066 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/GA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/GA_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Georgia Tax Calculation (top marginal 5.39%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Georgia Tax Calculation (top marginal 5.39%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Georgia Tax Calculation (top marginal 5.39%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $24,000 std ded, 5.39%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 24000.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0539</action_dsl>
 <action_postfix>
-result.agi 24000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0539 fmul cvi /result.computed_state_tax xdef
+result.agi 24000.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0539 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 24000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $18,000 std ded, 5.39%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 18000.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0539</action_dsl>
 <action_postfix>
-result.agi 18000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0539 fmul cvi /result.computed_state_tax xdef
+result.agi 18000.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0539 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 18000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>Default (Single/MFS): $12,000 std ded, 5.39%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 12000.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0539</action_dsl>
 <action_postfix>
-result.agi 12000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0539 fmul cvi /result.computed_state_tax xdef
+result.agi 12000.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0539 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/HI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/HI_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Hawaii Tax Calculation (top marginal 11.0%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Hawaii Tax Calculation (top marginal 11.0%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Hawaii Tax Calculation (top marginal 11.0%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $4,400 std ded, 11%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 4400.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.11</action_dsl>
 <action_postfix>
-result.agi 4400.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.11 fmul cvi /result.computed_state_tax xdef
+result.agi 4400.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.11 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 4400.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>HOH: $3,212 std ded, 11%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 3212.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.11</action_dsl>
 <action_postfix>
-result.agi 3212.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.11 fmul cvi /result.computed_state_tax xdef
+result.agi 3212.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.11 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 3212.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>Default (Single/MFS): $2,200 std ded, 11%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 2200.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.11</action_dsl>
 <action_postfix>
-result.agi 2200.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.11 fmul cvi /result.computed_state_tax xdef
+result.agi 2200.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.11 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/IA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/IA_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Iowa Tax Calculation (top marginal 3.8%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Iowa Tax Calculation (top marginal 3.8%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Iowa Tax Calculation (top marginal 3.8%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -41,7 +41,7 @@ true
 <action_comment>IA tax = max(AGI - $0, 0) x 3.8%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 0.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.038</action_dsl>
 <action_postfix>
-result.agi 0.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.038 fmul cvi /result.computed_state_tax xdef
+result.agi 0.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.038 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/ID_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/ID_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Idaho Tax Calculation (top marginal 5.695%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Idaho Tax Calculation (top marginal 5.695%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Idaho Tax Calculation (top marginal 5.695%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $30,000 std ded, 5.695%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 30000.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.05695</action_dsl>
 <action_postfix>
-result.agi 30000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.05695 fmul cvi /result.computed_state_tax xdef
+result.agi 30000.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.05695 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 30000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $22,500 std ded, 5.695%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 22500.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.05695</action_dsl>
 <action_postfix>
-result.agi 22500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.05695 fmul cvi /result.computed_state_tax xdef
+result.agi 22500.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.05695 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 22500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>Default (Single/MFS): $15,000 std ded, 5.695%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 15000.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.05695</action_dsl>
 <action_postfix>
-result.agi 15000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.05695 fmul cvi /result.computed_state_tax xdef
+result.agi 15000.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.05695 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/IL_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/IL_dt.xml
@@ -50,7 +50,7 @@ job.taxpayers length job.dependents length + il_personal_exemption fmul cvd /res
 <action_comment>Publish state result to the generic computed_state_tax fields</action_comment>
 <action_dsl>set result.computed_state_taxable_income = result.il_taxable_income; set result.computed_state_tax = result.il_state_tax</action_dsl>
 <action_postfix>
-result.il_taxable_income cvi /result.computed_state_taxable_income xdef result.il_state_tax cvi /result.computed_state_tax xdef
+result.il_taxable_income cvd /result.computed_state_taxable_income xdef result.il_state_tax cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/IN_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/IN_dt.xml
@@ -50,7 +50,7 @@ job.taxpayers length in_personal_exemption fmul job.dependents length in_depende
 <action_comment>Publish state result to the generic computed_state_tax fields</action_comment>
 <action_dsl>set result.computed_state_taxable_income = result.in_taxable_income; set result.computed_state_tax = result.in_state_tax</action_dsl>
 <action_postfix>
-result.in_taxable_income cvi /result.computed_state_taxable_income xdef result.in_state_tax cvi /result.computed_state_tax xdef
+result.in_taxable_income cvd /result.computed_state_taxable_income xdef result.in_state_tax cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/KS_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/KS_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Kansas Tax Calculation (top marginal 5.58%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Kansas Tax Calculation (top marginal 5.58%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Kansas Tax Calculation (top marginal 5.58%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $8,000 std ded, 5.58%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 8000.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0558</action_dsl>
 <action_postfix>
-result.agi 8000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0558 fmul cvi /result.computed_state_tax xdef
+result.agi 8000.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0558 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 8000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>HOH: $6,000 std ded, 5.58%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 6000.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0558</action_dsl>
 <action_postfix>
-result.agi 6000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0558 fmul cvi /result.computed_state_tax xdef
+result.agi 6000.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0558 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 6000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>Default (Single/MFS): $3,500 std ded, 5.58%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 3500.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0558</action_dsl>
 <action_postfix>
-result.agi 3500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0558 fmul cvi /result.computed_state_tax xdef
+result.agi 3500.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0558 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/KY_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/KY_dt.xml
@@ -79,7 +79,7 @@ result.agi ky_standard_deduction f- 0.0 fmax cvd /result.ky_taxable_income xdef 
 <action_comment>Publish state result to the generic computed_state_tax fields</action_comment>
 <action_dsl>set result.computed_state_taxable_income = result.ky_taxable_income; set result.computed_state_tax = result.ky_state_tax</action_dsl>
 <action_postfix>
-result.ky_taxable_income cvi /result.computed_state_taxable_income xdef result.ky_state_tax cvi /result.computed_state_tax xdef
+result.ky_taxable_income cvd /result.computed_state_taxable_income xdef result.ky_state_tax cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/LA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/LA_dt.xml
@@ -34,7 +34,7 @@ job.filing_status "married_filing_jointly" streq { pop job.filing_status "head_o
 <action_comment>Calculate LA tax with joint/HOH standard deduction</action_comment>
 <action_dsl>set result.la_standard_deduction = la_standard_deduction_joint; set result.la_taxable_income = the maximum of (result.agi - result.la_standard_deduction) and 0.0; set result.la_tax = result.la_taxable_income * la_tax_rate; add "  LA flat tax (3%, MFJ/HOH std deduction): $" + result.la_tax to job.audit_trail</action_dsl>
 <action_postfix>
-la_standard_deduction_joint cvi /result.la_standard_deduction xdef result.agi result.la_standard_deduction - 0.0 fmax cvi /result.la_taxable_income xdef result.la_taxable_income la_tax_rate fmul cvi /result.la_tax xdef "  LA flat tax (3%, MFJ/HOH std deduction): $" result.la_tax strconcat job.audit_trail swap addto
+la_standard_deduction_joint cvi /result.la_standard_deduction xdef result.agi result.la_standard_deduction f- 0.0 fmax cvi /result.la_taxable_income xdef result.la_taxable_income la_tax_rate fmul cvi /result.la_tax xdef "  LA flat tax (3%, MFJ/HOH std deduction): $" result.la_tax strconcat job.audit_trail swap addto
 </action_postfix>
 <columns>--</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/MA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MA_dt.xml
@@ -77,7 +77,7 @@ result.agi 4400.0 f- 0.0 fmax cvd /result.ma_taxable_income xdef result.ma_taxab
 <action_comment>Publish state result to the generic computed_state_tax fields</action_comment>
 <action_dsl>set result.computed_state_taxable_income = result.ma_taxable_income; set result.computed_state_tax = result.ma_state_tax</action_dsl>
 <action_postfix>
-result.ma_taxable_income cvi /result.computed_state_taxable_income xdef result.ma_state_tax cvi /result.computed_state_tax xdef
+result.ma_taxable_income cvd /result.computed_state_taxable_income xdef result.ma_state_tax cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>XXX</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/MD_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MD_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Maryland Tax Calculation (top marginal 5.75%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Maryland Tax Calculation (top marginal 5.75%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Maryland Tax Calculation (top marginal 5.75%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $5,150 std ded, 5.75%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 5150.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0575</action_dsl>
 <action_postfix>
-result.agi 5150.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0575 fmul cvi /result.computed_state_tax xdef
+result.agi 5150.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0575 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 5150.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>HOH: $2,550 std ded, 5.75%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 2550.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0575</action_dsl>
 <action_postfix>
-result.agi 2550.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0575 fmul cvi /result.computed_state_tax xdef
+result.agi 2550.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0575 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 2550.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>Default (Single/MFS): $2,550 std ded, 5.75%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 2550.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0575</action_dsl>
 <action_postfix>
-result.agi 2550.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0575 fmul cvi /result.computed_state_tax xdef
+result.agi 2550.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0575 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/ME_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/ME_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Maine Tax Calculation (top marginal 7.15%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Maine Tax Calculation (top marginal 7.15%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Maine Tax Calculation (top marginal 7.15%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $29,200 std ded, 7.15%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 29200.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0715</action_dsl>
 <action_postfix>
-result.agi 29200.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0715 fmul cvi /result.computed_state_tax xdef
+result.agi 29200.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0715 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 29200.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $21,900 std ded, 7.15%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 21900.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0715</action_dsl>
 <action_postfix>
-result.agi 21900.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0715 fmul cvi /result.computed_state_tax xdef
+result.agi 21900.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0715 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 21900.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>Default (Single/MFS): $14,600 std ded, 7.15%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 14600.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0715</action_dsl>
 <action_postfix>
-result.agi 14600.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0715 fmul cvi /result.computed_state_tax xdef
+result.agi 14600.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0715 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/MI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MI_dt.xml
@@ -50,7 +50,7 @@ job.taxpayers length job.dependents length + mi_exemption_single fmul cvd /resul
 <action_comment>Publish state result to the generic computed_state_tax fields</action_comment>
 <action_dsl>set result.computed_state_taxable_income = result.mi_taxable_income; set result.computed_state_tax = result.mi_state_tax</action_dsl>
 <action_postfix>
-result.mi_taxable_income cvi /result.computed_state_taxable_income xdef result.mi_state_tax cvi /result.computed_state_tax xdef
+result.mi_taxable_income cvd /result.computed_state_taxable_income xdef result.mi_state_tax cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/MN_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MN_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Minnesota Tax Calculation (top marginal 9.85%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Minnesota Tax Calculation (top marginal 9.85%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Minnesota Tax Calculation (top marginal 9.85%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $29,150 std ded, 9.85%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 29150.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0985</action_dsl>
 <action_postfix>
-result.agi 29150.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0985 fmul cvi /result.computed_state_tax xdef
+result.agi 29150.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0985 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 29150.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $21,900 std ded, 9.85%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 21900.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0985</action_dsl>
 <action_postfix>
-result.agi 21900.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0985 fmul cvi /result.computed_state_tax xdef
+result.agi 21900.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0985 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 21900.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>Default (Single/MFS): $14,575 std ded, 9.85%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 14575.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0985</action_dsl>
 <action_postfix>
-result.agi 14575.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0985 fmul cvi /result.computed_state_tax xdef
+result.agi 14575.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0985 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/MO_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MO_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Missouri Tax Calculation (top marginal 4.95%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Missouri Tax Calculation (top marginal 4.95%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Missouri Tax Calculation (top marginal 4.95%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $29,200 std ded, 4.95%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 29200.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0495</action_dsl>
 <action_postfix>
-result.agi 29200.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0495 fmul cvi /result.computed_state_tax xdef
+result.agi 29200.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0495 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 29200.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $21,900 std ded, 4.95%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 21900.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0495</action_dsl>
 <action_postfix>
-result.agi 21900.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0495 fmul cvi /result.computed_state_tax xdef
+result.agi 21900.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0495 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 21900.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>Default (Single/MFS): $14,600 std ded, 4.95%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 14600.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0495</action_dsl>
 <action_postfix>
-result.agi 14600.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0495 fmul cvi /result.computed_state_tax xdef
+result.agi 14600.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0495 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/MS_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MS_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Mississippi Tax Calculation (top marginal 4.4%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Mississippi Tax Calculation (top marginal 4.4%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Mississippi Tax Calculation (top marginal 4.4%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $4,600 std ded, 4.4%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 4600.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.044</action_dsl>
 <action_postfix>
-result.agi 4600.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.044 fmul cvi /result.computed_state_tax xdef
+result.agi 4600.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.044 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 4600.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>HOH: $3,400 std ded, 4.4%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 3400.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.044</action_dsl>
 <action_postfix>
-result.agi 3400.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.044 fmul cvi /result.computed_state_tax xdef
+result.agi 3400.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.044 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 3400.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>Default (Single/MFS): $2,300 std ded, 4.4%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 2300.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.044</action_dsl>
 <action_postfix>
-result.agi 2300.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.044 fmul cvi /result.computed_state_tax xdef
+result.agi 2300.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.044 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/MT_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MT_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Montana Tax Calculation (top marginal 5.9%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Montana Tax Calculation (top marginal 5.9%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Montana Tax Calculation (top marginal 5.9%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $29,200 std ded, 5.9%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 29200.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.059</action_dsl>
 <action_postfix>
-result.agi 29200.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.059 fmul cvi /result.computed_state_tax xdef
+result.agi 29200.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.059 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 29200.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $21,900 std ded, 5.9%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 21900.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.059</action_dsl>
 <action_postfix>
-result.agi 21900.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.059 fmul cvi /result.computed_state_tax xdef
+result.agi 21900.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.059 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 21900.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>Default (Single/MFS): $14,600 std ded, 5.9%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 14600.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.059</action_dsl>
 <action_postfix>
-result.agi 14600.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.059 fmul cvi /result.computed_state_tax xdef
+result.agi 14600.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.059 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/NC_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NC_dt.xml
@@ -77,7 +77,7 @@ result.agi 12750.0 f- 0.0 fmax cvd /result.nc_taxable_income xdef result.nc_taxa
 <action_comment>Publish state result to the generic computed_state_tax fields</action_comment>
 <action_dsl>set result.computed_state_taxable_income = result.nc_taxable_income; set result.computed_state_tax = result.nc_state_tax</action_dsl>
 <action_postfix>
-result.nc_taxable_income cvi /result.computed_state_taxable_income xdef result.nc_state_tax cvi /result.computed_state_tax xdef
+result.nc_taxable_income cvd /result.computed_state_taxable_income xdef result.nc_state_tax cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>XXX</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/ND_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/ND_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  North Dakota Tax Calculation (top marginal 2.5%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  North Dakota Tax Calculation (top marginal 2.5%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  North Dakota Tax Calculation (top marginal 2.5%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $29,200 std ded, 2.5%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 29200.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.025</action_dsl>
 <action_postfix>
-result.agi 29200.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.025 fmul cvi /result.computed_state_tax xdef
+result.agi 29200.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.025 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 29200.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $21,900 std ded, 2.5%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 21900.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.025</action_dsl>
 <action_postfix>
-result.agi 21900.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.025 fmul cvi /result.computed_state_tax xdef
+result.agi 21900.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.025 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 21900.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>Default (Single/MFS): $14,600 std ded, 2.5%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 14600.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.025</action_dsl>
 <action_postfix>
-result.agi 14600.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.025 fmul cvi /result.computed_state_tax xdef
+result.agi 14600.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.025 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/NE_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NE_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Nebraska Tax Calculation (top marginal 5.84%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Nebraska Tax Calculation (top marginal 5.84%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Nebraska Tax Calculation (top marginal 5.84%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $15,800 std ded, 5.84%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 15800.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0584</action_dsl>
 <action_postfix>
-result.agi 15800.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0584 fmul cvi /result.computed_state_tax xdef
+result.agi 15800.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0584 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 15800.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $11,650 std ded, 5.84%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 11650.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0584</action_dsl>
 <action_postfix>
-result.agi 11650.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0584 fmul cvi /result.computed_state_tax xdef
+result.agi 11650.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0584 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 11650.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>Default (Single/MFS): $7,900 std ded, 5.84%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 7900.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0584</action_dsl>
 <action_postfix>
-result.agi 7900.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0584 fmul cvi /result.computed_state_tax xdef
+result.agi 7900.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0584 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/NH_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NH_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  New Hampshire (Interest &amp; Dividends tax phased out 2025)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  New Hampshire (Interest &amp; Dividends tax phased out 2025)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  New Hampshire (Interest &amp; Dividends tax phased out 2025)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>

--- a/sampleprojects/TaxReturn/xml/states/NJ_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NJ_dt.xml
@@ -80,7 +80,7 @@ job.filing_status "married_filing_jointly" streq { pop job.filing_status "MFJ" s
 <action_comment>Publish state result to the generic computed_state_tax fields</action_comment>
 <action_dsl>set result.computed_state_taxable_income = result.nj_taxable_income; set result.computed_state_tax = result.nj_tax</action_dsl>
 <action_postfix>
-result.nj_taxable_income cvi /result.computed_state_taxable_income xdef result.nj_tax cvi /result.computed_state_tax xdef
+result.nj_taxable_income cvd /result.computed_state_taxable_income xdef result.nj_tax cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>XX</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/NY_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NY_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  New York Tax Calculation (top marginal 10.9%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  New York Tax Calculation (top marginal 10.9%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  New York Tax Calculation (top marginal 10.9%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $16,050 std ded, 10.9%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 16050.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.109</action_dsl>
 <action_postfix>
-result.agi 16050.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.109 fmul cvi /result.computed_state_tax xdef
+result.agi 16050.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.109 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 16050.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $11,200 std ded, 10.9%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 11200.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.109</action_dsl>
 <action_postfix>
-result.agi 11200.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.109 fmul cvi /result.computed_state_tax xdef
+result.agi 11200.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.109 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 11200.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>Default (Single/MFS): $8,000 std ded, 10.9%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 8000.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.109</action_dsl>
 <action_postfix>
-result.agi 8000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.109 fmul cvi /result.computed_state_tax xdef
+result.agi 8000.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.109 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/OH_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/OH_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Ohio Tax Calculation (top marginal 3.5%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Ohio Tax Calculation (top marginal 3.5%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Ohio Tax Calculation (top marginal 3.5%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -41,7 +41,7 @@ true
 <action_comment>OH tax = max(AGI - $0, 0) x 3.5%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 0.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.035</action_dsl>
 <action_postfix>
-result.agi 0.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.035 fmul cvi /result.computed_state_tax xdef
+result.agi 0.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.035 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/OR_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/OR_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Oregon Tax Calculation (top marginal 9.9%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Oregon Tax Calculation (top marginal 9.9%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Oregon Tax Calculation (top marginal 9.9%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $5,495 std ded, 9.9%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 5495.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.099</action_dsl>
 <action_postfix>
-result.agi 5495.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.099 fmul cvi /result.computed_state_tax xdef
+result.agi 5495.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.099 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 5495.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>HOH: $4,415 std ded, 9.9%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 4415.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.099</action_dsl>
 <action_postfix>
-result.agi 4415.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.099 fmul cvi /result.computed_state_tax xdef
+result.agi 4415.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.099 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 4415.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>Default (Single/MFS): $2,745 std ded, 9.9%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 2745.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.099</action_dsl>
 <action_postfix>
-result.agi 2745.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.099 fmul cvi /result.computed_state_tax xdef
+result.agi 2745.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.099 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/PA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/PA_dt.xml
@@ -50,7 +50,7 @@ result.agi 0.0 fmax cvd /result.pa_total_income xdef result.pa_total_income pa_t
 <action_comment>Publish state result to the generic computed_state_tax fields</action_comment>
 <action_dsl>set result.computed_state_taxable_income = result.pa_total_income; set result.computed_state_tax = result.pa_state_tax</action_dsl>
 <action_postfix>
-result.pa_total_income cvi /result.computed_state_taxable_income xdef result.pa_state_tax cvi /result.computed_state_tax xdef
+result.pa_total_income cvd /result.computed_state_taxable_income xdef result.pa_state_tax cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/RI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/RI_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Rhode Island Tax Calculation (top marginal 5.99%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Rhode Island Tax Calculation (top marginal 5.99%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Rhode Island Tax Calculation (top marginal 5.99%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $21,150 std ded, 5.99%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 21150.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0599</action_dsl>
 <action_postfix>
-result.agi 21150.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0599 fmul cvi /result.computed_state_tax xdef
+result.agi 21150.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0599 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 21150.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $15,850 std ded, 5.99%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 15850.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0599</action_dsl>
 <action_postfix>
-result.agi 15850.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0599 fmul cvi /result.computed_state_tax xdef
+result.agi 15850.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0599 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 15850.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>Default (Single/MFS): $10,550 std ded, 5.99%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 10550.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0599</action_dsl>
 <action_postfix>
-result.agi 10550.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0599 fmul cvi /result.computed_state_tax xdef
+result.agi 10550.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0599 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/SC_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/SC_dt.xml
@@ -72,7 +72,7 @@ job.state "SC" streq
 <action_comment>No SC tax for non-residents</action_comment>
 <action_dsl>set result.sc_state_tax = 0</action_dsl>
 <action_postfix>
-0 cvi /result.sc_state_tax xdef
+0 cvd /result.sc_state_tax xdef
 </action_postfix>
 <columns>-X</columns>
 </action_details>
@@ -81,7 +81,7 @@ job.state "SC" streq
 <action_comment>Publish state result to the generic computed_state_tax fields</action_comment>
 <action_dsl>set result.computed_state_taxable_income = result.sc_taxable_income; set result.computed_state_tax = result.sc_state_tax</action_dsl>
 <action_postfix>
-result.sc_taxable_income cvi /result.computed_state_taxable_income xdef result.sc_state_tax cvi /result.computed_state_tax xdef
+result.sc_taxable_income cvd /result.computed_state_taxable_income xdef result.sc_state_tax cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>XX</columns>
 </action_details>
@@ -211,7 +211,7 @@ result.sc_taxable_income 0 f&lt;=
 <action_comment>Bracket 1 tax (0%); set result.sc_state_tax = 0 (below $3,560)</action_comment>
 <action_dsl>set result.sc_state_tax = 0</action_dsl>
 <action_postfix>
-0 cvi /result.sc_state_tax xdef
+0 cvd /result.sc_state_tax xdef
 </action_postfix>
 <columns>X---</columns>
 </action_details>
@@ -220,7 +220,7 @@ result.sc_taxable_income 0 f&lt;=
 <action_comment>Bracket 2 tax (3%); set result.sc_state_tax = (income - $3,560) * 3%</action_comment>
 <action_dsl>set result.sc_state_tax = (result.sc_taxable_income - sc_bracket_1_limit) * sc_bracket_2_rate</action_dsl>
 <action_postfix>
-result.sc_taxable_income sc_bracket_1_limit f- sc_bracket_2_rate fmul cvi /result.sc_state_tax xdef
+result.sc_taxable_income sc_bracket_1_limit f- sc_bracket_2_rate fmul cvd /result.sc_state_tax xdef
 </action_postfix>
 <columns>-X--</columns>
 </action_details>
@@ -229,7 +229,7 @@ result.sc_taxable_income sc_bracket_1_limit f- sc_bracket_2_rate fmul cvi /resul
 <action_comment>Bracket 3 tax (6%); set result.sc_state_tax = $428.10 + (income - $17,830) * 6%</action_comment>
 <action_dsl>set result.sc_state_tax = (sc_bracket_2_limit - sc_bracket_1_limit) * sc_bracket_2_rate + (result.sc_taxable_income - sc_bracket_2_limit) * sc_bracket_3_rate</action_dsl>
 <action_postfix>
-sc_bracket_2_limit sc_bracket_1_limit f- sc_bracket_2_rate fmul result.sc_taxable_income sc_bracket_2_limit f- sc_bracket_3_rate fmul f+ cvi /result.sc_state_tax xdef
+sc_bracket_2_limit sc_bracket_1_limit f- sc_bracket_2_rate fmul result.sc_taxable_income sc_bracket_2_limit f- sc_bracket_3_rate fmul f+ cvd /result.sc_state_tax xdef
 </action_postfix>
 <columns>--X-</columns>
 </action_details>
@@ -238,7 +238,7 @@ sc_bracket_2_limit sc_bracket_1_limit f- sc_bracket_2_rate fmul result.sc_taxabl
 <action_comment>No tax (zero income)</action_comment>
 <action_dsl>set result.sc_state_tax = 0</action_dsl>
 <action_postfix>
-0 cvi /result.sc_state_tax xdef
+0 cvd /result.sc_state_tax xdef
 </action_postfix>
 <columns>---X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/VA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/VA_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Virginia Tax Calculation (top marginal 5.75%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Virginia Tax Calculation (top marginal 5.75%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Virginia Tax Calculation (top marginal 5.75%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $17,000 std ded, 5.75%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 17000.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0575</action_dsl>
 <action_postfix>
-result.agi 17000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0575 fmul cvi /result.computed_state_tax xdef
+result.agi 17000.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0575 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 17000.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $8,500 std ded, 5.75%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 8500.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0575</action_dsl>
 <action_postfix>
-result.agi 8500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0575 fmul cvi /result.computed_state_tax xdef
+result.agi 8500.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0575 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 8500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef res
 <action_comment>Default (Single/MFS): $8,500 std ded, 5.75%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 8500.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0575</action_dsl>
 <action_postfix>
-result.agi 8500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0575 fmul cvi /result.computed_state_tax xdef
+result.agi 8500.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0575 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/VT_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/VT_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Vermont Tax Calculation (top marginal 8.75%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Vermont Tax Calculation (top marginal 8.75%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Vermont Tax Calculation (top marginal 8.75%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $14,850 std ded, 8.75%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 14850.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0875</action_dsl>
 <action_postfix>
-result.agi 14850.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0875 fmul cvi /result.computed_state_tax xdef
+result.agi 14850.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0875 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 14850.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $11,500 std ded, 8.75%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 11500.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0875</action_dsl>
 <action_postfix>
-result.agi 11500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0875 fmul cvi /result.computed_state_tax xdef
+result.agi 11500.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0875 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 11500.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>Default (Single/MFS): $7,400 std ded, 8.75%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 7400.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0875</action_dsl>
 <action_postfix>
-result.agi 7400.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0875 fmul cvi /result.computed_state_tax xdef
+result.agi 7400.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0875 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/WI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/WI_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  Wisconsin Tax Calculation (top marginal 7.65%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  Wisconsin Tax Calculation (top marginal 7.65%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  Wisconsin Tax Calculation (top marginal 7.65%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -50,7 +50,7 @@ job.filing_status "HOH" streq
 <action_comment>MFJ/QSS: $25,090 std ded, 7.65%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 25090.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0765</action_dsl>
 <action_postfix>
-result.agi 25090.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0765 fmul cvi /result.computed_state_tax xdef
+result.agi 25090.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0765 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X--</columns>
 </action_details>
@@ -59,7 +59,7 @@ result.agi 25090.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>HOH: $17,790 std ded, 7.65%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 17790.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0765</action_dsl>
 <action_postfix>
-result.agi 17790.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0765 fmul cvi /result.computed_state_tax xdef
+result.agi 17790.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0765 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>-X-</columns>
 </action_details>
@@ -68,7 +68,7 @@ result.agi 17790.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef re
 <action_comment>Default (Single/MFS): $13,560 std ded, 7.65%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 13560.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0765</action_dsl>
 <action_postfix>
-result.agi 13560.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0765 fmul cvi /result.computed_state_tax xdef
+result.agi 13560.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0765 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>--X</columns>
 </action_details>

--- a/sampleprojects/TaxReturn/xml/states/WV_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/WV_dt.xml
@@ -20,7 +20,7 @@
 <initial_action>
 <initial_action_dsl>set result.computed_state_tax = 0; set result.computed_state_taxable_income = 0; add "  West Virginia Tax Calculation (top marginal 4.82%)" to job.audit_trail</initial_action_dsl>
 <initial_action_postfix>
-0 cvi /result.computed_state_tax xdef 0 cvi /result.computed_state_taxable_income xdef "  West Virginia Tax Calculation (top marginal 4.82%)" job.audit_trail swap addto
+0 cvd /result.computed_state_tax xdef 0 cvd /result.computed_state_taxable_income xdef "  West Virginia Tax Calculation (top marginal 4.82%)" job.audit_trail swap addto
 </initial_action_postfix>
 </initial_action>
 </initial_actions>
@@ -41,7 +41,7 @@ true
 <action_comment>WV tax = max(AGI - $0, 0) x 4.82%</action_comment>
 <action_dsl>set result.computed_state_taxable_income = the maximum of (result.agi - 0.0) and 0.0; set result.computed_state_tax = result.computed_state_taxable_income * 0.0482</action_dsl>
 <action_postfix>
-result.agi 0.0 f- 0.0 fmax cvi /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0482 fmul cvi /result.computed_state_tax xdef
+result.agi 0.0 f- 0.0 fmax cvd /result.computed_state_taxable_income xdef result.computed_state_taxable_income 0.0482 fmul cvd /result.computed_state_tax xdef
 </action_postfix>
 <columns>X</columns>
 </action_details>


### PR DESCRIPTION
## What

A workbook's decision tables were compiled against a symbol table holding only
that workbook's own EDD. The project-wide map was seeded once at the start of
the build and then written over by the first workbook carrying an EDD sheet.

Unknown types fall back to integer, so a table reading an entity declared in
*another* workbook compiled money as integers:

```
apportionment.state_credits f-   ->   apportionment.state_credits -
cvd /apportionment.state_tax     ->   cvi /apportionment.state_tax
```

The replacement also leaked forward — one importer is reused for every
workbook in the build loop with no save/restore, so a DT-only workbook
compiled against whichever EDD happened to be imported before it.

## Fix

The per-workbook EDD is layered over the project map rather than replacing it,
rebuilt from a clean copy per workbook. The workbook's own declarations still
win.

The downgrade detector never fired on any of this: it covered fixed-point
losses and the `f<` comparisons added when NV hit the same class, but not
double arithmetic or `cvd` -> `cvi`. Those entries are added, so this class
cannot regress silently.

## Blast radius

TaxReturn is regenerated — 219 assignments that truncated to integer now store
as double. CorporateTax already had five state files carrying the downgraded
form and 26 carrying the correct one, which is what a silent downgrade looks
like after a few rebuilds.

## Verification

- `make check` and the archive lane both pass; TaxReturn's tests pass unchanged
- All 11 sample projects verify with zero `[build]` findings
- Three new tests pin the merge, the precedence, and the no-leak property

🤖 Generated with [Claude Code](https://claude.com/claude-code)