### PR TITLE
fix(el): reject operator calls with the wrong argument count (#1105)

### DIFF
--- a/cmd/dtrules/build.go
+++ b/cmd/dtrules/build.go
@@ -48,6 +48,11 @@ func newWorkbookImporter(xmlDir string) *excel.WorkbookImporter {
 		_, ok := operators.GetByString(name)
 		return ok
 	})
+	// And with the declared number of arguments (#1105).
+	c.SetOperatorArity(func(name string) (int, int, bool) {
+		a, ok := operators.ArityOf(name)
+		return a.Min, a.Max, ok
+	})
 	imp.SetELCompiler(c)
 	if syms := authoring.LoadEDDSymbols(xmlDir); len(syms) > 0 {
 		imp.SetSymbols(syms)

--- a/pkg/dtrules/authoring/el_check.go
+++ b/pkg/dtrules/authoring/el_check.go
@@ -136,5 +136,12 @@ func newCheckedCompiler() *el.Compiler {
 		_, ok := operators.GetByString(name)
 		return ok
 	})
+	// And with the right number of arguments — a short call is worse than a
+	// misspelled one, because it silently consumes whatever is beneath it on
+	// the stack rather than failing (#1105).
+	c.SetOperatorArity(func(name string) (int, int, bool) {
+		a, ok := operators.ArityOf(name)
+		return a.Min, a.Max, ok
+	})
 	return c
 }

--- a/pkg/dtrules/authoring/operator_arity_test.go
+++ b/pkg/dtrules/authoring/operator_arity_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestOperatorArityIsChecked pins #1105, the half #1020 deferred.
+//
+// The name check landed in #1046; arity did not, because the registry recorded
+// no argument count. A short call is the worse of the two failures: the
+// runtime pops by position, so `subsets(hand.cards)` does not fail for want of
+// three arguments — it takes whatever three values sit beneath it on the stack
+// and treats them as the type name, sum field and destination array. That is a
+// wrong answer, or a write into an unrelated array, not an error.
+//
+// Lives in authoring for the same reason as TestUnknownOperatorIsRejected: el
+// cannot import the operator registry, so the lookup is injected, and this is
+// the layer that injects it.
+func TestOperatorArityIsChecked(t *testing.T) {
+	symbols := map[string]string{
+		"hand.cards": "array", "hand.combos": "array", "num": "integer",
+	}
+
+	for _, tc := range []struct {
+		dsl  string
+		want string // fragment the error must carry
+	}{
+		{`subsets(hand.cards)`, "4 arguments"},
+		{`subsets(hand.cards, "combo", "value", hand.combos, num)`, "4 arguments"},
+		{`groupby(hand.cards, "rank", "grp")`, "4 arguments"},
+		{`combinations(hand.cards, num, "combo", "value")`, "5 arguments"},
+		{`maximalruns(hand.cards, "rank", num, "seq")`, "5 arguments"},
+		{`suffixes(hand.cards, num, "rank", "combo")`, "5 arguments"},
+	} {
+		_, err := CheckAction(tc.dsl, symbols)
+		if err == nil {
+			t.Errorf("compiled a call with the wrong argument count: %s", tc.dsl)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("error should say what was expected for %s\n  want fragment: %s\n  got: %v",
+				tc.dsl, tc.want, err)
+		}
+		if !strings.Contains(err.Error(), "arguments") {
+			t.Errorf("error should read as an arity problem for %s, got: %v", tc.dsl, err)
+		}
+	}
+}
+
+// TestCorrectArityStillCompiles is the guard that matters more than the check:
+// rejecting a correct call would break every project using these operators.
+// The Cribbage sample's eleven tables are the live case.
+func TestCorrectArityStillCompiles(t *testing.T) {
+	symbols := map[string]string{"src": "array", "dest": "array", "num": "integer"}
+	for _, dsl := range []string{
+		`subsets(src, "c", "v", dest)`,
+		`combinations(src, num, "c", "v", dest)`,
+		`groupby(src, "k", "g", dest)`,
+		`maximalruns(src, "r", num, "g", dest)`,
+		`suffixes(src, num, "r", "c", dest)`,
+	} {
+		if _, err := CheckAction(dsl, symbols); err != nil {
+			t.Errorf("correct call rejected: %s\n  %v", dsl, err)
+		}
+	}
+}
+
+// TestUndeclaredArityIsNotChecked keeps the table sparse by design: an
+// operator that never appears in the `name(a, b, …)` call form needs no
+// entry, and must not be rejected for lacking one.
+func TestUndeclaredArityIsNotChecked(t *testing.T) {
+	symbols := map[string]string{"src": "array", "dest": "array"}
+	// `copy` is registered and has no declared arity.
+	if _, err := CheckAction(`copy(src, dest)`, symbols); err != nil &&
+		strings.Contains(err.Error(), "arguments") {
+		t.Errorf("an operator with no declared arity was arity-checked: %v", err)
+	}
+}

