### PR TITLE
fix(excel): derive el_compiled from the rows, not from how the run got here (#1051)

### DIFF
--- a/pkg/dtrules/excel/dt_importer.go
+++ b/pkg/dtrules/excel/dt_importer.go
@@ -700,11 +700,55 @@ func (i *DTImporter) WriteXML(tables *DecisionTablesXML, filename string) error 
 // Empty optional elements (DSL, postfix, comment) are emitted as
 // self-closing tags when empty, matching what the loader expects and what
 // hand-authored XML in the project looks like.
+
+// elCompiled reports whether this table's postfix was generated from EL.
+//
+// The attribute used to be written straight from the in-memory flag, which
+// records how *this run* obtained the table rather than what the file
+// contains. The two answers differ depending on which way a build went, and
+// nothing could reconcile them: verify imports into an empty directory, so
+// every table is freshly compiled and the flag is true, while a build running
+// in place reads the flag back from XML that predates the attribute and writes
+// false again. A project maintained with `build` was then permanently red on
+// `content differs from build output`, differing by exactly this attribute and
+// nothing else -- and the authoring contract forbids the only fix available,
+// which was to hand-edit it in (#1051).
+//
+// Derived from the rows instead: a row carrying both DSL and postfix says the
+// postfix came from the DSL, which is what the attribute means. Tables with
+// hand-written postfix and no DSL stay unmarked, which is also what it means.
+func elCompiled(table *DecisionTableXML) bool {
+	if table.ELCompiled {
+		return true
+	}
+	compiled := func(dsl, postfix string) bool {
+		return strings.TrimSpace(dsl) != "" && strings.TrimSpace(postfix) != ""
+	}
+	for _, c := range table.Conditions {
+		if compiled(c.DSL, c.Postfix) {
+			return true
+		}
+	}
+	for _, a := range table.Actions {
+		if compiled(a.DSL, a.Postfix) {
+			return true
+		}
+	}
+	for _, a := range table.EffectiveInitialActions() {
+		// Through the accessors: initial actions carry two element spellings
+		// and reading the field directly sees only one of them.
+		if compiled(a.EffectiveDSL(), a.EffectivePostfix()) {
+			return true
+		}
+	}
+	return false
+}
+
 func (i *DTImporter) writeTable(f *os.File, table *DecisionTableXML) error {
 	tableNum := table.AttributeFields.TableNumber
 	f.WriteString(fmt.Sprintf("\n<!-- TABLE %s: %s -->\n", tableNum, table.TableName))
 
-	if table.ELCompiled {
+	if elCompiled(table) {
 		f.WriteString("<decision_table el_compiled=\"true\">\n")
 	} else {
 		f.WriteString("<decision_table>\n")

--- a/pkg/dtrules/excel/el_compiled_test.go
+++ b/pkg/dtrules/excel/el_compiled_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import "testing"
+
+// `el_compiled` has to describe the file, not the run that produced it.
+//
+// Written straight from the in-memory flag, the two build directions gave
+// different answers and nothing could reconcile them: verify imports into an
+// empty directory so every table is freshly compiled and the flag is true,
+// while a build in place reads the flag back from XML predating the attribute
+// and writes false again. A project maintained with `build` was permanently
+// red on `content differs from build output`, differing by this attribute and
+// nothing else -- and the only available fix, hand-editing it in, is what the
+// authoring contract forbids (#1051).
+
+func TestELCompiledIsDerivedFromTheRows(t *testing.T) {
+	// A table whose flag was lost, but whose rows plainly came from EL.
+	table := &DecisionTableXML{
+		TableName:  "Recovered",
+		Conditions: []ConditionXML{{DSL: "a is equal to b", Postfix: "a b eq"}},
+	}
+	if !elCompiled(table) {
+		t.Error("a row with both DSL and postfix says the postfix came from the DSL; " +
+			"reporting otherwise leaves the project permanently red")
+	}
+}
+
+func TestHandWrittenPostfixIsNotMarked(t *testing.T) {
+	// Postfix with no DSL is exactly what the attribute must not claim.
+	table := &DecisionTableXML{
+		TableName: "HandAuthored",
+		Actions:   []ActionXML{{Postfix: "1 2 add"}},
+	}
+	if elCompiled(table) {
+		t.Error("postfix with no DSL was marked as EL-compiled")
+	}
+}
+
+func TestInitialActionsCountThroughBothSpellings(t *testing.T) {
+	// Initial actions carry two element spellings; reading the field directly
+	// sees only one of them.
+	legacy := &DecisionTableXML{
+		TableName:            "LegacySpelling",
+		InitialActionsLegacy: []InitialActionXML{{ActionDSL: "perform X", ActionPostfix: "/X perform"}},
+	}
+	if !elCompiled(legacy) {
+		t.Error("the legacy initial-action spelling was not consulted")
+	}
+}
+
+// The in-memory flag still wins when it is set, so a fresh compile of a table
+// whose rows are all empty is still marked.
+func TestExplicitFlagStillCounts(t *testing.T) {
+	if !elCompiled(&DecisionTableXML{TableName: "Empty", ELCompiled: true}) {
+		t.Error("an explicitly compiled table lost its marker")
+	}
+}


### PR DESCRIPTION
`el_compiled` was written straight from the in-memory flag — which records how
*this run* obtained the table, not what the file contains. The two build
directions then gave different answers and nothing could reconcile them:

- **verify** imports into an empty directory, so every table is freshly
  compiled and the flag is true
- **build** running in place reads the flag back from XML that predates the
  attribute, and writes false again

The postfix is recompiled from EL either way. Only the marker disagreed, so a
project maintained with `build` was permanently red on `content differs from
build output` — differing by this attribute and nothing else. The only fix
available was to hand-edit it in, which the authoring contract forbids.

## Fix

Derived from the rows: a row carrying **both DSL and postfix** says the postfix
came from the DSL, which is what the attribute means. Hand-written postfix with
no DSL stays unmarked, which is also what it means. Initial actions are read
through the accessors, since they carry two element spellings and the field
sees only one.

## Reproduction

```
$ sed -i 's/<decision_table el_compiled="true">/<decision_table>/' xml/kidaid_dt.xml
$ dtrules build . && dtrules verify .
```

| | attribute after build | verify |
|---|---|---|
| before | absent | `[build] content differs from build output` |
| after | restored | clean, exit 0 |

`make check` passes and all 11 samples still verify with zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)