### PR TITLE
feat(authoring): expose the workbook a table belongs in (#1068)

### DIFF
--- a/cmd/dtrules/schemas.go
+++ b/cmd/dtrules/schemas.go
@@ -28,6 +28,7 @@ const tableSchemaJSON = `{
     "name":   {"type": "string"},
     "number": {"type": "integer", "minimum": 1, "description": "TABLE_NUMBER for load/sheet ordering; omit to auto-assign within the file's range"},
     "file":   {"type": "string", "description": "DT file (relative to xml/, _dt.xml auto-suffixed) the table lives in; required when creating a table"},
+    "workbook": {"type": "string", "description": "Excel file (xls_file) the table belongs in, deciding which workbook an export writes it to; omit to leave it where it is"},
     "policy": {"type": "string", "enum": ["FIRST", "ALL", "NONE", ""]},
     "contexts": {
       "type": "array",

--- a/cmd/dtrules/table_json.go
+++ b/cmd/dtrules/table_json.go
@@ -27,13 +27,17 @@ import (
 	"strconv"
 
 	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+	"strings"
 )
 
 // TableJSON is the JSON projection of a decision table.
 type TableJSON struct {
-	Name           string              `json:"name"`
-	Number         int                 `json:"number,omitempty"`
-	File           string              `json:"file,omitempty"`
+	Name   string `json:"name"`
+	Number int    `json:"number,omitempty"`
+	File   string `json:"file,omitempty"`
+	// Workbook is the Excel file the table belongs in (`xls_file`). Set it to
+	// move a table to a different workbook; omit it to leave it where it is.
+	Workbook       string              `json:"workbook,omitempty"`
 	Policy         string              `json:"policy,omitempty"`
 	Contexts       []ContextJSON       `json:"contexts,omitempty"`
 	InitialActions []InitialActionJSON `json:"initial_actions,omitempty"`
@@ -117,9 +121,10 @@ type OptionJSON struct {
 // tableToJSON converts an authoring.Table into its JSON-safe projection.
 func tableToJSON(t *authoring.Table) TableJSON {
 	out := TableJSON{
-		Name:   t.Name,
-		Number: t.Number,
-		Policy: t.Policy,
+		Name:     t.Name,
+		Number:   t.Number,
+		Policy:   t.Policy,
+		Workbook: t.Workbook,
 	}
 	for _, c := range t.Contexts {
 		out.Contexts = append(out.Contexts, ContextJSON{DSL: c.DSL})
@@ -190,6 +195,12 @@ func eddToJSON(e *authoring.EDD) EDDJSON {
 func (tj *TableJSON) ApplyTo(t *authoring.Table) error {
 	t.Name = tj.Name
 	t.Policy = tj.Policy
+	// Omitting `workbook` leaves the table in the workbook it already names;
+	// setting it repoints the table, which is the only sanctioned way to fix
+	// one naming a workbook that does not exist (#1068).
+	if strings.TrimSpace(tj.Workbook) != "" {
+		t.Workbook = tj.Workbook
+	}
 	// An explicit number overrides AddTable's auto-assignment; omitting it
 	// (0) keeps whatever the table already has. SetNumber validates it against
 	// the file's range and uniqueness. (`file` is handled by the CLI/MCP layer,

--- a/cmd/dtrules/table_workbook_test.go
+++ b/cmd/dtrules/table_workbook_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+// A table records the workbook it belongs in, and that decides where an export
+// writes it. With no authoring surface for it, a table naming a workbook that
+// does not exist could not be repointed at one that does by any sanctioned
+// route: `get` did not return it, `put` could not set it, and hand-editing the
+// XML is what the contract forbids. CHIP's seven tables named
+// ChipEligibility_dt.xls long after the consolidation replaced it (#1068).
+
+func TestTableJSONCarriesTheWorkbook(t *testing.T) {
+	out := tableToJSON(&authoring.Table{Name: "T", Workbook: "CHIP.xlsx"})
+	if out.Workbook != "CHIP.xlsx" {
+		t.Errorf("workbook = %q, want CHIP.xlsx", out.Workbook)
+	}
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"workbook":"CHIP.xlsx"`) {
+		t.Errorf("workbook is missing from the emitted JSON: %s", data)
+	}
+}
+
+func TestPutRepointsTheWorkbook(t *testing.T) {
+	tbl := &authoring.Table{Name: "T", Workbook: "ChipEligibility_dt.xls"}
+	tj := &TableJSON{Name: "T", Workbook: "CHIP.xlsx"}
+
+	if err := tj.ApplyTo(tbl); err != nil {
+		t.Fatal(err)
+	}
+	if tbl.Workbook != "CHIP.xlsx" {
+		t.Errorf("workbook = %q, want CHIP.xlsx — a table could not be moved to a workbook that exists", tbl.Workbook)
+	}
+}
+
+// Omitting the field is not a request to unset it. Every caller that predates
+// this field omits it, and none of them mean "put this table in no workbook".
+func TestOmittingTheWorkbookLeavesItAlone(t *testing.T) {
+	tbl := &authoring.Table{Name: "T", Workbook: "CHIP.xlsx"}
+
+	if err := (&TableJSON{Name: "T"}).ApplyTo(tbl); err != nil {
+		t.Fatal(err)
+	}
+	if tbl.Workbook != "CHIP.xlsx" {
+		t.Errorf("workbook was cleared to %q by a payload that never mentioned it", tbl.Workbook)
+	}
+}
+
+func TestSchemaDocumentsTheWorkbook(t *testing.T) {
+	if !strings.Contains(tableSchemaJSON, `"workbook"`) {
+		t.Error("the schema does not mention workbook, so no caller can discover it")
+	}
+}