--- a/pkg/dtrules/compiler/el/compiler.go
+++ b/pkg/dtrules/compiler/el/compiler.go
@@ -77,6 +77,21 @@ func (c *Compiler) SetOperatorChecker(exists func(string) bool) {
 	c.emitter.operatorExists = exists
 }
 
+// SetOperatorArity supplies the lookup used to reject statement-form calls
+// with the wrong number of arguments.
+//
+// Separate from SetOperatorChecker rather than folded into it: the name check
+// applies to every operator, while arity is declared only for those reachable
+// as `name(a, b, …)`, and a caller that wants one may not have the other. The
+// lookup returns ok == false for an operator with no declared arity, which is
+// not an error — it means unchecked (#1105).
+//
+// Injected for the same reason as the name check; pass a closure over
+// operators.ArityOf.
+func (c *Compiler) SetOperatorArity(arity func(name string) (min, max int, ok bool)) {
+	c.emitter.operatorArity = arity
+}
+
 // ResetLocals clears per-table local variable state (names + slot indices).
 // Callers that reuse a Compiler across multiple tables must call this between
 // tables so slot indices don't bleed across independent compilation scopes.

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -49,7 +49,12 @@ type PostfixEmitter struct {
 	// and pkg/dtrules's own tests import this package — importing it here
 	// closes that loop. nil means no check, which is what el's isolated unit
 	// tests want when they exercise emission with a stand-in operator name.
-	operatorExists    func(string) bool
+	operatorExists func(string) bool
+	// operatorArity reports the declared argument count of a statement-form
+	// operator, and whether one was declared. Injected for the same reason as
+	// operatorExists. nil, or ok == false, means the call is not arity-checked
+	// (#1105).
+	operatorArity     func(string) (min, max int, ok bool)
 	locals            map[string]LocalVar // local variable stack frame indices
 	localCnt          int                 // next available local variable index
 	resolveCollection func(entityType string) (ownerEntity, fieldName string, err error)
@@ -5790,9 +5795,67 @@ func (e *PostfixEmitter) VisitOperatorstatements(ctx *OperatorstatementsContext)
 		return nil
 	}
 
+	// Reject a call with the wrong number of arguments, for the operators that
+	// declare one.
+	//
+	// The name check above catches typos, which is the loud failure. This is
+	// the quiet one: the runtime pops arguments off the stack by position, so
+	// `subsets(hand.cards)` does not fail for want of three arguments — it
+	// takes whatever three values happen to be beneath it and treats them as
+	// the typename, sum field and destination. That is a wrong answer or a
+	// write into the wrong array, not an error (#1105).
+	if e.operatorArity != nil {
+		if min, max, ok := e.operatorArity(name); ok {
+			got := countOperatorArgs(ctx.Operatorlist())
+			if got < min || (max >= 0 && got > max) {
+				e.emitError("operator %q takes %s, got %d",
+					name, describeArity(min, max), got)
+				return nil
+			}
+		}
+	}
+
 	e.Visit(ctx.Operatorlist())
 	e.emit(name)
 	return nil
+}
+
+// countOperatorArgs counts the arguments in an operator call's argument list.
+//
+// `operatorlist` is right-recursive — each `x, rest` alternative holds one
+// expression and a nested operatorlist, and the four `…Single` alternatives
+// terminate it — so the count is the length of that chain. Walking children
+// for the nested context avoids type-switching over all eight labelled
+// alternatives, which would have to be revisited every time the grammar grows
+// an argument type.
+func countOperatorArgs(ctx IOperatorlistContext) int {
+	n := 0
+	for cur := ctx; cur != nil; {
+		n++
+		var next IOperatorlistContext
+		for _, child := range cur.GetChildren() {
+			if sub, ok := child.(IOperatorlistContext); ok {
+				next = sub
+				break
+			}
+		}
+		cur = next
+	}
+	return n
+}
+
+// describeArity renders an expected argument count for an error message.
+func describeArity(min, max int) string {
+	switch {
+	case max < 0:
+		return fmt.Sprintf("at least %d arguments", min)
+	case min == max && min == 1:
+		return "1 argument"
+	case min == max:
+		return fmt.Sprintf("%d arguments", min)
+	default:
+		return fmt.Sprintf("%d to %d arguments", min, max)
+	}
 }
 
 // VisitRemoveEachWhere: `remove each <eexpr> from <arrayExpr> where <bexpr>`

