### PR TITLE
feat(operators): argmax / argmin — which option wins, not just the winning value (#1024)

### DIFF
--- a/cmd/dtrules/docs.go
+++ b/cmd/dtrules/docs.go
@@ -1815,7 +1815,9 @@ groups, consecutive runs — and materialize each structure as an entity of
 a caller-named EDD type appended to a destination array. Tables then
 iterate the results with ordinary 'for all' contexts and score them with
 ordinary conditions: the loop stays in the operator, the policy stays in
-the table. All four are statement-form operator calls (#980).
+the table. All are statement-form operator calls (#980), as are argmax
+and argmin below, which pick a winner rather than generate candidates
+(#1024).
 
     combinations(src, k, "combo", "value", dest)
         Every k-card combination of src as a "combo" entity with fields
@@ -1848,6 +1850,24 @@ the table. All four are statement-form operator calls (#980).
         order is part of the contract — "longest run only" policies
         read as "the first qualifying window" behind a zero-guard.
         Source cap: 64.
+
+    argmax(src, "rank", dest)
+    argmin(src, "rank", dest)
+        The element of src with the largest (or smallest) value of the
+        named integer field, placed in dest. Not the value — 'max of
+        <field> in <array>' gives that — but the element attaining it,
+        so the rule can then read its other fields: the highest-EV
+        discard, the most favourable filing status, the cheapest
+        qualifying plan.
+
+        dest receives the element itself, not a copy, so reading a field
+        off the result reads the original entity. It is cleared first, so
+        a table that runs twice selects rather than accumulates.
+
+        Ties go to the first element in array order, which keeps the
+        result stable across runs on the same data. An empty source
+        leaves dest empty rather than failing — "no options to choose
+        between" is a state a rule can test with 'number of'.
 
 Example — cribbage fifteens, pairs, and runs from decision tables:
 

--- a/pkg/dtrules/operators/argselect.go
+++ b/pkg/dtrules/operators/argselect.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operators
+
+import (
+	"fmt"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+)
+
+// argmax / argmin — which element wins, not what the winning value is.
+//
+// `max of <field> in <array>` gives the value. The piece that keeps a choice
+// rule inside the tables is the element that attains it, because the rule then
+// goes on to read that element's other fields: the highest-EV discard, the most
+// favourable filing status, the cheapest qualifying plan. Without it the table
+// can score the options and not say which one won, and the choice moves to host
+// code even when the criterion is pure policy (#1024).
+//
+// Statement-form EL calls, in the shape the other selection operators use:
+//
+//	argmax(hand.cards, "rank", hand.best)
+//
+// which compiles to `hand.cards "rank" hand.best argmax`.
+//
+// The destination is an array, matching the generators, and it receives the
+// winning element itself rather than a copy — reading a field off the result
+// reads the original entity. It is cleared first, so a table that runs twice
+// does not accumulate winners.
+//
+// Ties go to the first element in array order. That is a decision, not an
+// accident: it makes the result stable under re-running the same rules on the
+// same data, which matters more for an advice rule than any rule about which
+// of two equal options is better.
+//
+// An empty source leaves the destination empty rather than failing. "No options
+// to choose between" is a state a rule can test with `number of`, and a table
+// that has already established there are options should not have to defend
+// against the operator throwing.
+func init() {
+	RegisterWithArity("argmax", opArgMax, 3) // source, field, dest
+	RegisterWithArity("argmin", opArgMin, 3) // source, field, dest
+}
+
+func opArgMax(state dtrules.State) error { return argSelect(state, "argmax", true) }
+func opArgMin(state dtrules.State) error { return argSelect(state, "argmin", false) }
+
+// argSelect: ( src field dest -- ) put the element of src with the largest
+// (or smallest) value of the named integer field into dest.
+func argSelect(state dtrules.State, op string, wantMax bool) error {
+	destObj, err := state.DataPop()
+	if err != nil {
+		return err
+	}
+	dest, err := destObj.RArrayValue()
+	if err != nil {
+		return fmt.Errorf("%s: dest must be an array: %w", op, err)
+	}
+	fieldText, err := popString(state, op, "field")
+	if err != nil {
+		return err
+	}
+	_, ents, err := popEntityArray(state, op)
+	if err != nil {
+		return err
+	}
+
+	// Clear first: a table that runs twice must select, not accumulate.
+	dest.Clear()
+	if len(ents) == 0 {
+		return nil
+	}
+
+	field := dtrules.GetRName(fieldText)
+	if field == nil {
+		return fmt.Errorf("%s: invalid field name syntax: %q", op, fieldText)
+	}
+
+	best := 0
+	bestSet := false
+	var winner dtrules.Entity
+	for _, ent := range ents {
+		v, err := intField(op, ent, field)
+		if err != nil {
+			return err
+		}
+		// Strictly better only, so the first of equal values keeps the win.
+		if !bestSet || (wantMax && v > best) || (!wantMax && v < best) {
+			best, bestSet, winner = v, true, ent
+		}
+	}
+	dest.Add(winner.(dtrules.Object))
+	dtrules.TraceArrayAdd(state, dest, winner.(dtrules.Object))
+	return nil
+}

--- a/pkg/dtrules/operators/argselect_test.go
+++ b/pkg/dtrules/operators/argselect_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operators_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// `max of <field> in <array>` gives the winning value; these give the winning
+// element, which is what a rule needs before it can read that element's other
+// fields. Without them the table can score the options and not say which one
+// won, so the choice moves to host code even when the criterion is pure
+// policy (#1024).
+
+func TestArgMaxSelectsTheWinningElement(t *testing.T) {
+	h := newCombHarness(t)
+	src := h.cards(t, 5, 11, 3)
+	dest := h.emptyArray(t)
+
+	if err := h.exec(t, "argmax", src, str("rank"), dest); err != nil {
+		t.Fatalf("argmax: %v", err)
+	}
+	if dest.Size() != 1 {
+		t.Fatalf("expected exactly one winner, got %d", dest.Size())
+	}
+	elems, _ := dest.ArrayValue()
+	if got := intAttr(t, elems[0], "rank"); got != 11 {
+		t.Errorf("argmax picked rank %d, want 11", got)
+	}
+	if h.state.DataStackDepth() != 0 {
+		t.Errorf("stack not clean: depth %d", h.state.DataStackDepth())
+	}
+}
+
+func TestArgMinSelectsTheSmallest(t *testing.T) {
+	h := newCombHarness(t)
+	dest := h.emptyArray(t)
+
+	if err := h.exec(t, "argmin", h.cards(t, 5, 11, 3), str("rank"), dest); err != nil {
+		t.Fatalf("argmin: %v", err)
+	}
+	elems, _ := dest.ArrayValue()
+	if got := intAttr(t, elems[0], "rank"); got != 3 {
+		t.Errorf("argmin picked rank %d, want 3", got)
+	}
+}
+
+// Ties go to the first in array order, so re-running the same rules on the
+// same data gives the same answer. That matters more for an advice rule than
+// any rule about which of two equal options is better.
+func TestTiesGoToTheFirstElement(t *testing.T) {
+	h := newCombHarness(t)
+	dest := h.emptyArray(t)
+
+	src := h.cards(t, 7, 7, 2)
+	if err := h.exec(t, "argmax", src, str("rank"), dest); err != nil {
+		t.Fatalf("argmax: %v", err)
+	}
+	srcElems, _ := src.ArrayValue()
+	destElems, _ := dest.ArrayValue()
+	if destElems[0] != srcElems[0] {
+		t.Error("a tie did not go to the first element, so the result is not stable across runs")
+	}
+}
+
+// "No options to choose between" is a state a rule can test with `number of`;
+// the operator should not throw at a table that has already established there
+// are options.
+func TestEmptySourceLeavesDestEmpty(t *testing.T) {
+	h := newCombHarness(t)
+	dest := h.emptyArray(t)
+
+	if err := h.exec(t, "argmax", h.emptyArray(t), str("rank"), dest); err != nil {
+		t.Fatalf("argmax on an empty source should not fail: %v", err)
+	}
+	if dest.Size() != 0 {
+		t.Errorf("empty source produced %d winners", dest.Size())
+	}
+}
+
+// A table that runs twice must select, not accumulate.
+func TestDestIsClearedNotAppendedTo(t *testing.T) {
+	h := newCombHarness(t)
+	dest := h.emptyArray(t)
+
+	for i := 0; i < 2; i++ {
+		if err := h.exec(t, "argmax", h.cards(t, 4, 9), str("rank"), dest); err != nil {
+			t.Fatalf("argmax run %d: %v", i, err)
+		}
+	}
+	if dest.Size() != 1 {
+		t.Errorf("after two runs dest holds %d elements, want 1", dest.Size())
+	}
+}
+
+func TestMissingFieldIsADescriptiveError(t *testing.T) {
+	h := newCombHarness(t)
+	err := h.exec(t, "argmax", h.cards(t, 1), str("nosuchfield"), h.emptyArray(t))
+	if err == nil {
+		t.Fatal("selecting on a field that does not exist should be an error")
+	}
+	if !strings.Contains(err.Error(), "nosuchfield") {
+		t.Errorf("error should name the missing field: %v", err)
+	}
+}

--- a/pkg/dtrules/operators/registration_test.go
+++ b/pkg/dtrules/operators/registration_test.go
@@ -53,6 +53,8 @@ func TestAllOperatorsRegistered(t *testing.T) {
 	">",
 	">=",
 	"abort",
+	"argmax",
+	"argmin",
 	"abs",
 	"addarray",
 	"addat",


### PR DESCRIPTION
`max of <field> in <array>` (#1122) gives the winning **value**. The piece that
keeps a choice rule inside the tables is the **element** attaining it, because
the rule then goes on to read that element's other fields — the highest-EV
discard, the most favourable filing status, the cheapest qualifying plan.

Without it a table can score the options and not say which one won, so the
choice moves to host code even when the criterion is pure policy.

```
argmax(hand.cards, "rank", hand.best)
argmin(plan.options, "premium", plan.cheapest)
```

Statement-form calls in the shape the other selection operators use, with arity
recorded so a short call is refused at authoring time (#1105).

## Three decisions, made rather than left to fall out

| decision | why |
|---|---|
| **Ties go to the first element** in array order | The result is stable under re-running the same rules on the same data, which matters more for an advice rule than any rule about which of two equal options is better. |
| **An empty source leaves dest empty**, no error | "No options to choose between" is a state a rule can test with `number of`; a table that has already established there are options shouldn't have to defend against the operator throwing. |
| **dest is cleared first and gets the element itself**, not a copy | A table that runs twice selects rather than accumulates, and reading a field off the result reads the original entity — which is the whole point. |

## Tests

Six runtime tests, not just compile checks: selection, tie stability (asserted
by object identity against the source array), empty source, the clear-not-append
property across two runs, and that a missing field names itself in the error.

## Still open on #1024

This is the operator form. The surface syntax the issue sketches — `the
<entity> in <array> with the max <field>` — is a separate question about how it
binds, and the issue stays open for it.

`make check` passes; `dtrules docs operators` documents both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)