### PR TITLE
feat(el): check operator arity, the deferred half of #1020 (#1105)

### DIFF
--- a/cmd/dtrules/build.go
+++ b/cmd/dtrules/build.go
@@ -48,6 +48,14 @@ func newWorkbookImporter(xmlDir string) *excel.WorkbookImporter {
 		_, ok := operators.GetByString(name)
 		return ok
 	})
+	// And the argument count, where the registry records one (#1105).
+	c.SetOperatorArity(func(name string) int {
+		op, ok := operators.GetByString(name)
+		if !ok {
+			return 0
+		}
+		return op.Arity()
+	})
 	imp.SetELCompiler(c)
 	if syms := authoring.LoadEDDSymbols(xmlDir); len(syms) > 0 {
 		imp.SetSymbols(syms)

--- a/pkg/dtrules/authoring/el_check.go
+++ b/pkg/dtrules/authoring/el_check.go
@@ -136,5 +136,13 @@ func newCheckedCompiler() *el.Compiler {
 		_, ok := operators.GetByString(name)
 		return ok
 	})
+	// And the argument count, where the registry records one (#1105).
+	c.SetOperatorArity(func(name string) int {
+		op, ok := operators.GetByString(name)
+		if !ok {
+			return 0
+		}
+		return op.Arity()
+	})
 	return c
 }

--- a/pkg/dtrules/compiler/el/arity_check_test.go
+++ b/pkg/dtrules/compiler/el/arity_check_test.go
@@ -1,0 +1,47 @@
+package el_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+	"github.com/DTRules/DTRules/pkg/dtrules/operators"
+)
+
+func compileWith(t *testing.T, src string) (string, error) {
+	t.Helper()
+	c := el.NewCompiler()
+	c.SetOperatorChecker(func(n string) bool { _, ok := operators.GetByString(n); return ok })
+	c.SetOperatorArity(func(n string) int {
+		op, ok := operators.GetByString(n)
+		if !ok {
+			return 0
+		}
+		return op.Arity()
+	})
+	return c.CompileAction(src)
+}
+
+func TestShortCallIsRefused(t *testing.T) {
+	if out, err := compileWith(t, `subsets(hand.cards)`); err == nil {
+		t.Fatalf("a one-argument subsets compiled clean: %q", out)
+	} else if !strings.Contains(err.Error(), "4") || !strings.Contains(err.Error(), "subsets") {
+		t.Errorf("error should name the operator and the counts: %v", err)
+	}
+}
+
+func TestOverlongCallIsRefused(t *testing.T) {
+	if out, err := compileWith(t, `subsets(hand.cards, "combo", "value", hand.combos, 7)`); err == nil {
+		t.Fatalf("a five-argument subsets compiled clean: %q", out)
+	}
+}
+
+func TestCorrectCallStillCompiles(t *testing.T) {
+	out, err := compileWith(t, `subsets(hand.cards, "combo", "value", hand.combos)`)
+	if err != nil {
+		t.Fatalf("the correct four-argument form was refused: %v", err)
+	}
+	if !strings.Contains(out, "subsets") {
+		t.Errorf("postfix lost the operator: %q", out)
+	}
+}

--- a/pkg/dtrules/compiler/el/compiler.go
+++ b/pkg/dtrules/compiler/el/compiler.go
@@ -77,6 +77,17 @@ func (c *Compiler) SetOperatorChecker(exists func(string) bool) {
 	c.emitter.operatorExists = exists
 }
 
+// SetOperatorArity supplies the lookup used to reject statement-form calls with
+// the wrong number of arguments. Return <= 0 for operators whose arity is not
+// recorded; those are not checked.
+//
+// Separate from SetOperatorChecker so a caller that only knows which names
+// exist keeps working unchanged -- the name check and the count check are
+// independently useful, and the name check shipped first (#1046, #1105).
+func (c *Compiler) SetOperatorArity(arity func(string) int) {
+	c.emitter.operatorArity = arity
+}
+
 // ResetLocals clears per-table local variable state (names + slot indices).
 // Callers that reuse a Compiler across multiple tables must call this between
 // tables so slot indices don't bleed across independent compilation scopes.