--- a/pkg/dtrules/operators/combinatorics.go
+++ b/pkg/dtrules/operators/combinatorics.go
@@ -41,6 +41,18 @@ func init() {
 	Register("groupby", opGroupBy)
 	Register("maximalruns", opMaximalRuns)
 	Register("suffixes", opSuffixes)
+
+	// Arity, so a miscounted call is refused at authoring time (#1105). These
+	// are the operators most exposed to it: every one is called in the
+	// `name(a, b, …)` form with four or five positional arguments, three of
+	// them bare strings naming EDD types and fields. A short call does not
+	// fail cleanly — it pops whatever is beneath it on the stack and treats
+	// that as the missing arguments.
+	RegisterArity("combinations", 5, 5) // src k typename sumfield dest
+	RegisterArity("subsets", 4, 4)      // src typename sumfield dest
+	RegisterArity("groupby", 4, 4)      // src keyfield typename dest
+	RegisterArity("maximalruns", 5, 5)  // src rankfield minlen typename dest
+	RegisterArity("suffixes", 5, 5)     // src minlen statfield typename dest
 }
 
 // subsetsCap bounds opSubsets: 2^12-1 = 4095 entities is the design ceiling.

--- a/pkg/dtrules/operators/registry.go
+++ b/pkg/dtrules/operators/registry.go
@@ -94,6 +94,42 @@ func RegisterWithPriority(name string, fn OperatorFunc, priority int) *Operator 
 	return op
 }
 
+// Arity is how many arguments a statement-form call `name(a, b, …)` takes.
+// Max < 0 means variadic — at least Min, no upper bound.
+type Arity struct{ Min, Max int }
+
+// operatorArity records the declared arity of statement-form operators.
+//
+// Deliberately sparse. Most operators are reached through EL syntax the
+// grammar already shapes (`sum of x in y`), where a wrong argument count
+// cannot be written; only the `name(a, b, …)` call form can be miscounted,
+// so only those operators need an entry. An operator with no entry is not
+// arity-checked, which keeps this from becoming a table that must be kept
+// exhaustive to be correct.
+//
+// Written during init() alongside Register, read after. Same happens-before
+// argument as `operators` — see Get.
+var operatorArity = make(map[string]Arity)
+
+// RegisterArity declares the argument count of a statement-form operator, so
+// a miscounted call is refused when the rule is written rather than popping
+// whatever happens to be under it at execution (#1105).
+//
+// Call from init(), next to Register. min == max for a fixed count; pass
+// max < 0 for variadic.
+func RegisterArity(name string, min, max int) {
+	operatorsMu.Lock()
+	defer operatorsMu.Unlock()
+	operatorArity[name] = Arity{Min: min, Max: max}
+}
+
+// ArityOf returns the declared arity of an operator, and whether one was
+// declared at all. Undeclared operators are not checked.
+func ArityOf(name string) (Arity, bool) {
+	a, ok := operatorArity[name]
+	return a, ok
+}
+
 // Alias creates an alias for an existing operator.
 // Panics if the names are invalid or if there's a conflicting alias.
 // This is intended for use in init() functions with known-good names.


### PR DESCRIPTION
Closes #1105 — the half #1020 deferred.

#1046 resolved statement-form operator names against the registry and said in its own commit message that arity was left for later: the registry recorded no argument count, so `subsets(hand.cards)` with one of four arguments still compiled clean.

The name check catches typos, the loud failure. Arity is the quiet one, and for these operators it is the worse of the two: the runtime pops arguments by position, so a short call does not fail for want of arguments — it takes whatever values sit beneath it on the stack and treats them as the type name, sum field and destination array. Depending on what the row did before, that is a runtime error, a write into an unrelated array, or a plausible-looking wrong answer.

## Approach

- Arity is declared next to `Register`, and **deliberately sparse**. Most operators are reached through EL syntax the grammar already shapes (`sum of x in y`), where the count cannot be miscounted; only the `name(a, b, …)` form can be. An operator with no entry is not checked, so this does not become a table that must stay exhaustive to be correct.
- Injected rather than imported, as in #1046, and set on the same two authoring paths: the authoring SDK and `dtrules build`.
- Counting walks the right-recursive `operatorlist` chain looking for a nested operatorlist among the children, rather than type-switching over all eight labelled alternatives — which would need revisiting every time the grammar grows an argument type.

## Verification

- Six wrong-count calls refused, each error naming the expected count.
- The five correct forms still compile; an operator with no declared arity is untouched.
- The Cribbage sample's eleven tables still build from their workbook and `dtrules verify` passes.
- `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)