### PR TITLE
fix(excel): refuse an export that would delete a workbook's EDD sheet (#1094)

### DIFF
--- a/pkg/dtrules/excel/export_owned_test.go
+++ b/pkg/dtrules/excel/export_owned_test.go
@@ -15,9 +15,12 @@
 package excel
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/DTRules/DTRules/pkg/dtrules/session"
+	"github.com/xuri/excelize/v2"
 )
 
 // Refreshing a project's workbooks used to call ExportDecisionTables once per
@@ -69,4 +72,67 @@ func TestExportOwnedByLeavesAnUnclaimedWorkbookAlone(t *testing.T) {
 	}
 	// The path does not exist; reaching SaveAs would have errored above. That
 	// it did not is the assertion.
+}
+
+// A workbook that keeps its tables and loses its dictionary has no legitimate
+// form. The entities come from the loaded rule set, so an empty set means the
+// EDD did not load -- and exporting anyway deletes the dictionary from the
+// system of record, after which the next build compiles every field as an
+// integer (#1094).
+func TestExportOwnedByRefusesToDropTheEDDSheet(t *testing.T) {
+	// Decision tables but no EDD: the shape a project takes when its EDD files
+	// were never loaded. The tables claim a workbook, so the export runs.
+	rs := session.NewRuleSet("no-edd")
+	if rs == nil {
+		t.Skip("could not create rule set")
+	}
+	if err := rs.LoadDecisionTablesFile(kidAidDT); err != nil {
+		t.Skipf("skip DT load: %v", err)
+	}
+	names := rs.GetDecisionTableNames()
+	if len(names) == 0 {
+		t.Skip("no decision tables loaded")
+	}
+	e := NewExporter(rs)
+	claimed := ""
+	for _, dt := range e.getAllDecisionTables() {
+		if p := dt.GetFilePath(); p != "" {
+			claimed = filepath.Base(p)
+			break
+		}
+	}
+	if claimed == "" {
+		t.Skip("no table names a workbook")
+	}
+
+	// The workbook on disk has a dictionary.
+	path := filepath.Join(t.TempDir(), claimed)
+	f := excelize.NewFile()
+	if _, err := f.NewSheet("EDD"); err != nil {
+		t.Fatal(err)
+	}
+	f.DeleteSheet(f.GetSheetName(0))
+	if err := f.SaveAs(path); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	if _, err := e.ExportDecisionTablesOwnedBy(path); err == nil {
+		t.Fatal("exported a workbook with no entities over one that had an EDD sheet; " +
+			"that deletes the dictionary from the system of record")
+	} else if !strings.Contains(err.Error(), "EDD") {
+		t.Errorf("error does not say what was at stake: %v", err)
+	}
+
+	back, err := excelize.OpenFile(path)
+	if err != nil {
+		t.Fatalf("the workbook is gone: %v", err)
+	}
+	defer back.Close()
+	for _, s := range back.GetSheetList() {
+		if strings.EqualFold(s, "EDD") {
+			return
+		}
+	}
+	t.Error("the EDD sheet was deleted from the system of record")
 }

--- a/pkg/dtrules/excel/exporter.go
+++ b/pkg/dtrules/excel/exporter.go
@@ -145,6 +145,10 @@ func (e *Exporter) ExportDecisionTablesOwnedBy(filename string) (int, error) {
 		if err := e.writeEDDSheet(f, styler, "EDD", ents); err != nil {
 			return 0, fmt.Errorf("failed to write EDD sheet: %w", err)
 		}
+	} else if len(e.allEntities()) == 0 {
+		if err := refuseToDropEDDSheet(filename); err != nil {
+			return 0, err
+		}
 	}
 
 	if len(f.GetSheetList()) > 1 {
@@ -153,6 +157,46 @@ func (e *Exporter) ExportDecisionTablesOwnedBy(filename string) (int, error) {
 	// Count both: the caller uses this to decide whether anything was
 	// written, and an EDD-only workbook writes no tables.
 	return len(owned) + len(ents), f.SaveAs(filename)
+}
+
+// refuseToDropEDDSheet blocks an export that would replace a workbook holding
+// an EDD sheet with one holding none.
+//
+// Losing a sheet is losing rules. Excel is the system of record, so a refresh
+// that drops the dictionary deletes it from the record, and the next build
+// imports a workbook with no types and compiles the DSL untyped -- `f<` becomes
+// `<`, two fixed-point amounts compared as integers (#1094).
+//
+// The condition is deliberately narrow, and the caller narrows it further to
+// "the rule set has no entities at all". `dtrules table delete` legitimately
+// removes a sheet, so a blanket "sheet count must not decrease" rule would
+// refuse real work. A rule set with no entities whatsoever is not an editorial
+// decision -- it is an export running before the EDD files were loaded, which
+// is the shape #1094 describes.
+//
+// It stops short of "no entity claims *this* workbook", which is a real
+// condition but not always this bug: TaxReturn's 50 state EDDs each declare
+// the shared `result` entity naming their own workbook, and only one survives
+// the merge, so 49 workbooks are unclaimed by an entity that genuinely
+// describes them. Ownership needs to follow the declaration rather than the
+// merged winner before that case can be refused.
+func refuseToDropEDDSheet(filename string) error {
+	existing, err := excelize.OpenFile(filename)
+	if err != nil {
+		// No file yet, or unreadable: nothing is being dropped.
+		return nil
+	}
+	defer existing.Close()
+	for _, sheet := range existing.GetSheetList() {
+		if !strings.EqualFold(strings.TrimSpace(sheet), "EDD") {
+			continue
+		}
+		return fmt.Errorf("refusing to export %s: it has an EDD sheet and no entity "+
+			"claims this workbook, so the export would delete the dictionary. "+
+			"The entities come from the loaded rule set — load the project's EDD "+
+			"files before exporting", filepath.Base(filename))
+	}
+	return nil
 }
 
 // workbookKey reduces a workbook reference to something comparable: base name,


### PR DESCRIPTION
The last item on #1094. Losing a sheet is losing rules: Excel is the system of
record, so an export that drops the dictionary deletes it from the record, and
the next build imports a workbook with no types and compiles the DSL untyped.

An export that would replace a workbook holding an EDD sheet with one holding
none is now refused.

## Why the condition is narrow

`dtrules table delete` legitimately removes a sheet, so a blanket "sheet count
must not decrease" rule would refuse real work. What is never editorial is a
rule set with **no entities at all** — that is an export running before the EDD
files were loaded, which is exactly the shape the issue describes.

## What it found on the way

It stops short of "no entity claims *this* workbook", which is a real condition
but not always this bug. Testing it against every sample turned up a live case:
TaxReturn's 50 state EDDs each declare the shared `result` entity naming their
own workbook, and only one survives the merge — so 49 workbooks are described
by an entity that does not claim them. Ownership has to follow the declaration
rather than the merged winner before that case can be refused. Filed separately.

## Verification

- A no-op `table get | table put` on all 11 samples still succeeds
- All 11 verify with zero `[build]` findings
- `make check` passes; the new test fails if the export is allowed to proceed

🤖 Generated with [Claude Code](https://claude.com/claude-code)