--- a/pkg/dtrules/compiler/el/postfix_emitter.go
+++ b/pkg/dtrules/compiler/el/postfix_emitter.go
@@ -49,7 +49,10 @@ type PostfixEmitter struct {
 	// and pkg/dtrules's own tests import this package — importing it here
 	// closes that loop. nil means no check, which is what el's isolated unit
 	// tests want when they exercise emission with a stand-in operator name.
-	operatorExists    func(string) bool
+	operatorExists func(string) bool
+	// operatorArity reports how many arguments a statement-form call to this
+	// operator must supply, or <= 0 when unrecorded.
+	operatorArity     func(string) int
 	locals            map[string]LocalVar // local variable stack frame indices
 	localCnt          int                 // next available local variable index
 	resolveCollection func(entityType string) (ownerEntity, fieldName string, err error)
@@ -5790,9 +5793,56 @@ func (e *PostfixEmitter) VisitOperatorstatements(ctx *OperatorstatementsContext)
 		return nil
 	}
 
+	// And the count. The name check catches typos; a short call is the quiet
+	// failure. Every argument after the source is a bare string or an array,
+	// so `subsets(hand.cards)` with one of four compiles clean, then pops
+	// whatever three values sit beneath it and reads them as typename,
+	// sumfield and destination -- a runtime error, a write into the wrong
+	// array, or a plausible-looking wrong answer, depending on what the row
+	// did before (#1105).
+	if e.operatorArity != nil {
+		if want := e.operatorArity(name); want > 0 {
+			if got := countOperatorArgs(ctx.Operatorlist()); got != want {
+				e.emitError("operator %q takes %d arguments, got %d — "+
+					"see `dtrules docs operators` for the argument order", name, want, got)
+				return nil
+			}
+		}
+	}
+
 	e.Visit(ctx.Operatorlist())
 	e.emit(name)
 	return nil
+}
+
+// countOperatorArgs counts the arguments in a statement-form call.
+//
+// The list is right-recursive: each element node carries one expression and
+// the tail, and the `...Single` variants are the last element. Counting the
+// chain rather than visiting it means no postfix is emitted for a call that is
+// about to be rejected.
+func countOperatorArgs(ctx IOperatorlistContext) int {
+	n := 0
+	for ctx != nil {
+		switch c := ctx.(type) {
+		case *OpListFloatSingleContext, *OpListIntSingleContext, *OpListStrSingleContext:
+			return n + 1
+		case *OpListFloatContext:
+			n++
+			ctx = c.Operatorlist()
+		case *OpListIntContext:
+			n++
+			ctx = c.Operatorlist()
+		case *OpListStrContext:
+			n++
+			ctx = c.Operatorlist()
+		default:
+			// An alternative this does not know: count it as one argument and
+			// stop, so an unrecognised shape cannot manufacture a mismatch.
+			return n + 1
+		}
+	}
+	return n
 }
 
 // VisitRemoveEachWhere: `remove each <eexpr> from <arrayExpr> where <bexpr>`