--- a/pkg/dtrules/authoring/table.go
+++ b/pkg/dtrules/authoring/table.go
@@ -26,9 +26,19 @@ import (
 // Table is a typed view of a single decision table. All mutations validate EL
 // before committing, so invalid expressions are rejected at the API boundary.
 type Table struct {
-	Name             string
-	Number           int // TABLE_NUMBER — load/sheet ordering; 0 means unset
-	Policy           string
+	Name   string
+	Number int // TABLE_NUMBER — load/sheet ordering; 0 means unset
+	Policy string
+	// Workbook is the Excel file this table belongs in (`xls_file`), which
+	// decides which workbook an export writes it to.
+	//
+	// It had no authoring surface at all, so a table naming a workbook that
+	// does not exist could not be repointed at one that does by any sanctioned
+	// route: `table get` did not return it, `table put` could not set it, and
+	// hand-editing the XML is what the contract forbids. CHIP's seven tables
+	// named ChipEligibility_dt.xls for as long as the consolidation that
+	// replaced it with CHIP.xlsx (#1068).
+	Workbook         string
 	Contexts         []Context
 	InitialActions   []InitialAction
 	Conditions       []Condition
@@ -128,10 +138,11 @@ func (t *Table) HandCodedRows() []string {
 // newTable builds a Table view from an underlying XML struct.
 func newTable(x *excel.DecisionTableXML, symbols map[string]string) *Table {
 	t := &Table{
-		Name:    x.TableName,
-		Policy:  x.AttributeFields.EffectiveType(),
-		xml:     x,
-		symbols: symbols,
+		Name:     x.TableName,
+		Policy:   x.AttributeFields.EffectiveType(),
+		Workbook: x.XLSFile,
+		xml:      x,
+		symbols:  symbols,
 	}
 	t.syncFromXML()
 	return t
@@ -236,6 +247,11 @@ func (t *Table) syncToXML() {
 	tc := newTableCompiler(t.symbols)
 
 	t.xml.TableName = t.Name
+	// An empty Workbook leaves the recorded one alone: callers that never set
+	// the field are not asking to unset it.
+	if strings.TrimSpace(t.Workbook) != "" {
+		t.xml.XLSFile = t.Workbook
+	}
 	// Write the canonical spelling and clear the legacy ones, so a table
 	// cannot end up carrying two different types.
 	t.xml.AttributeFields.Type = t.Policy


### PR DESCRIPTION
A decision table records its Excel file in `xls_file`, and that decides which
workbook an export writes it to. It had **no authoring surface at all**, so a
table naming a workbook that does not exist could not be repointed at one that
does by any sanctioned route:

- `table get` did not return it
- `table put` could not set it
- hand-editing the XML is what the authoring contract forbids

CHIP's seven tables named `ChipEligibility_dt.xls` for as long as the samples
consolidation that replaced it with `CHIP.xlsx`.

## Change

`workbook` is part of the table document now — in `get`, in `put`, and in
`table schema` so callers can discover it. Omitting it leaves the table where
it is: every caller predating the field omits it, and none of them mean "put
this table in no workbook".

## Round-tripped on CHIP

```
$ dtrules table get Compute_Eligibility | jq .workbook
"CHIP.xlsx"
$ # repoint at the workbook that does not exist
$ jq '.workbook="ChipEligibility_dt.xls"' | dtrules table put Compute_Eligibility
$ grep xls_file xml/CHIP_dt.xml | sort | uniq -c
      1 <xls_file>ChipEligibility_dt.xls</xls_file>
      6 <xls_file>CHIP.xlsx</xls_file>
$ # and repair it through the same surface
$ jq '.workbook="CHIP.xlsx"' | dtrules table put Compute_Eligibility
      7 <xls_file>CHIP.xlsx</xls_file>
$ dtrules verify .   # clean, exit 0
```

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)