--- a/pkg/dtrules/operators/combinatorics.go
+++ b/pkg/dtrules/operators/combinatorics.go
@@ -36,11 +36,15 @@ import (
 // which compiles to `hand.cards "combo" "value" hand.combos subsets`.
 
 func init() {
-	Register("combinations", opCombinations)
-	Register("subsets", opSubsets)
-	Register("groupby", opGroupBy)
-	Register("maximalruns", opMaximalRuns)
-	Register("suffixes", opSuffixes)
+	// Arity is recorded because these are the operators a short call misreads
+	// silently: every argument after the source is a bare string or an array,
+	// so `subsets(hand.cards)` pops whatever three values sit beneath it and
+	// treats them as typename, sumfield and destination (#1105).
+	RegisterWithArity("combinations", opCombinations, 5) // source, k, typename, sumfield, dest
+	RegisterWithArity("subsets", opSubsets, 4)           // source, typename, sumfield, dest
+	RegisterWithArity("groupby", opGroupBy, 4)           // source, keyfield, typename, dest
+	RegisterWithArity("maximalruns", opMaximalRuns, 5)   // source, rankfield, minlen, typename, dest
+	RegisterWithArity("suffixes", opSuffixes, 5)         // source, minlen, statfield, typename, dest
 }
 
 // subsetsCap bounds opSubsets: 2^12-1 = 4095 entities is the design ceiling.

--- a/pkg/dtrules/operators/registry.go
+++ b/pkg/dtrules/operators/registry.go
@@ -34,7 +34,22 @@ type Operator struct {
 	fn       OperatorFunc
 	priority int
 	index    int // Index in operatorTable for fast lookup
+	// arity is how many arguments a statement-form call must supply, or -1
+	// when unrecorded. Operators reached through infix syntax take their
+	// operands from the stack and have nothing to count, so most are -1.
+	//
+	// The name check added in #1046 catches typos; a short call is the quiet
+	// failure. `subsets(hand.cards)` with one of four arguments compiled
+	// clean, then popped whatever three values happened to be beneath it and
+	// read them as typename, sumfield and destination -- a runtime error, a
+	// write into the wrong array, or a plausible-looking wrong answer,
+	// depending on what the row did before (#1105).
+	arity int
 }
+
+// Arity is how many arguments a statement-form call must supply, or -1 when
+// unrecorded. Callers must treat -1 as "do not check" rather than "zero".
+func (o *Operator) Arity() int { return o.arity }
 
 var (
 	operatorsMu sync.RWMutex
@@ -44,6 +59,17 @@ var (
 	operatorTableMu  sync.RWMutex
 	operatorIndexMap = make(map[*dtrules.RName]int)
 )
+
+// RegisterWithArity registers a statement-form operator and records how many
+// arguments a call must supply, so a short call is refused at authoring time
+// rather than misread at run time (#1105).
+func RegisterWithArity(name string, fn OperatorFunc, arity int) *Operator {
+	op := RegisterWithPriority(name, fn, 0)
+	if op != nil {
+		op.arity = arity
+	}
+	return op
+}
 
 // Register registers an operator with the given name.
 func Register(name string, fn OperatorFunc) *Operator {
@@ -83,6 +109,7 @@ func RegisterWithPriority(name string, fn OperatorFunc, priority int) *Operator 
 		fn:       fn,
 		priority: priority,
 		index:    idx,
+		arity:    -1, // unrecorded until a caller says otherwise
 	}
 	operators[rname] = op
 


### PR DESCRIPTION
#1046 resolved statement-form operator *names* against the registry, which
catches typos. Arity is the quiet failure, and for these operators it is worse
than a wrong name: every argument after the source is a bare string or an
array, so a short call leaves the stack **wrong**, not empty.

```
subsets(hand.cards)                                     was: OK
subsets(hand.cards, "combo", "value", hand.combos, 7)   was: OK
```

The first popped whatever three values happened to sit beneath it and read them
as typename, sumfield and destination — a runtime error, a write into the wrong
array, or a plausible-looking wrong answer, depending on what the row did
before.

## Change

The registry records arity, defaulting to `-1` for operators with nothing to
count (infix forms take their operands from the stack). The five combinatorial
generators declare theirs, with the argument order in a comment beside each:

| operator | arity | arguments |
|---|---|---|
| `combinations` | 5 | source, k, typename, sumfield, dest |
| `subsets` | 4 | source, typename, sumfield, dest |
| `groupby` | 4 | source, keyfield, typename, dest |
| `maximalruns` | 5 | source, rankfield, minlen, typename, dest |
| `suffixes` | 5 | source, minlen, statfield, typename, dest |

The compiler asks through a **second** injected hook rather than a widened one,
so a caller that only knows which names exist keeps working. Both hooks are set
at the two places that compile rules for real (`cmd/dtrules/build.go`,
`authoring/el_check.go`).

The count comes from walking the argument list rather than visiting it, so no
postfix is emitted for a call that is about to be rejected.

```
operator "subsets" takes 4 arguments, got 1 — see `dtrules docs operators` for the argument order
```

## Verification

- Both forms from the issue are refused; the correct four-argument form still compiles
- `make check` and the archive lane pass
- All 11 samples verify unchanged — Cribbage exercises these operators throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)