### PR TITLE
feat(sync): provenance in the XML decides direction, not timestamps (#1091)

### DIFF
--- a/cmd/dtrules/testdata/custom_layout/rules/Simple_dt.xml
+++ b/cmd/dtrules/testdata/custom_layout/rules/Simple_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>Simple.xlsx</relative_path>
 <file_name>Simple.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:eee655ca5e399dfcdef20ae084a3dd2d6dd8febdc8e227e3c723afa37519e2e8</source_hash>
 </source>
 <table_name>SimpleRule</table_name>
 <xls_file>Simple.xlsx</xls_file>

--- a/cmd/sinusitis-web/rules/xml/service1_medication_dt.xml
+++ b/cmd/sinusitis-web/rules/xml/service1_medication_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>service1_medication.xlsx</relative_path>
 <file_name>service1_medication.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:36078765476394bac61d22d0137cb74d0ebdc20f19f92c49be8ff198393bce25</source_hash>
 </source>
 <table_name>Determine_Medication_And_Dosing</table_name>
 <xls_file>service1_medication.xlsx</xls_file>
@@ -57,6 +58,7 @@ true
 <relative_path>service1_medication.xlsx</relative_path>
 <file_name>service1_medication.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:36078765476394bac61d22d0137cb74d0ebdc20f19f92c49be8ff198393bce25</source_hash>
 </source>
 <table_name>Select_Medication</table_name>
 <xls_file>service1_medication.xlsx</xls_file>
@@ -152,6 +154,7 @@ patient.age constants.adult_age &gt;=
 <relative_path>service1_medication.xlsx</relative_path>
 <file_name>service1_medication.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:36078765476394bac61d22d0137cb74d0ebdc20f19f92c49be8ff198393bce25</source_hash>
 </source>
 <table_name>Determine_Dose</table_name>
 <xls_file>service1_medication.xlsx</xls_file>

--- a/cmd/sinusitis-web/rules/xml/service2_creatinine_dt.xml
+++ b/cmd/sinusitis-web/rules/xml/service2_creatinine_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>service2_creatinine.xlsx</relative_path>
 <file_name>service2_creatinine.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:a418769770baee0f21ad335cc43684dc7eeb8c99dad57218bf024833f033f1c6</source_hash>
 </source>
 <table_name>Determine_Creatinine_Clearance</table_name>
 <xls_file>service2_creatinine.xlsx</xls_file>

--- a/cmd/sinusitis-web/rules/xml/service3_interactions_dt.xml
+++ b/cmd/sinusitis-web/rules/xml/service3_interactions_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>service3_interactions.xlsx</relative_path>
 <file_name>service3_interactions.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:94722d7b0bfad1eebc2828435ac191304cdb2248d6073898e487fa4d2deabf92</source_hash>
 </source>
 <table_name>Check_Drug_Interactions</table_name>
 <xls_file>service3_interactions.xlsx</xls_file>

--- a/cmd/sinusitis-web/rules/xml/sinusitis_map.xml
+++ b/cmd/sinusitis-web/rules/xml/sinusitis_map.xml
@@ -1,38 +1,33 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <mapping>
 	<XMLtoEDD>
 		<map>
 			<!-- Patient fields (resolved against the patient singleton on the context stack) -->
-			<setattribute tag='age'                 RAttribute='age'                 enclosure='patient'    type='integer'></setattribute>
-			<setattribute tag='lean_body_weight'    RAttribute='lean_body_weight'    enclosure='patient'    type='double'></setattribute>
-			<setattribute tag='pcr'                 RAttribute='pcr'                 enclosure='patient'    type='double'></setattribute>
-			<setattribute tag='penicillin_allergic' RAttribute='penicillin_allergic' enclosure='patient'    type='boolean'></setattribute>
-			<setattribute tag='diagnosis'           RAttribute='diagnosis'           enclosure='patient'    type='string'></setattribute>
-
+			<setattribute tag='age' RAttribute='age' enclosure='patient' type='integer'></setattribute>
+			<setattribute tag='lean_body_weight' RAttribute='lean_body_weight' enclosure='patient' type='double'></setattribute>
+			<setattribute tag='pcr' RAttribute='pcr' enclosure='patient' type='double'></setattribute>
+			<setattribute tag='penicillin_allergic' RAttribute='penicillin_allergic' enclosure='patient' type='boolean'></setattribute>
+			<setattribute tag='diagnosis' RAttribute='diagnosis' enclosure='patient' type='string'></setattribute>
 			<!-- Active medication fields -->
-			<setattribute tag='name'                RAttribute='name'                enclosure='medication' type='string'></setattribute>
-
+			<setattribute tag='name' RAttribute='name' enclosure='medication' type='string'></setattribute>
 			<!-- The patient root element becomes the patient singleton. Without
 			     this, a run that loads input data before pushing singletons
 			     leaves the patient fields with no entity to attach to, and the
 			     singleton is pushed empty. -->
-			<createentity entity='patient' tag='patient' id='id'></createentity>
-
 			<!-- Each <medication> element becomes a medication entity on patient.active_medications -->
+			<createentity entity='patient' tag='patient' id='id'></createentity>
 			<createentity entity='medication' tag='medication' id='name' list='active_medications'></createentity>
 		</map>
-
 		<entities>
-			<entity name='patient'    number='1'></entity>
+			<entity name='patient' number='1'></entity>
 			<entity name='medication' number='*'></entity>
-			<entity name='result'     number='1'></entity>
-			<entity name='constants'  number='1'></entity>
+			<entity name='result' number='1'></entity>
+			<entity name='constants' number='1'></entity>
 		</entities>
-
 		<initialization>
 			<initialentity entity='constants' epush='true'></initialentity>
-			<initialentity entity='result'    epush='true'></initialentity>
-			<initialentity entity='patient'   epush='true'></initialentity>
+			<initialentity entity='result' epush='true'></initialentity>
+			<initialentity entity='patient' epush='true'></initialentity>
 		</initialization>
 	</XMLtoEDD>
 </mapping>

--- a/cmd/sinusitis-web/rules/xml/therapy_dt.xml
+++ b/cmd/sinusitis-web/rules/xml/therapy_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>therapy.xlsx</relative_path>
 <file_name>therapy.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:5f328470ed25042b5cf35042e01970e4da1562a3652815a569f7b36ddd73e874</source_hash>
 </source>
 <table_name>Determine_Therapy</table_name>
 <xls_file>therapy.xlsx</xls_file>

--- a/pkg/dtrules/authoring/excel_sync.go
+++ b/pkg/dtrules/authoring/excel_sync.go
@@ -15,6 +15,7 @@
 package authoring
 
 import (
+	"encoding/xml"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -64,7 +65,7 @@ func GuardExcelIn(xmlDir, excelDir string, overwrite bool) error {
 	if m == nil {
 		return nil
 	}
-	for excelRel := range m.Files {
+	for excelRel, entry := range m.Files {
 		excelPath := filepath.Join(manifestDir, excelRel)
 		if err := excelLockError(excelPath); err != nil {
 			return err
@@ -72,11 +73,57 @@ func GuardExcelIn(xmlDir, excelDir string, overwrite bool) error {
 		if overwrite {
 			continue
 		}
+		// Provenance first, where the XML records it.
+		//
+		// The guard's question is "has this workbook changed since the XML was
+		// generated, so that writing XML over it would discard someone's
+		// edit". The recorded hash answers exactly that; the mtime comparison
+		// only approximated it, and the approximation failed constantly --
+		// checkout stamps every file, so a fresh clone started locked (#1061),
+		// and any rebuild of the workbooks locked every project on the machine
+		// until the manifest caught up.
+		//
+		// The manifest is still the workbook-to-XML index here. What it is no
+		// longer asked for is the time (#1091).
+		if recorded := recordedHashFor(manifestDir, entry.XMLFiles); recorded != "" {
+			if recorded != excel.WorkbookHash(excelPath) {
+				return &sync.ExcelModifiedError{
+					ExcelPath: excelPath,
+					Message: fmt.Sprintf("Excel file %q has changed since the XML was compiled "+
+						"from it; user changes would be lost. Import Excel to XML first, then "+
+						"re-apply your changes.", excelPath),
+				}
+			}
+			continue
+		}
 		if err := m.ExportGuard(excelPath); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// recordedHashFor reads the provenance stamp out of the XML files a manifest
+// entry pairs with a workbook. Returns "" when none of them carry one, or when
+// they disagree -- both cases leave the caller on its previous behaviour.
+func recordedHashFor(manifestDir string, xmlFiles []string) string {
+	for _, rel := range xmlFiles {
+		if !strings.HasSuffix(rel, "_dt.xml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(manifestDir, rel))
+		if err != nil {
+			continue
+		}
+		var doc excel.DecisionTablesXML
+		if err := xml.Unmarshal(data, &doc); err != nil {
+			continue
+		}
+		if h := excel.RecordedWorkbookHash(doc.Tables); h != "" {
+			return h
+		}
+	}
+	return ""
 }
 
 // RefreshExcelInDir re-exports every Excel file the project's sync

--- a/pkg/dtrules/excel/artifact_type.go
+++ b/pkg/dtrules/excel/artifact_type.go
@@ -73,4 +73,3 @@ func artifactTypeMismatch(suffix string, hasdt, hasedd, hasmap bool) string {
 	}
 	return ""
 }
-

--- a/pkg/dtrules/excel/clobber_test.go
+++ b/pkg/dtrules/excel/clobber_test.go
@@ -26,7 +26,8 @@ import (
 
 // buildExporterFormatSheet writes an xlsx sheet in the exporter.go format with
 // one condition and one action. The layout mirrors what exporter.go produces:
-//   col A=number, col B=comment, col C=DSL, col D+=decision column values
+//
+//	col A=number, col B=comment, col C=DSL, col D+=decision column values
 //
 // The header section uses "Name: <table>" as the first row so detectFormat
 // identifies it as "exporter" format.

--- a/pkg/dtrules/excel/dt_importer.go
+++ b/pkg/dtrules/excel/dt_importer.go
@@ -95,6 +95,28 @@ type SourceXML struct {
 	RelativePath string `xml:"relative_path"`
 	FileName     string `xml:"file_name"`
 	SheetNumber  int    `xml:"sheet_number"`
+	// SourceHash is the hash of the workbook this XML was compiled from.
+	//
+	// Excel is the system of record, so the relationship is one-directional
+	// and one hash is enough: only the derived artifact records where it came
+	// from. Two files cannot hold each other's hashes, and the workbook
+	// records nothing.
+	//
+	// It replaces asking the filesystem which file was touched last.
+	// Timestamps answer "which was touched", a proxy for "which changed", and
+	// the proxy is wrong constantly -- checkout, `cp`, containers, CI, mtime
+	// granularity. `build --from-excel` once asked mtimes, got "no sync",
+	// imported nothing and exited 0 (#1057); the export guard compared mtime
+	// to a recorded export time, and since checkout stamps every file, every
+	// fresh clone started locked (#1061).
+	//
+	// Provenance travels with the artifact through git, `cp` and CI, which is
+	// what `.sync-manifest.json` could never do -- it is gitignored, so the
+	// baseline never left the machine that made it (#1091).
+	//
+	// Empty on XML written before this existed, and on XML that was never
+	// compiled from a workbook; callers fall back to timestamps.
+	SourceHash string `xml:"source_hash,omitempty"`
 }
 
 // DecisionTablesXML represents the root XML element for decision tables.
@@ -759,6 +781,9 @@ func (i *DTImporter) writeTable(f *os.File, table *DecisionTableXML) error {
 		f.WriteString(fmt.Sprintf("<relative_path>%s</relative_path>\n", xmlEscapeText(table.Source.RelativePath)))
 		f.WriteString(fmt.Sprintf("<file_name>%s</file_name>\n", xmlEscapeText(table.Source.FileName)))
 		f.WriteString(fmt.Sprintf("<sheet_number>%d</sheet_number>\n", table.Source.SheetNumber))
+		if table.Source.SourceHash != "" {
+			f.WriteString(fmt.Sprintf("<source_hash>%s</source_hash>\n", xmlEscapeText(table.Source.SourceHash)))
+		}
 		f.WriteString("</source>\n")
 	}
 

--- a/pkg/dtrules/excel/extract_test.go
+++ b/pkg/dtrules/excel/extract_test.go
@@ -139,9 +139,9 @@ func TestExtractExcel_FromFixture(t *testing.T) {
 	}
 
 	src := fstest.MapFS{
-		"states/AK_edd.xml":   &fstest.MapFile{Data: akEDD},
-		"states/AK_dt.xml":    &fstest.MapFile{Data: akDT},
-		"TaxReturn_map.xml":   &fstest.MapFile{Data: mapXML},
+		"states/AK_edd.xml": &fstest.MapFile{Data: akEDD},
+		"states/AK_dt.xml":  &fstest.MapFile{Data: akDT},
+		"TaxReturn_map.xml": &fstest.MapFile{Data: mapXML},
 	}
 
 	dst := t.TempDir()
@@ -213,7 +213,7 @@ func TestExtractExcel_NoLoaderWarnings(t *testing.T) {
 </decision_tables>`
 
 	src := fstest.MapFS{
-		"CO_dt.xml": &fstest.MapFile{Data: []byte(crossRefDT)},
+		"CO_dt.xml":         &fstest.MapFile{Data: []byte(crossRefDT)},
 		"TaxReturn_edd.xml": &fstest.MapFile{Data: []byte(minimalEDD)},
 	}
 
@@ -303,4 +303,3 @@ func TestExtractExcel_RoundTrip(t *testing.T) {
 		f.Close()
 	}
 }
-

--- a/pkg/dtrules/excel/map_exporter.go
+++ b/pkg/dtrules/excel/map_exporter.go
@@ -104,8 +104,8 @@ func (e *MapExporter) writeMapSheet(f *excelize.File, styler *Styler, sheet stri
 
 	// Rows 3+: data
 	sectionStyle, err := f.NewStyle(&excelize.Style{
-		Font:  &excelize.Font{Italic: true, Family: fontSansSerif, Size: 10, Color: "666666"},
-		Fill:  excelize.Fill{Type: "pattern", Pattern: 1, Color: []string{"F8F8F8"}},
+		Font:   &excelize.Font{Italic: true, Family: fontSansSerif, Size: 10, Color: "666666"},
+		Fill:   excelize.Fill{Type: "pattern", Pattern: 1, Color: []string{"F8F8F8"}},
 		Border: thinBorder(),
 	})
 	if err != nil {

--- a/pkg/dtrules/excel/source_hash.go
+++ b/pkg/dtrules/excel/source_hash.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+)
+
+// WorkbookHash is the provenance stamp a compiled XML file carries: the hash
+// of the workbook bytes it was compiled from.
+//
+// Hashing the file rather than its contents-as-parsed is deliberate. The
+// question is "did this workbook change since the XML was generated", and the
+// bytes answer it without needing to agree with the importer about what counts
+// as a meaningful change. The exporter is byte-deterministic -- consecutive
+// exports of the same rule set produce identical files -- so the stamp is
+// stable across rebuilds that changed nothing (#1091).
+//
+// Returns "" when the file cannot be read. A missing hash means "unknown
+// provenance", which callers must treat as "fall back to timestamps" rather
+// than as "unchanged".
+func WorkbookHash(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return ""
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// RecordedWorkbookHash returns the provenance stamp the tables in this file
+// agree on, or "" when they carry none or disagree.
+//
+// Disagreement is not an error to report here: a file assembled from more than
+// one workbook has no single provenance, and the caller's fallback is the
+// right answer for it.
+func RecordedWorkbookHash(tables []DecisionTableXML) string {
+	seen := ""
+	for i := range tables {
+		src := tables[i].Source
+		if src == nil || src.SourceHash == "" {
+			continue
+		}
+		if seen == "" {
+			seen = src.SourceHash
+			continue
+		}
+		if seen != src.SourceHash {
+			return ""
+		}
+	}
+	return seen
+}

--- a/pkg/dtrules/excel/source_hash_test.go
+++ b/pkg/dtrules/excel/source_hash_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package excel
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Provenance replaces asking the filesystem which file was touched last.
+// Timestamps answer "which was touched", a proxy for "which changed", and the
+// proxy is wrong constantly — checkout, `cp`, containers, CI (#1091).
+
+func TestWorkbookHashChangesWithTheBytes(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "wb.xlsx")
+	if err := os.WriteFile(p, []byte("one"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	first := WorkbookHash(p)
+	if !strings.HasPrefix(first, "sha256:") {
+		t.Errorf("hash should name its algorithm, got %q", first)
+	}
+	if WorkbookHash(p) != first {
+		t.Error("hashing the same bytes twice gave different answers")
+	}
+	if err := os.WriteFile(p, []byte("two"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if WorkbookHash(p) == first {
+		t.Error("changed bytes produced the same hash")
+	}
+}
+
+// A missing hash means "unknown provenance", which callers must treat as
+// "fall back to timestamps" rather than as "unchanged".
+func TestMissingFileHashesToEmpty(t *testing.T) {
+	if got := WorkbookHash(filepath.Join(t.TempDir(), "absent.xlsx")); got != "" {
+		t.Errorf("a file that does not exist hashed to %q, want empty", got)
+	}
+}
+
+func TestRecordedHashNeedsAgreement(t *testing.T) {
+	stamped := func(h string) DecisionTableXML {
+		return DecisionTableXML{Source: &SourceXML{SourceHash: h}}
+	}
+
+	if got := RecordedWorkbookHash([]DecisionTableXML{stamped("a"), stamped("a")}); got != "a" {
+		t.Errorf("tables agreeing on a stamp gave %q, want a", got)
+	}
+	// A file assembled from several workbooks has no single provenance, and
+	// the timestamp fallback is the right answer for it.
+	if got := RecordedWorkbookHash([]DecisionTableXML{stamped("a"), stamped("b")}); got != "" {
+		t.Errorf("disagreeing stamps gave %q, want empty so the caller falls back", got)
+	}
+	if got := RecordedWorkbookHash([]DecisionTableXML{{}}); got != "" {
+		t.Errorf("an unstamped table gave %q, want empty", got)
+	}
+	// One stamped table is enough; unstamped siblings do not veto it.
+	if got := RecordedWorkbookHash([]DecisionTableXML{{}, stamped("a")}); got != "a" {
+		t.Errorf("mixed stamped/unstamped gave %q, want a", got)
+	}
+}

--- a/pkg/dtrules/excel/workbook_importer.go
+++ b/pkg/dtrules/excel/workbook_importer.go
@@ -184,6 +184,10 @@ func (w *WorkbookImporter) importWorkbookWithSource(excelPath, xlsFile, relPath 
 		return nil, fmt.Errorf("no sheets found in Excel file")
 	}
 
+	// Hashed before anything is written, so the stamp describes the workbook
+	// this import actually read.
+	workbookHash := WorkbookHash(excelPath)
+
 	// Build sheet index map (1-based) for source tracking
 	sheetIndexMap := make(map[string]int, len(sheets))
 	for idx, name := range sheets {
@@ -259,11 +263,14 @@ func (w *WorkbookImporter) importWorkbookWithSource(excelPath, xlsFile, relPath 
 				w.stats.Actions += len(table.Actions)
 				w.stats.Conditions += len(table.Conditions)
 			}
-			// Attach source metadata
+			// Attach source metadata, including the provenance stamp: this
+			// XML was compiled from these workbook bytes, and a later build
+			// can tell whether that is still the workbook on disk (#1091).
 			table.Source = &SourceXML{
 				RelativePath: srcRelPath,
 				FileName:     filepath.Base(excelPath),
 				SheetNumber:  sheetIndexMap[sheet],
+				SourceHash:   workbookHash,
 			}
 			result.DTables.Tables = append(result.DTables.Tables, *table)
 		}

--- a/pkg/dtrules/excel/workbook_importer_test.go
+++ b/pkg/dtrules/excel/workbook_importer_test.go
@@ -190,9 +190,9 @@ func TestWorkbookImporter_RecursiveDirectory(t *testing.T) {
 
 	// Check file paths are relative
 	expectedPaths := map[string]bool{
-		"main.xlsx":        false,
-		"states/CA.xlsx":   false,
-		"states/CO.xlsx":   false,
+		"main.xlsx":      false,
+		"states/CA.xlsx": false,
+		"states/CO.xlsx": false,
 	}
 
 	for _, result := range results {

--- a/pkg/dtrules/sync/provenance_test.go
+++ b/pkg/dtrules/sync/provenance_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/excel"
+)
+
+// The failure this replaces: checkout stamps every file with the same time, so
+// a fresh clone had no usable timestamp signal at all — and the export guard,
+// comparing mtime against a recorded export time, started every clone locked
+// (#1061). Provenance travels with the artifact, so a clone answers correctly.
+
+func writeStampedProject(t *testing.T, dir, hash string) *CombinedWorkbook {
+	t.Helper()
+	wb := filepath.Join(dir, "book.xlsx")
+	dt := filepath.Join(dir, "book_dt.xml")
+	if err := os.WriteFile(wb, []byte("workbook bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if hash == "" {
+		hash = excel.WorkbookHash(wb)
+	}
+	body := fmt.Sprintf(`<decision_tables><decision_table><table_name>T</table_name>`+
+		`<source><relative_path>book.xlsx</relative_path><file_name>book.xlsx</file_name>`+
+		`<sheet_number>1</sheet_number><source_hash>%s</source_hash></source>`+
+		`</decision_table></decision_tables>`, hash)
+	if err := os.WriteFile(dt, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return &CombinedWorkbook{
+		ExcelPath: wb, DTXMLPath: dt,
+		ExcelExists: true, DTExists: true,
+	}
+}
+
+func TestProvenanceSurvivesEveryFileBeingTouched(t *testing.T) {
+	dir := t.TempDir()
+	wb := writeStampedProject(t, dir, "")
+
+	// What a checkout does: one timestamp on everything.
+	stamp := time.Now()
+	for _, p := range []string{wb.ExcelPath, wb.DTXMLPath} {
+		if err := os.Chtimes(p, stamp, stamp); err != nil {
+			t.Fatal(err)
+		}
+	}
+	wb.ExcelMod, wb.DTMod = stamp, stamp
+
+	s := NewSyncerWithOptions(dir, dir, DefaultOptions())
+	if got := s.determineWorkbookDirection(wb); got != NoSync {
+		t.Errorf("direction = %v, want NoSync — the workbook is the one the XML was compiled from", got)
+	}
+}
+
+func TestChangedWorkbookIsDetectedWhateverTheClockSays(t *testing.T) {
+	dir := t.TempDir()
+	wb := writeStampedProject(t, dir, "sha256:stale")
+
+	// Make the XML look far newer, which timestamps would read as XMLToExcel.
+	future := time.Now().Add(24 * time.Hour)
+	if err := os.Chtimes(wb.DTXMLPath, future, future); err != nil {
+		t.Fatal(err)
+	}
+	wb.DTMod, wb.ExcelMod = future, time.Now()
+
+	s := NewSyncerWithOptions(dir, dir, DefaultOptions())
+	if got := s.determineWorkbookDirection(wb); got != ExcelToXML {
+		t.Errorf("direction = %v, want ExcelToXML — the recorded provenance does not match the workbook", got)
+	}
+}
+
+// XML written before the stamp existed must still work.
+func TestUnstampedXMLFallsBackToTimestamps(t *testing.T) {
+	dir := t.TempDir()
+	wb := filepath.Join(dir, "book.xlsx")
+	dt := filepath.Join(dir, "book_dt.xml")
+	if err := os.WriteFile(wb, []byte("workbook"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dt, []byte(`<decision_tables><decision_table><table_name>T</table_name></decision_table></decision_tables>`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	cw := &CombinedWorkbook{
+		ExcelPath: wb, DTXMLPath: dt, ExcelExists: true, DTExists: true,
+		ExcelMod: now, DTMod: now.Add(-48 * time.Hour),
+	}
+
+	s := NewSyncerWithOptions(dir, dir, DefaultOptions())
+	if got := s.determineWorkbookDirection(cw); got != ExcelToXML {
+		t.Errorf("direction = %v, want ExcelToXML from the timestamp fallback", got)
+	}
+}

--- a/pkg/dtrules/sync/sync.go
+++ b/pkg/dtrules/sync/sync.go
@@ -18,12 +18,15 @@
 package sync
 
 import (
+	"encoding/xml"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/excel"
 )
 
 // SyncDirection indicates which way to sync files.
@@ -1163,6 +1166,27 @@ func assertNoOutputCollision(workbooks []CombinedWorkbook) error {
 }
 
 // determineWorkbookDirection determines the sync direction for a combined workbook.
+
+// recordedSourceHash reads the provenance stamp out of the workbook's DT XML.
+//
+// Returns "" when the file is absent, unreadable, carries no stamp, or carries
+// more than one -- a file assembled from several workbooks has no single
+// provenance, and the timestamp fallback is the right answer for it.
+func (s *Syncer) recordedSourceHash(wb *CombinedWorkbook) string {
+	if !wb.DTExists {
+		return ""
+	}
+	data, err := os.ReadFile(wb.DTXMLPath)
+	if err != nil {
+		return ""
+	}
+	var doc excel.DecisionTablesXML
+	if err := xml.Unmarshal(data, &doc); err != nil {
+		return ""
+	}
+	return excel.RecordedWorkbookHash(doc.Tables)
+}
+
 func (s *Syncer) determineWorkbookDirection(wb *CombinedWorkbook) SyncDirection {
 	// If Excel doesn't exist but XML does, export to Excel
 	if !wb.ExcelExists && (wb.DTExists || wb.EDDExists) {
@@ -1179,6 +1203,31 @@ func (s *Syncer) determineWorkbookDirection(wb *CombinedWorkbook) SyncDirection 
 		return NoSync
 	}
 
+	// Provenance first: the XML records the workbook it was compiled from, so
+	// "did the workbook change" is two file reads and no guessing.
+	//
+	// Timestamps answer "which was touched last", a proxy for "which changed",
+	// and the proxy is wrong constantly -- checkout, `cp`, containers, CI,
+	// mtime granularity. `build --from-excel` once asked mtimes, got NoSync,
+	// imported nothing and exited 0 (#1057); every fresh clone started locked
+	// because checkout stamps every file (#1061). Provenance travels with the
+	// artifact through all of those (#1091).
+	//
+	// Only two answers are possible here, and that is the model rather than an
+	// omission: the XML is derived. Either the workbook is the one it was
+	// compiled from, or it is not and the XML is stale. Hand-edited XML is
+	// overwritten by the next build, which is what "Excel is the system of
+	// record" means.
+	if recorded := s.recordedSourceHash(wb); recorded != "" {
+		if recorded == excel.WorkbookHash(wb.ExcelPath) {
+			return NoSync
+		}
+		return ExcelToXML
+	}
+
+	// No provenance recorded -- XML written before the stamp existed, or never
+	// compiled from a workbook. Fall back to timestamps.
+	//
 	// Both exist - compare timestamps
 	// Use the newest XML file for comparison
 	var newestXMLMod time.Time

--- a/sampleprojects/CHIP/xml/CHIP_dt.xml
+++ b/sampleprojects/CHIP/xml/CHIP_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>CHIP.xlsx</relative_path>
 <file_name>CHIP.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:f4aada4272aaf9225a457f5b2158c2ecaf9ffb33b07436226544a404e01a3be9</source_hash>
 </source>
 <table_name>Compute_Eligibility</table_name>
 <xls_file>CHIP.xlsx</xls_file>
@@ -137,6 +138,7 @@ otherwise
 <relative_path>CHIP.xlsx</relative_path>
 <file_name>CHIP.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:f4aada4272aaf9225a457f5b2158c2ecaf9ffb33b07436226544a404e01a3be9</source_hash>
 </source>
 <table_name>Calculate_Individual_Income</table_name>
 <xls_file>CHIP.xlsx</xls_file>
@@ -204,6 +206,7 @@ income.amount client.totalIncome + /client.totalIncome xdef
 <relative_path>CHIP.xlsx</relative_path>
 <file_name>CHIP.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:f4aada4272aaf9225a457f5b2158c2ecaf9ffb33b07436226544a404e01a3be9</source_hash>
 </source>
 <table_name>Calculate_Group_Size</table_name>
 <xls_file>CHIP.xlsx</xls_file>
@@ -337,6 +340,7 @@ client.totalIncome 0 local@ entitypush totalGroupIncome + /totalGroupIncome xdef
 <relative_path>CHIP.xlsx</relative_path>
 <file_name>CHIP.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:f4aada4272aaf9225a457f5b2158c2ecaf9ffb33b07436226544a404e01a3be9</source_hash>
 </source>
 <table_name>Evaluate_CHIP_Eligibility</table_name>
 <xls_file>CHIP.xlsx</xls_file>
@@ -555,6 +559,7 @@ policystatements client.notes true addarray
 <relative_path>CHIP.xlsx</relative_path>
 <file_name>CHIP.xlsx</file_name>
 <sheet_number>5</sheet_number>
+<source_hash>sha256:f4aada4272aaf9225a457f5b2158c2ecaf9ffb33b07436226544a404e01a3be9</source_hash>
 </source>
 <table_name>Evaluate_MEDICAID_Eligibility</table_name>
 <xls_file>CHIP.xlsx</xls_file>
@@ -614,6 +619,7 @@ false cvb /client.eligible xdef
 <relative_path>CHIP.xlsx</relative_path>
 <file_name>CHIP.xlsx</file_name>
 <sheet_number>6</sheet_number>
+<source_hash>sha256:f4aada4272aaf9225a457f5b2158c2ecaf9ffb33b07436226544a404e01a3be9</source_hash>
 </source>
 <table_name>Evaluate_FOODSTAMPS_Eligibilty</table_name>
 <xls_file>CHIP.xlsx</xls_file>
@@ -673,6 +679,7 @@ false cvb /client.eligible xdef
 <relative_path>CHIP.xlsx</relative_path>
 <file_name>CHIP.xlsx</file_name>
 <sheet_number>7</sheet_number>
+<source_hash>sha256:f4aada4272aaf9225a457f5b2158c2ecaf9ffb33b07436226544a404e01a3be9</source_hash>
 </source>
 <table_name>Evaluate_Results</table_name>
 <xls_file>CHIP.xlsx</xls_file>

--- a/sampleprojects/ChipApp/xml/CHIP_dt.xml
+++ b/sampleprojects/ChipApp/xml/CHIP_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>CHIP.xlsx</relative_path>
 <file_name>CHIP.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:ba1f7384a412dfd2f4b5dbbda18b14ed43cc39a5dd13a5bbc2390e2baef36099</source_hash>
 </source>
 <table_name>Compute_Eligibility</table_name>
 <xls_file>CHIP.xlsx</xls_file>
@@ -137,6 +138,7 @@ otherwise
 <relative_path>CHIP.xlsx</relative_path>
 <file_name>CHIP.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:ba1f7384a412dfd2f4b5dbbda18b14ed43cc39a5dd13a5bbc2390e2baef36099</source_hash>
 </source>
 <table_name>Calculate_Individual_Income</table_name>
 <xls_file>CHIP.xlsx</xls_file>
@@ -204,6 +206,7 @@ income.amount client.totalIncome + /client.totalIncome xdef
 <relative_path>CHIP.xlsx</relative_path>
 <file_name>CHIP.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:ba1f7384a412dfd2f4b5dbbda18b14ed43cc39a5dd13a5bbc2390e2baef36099</source_hash>
 </source>
 <table_name>Calculate_Group_Size</table_name>
 <xls_file>CHIP.xlsx</xls_file>
@@ -337,6 +340,7 @@ client.totalIncome 0 local@ entitypush totalGroupIncome + /totalGroupIncome xdef
 <relative_path>CHIP.xlsx</relative_path>
 <file_name>CHIP.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:ba1f7384a412dfd2f4b5dbbda18b14ed43cc39a5dd13a5bbc2390e2baef36099</source_hash>
 </source>
 <table_name>Evaluate_CHIP_Eligibility</table_name>
 <xls_file>CHIP.xlsx</xls_file>
@@ -555,6 +559,7 @@ policystatements client.notes true addarray
 <relative_path>CHIP.xlsx</relative_path>
 <file_name>CHIP.xlsx</file_name>
 <sheet_number>5</sheet_number>
+<source_hash>sha256:ba1f7384a412dfd2f4b5dbbda18b14ed43cc39a5dd13a5bbc2390e2baef36099</source_hash>
 </source>
 <table_name>Evaluate_MEDICAID_Eligibility</table_name>
 <xls_file>CHIP.xlsx</xls_file>
@@ -614,6 +619,7 @@ false cvb /client.eligible xdef
 <relative_path>CHIP.xlsx</relative_path>
 <file_name>CHIP.xlsx</file_name>
 <sheet_number>6</sheet_number>
+<source_hash>sha256:ba1f7384a412dfd2f4b5dbbda18b14ed43cc39a5dd13a5bbc2390e2baef36099</source_hash>
 </source>
 <table_name>Evaluate_FOODSTAMPS_Eligibilty</table_name>
 <xls_file>CHIP.xlsx</xls_file>
@@ -673,6 +679,7 @@ false cvb /client.eligible xdef
 <relative_path>CHIP.xlsx</relative_path>
 <file_name>CHIP.xlsx</file_name>
 <sheet_number>7</sheet_number>
+<source_hash>sha256:ba1f7384a412dfd2f4b5dbbda18b14ed43cc39a5dd13a5bbc2390e2baef36099</source_hash>
 </source>
 <table_name>Evaluate_Results</table_name>
 <xls_file>CHIP.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/orchestrator_dt.xml
+++ b/sampleprojects/CorporateTax/xml/orchestrator_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>orchestrator.xlsx</relative_path>
 <file_name>orchestrator.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:0cbd51389826c0abfb313e8d8192884e7d3bc79a3da2bd01fb1d9faaaa1429ee</source_hash>
 </source>
 <table_name>Run_Corporate_Tax</table_name>
 <xls_file>orchestrator.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/AK_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/AK_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>AK_corp.xlsx</relative_path>
 <file_name>AK_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:73c22f4bba06ec1a1c4b8374c4930bc82619938f6f6acfd01381436b13492976</source_hash>
 </source>
 <table_name>Determine_AK_Filing_Requirement</table_name>
 <xls_file>AK_corp.xlsx</xls_file>
@@ -71,6 +72,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AK" st
 <relative_path>AK_corp.xlsx</relative_path>
 <file_name>AK_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:73c22f4bba06ec1a1c4b8374c4930bc82619938f6f6acfd01381436b13492976</source_hash>
 </source>
 <table_name>Calculate_AK_Income_Adjustments</table_name>
 <xls_file>AK_corp.xlsx</xls_file>
@@ -121,6 +123,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>AK_corp.xlsx</relative_path>
 <file_name>AK_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:73c22f4bba06ec1a1c4b8374c4930bc82619938f6f6acfd01381436b13492976</source_hash>
 </source>
 <table_name>Calculate_AK_State_Tax</table_name>
 <xls_file>AK_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/AL_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/AL_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>AL_corp.xlsx</relative_path>
 <file_name>AL_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:75ab0c4b21fbf19992c1cda07512339138f299f784df54c9f8a8e1af1a4e45fa</source_hash>
 </source>
 <table_name>Determine_AL_Filing_Requirement</table_name>
 <xls_file>AL_corp.xlsx</xls_file>
@@ -71,6 +72,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AL" st
 <relative_path>AL_corp.xlsx</relative_path>
 <file_name>AL_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:75ab0c4b21fbf19992c1cda07512339138f299f784df54c9f8a8e1af1a4e45fa</source_hash>
 </source>
 <table_name>Calculate_AL_Income_Adjustments</table_name>
 <xls_file>AL_corp.xlsx</xls_file>
@@ -121,6 +123,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>AL_corp.xlsx</relative_path>
 <file_name>AL_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:75ab0c4b21fbf19992c1cda07512339138f299f784df54c9f8a8e1af1a4e45fa</source_hash>
 </source>
 <table_name>Calculate_AL_State_Tax</table_name>
 <xls_file>AL_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/AR_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/AR_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>AR_corp.xlsx</relative_path>
 <file_name>AR_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:6d78878156c57737bd4006ffa616a38521bff8f938eed45966ac4a32e0492128</source_hash>
 </source>
 <table_name>Determine_AR_Filing_Requirement</table_name>
 <xls_file>AR_corp.xlsx</xls_file>
@@ -71,6 +72,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AR" st
 <relative_path>AR_corp.xlsx</relative_path>
 <file_name>AR_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:6d78878156c57737bd4006ffa616a38521bff8f938eed45966ac4a32e0492128</source_hash>
 </source>
 <table_name>Calculate_AR_Income_Adjustments</table_name>
 <xls_file>AR_corp.xlsx</xls_file>
@@ -121,6 +123,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>AR_corp.xlsx</relative_path>
 <file_name>AR_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:6d78878156c57737bd4006ffa616a38521bff8f938eed45966ac4a32e0492128</source_hash>
 </source>
 <table_name>Calculate_AR_State_Tax</table_name>
 <xls_file>AR_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/AZ_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/AZ_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>AZ_corp.xlsx</relative_path>
 <file_name>AZ_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:f381a4e3adacf41b4578ee351e03a840c63188905e003d93ceae3330aecd09ce</source_hash>
 </source>
 <table_name>Determine_AZ_Filing_Requirement</table_name>
 <xls_file>AZ_corp.xlsx</xls_file>
@@ -71,6 +72,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "AZ" st
 <relative_path>AZ_corp.xlsx</relative_path>
 <file_name>AZ_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:f381a4e3adacf41b4578ee351e03a840c63188905e003d93ceae3330aecd09ce</source_hash>
 </source>
 <table_name>Calculate_AZ_Income_Adjustments</table_name>
 <xls_file>AZ_corp.xlsx</xls_file>
@@ -121,6 +123,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>AZ_corp.xlsx</relative_path>
 <file_name>AZ_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:f381a4e3adacf41b4578ee351e03a840c63188905e003d93ceae3330aecd09ce</source_hash>
 </source>
 <table_name>Calculate_AZ_State_Tax</table_name>
 <xls_file>AZ_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/CA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/CA_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>CA_corp.xlsx</relative_path>
 <file_name>CA_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:fdeb6437a18b0126fb47f88dc84357da4a236b1c9bcb728415721ff7dace12ce</source_hash>
 </source>
 <table_name>Determine_CA_Filing_Requirement</table_name>
 <xls_file>CA_corp.xlsx</xls_file>
@@ -71,6 +72,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "CA" st
 <relative_path>CA_corp.xlsx</relative_path>
 <file_name>CA_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:fdeb6437a18b0126fb47f88dc84357da4a236b1c9bcb728415721ff7dace12ce</source_hash>
 </source>
 <table_name>Calculate_CA_Income_Adjustments</table_name>
 <xls_file>CA_corp.xlsx</xls_file>
@@ -121,6 +123,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>CA_corp.xlsx</relative_path>
 <file_name>CA_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:fdeb6437a18b0126fb47f88dc84357da4a236b1c9bcb728415721ff7dace12ce</source_hash>
 </source>
 <table_name>Calculate_CA_State_Tax</table_name>
 <xls_file>CA_corp.xlsx</xls_file>
@@ -189,6 +192,7 @@ ca_result.minimum_franchise_tax cvd /apportionment.state_tax xdef apportionment.
 <relative_path>CA_corp.xlsx</relative_path>
 <file_name>CA_corp.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:fdeb6437a18b0126fb47f88dc84357da4a236b1c9bcb728415721ff7dace12ce</source_hash>
 </source>
 <table_name>Apply_CA_Waters_Edge_Election</table_name>
 <xls_file>CA_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/CO_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/CO_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>CO_corp.xlsx</relative_path>
 <file_name>CO_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:64a83bc42c91212a3931b9ddd37a0d29f05e4e60456a014dc72e3f1b5f06ae32</source_hash>
 </source>
 <table_name>Determine_CO_Filing_Requirement</table_name>
 <xls_file>CO_corp.xlsx</xls_file>
@@ -76,6 +77,7 @@ false cvb /co_result.has_nexus xdef 0.0 cvd /co_result.tax_liability xdef
 <relative_path>CO_corp.xlsx</relative_path>
 <file_name>CO_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:64a83bc42c91212a3931b9ddd37a0d29f05e4e60456a014dc72e3f1b5f06ae32</source_hash>
 </source>
 <table_name>Calculate_CO_Income_Adjustments</table_name>
 <xls_file>CO_corp.xlsx</xls_file>
@@ -131,6 +133,7 @@ co_result.us_interest_income cvd /co_result.state_additions xdef co_result.state
 <relative_path>CO_corp.xlsx</relative_path>
 <file_name>CO_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:64a83bc42c91212a3931b9ddd37a0d29f05e4e60456a014dc72e3f1b5f06ae32</source_hash>
 </source>
 <table_name>Calculate_CO_State_Tax</table_name>
 <xls_file>CO_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/CT_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/CT_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>CT_corp.xlsx</relative_path>
 <file_name>CT_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:5e0c3aa8d5300ea48b06064a0ad27c9053a0500d21410d75eb70b8b4d1da0483</source_hash>
 </source>
 <table_name>Determine_CT_Filing_Requirement</table_name>
 <xls_file>CT_corp.xlsx</xls_file>
@@ -76,6 +77,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "CT" st
 <relative_path>CT_corp.xlsx</relative_path>
 <file_name>CT_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:5e0c3aa8d5300ea48b06064a0ad27c9053a0500d21410d75eb70b8b4d1da0483</source_hash>
 </source>
 <table_name>Calculate_CT_Income_Adjustments</table_name>
 <xls_file>CT_corp.xlsx</xls_file>
@@ -131,6 +133,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>CT_corp.xlsx</relative_path>
 <file_name>CT_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:5e0c3aa8d5300ea48b06064a0ad27c9053a0500d21410d75eb70b8b4d1da0483</source_hash>
 </source>
 <table_name>Calculate_CT_State_Tax</table_name>
 <xls_file>CT_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/DC_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/DC_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>DC_corp.xlsx</relative_path>
 <file_name>DC_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:d13056035fa5028ee26f0fae2c7d73fd3bca3b941c1fe56bfe6afbd17b57801a</source_hash>
 </source>
 <table_name>Determine_DC_Filing_Requirement</table_name>
 <xls_file>DC_corp.xlsx</xls_file>
@@ -69,6 +70,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "DC" st
 <relative_path>DC_corp.xlsx</relative_path>
 <file_name>DC_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:d13056035fa5028ee26f0fae2c7d73fd3bca3b941c1fe56bfe6afbd17b57801a</source_hash>
 </source>
 <table_name>Calculate_DC_Income_Adjustments</table_name>
 <xls_file>DC_corp.xlsx</xls_file>
@@ -115,6 +117,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>DC_corp.xlsx</relative_path>
 <file_name>DC_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:d13056035fa5028ee26f0fae2c7d73fd3bca3b941c1fe56bfe6afbd17b57801a</source_hash>
 </source>
 <table_name>Calculate_DC_State_Tax</table_name>
 <xls_file>DC_corp.xlsx</xls_file>
@@ -177,6 +180,7 @@ apportionment.state_taxable_income 0.0 f&gt;
 <relative_path>DC_corp.xlsx</relative_path>
 <file_name>DC_corp.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:d13056035fa5028ee26f0fae2c7d73fd3bca3b941c1fe56bfe6afbd17b57801a</source_hash>
 </source>
 <table_name>Calculate_DC_Minimum_Tax</table_name>
 <xls_file>DC_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/DE_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/DE_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>DE_corp.xlsx</relative_path>
 <file_name>DE_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:b4083c651e2ac0f03a271c7006112d9785d7452308d11bad8c5ddf9c297cae6a</source_hash>
 </source>
 <table_name>Determine_DE_Filing_Requirement</table_name>
 <xls_file>DE_corp.xlsx</xls_file>
@@ -71,6 +72,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "DE" st
 <relative_path>DE_corp.xlsx</relative_path>
 <file_name>DE_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:b4083c651e2ac0f03a271c7006112d9785d7452308d11bad8c5ddf9c297cae6a</source_hash>
 </source>
 <table_name>Calculate_DE_Income_Adjustments</table_name>
 <xls_file>DE_corp.xlsx</xls_file>
@@ -121,6 +123,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>DE_corp.xlsx</relative_path>
 <file_name>DE_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:b4083c651e2ac0f03a271c7006112d9785d7452308d11bad8c5ddf9c297cae6a</source_hash>
 </source>
 <table_name>Calculate_DE_State_Tax</table_name>
 <xls_file>DE_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/FL_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/FL_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>FL_corp.xlsx</relative_path>
 <file_name>FL_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:098a7f187486ae03b304bf5c89f37cdec3d51e1dd1c949c6295eda41a32015f1</source_hash>
 </source>
 <table_name>Determine_FL_Filing_Requirement</table_name>
 <xls_file>FL_corp.xlsx</xls_file>
@@ -84,6 +85,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "FL" st
 <relative_path>FL_corp.xlsx</relative_path>
 <file_name>FL_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:098a7f187486ae03b304bf5c89f37cdec3d51e1dd1c949c6295eda41a32015f1</source_hash>
 </source>
 <table_name>Calculate_FL_Income_Adjustments</table_name>
 <xls_file>FL_corp.xlsx</xls_file>
@@ -143,6 +145,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>FL_corp.xlsx</relative_path>
 <file_name>FL_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:098a7f187486ae03b304bf5c89f37cdec3d51e1dd1c949c6295eda41a32015f1</source_hash>
 </source>
 <table_name>Calculate_FL_State_Tax</table_name>
 <xls_file>FL_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/GA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/GA_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>GA_corp.xlsx</relative_path>
 <file_name>GA_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:2d23bd894c58519f7db259cb2c221dd37d75a85e820c96be0700ef05b9d1a3d8</source_hash>
 </source>
 <table_name>Determine_GA_Filing_Requirement</table_name>
 <xls_file>GA_corp.xlsx</xls_file>
@@ -75,6 +76,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "GA" st
 <relative_path>GA_corp.xlsx</relative_path>
 <file_name>GA_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:2d23bd894c58519f7db259cb2c221dd37d75a85e820c96be0700ef05b9d1a3d8</source_hash>
 </source>
 <table_name>Calculate_GA_Income_Adjustments</table_name>
 <xls_file>GA_corp.xlsx</xls_file>
@@ -125,6 +127,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>GA_corp.xlsx</relative_path>
 <file_name>GA_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:2d23bd894c58519f7db259cb2c221dd37d75a85e820c96be0700ef05b9d1a3d8</source_hash>
 </source>
 <table_name>Calculate_GA_State_Tax</table_name>
 <xls_file>GA_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/HI_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/HI_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>HI_corp.xlsx</relative_path>
 <file_name>HI_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:7be08fa37e38c54b1377bff57820ddb24f22b72dc493bbe653157d40055ba19b</source_hash>
 </source>
 <table_name>Determine_HI_Filing_Requirement</table_name>
 <xls_file>HI_corp.xlsx</xls_file>
@@ -84,6 +85,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "HI" st
 <relative_path>HI_corp.xlsx</relative_path>
 <file_name>HI_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:7be08fa37e38c54b1377bff57820ddb24f22b72dc493bbe653157d40055ba19b</source_hash>
 </source>
 <table_name>Calculate_HI_Income_Adjustments</table_name>
 <xls_file>HI_corp.xlsx</xls_file>
@@ -143,6 +145,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>HI_corp.xlsx</relative_path>
 <file_name>HI_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:7be08fa37e38c54b1377bff57820ddb24f22b72dc493bbe653157d40055ba19b</source_hash>
 </source>
 <table_name>Calculate_HI_State_Tax</table_name>
 <xls_file>HI_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/IA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/IA_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>IA_corp.xlsx</relative_path>
 <file_name>IA_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:f699b680c6719c7a094634a18783437d88de942674b5684165c1997f5400e191</source_hash>
 </source>
 <table_name>Determine_IA_Filing_Requirement</table_name>
 <xls_file>IA_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ false cvb /ia_result.has_nexus xdef 0.0 cvd /ia_result.tax_liability xdef
 <relative_path>IA_corp.xlsx</relative_path>
 <file_name>IA_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:f699b680c6719c7a094634a18783437d88de942674b5684165c1997f5400e191</source_hash>
 </source>
 <table_name>Calculate_IA_Income_Adjustments</table_name>
 <xls_file>IA_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ ia_result.has_nexus true beq
 <relative_path>IA_corp.xlsx</relative_path>
 <file_name>IA_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:f699b680c6719c7a094634a18783437d88de942674b5684165c1997f5400e191</source_hash>
 </source>
 <table_name>Calculate_IA_State_Tax</table_name>
 <xls_file>IA_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/ID_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/ID_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>ID_corp.xlsx</relative_path>
 <file_name>ID_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:3f3ef38eab87a38829e81b1daf3c675ca79a3842a75921f095e916e70c14d49e</source_hash>
 </source>
 <table_name>Determine_ID_Filing_Requirement</table_name>
 <xls_file>ID_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ false cvb /id_result.has_nexus xdef 0.0 cvd /id_result.tax_liability xdef
 <relative_path>ID_corp.xlsx</relative_path>
 <file_name>ID_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:3f3ef38eab87a38829e81b1daf3c675ca79a3842a75921f095e916e70c14d49e</source_hash>
 </source>
 <table_name>Calculate_ID_Income_Adjustments</table_name>
 <xls_file>ID_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ id_result.has_nexus true beq
 <relative_path>ID_corp.xlsx</relative_path>
 <file_name>ID_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:3f3ef38eab87a38829e81b1daf3c675ca79a3842a75921f095e916e70c14d49e</source_hash>
 </source>
 <table_name>Calculate_ID_State_Tax</table_name>
 <xls_file>ID_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/IL_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/IL_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>IL_corp.xlsx</relative_path>
 <file_name>IL_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:e23f71c64dfadc2db229f854ce32723175a0a3c70314b4dd3d923378d161956c</source_hash>
 </source>
 <table_name>Determine_IL_Filing_Requirement</table_name>
 <xls_file>IL_corp.xlsx</xls_file>
@@ -75,6 +76,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "IL" st
 <relative_path>IL_corp.xlsx</relative_path>
 <file_name>IL_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:e23f71c64dfadc2db229f854ce32723175a0a3c70314b4dd3d923378d161956c</source_hash>
 </source>
 <table_name>Calculate_IL_Income_Adjustments</table_name>
 <xls_file>IL_corp.xlsx</xls_file>
@@ -125,6 +127,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>IL_corp.xlsx</relative_path>
 <file_name>IL_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:e23f71c64dfadc2db229f854ce32723175a0a3c70314b4dd3d923378d161956c</source_hash>
 </source>
 <table_name>Calculate_IL_State_Tax</table_name>
 <xls_file>IL_corp.xlsx</xls_file>
@@ -193,6 +196,7 @@ apportionment.state_taxable_income il_apportionment.state_tax_rate fmul cvd /app
 <relative_path>IL_corp.xlsx</relative_path>
 <file_name>IL_corp.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:e23f71c64dfadc2db229f854ce32723175a0a3c70314b4dd3d923378d161956c</source_hash>
 </source>
 <table_name>Calculate_IL_Replacement_Tax</table_name>
 <xls_file>IL_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/IN_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/IN_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>IN_corp.xlsx</relative_path>
 <file_name>IN_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:065f8ab58798985ac4f3c401a833f9644f26812acfc46cc2e42edf63e2a0ebf3</source_hash>
 </source>
 <table_name>Determine_IN_Filing_Requirement</table_name>
 <xls_file>IN_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ false cvb /in_result.has_nexus xdef 0.0 cvd /in_result.tax_liability xdef
 <relative_path>IN_corp.xlsx</relative_path>
 <file_name>IN_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:065f8ab58798985ac4f3c401a833f9644f26812acfc46cc2e42edf63e2a0ebf3</source_hash>
 </source>
 <table_name>Calculate_IN_Income_Adjustments</table_name>
 <xls_file>IN_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ in_result.has_nexus true beq
 <relative_path>IN_corp.xlsx</relative_path>
 <file_name>IN_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:065f8ab58798985ac4f3c401a833f9644f26812acfc46cc2e42edf63e2a0ebf3</source_hash>
 </source>
 <table_name>Calculate_IN_State_Tax</table_name>
 <xls_file>IN_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/KS_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/KS_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>KS_corp.xlsx</relative_path>
 <file_name>KS_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:f2b3ddae94810d9b654926dc09da143ce48f5457ec36ace337e77cdadf481ce8</source_hash>
 </source>
 <table_name>Determine_KS_Filing_Requirement</table_name>
 <xls_file>KS_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ false cvb /ks_result.has_nexus xdef 0.0 cvd /ks_result.tax_liability xdef
 <relative_path>KS_corp.xlsx</relative_path>
 <file_name>KS_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:f2b3ddae94810d9b654926dc09da143ce48f5457ec36ace337e77cdadf481ce8</source_hash>
 </source>
 <table_name>Calculate_KS_Income_Adjustments</table_name>
 <xls_file>KS_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ ks_result.has_nexus true beq
 <relative_path>KS_corp.xlsx</relative_path>
 <file_name>KS_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:f2b3ddae94810d9b654926dc09da143ce48f5457ec36ace337e77cdadf481ce8</source_hash>
 </source>
 <table_name>Calculate_KS_State_Tax</table_name>
 <xls_file>KS_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/KY_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/KY_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>KY_corp.xlsx</relative_path>
 <file_name>KY_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:f7804eef69b2b4f98e7bb0866435ebd1ec7c9b21f4d19d823769804860b97d3b</source_hash>
 </source>
 <table_name>Determine_KY_Filing_Requirement</table_name>
 <xls_file>KY_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ false cvb /ky_result.has_nexus xdef 0.0 cvd /ky_result.tax_liability xdef
 <relative_path>KY_corp.xlsx</relative_path>
 <file_name>KY_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:f7804eef69b2b4f98e7bb0866435ebd1ec7c9b21f4d19d823769804860b97d3b</source_hash>
 </source>
 <table_name>Calculate_KY_Income_Adjustments</table_name>
 <xls_file>KY_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ ky_result.has_nexus true beq
 <relative_path>KY_corp.xlsx</relative_path>
 <file_name>KY_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:f7804eef69b2b4f98e7bb0866435ebd1ec7c9b21f4d19d823769804860b97d3b</source_hash>
 </source>
 <table_name>Calculate_KY_State_Tax</table_name>
 <xls_file>KY_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/LA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/LA_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>LA_corp.xlsx</relative_path>
 <file_name>LA_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:15f90dcf3e2437b551fc409215cd1e8a5647b7a116824613def51bab1570a887</source_hash>
 </source>
 <table_name>Determine_LA_Filing_Requirement</table_name>
 <xls_file>LA_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ false cvb /la_result.has_nexus xdef 0.0 cvd /la_result.tax_liability xdef
 <relative_path>LA_corp.xlsx</relative_path>
 <file_name>LA_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:15f90dcf3e2437b551fc409215cd1e8a5647b7a116824613def51bab1570a887</source_hash>
 </source>
 <table_name>Calculate_LA_Income_Adjustments</table_name>
 <xls_file>LA_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ la_result.has_nexus true beq
 <relative_path>LA_corp.xlsx</relative_path>
 <file_name>LA_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:15f90dcf3e2437b551fc409215cd1e8a5647b7a116824613def51bab1570a887</source_hash>
 </source>
 <table_name>Calculate_LA_State_Tax</table_name>
 <xls_file>LA_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/MA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/MA_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MA_corp.xlsx</relative_path>
 <file_name>MA_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:6a8451685c5970561e5b092b30286c29e08a7b47a97cac8af408e4eb8ad0fbdd</source_hash>
 </source>
 <table_name>Determine_MA_Filing_Requirement</table_name>
 <xls_file>MA_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ false cvb /ma_result.has_nexus xdef 0.0 cvd /ma_result.tax_liability xdef
 <relative_path>MA_corp.xlsx</relative_path>
 <file_name>MA_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:6a8451685c5970561e5b092b30286c29e08a7b47a97cac8af408e4eb8ad0fbdd</source_hash>
 </source>
 <table_name>Calculate_MA_Income_Adjustments</table_name>
 <xls_file>MA_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ ma_result.has_nexus true beq
 <relative_path>MA_corp.xlsx</relative_path>
 <file_name>MA_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:6a8451685c5970561e5b092b30286c29e08a7b47a97cac8af408e4eb8ad0fbdd</source_hash>
 </source>
 <table_name>Calculate_MA_State_Tax</table_name>
 <xls_file>MA_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/MD_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/MD_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MD_corp.xlsx</relative_path>
 <file_name>MD_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:7aaea2e4f54a8b66652f465dd5bdf08661cd11ce4a95a39765c3362b312a0d52</source_hash>
 </source>
 <table_name>Determine_MD_Filing_Requirement</table_name>
 <xls_file>MD_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ false cvb /md_result.has_nexus xdef 0.0 cvd /md_result.tax_liability xdef
 <relative_path>MD_corp.xlsx</relative_path>
 <file_name>MD_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:7aaea2e4f54a8b66652f465dd5bdf08661cd11ce4a95a39765c3362b312a0d52</source_hash>
 </source>
 <table_name>Calculate_MD_Income_Adjustments</table_name>
 <xls_file>MD_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ md_result.has_nexus true beq
 <relative_path>MD_corp.xlsx</relative_path>
 <file_name>MD_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:7aaea2e4f54a8b66652f465dd5bdf08661cd11ce4a95a39765c3362b312a0d52</source_hash>
 </source>
 <table_name>Calculate_MD_State_Tax</table_name>
 <xls_file>MD_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/ME_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/ME_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>ME_corp.xlsx</relative_path>
 <file_name>ME_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:280afa06928694a8167aadc72883e392ddc09c29cf3026e321e3074f1186661a</source_hash>
 </source>
 <table_name>Determine_ME_Filing_Requirement</table_name>
 <xls_file>ME_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ false cvb /me_result.has_nexus xdef 0.0 cvd /me_result.tax_liability xdef
 <relative_path>ME_corp.xlsx</relative_path>
 <file_name>ME_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:280afa06928694a8167aadc72883e392ddc09c29cf3026e321e3074f1186661a</source_hash>
 </source>
 <table_name>Calculate_ME_Income_Adjustments</table_name>
 <xls_file>ME_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ me_result.has_nexus true beq
 <relative_path>ME_corp.xlsx</relative_path>
 <file_name>ME_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:280afa06928694a8167aadc72883e392ddc09c29cf3026e321e3074f1186661a</source_hash>
 </source>
 <table_name>Calculate_ME_State_Tax</table_name>
 <xls_file>ME_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/MI_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/MI_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MI_corp.xlsx</relative_path>
 <file_name>MI_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:d66588572ef2295004651819e86f63d29818e32ddd7e9fca95bdeb5ff8327423</source_hash>
 </source>
 <table_name>Determine_MI_Filing_Requirement</table_name>
 <xls_file>MI_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ false cvb /mi_result.has_nexus xdef 0.0 cvd /mi_result.tax_liability xdef
 <relative_path>MI_corp.xlsx</relative_path>
 <file_name>MI_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:d66588572ef2295004651819e86f63d29818e32ddd7e9fca95bdeb5ff8327423</source_hash>
 </source>
 <table_name>Calculate_MI_Income_Adjustments</table_name>
 <xls_file>MI_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ mi_result.has_nexus true beq
 <relative_path>MI_corp.xlsx</relative_path>
 <file_name>MI_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:d66588572ef2295004651819e86f63d29818e32ddd7e9fca95bdeb5ff8327423</source_hash>
 </source>
 <table_name>Calculate_MI_State_Tax</table_name>
 <xls_file>MI_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/MN_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/MN_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MN_corp.xlsx</relative_path>
 <file_name>MN_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:732bcde6f03703242c0fcc1ab46213b1f26cd7ff62f266b25a0d7294ebc343cd</source_hash>
 </source>
 <table_name>Determine_MN_Filing_Requirement</table_name>
 <xls_file>MN_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ false cvb /mn_result.has_nexus xdef 0.0 cvd /mn_result.tax_liability xdef
 <relative_path>MN_corp.xlsx</relative_path>
 <file_name>MN_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:732bcde6f03703242c0fcc1ab46213b1f26cd7ff62f266b25a0d7294ebc343cd</source_hash>
 </source>
 <table_name>Calculate_MN_Income_Adjustments</table_name>
 <xls_file>MN_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ mn_result.has_nexus true beq
 <relative_path>MN_corp.xlsx</relative_path>
 <file_name>MN_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:732bcde6f03703242c0fcc1ab46213b1f26cd7ff62f266b25a0d7294ebc343cd</source_hash>
 </source>
 <table_name>Calculate_MN_State_Tax</table_name>
 <xls_file>MN_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/MO_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/MO_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MO_corp.xlsx</relative_path>
 <file_name>MO_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:db233d0384a4419f4550f721c6335d55cc26d18aa410f63105042d1a2d13b1f1</source_hash>
 </source>
 <table_name>Determine_MO_Filing_Requirement</table_name>
 <xls_file>MO_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ false cvb /mo_result.has_nexus xdef 0.0 cvd /mo_result.tax_liability xdef
 <relative_path>MO_corp.xlsx</relative_path>
 <file_name>MO_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:db233d0384a4419f4550f721c6335d55cc26d18aa410f63105042d1a2d13b1f1</source_hash>
 </source>
 <table_name>Calculate_MO_Income_Adjustments</table_name>
 <xls_file>MO_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ mo_result.has_nexus true beq
 <relative_path>MO_corp.xlsx</relative_path>
 <file_name>MO_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:db233d0384a4419f4550f721c6335d55cc26d18aa410f63105042d1a2d13b1f1</source_hash>
 </source>
 <table_name>Calculate_MO_State_Tax</table_name>
 <xls_file>MO_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/MS_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/MS_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MS_corp.xlsx</relative_path>
 <file_name>MS_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:4eed4e1c1106f20f5a8a360221ad8a1f2c1c98e7a35fd5c86a63b43471bb38a9</source_hash>
 </source>
 <table_name>Determine_MS_Filing_Requirement</table_name>
 <xls_file>MS_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ false cvb /ms_result.has_nexus xdef 0.0 cvd /ms_result.tax_liability xdef
 <relative_path>MS_corp.xlsx</relative_path>
 <file_name>MS_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:4eed4e1c1106f20f5a8a360221ad8a1f2c1c98e7a35fd5c86a63b43471bb38a9</source_hash>
 </source>
 <table_name>Calculate_MS_Income_Adjustments</table_name>
 <xls_file>MS_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ ms_result.has_nexus true beq
 <relative_path>MS_corp.xlsx</relative_path>
 <file_name>MS_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:4eed4e1c1106f20f5a8a360221ad8a1f2c1c98e7a35fd5c86a63b43471bb38a9</source_hash>
 </source>
 <table_name>Calculate_MS_State_Tax</table_name>
 <xls_file>MS_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/MT_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/MT_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MT_corp.xlsx</relative_path>
 <file_name>MT_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:b33bb78f3d5ab02acd5a7e9a57fb3c60ee64e583352f02edcaac236150242eb3</source_hash>
 </source>
 <table_name>Determine_MT_Filing_Requirement</table_name>
 <xls_file>MT_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ false cvb /mt_result.has_nexus xdef 0.0 cvd /mt_result.tax_liability xdef
 <relative_path>MT_corp.xlsx</relative_path>
 <file_name>MT_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:b33bb78f3d5ab02acd5a7e9a57fb3c60ee64e583352f02edcaac236150242eb3</source_hash>
 </source>
 <table_name>Calculate_MT_Income_Adjustments</table_name>
 <xls_file>MT_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ mt_result.has_nexus true beq
 <relative_path>MT_corp.xlsx</relative_path>
 <file_name>MT_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:b33bb78f3d5ab02acd5a7e9a57fb3c60ee64e583352f02edcaac236150242eb3</source_hash>
 </source>
 <table_name>Calculate_MT_State_Tax</table_name>
 <xls_file>MT_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/NC_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NC_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>NC_corp.xlsx</relative_path>
 <file_name>NC_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:c71fa6d4c13a8a5bceb4fcc7ba633aa5024247a4ccbd7203fd98e15a49c596d1</source_hash>
 </source>
 <table_name>Determine_NC_Filing_Requirement</table_name>
 <xls_file>NC_corp.xlsx</xls_file>
@@ -71,6 +72,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "NC" st
 <relative_path>NC_corp.xlsx</relative_path>
 <file_name>NC_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:c71fa6d4c13a8a5bceb4fcc7ba633aa5024247a4ccbd7203fd98e15a49c596d1</source_hash>
 </source>
 <table_name>Calculate_NC_Income_Adjustments</table_name>
 <xls_file>NC_corp.xlsx</xls_file>
@@ -121,6 +123,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>NC_corp.xlsx</relative_path>
 <file_name>NC_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:c71fa6d4c13a8a5bceb4fcc7ba633aa5024247a4ccbd7203fd98e15a49c596d1</source_hash>
 </source>
 <table_name>Calculate_NC_State_Tax</table_name>
 <xls_file>NC_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/ND_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/ND_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>ND_corp.xlsx</relative_path>
 <file_name>ND_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:c3e8ebd7edfc40a6351de9c1ddbec1fa74c8b37f6ff6fd36f5eac67ee84412d4</source_hash>
 </source>
 <table_name>Determine_ND_Filing_Requirement</table_name>
 <xls_file>ND_corp.xlsx</xls_file>
@@ -71,6 +72,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "ND" st
 <relative_path>ND_corp.xlsx</relative_path>
 <file_name>ND_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:c3e8ebd7edfc40a6351de9c1ddbec1fa74c8b37f6ff6fd36f5eac67ee84412d4</source_hash>
 </source>
 <table_name>Calculate_ND_Income_Adjustments</table_name>
 <xls_file>ND_corp.xlsx</xls_file>
@@ -121,6 +123,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>ND_corp.xlsx</relative_path>
 <file_name>ND_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:c3e8ebd7edfc40a6351de9c1ddbec1fa74c8b37f6ff6fd36f5eac67ee84412d4</source_hash>
 </source>
 <table_name>Calculate_ND_State_Tax</table_name>
 <xls_file>ND_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/NE_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NE_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>NE_corp.xlsx</relative_path>
 <file_name>NE_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:b7f8e6e67adb8509176452cc2c909eb50ab40745b447d99da00b2748f93b46a0</source_hash>
 </source>
 <table_name>Determine_NE_Filing_Requirement</table_name>
 <xls_file>NE_corp.xlsx</xls_file>
@@ -71,6 +72,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "NE" st
 <relative_path>NE_corp.xlsx</relative_path>
 <file_name>NE_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:b7f8e6e67adb8509176452cc2c909eb50ab40745b447d99da00b2748f93b46a0</source_hash>
 </source>
 <table_name>Calculate_NE_Income_Adjustments</table_name>
 <xls_file>NE_corp.xlsx</xls_file>
@@ -121,6 +123,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>NE_corp.xlsx</relative_path>
 <file_name>NE_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:b7f8e6e67adb8509176452cc2c909eb50ab40745b447d99da00b2748f93b46a0</source_hash>
 </source>
 <table_name>Calculate_NE_State_Tax</table_name>
 <xls_file>NE_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/NH_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NH_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>NH_corp.xlsx</relative_path>
 <file_name>NH_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:448f3cdcd0031580366993848a979d5613c13c31495b9e1053c764a388bcda18</source_hash>
 </source>
 <table_name>Determine_NH_Filing_Requirement</table_name>
 <xls_file>NH_corp.xlsx</xls_file>
@@ -71,6 +72,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "NH" st
 <relative_path>NH_corp.xlsx</relative_path>
 <file_name>NH_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:448f3cdcd0031580366993848a979d5613c13c31495b9e1053c764a388bcda18</source_hash>
 </source>
 <table_name>Calculate_NH_Income_Adjustments</table_name>
 <xls_file>NH_corp.xlsx</xls_file>
@@ -121,6 +123,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>NH_corp.xlsx</relative_path>
 <file_name>NH_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:448f3cdcd0031580366993848a979d5613c13c31495b9e1053c764a388bcda18</source_hash>
 </source>
 <table_name>Calculate_NH_State_Tax</table_name>
 <xls_file>NH_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/NJ_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NJ_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>NJ_corp.xlsx</relative_path>
 <file_name>NJ_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:b2378eb33d11c01028ca3b50258070cb0150bc6ac76e1f9ddc3792cc62e77525</source_hash>
 </source>
 <table_name>Determine_NJ_Filing_Requirement</table_name>
 <xls_file>NJ_corp.xlsx</xls_file>
@@ -84,6 +85,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "NJ" st
 <relative_path>NJ_corp.xlsx</relative_path>
 <file_name>NJ_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:b2378eb33d11c01028ca3b50258070cb0150bc6ac76e1f9ddc3792cc62e77525</source_hash>
 </source>
 <table_name>Calculate_NJ_Income_Adjustments</table_name>
 <xls_file>NJ_corp.xlsx</xls_file>
@@ -143,6 +145,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>NJ_corp.xlsx</relative_path>
 <file_name>NJ_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:b2378eb33d11c01028ca3b50258070cb0150bc6ac76e1f9ddc3792cc62e77525</source_hash>
 </source>
 <table_name>Calculate_NJ_State_Tax</table_name>
 <xls_file>NJ_corp.xlsx</xls_file>
@@ -224,6 +227,7 @@ apportionment.state_taxable_income nj_apportionment.state_tax_rate fmul apportio
 <relative_path>NJ_corp.xlsx</relative_path>
 <file_name>NJ_corp.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:b2378eb33d11c01028ca3b50258070cb0150bc6ac76e1f9ddc3792cc62e77525</source_hash>
 </source>
 <table_name>Calculate_NJ_Surtax</table_name>
 <xls_file>NJ_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/NM_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NM_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>NM_corp.xlsx</relative_path>
 <file_name>NM_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:144c73a9efb4ce6c51b8f2aa0fdf0fce12ff9a30209c0c86340a85943430e80a</source_hash>
 </source>
 <table_name>Determine_NM_Filing_Requirement</table_name>
 <xls_file>NM_corp.xlsx</xls_file>
@@ -71,6 +72,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "NM" st
 <relative_path>NM_corp.xlsx</relative_path>
 <file_name>NM_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:144c73a9efb4ce6c51b8f2aa0fdf0fce12ff9a30209c0c86340a85943430e80a</source_hash>
 </source>
 <table_name>Calculate_NM_Income_Adjustments</table_name>
 <xls_file>NM_corp.xlsx</xls_file>
@@ -121,6 +123,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>NM_corp.xlsx</relative_path>
 <file_name>NM_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:144c73a9efb4ce6c51b8f2aa0fdf0fce12ff9a30209c0c86340a85943430e80a</source_hash>
 </source>
 <table_name>Calculate_NM_State_Tax</table_name>
 <xls_file>NM_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/NV_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NV_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>NV_corp.xlsx</relative_path>
 <file_name>NV_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:65be8e333bc1a9910dcd72d32035fa0f93a9bee470a924e5ab6b7d07e395d630</source_hash>
 </source>
 <table_name>Determine_NV_Filing_Requirement</table_name>
 <xls_file>NV_corp.xlsx</xls_file>
@@ -98,6 +99,7 @@ true cvb /nv_result.qualifies_for_exemption xdef 0.0 cvd /nv_result.commerce_tax
 <relative_path>NV_corp.xlsx</relative_path>
 <file_name>NV_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:65be8e333bc1a9910dcd72d32035fa0f93a9bee470a924e5ab6b7d07e395d630</source_hash>
 </source>
 <table_name>Calculate_NV_Income_Adjustments</table_name>
 <xls_file>NV_corp.xlsx</xls_file>
@@ -148,6 +150,7 @@ result.has_physical_presence_nv { pop nv_result.gross_revenue result.nv_economic
 <relative_path>NV_corp.xlsx</relative_path>
 <file_name>NV_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:65be8e333bc1a9910dcd72d32035fa0f93a9bee470a924e5ab6b7d07e395d630</source_hash>
 </source>
 <table_name>Determine_NV_Business_Classification</table_name>
 <xls_file>NV_corp.xlsx</xls_file>
@@ -311,6 +314,7 @@ nv_result.other_rate cvd /nv_result.commerce_tax_rate xdef
 <relative_path>NV_corp.xlsx</relative_path>
 <file_name>NV_corp.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:65be8e333bc1a9910dcd72d32035fa0f93a9bee470a924e5ab6b7d07e395d630</source_hash>
 </source>
 <table_name>Calculate_NV_Sitused_Revenue</table_name>
 <xls_file>NV_corp.xlsx</xls_file>
@@ -384,6 +388,7 @@ result.total_revenue cvd /nv_result.sitused_revenue xdef result.total_revenue cv
 <relative_path>NV_corp.xlsx</relative_path>
 <file_name>NV_corp.xlsx</file_name>
 <sheet_number>5</sheet_number>
+<source_hash>sha256:65be8e333bc1a9910dcd72d32035fa0f93a9bee470a924e5ab6b7d07e395d630</source_hash>
 </source>
 <table_name>Calculate_NV_State_Tax</table_name>
 <xls_file>NV_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/NY_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/NY_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>NY_corp.xlsx</relative_path>
 <file_name>NY_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:ee0db94156e3ec838b6e9f8ad00f695f4614edae1658ae93011b6be14cf7d7eb</source_hash>
 </source>
 <table_name>Determine_NY_Filing_Requirement</table_name>
 <xls_file>NY_corp.xlsx</xls_file>
@@ -71,6 +72,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "NY" st
 <relative_path>NY_corp.xlsx</relative_path>
 <file_name>NY_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:ee0db94156e3ec838b6e9f8ad00f695f4614edae1658ae93011b6be14cf7d7eb</source_hash>
 </source>
 <table_name>Calculate_NY_Income_Adjustments</table_name>
 <xls_file>NY_corp.xlsx</xls_file>
@@ -121,6 +123,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>NY_corp.xlsx</relative_path>
 <file_name>NY_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:ee0db94156e3ec838b6e9f8ad00f695f4614edae1658ae93011b6be14cf7d7eb</source_hash>
 </source>
 <table_name>Calculate_NY_State_Tax</table_name>
 <xls_file>NY_corp.xlsx</xls_file>
@@ -189,6 +192,7 @@ apportionment.state_taxable_income ny_apportionment.state_tax_rate fmul apportio
 <relative_path>NY_corp.xlsx</relative_path>
 <file_name>NY_corp.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:ee0db94156e3ec838b6e9f8ad00f695f4614edae1658ae93011b6be14cf7d7eb</source_hash>
 </source>
 <table_name>Calculate_NY_MTA_Surcharge</table_name>
 <xls_file>NY_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/OH_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/OH_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>OH_corp.xlsx</relative_path>
 <file_name>OH_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:ab43db0d375131e9a09e3319bb7294111e7fa4a365b2e4a8579b28b02881669d</source_hash>
 </source>
 <table_name>Determine_OH_Filing_Requirement</table_name>
 <xls_file>OH_corp.xlsx</xls_file>
@@ -93,6 +94,7 @@ true cvb /oh_result.qualifies_for_no_cat xdef 0.0 cvd /oh_result.cat_tax xdef 0.
 <relative_path>OH_corp.xlsx</relative_path>
 <file_name>OH_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:ab43db0d375131e9a09e3319bb7294111e7fa4a365b2e4a8579b28b02881669d</source_hash>
 </source>
 <table_name>Calculate_OH_Taxable_Gross_Receipts</table_name>
 <xls_file>OH_corp.xlsx</xls_file>
@@ -159,6 +161,7 @@ oh_result.taxable_gross_receipts oh_result.cat_excluded_receipts f- 0.0 fmax cvd
 <relative_path>OH_corp.xlsx</relative_path>
 <file_name>OH_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:ab43db0d375131e9a09e3319bb7294111e7fa4a365b2e4a8579b28b02881669d</source_hash>
 </source>
 <table_name>Calculate_OH_CAT</table_name>
 <xls_file>OH_corp.xlsx</xls_file>
@@ -245,6 +248,7 @@ oh_result.cat_minimum_tax cvd /oh_result.cat_tax xdef oh_result.cat_tax cvd /app
 <relative_path>OH_corp.xlsx</relative_path>
 <file_name>OH_corp.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:ab43db0d375131e9a09e3319bb7294111e7fa4a365b2e4a8579b28b02881669d</source_hash>
 </source>
 <table_name>Calculate_OH_Income_Adjustments</table_name>
 <xls_file>OH_corp.xlsx</xls_file>
@@ -286,6 +290,7 @@ apportionment.state_code "OH" streq
 <relative_path>OH_corp.xlsx</relative_path>
 <file_name>OH_corp.xlsx</file_name>
 <sheet_number>5</sheet_number>
+<source_hash>sha256:ab43db0d375131e9a09e3319bb7294111e7fa4a365b2e4a8579b28b02881669d</source_hash>
 </source>
 <table_name>Calculate_OH_State_Tax</table_name>
 <xls_file>OH_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/OK_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/OK_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>OK_corp.xlsx</relative_path>
 <file_name>OK_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:1513afeaa7b2b1577e386ef6f5f17402334cf7aeacd3cf9ed085d330784fa6df</source_hash>
 </source>
 <table_name>Determine_OK_Filing_Requirement</table_name>
 <xls_file>OK_corp.xlsx</xls_file>
@@ -71,6 +72,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code 'OK' st
 <relative_path>OK_corp.xlsx</relative_path>
 <file_name>OK_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:1513afeaa7b2b1577e386ef6f5f17402334cf7aeacd3cf9ed085d330784fa6df</source_hash>
 </source>
 <table_name>Calculate_OK_Income_Adjustments</table_name>
 <xls_file>OK_corp.xlsx</xls_file>
@@ -121,6 +123,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>OK_corp.xlsx</relative_path>
 <file_name>OK_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:1513afeaa7b2b1577e386ef6f5f17402334cf7aeacd3cf9ed085d330784fa6df</source_hash>
 </source>
 <table_name>Calculate_OK_State_Tax</table_name>
 <xls_file>OK_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/OR_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/OR_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>OR_corp.xlsx</relative_path>
 <file_name>OR_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:64fcc6c15f8d53efe10407c6210f6d708a3120da94436d891de586cb1bc423b9</source_hash>
 </source>
 <table_name>Determine_OR_Filing_Requirement</table_name>
 <xls_file>OR_corp.xlsx</xls_file>
@@ -84,6 +85,7 @@ apportionment.has_economic_nexus true beq { pop state_code 'OR' streq } over if
 <relative_path>OR_corp.xlsx</relative_path>
 <file_name>OR_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:64fcc6c15f8d53efe10407c6210f6d708a3120da94436d891de586cb1bc423b9</source_hash>
 </source>
 <table_name>Calculate_OR_Income_Adjustments</table_name>
 <xls_file>OR_corp.xlsx</xls_file>
@@ -143,6 +145,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>OR_corp.xlsx</relative_path>
 <file_name>OR_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:64fcc6c15f8d53efe10407c6210f6d708a3120da94436d891de586cb1bc423b9</source_hash>
 </source>
 <table_name>Calculate_OR_State_Tax</table_name>
 <xls_file>OR_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/PA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/PA_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>PA_corp.xlsx</relative_path>
 <file_name>PA_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:ea460d94e2334dd0f9dffffd1968be1a518da5a68ad4fb30675e53605c6a2d81</source_hash>
 </source>
 <table_name>Determine_PA_Filing_Requirement</table_name>
 <xls_file>PA_corp.xlsx</xls_file>
@@ -75,6 +76,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "PA" st
 <relative_path>PA_corp.xlsx</relative_path>
 <file_name>PA_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:ea460d94e2334dd0f9dffffd1968be1a518da5a68ad4fb30675e53605c6a2d81</source_hash>
 </source>
 <table_name>Calculate_PA_Income_Adjustments</table_name>
 <xls_file>PA_corp.xlsx</xls_file>
@@ -125,6 +127,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>PA_corp.xlsx</relative_path>
 <file_name>PA_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:ea460d94e2334dd0f9dffffd1968be1a518da5a68ad4fb30675e53605c6a2d81</source_hash>
 </source>
 <table_name>Calculate_PA_State_Tax</table_name>
 <xls_file>PA_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/RI_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/RI_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>RI_corp.xlsx</relative_path>
 <file_name>RI_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:cca035220e585d842185ee6574be17443369aad755791a4cfa864362d6359342</source_hash>
 </source>
 <table_name>Determine_RI_Filing_Requirement</table_name>
 <xls_file>RI_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "RI" st
 <relative_path>RI_corp.xlsx</relative_path>
 <file_name>RI_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:cca035220e585d842185ee6574be17443369aad755791a4cfa864362d6359342</source_hash>
 </source>
 <table_name>Calculate_RI_Income_Adjustments</table_name>
 <xls_file>RI_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>RI_corp.xlsx</relative_path>
 <file_name>RI_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:cca035220e585d842185ee6574be17443369aad755791a4cfa864362d6359342</source_hash>
 </source>
 <table_name>Calculate_RI_State_Tax</table_name>
 <xls_file>RI_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/SC_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/SC_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>SC_corp.xlsx</relative_path>
 <file_name>SC_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:51c5de1ec4bdd9a73c2008faa71abd9b55a204b90edfbd0f79d2adf245dee755</source_hash>
 </source>
 <table_name>Determine_SC_Filing_Requirement</table_name>
 <xls_file>SC_corp.xlsx</xls_file>
@@ -75,6 +76,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "SC" st
 <relative_path>SC_corp.xlsx</relative_path>
 <file_name>SC_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:51c5de1ec4bdd9a73c2008faa71abd9b55a204b90edfbd0f79d2adf245dee755</source_hash>
 </source>
 <table_name>Calculate_SC_Income_Adjustments</table_name>
 <xls_file>SC_corp.xlsx</xls_file>
@@ -125,6 +127,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>SC_corp.xlsx</relative_path>
 <file_name>SC_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:51c5de1ec4bdd9a73c2008faa71abd9b55a204b90edfbd0f79d2adf245dee755</source_hash>
 </source>
 <table_name>Calculate_SC_State_Tax</table_name>
 <xls_file>SC_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/SD_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/SD_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>SD_corp.xlsx</relative_path>
 <file_name>SD_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:68aa92d712a1ae25d7c4a517272e05d89dc5967721df1d1e4c3139031aff8956</source_hash>
 </source>
 <table_name>Determine_SD_Filing_Requirement</table_name>
 <xls_file>SD_corp.xlsx</xls_file>
@@ -84,6 +85,7 @@ sd_result.insurance_premium_tax cvd /apportionment.state_tax xdef 0.0 cvd /sd_ap
 <relative_path>SD_corp.xlsx</relative_path>
 <file_name>SD_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:68aa92d712a1ae25d7c4a517272e05d89dc5967721df1d1e4c3139031aff8956</source_hash>
 </source>
 <table_name>Calculate_SD_Income_Adjustments</table_name>
 <xls_file>SD_corp.xlsx</xls_file>
@@ -134,6 +136,7 @@ sd_result.is_financial_institution false beq { pop sd_result.is_insurance_compan
 <relative_path>SD_corp.xlsx</relative_path>
 <file_name>SD_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:68aa92d712a1ae25d7c4a517272e05d89dc5967721df1d1e4c3139031aff8956</source_hash>
 </source>
 <table_name>Calculate_SD_State_Tax</table_name>
 <xls_file>SD_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/TN_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/TN_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>TN_corp.xlsx</relative_path>
 <file_name>TN_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:31c5c00a0bceb63cff1bd754760650b0e2a0095e96a6cf7b235d6c5ad365752b</source_hash>
 </source>
 <table_name>Determine_TN_Filing_Requirement</table_name>
 <xls_file>TN_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "TN" st
 <relative_path>TN_corp.xlsx</relative_path>
 <file_name>TN_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:31c5c00a0bceb63cff1bd754760650b0e2a0095e96a6cf7b235d6c5ad365752b</source_hash>
 </source>
 <table_name>Calculate_TN_Income_Adjustments</table_name>
 <xls_file>TN_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>TN_corp.xlsx</relative_path>
 <file_name>TN_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:31c5c00a0bceb63cff1bd754760650b0e2a0095e96a6cf7b235d6c5ad365752b</source_hash>
 </source>
 <table_name>Calculate_TN_Franchise_Tax</table_name>
 <xls_file>TN_corp.xlsx</xls_file>
@@ -208,6 +211,7 @@ tn_result.net_worth tn_result.franchise_tax_rate fmul cvd /tn_result.franchise_t
 <relative_path>TN_corp.xlsx</relative_path>
 <file_name>TN_corp.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:31c5c00a0bceb63cff1bd754760650b0e2a0095e96a6cf7b235d6c5ad365752b</source_hash>
 </source>
 <table_name>Calculate_TN_Excise_Tax</table_name>
 <xls_file>TN_corp.xlsx</xls_file>
@@ -281,6 +285,7 @@ apportionment.state_taxable_income tn_apportionment.state_tax_rate fmul cvd /tn_
 <relative_path>TN_corp.xlsx</relative_path>
 <file_name>TN_corp.xlsx</file_name>
 <sheet_number>5</sheet_number>
+<source_hash>sha256:31c5c00a0bceb63cff1bd754760650b0e2a0095e96a6cf7b235d6c5ad365752b</source_hash>
 </source>
 <table_name>Calculate_TN_State_Tax</table_name>
 <xls_file>TN_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/TX_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/TX_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>TX_corp.xlsx</relative_path>
 <file_name>TX_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:cb8624ebb7634ccf819b6ebb7f864c437722835f11141c71a1ef28df9a1186e2</source_hash>
 </source>
 <table_name>Determine_TX_Filing_Requirement</table_name>
 <xls_file>TX_corp.xlsx</xls_file>
@@ -93,6 +94,7 @@ true cvb /tx_result.qualifies_for_no_tax_due xdef 0.0 cvd /tx_result.franchise_t
 <relative_path>TX_corp.xlsx</relative_path>
 <file_name>TX_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:cb8624ebb7634ccf819b6ebb7f864c437722835f11141c71a1ef28df9a1186e2</source_hash>
 </source>
 <table_name>Determine_TX_Deduction_Method</table_name>
 <xls_file>TX_corp.xlsx</xls_file>
@@ -170,6 +172,7 @@ tx_result.cogs tx_result.compensation f&gt;
 <relative_path>TX_corp.xlsx</relative_path>
 <file_name>TX_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:cb8624ebb7634ccf819b6ebb7f864c437722835f11141c71a1ef28df9a1186e2</source_hash>
 </source>
 <table_name>Calculate_TX_Margin</table_name>
 <xls_file>TX_corp.xlsx</xls_file>
@@ -238,6 +241,7 @@ false cvb /tx_result.qualifies_for_ez_computation xdef tx_result.total_revenue t
 <relative_path>TX_corp.xlsx</relative_path>
 <file_name>TX_corp.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:cb8624ebb7634ccf819b6ebb7f864c437722835f11141c71a1ef28df9a1186e2</source_hash>
 </source>
 <table_name>Calculate_TX_Franchise_Tax</table_name>
 <xls_file>TX_corp.xlsx</xls_file>
@@ -342,6 +346,7 @@ tx_result.total_revenue tx_result.no_tax_due_threshold f- 0.0 fmax tx_result.ez_
 <relative_path>TX_corp.xlsx</relative_path>
 <file_name>TX_corp.xlsx</file_name>
 <sheet_number>5</sheet_number>
+<source_hash>sha256:cb8624ebb7634ccf819b6ebb7f864c437722835f11141c71a1ef28df9a1186e2</source_hash>
 </source>
 <table_name>Calculate_TX_Income_Adjustments</table_name>
 <xls_file>TX_corp.xlsx</xls_file>
@@ -392,6 +397,7 @@ apportionment.state_code "TX" streq
 <relative_path>TX_corp.xlsx</relative_path>
 <file_name>TX_corp.xlsx</file_name>
 <sheet_number>6</sheet_number>
+<source_hash>sha256:cb8624ebb7634ccf819b6ebb7f864c437722835f11141c71a1ef28df9a1186e2</source_hash>
 </source>
 <table_name>Calculate_TX_State_Tax</table_name>
 <xls_file>TX_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/UT_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/UT_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>UT_corp.xlsx</relative_path>
 <file_name>UT_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:dc62bc77874e76c32fc7fd2eb5aa6522b3d299dbe2277355dd3372ba32d5e4b7</source_hash>
 </source>
 <table_name>Determine_UT_Filing_Requirement</table_name>
 <xls_file>UT_corp.xlsx</xls_file>
@@ -75,6 +76,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "UT" st
 <relative_path>UT_corp.xlsx</relative_path>
 <file_name>UT_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:dc62bc77874e76c32fc7fd2eb5aa6522b3d299dbe2277355dd3372ba32d5e4b7</source_hash>
 </source>
 <table_name>Calculate_UT_Income_Adjustments</table_name>
 <xls_file>UT_corp.xlsx</xls_file>
@@ -125,6 +127,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>UT_corp.xlsx</relative_path>
 <file_name>UT_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:dc62bc77874e76c32fc7fd2eb5aa6522b3d299dbe2277355dd3372ba32d5e4b7</source_hash>
 </source>
 <table_name>Calculate_UT_State_Tax</table_name>
 <xls_file>UT_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/VA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/VA_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>VA_corp.xlsx</relative_path>
 <file_name>VA_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:6ebcdf1eefc1ff1a36ad713f9aae19e462d49a9f46385b45ae66de021e38b302</source_hash>
 </source>
 <table_name>Determine_VA_Filing_Requirement</table_name>
 <xls_file>VA_corp.xlsx</xls_file>
@@ -75,6 +76,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "VA" st
 <relative_path>VA_corp.xlsx</relative_path>
 <file_name>VA_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:6ebcdf1eefc1ff1a36ad713f9aae19e462d49a9f46385b45ae66de021e38b302</source_hash>
 </source>
 <table_name>Calculate_VA_Income_Adjustments</table_name>
 <xls_file>VA_corp.xlsx</xls_file>
@@ -125,6 +127,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>VA_corp.xlsx</relative_path>
 <file_name>VA_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:6ebcdf1eefc1ff1a36ad713f9aae19e462d49a9f46385b45ae66de021e38b302</source_hash>
 </source>
 <table_name>Calculate_VA_State_Tax</table_name>
 <xls_file>VA_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/VT_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/VT_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>VT_corp.xlsx</relative_path>
 <file_name>VT_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:dfe280f24ff2b299d2397260a6f2523070c6fdf1e17079091ed2b83ea0d2e4d0</source_hash>
 </source>
 <table_name>Determine_VT_Filing_Requirement</table_name>
 <xls_file>VT_corp.xlsx</xls_file>
@@ -75,6 +76,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "VT" st
 <relative_path>VT_corp.xlsx</relative_path>
 <file_name>VT_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:dfe280f24ff2b299d2397260a6f2523070c6fdf1e17079091ed2b83ea0d2e4d0</source_hash>
 </source>
 <table_name>Calculate_VT_Income_Adjustments</table_name>
 <xls_file>VT_corp.xlsx</xls_file>
@@ -125,6 +127,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>VT_corp.xlsx</relative_path>
 <file_name>VT_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:dfe280f24ff2b299d2397260a6f2523070c6fdf1e17079091ed2b83ea0d2e4d0</source_hash>
 </source>
 <table_name>Calculate_VT_State_Tax</table_name>
 <xls_file>VT_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/WA_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/WA_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>WA_corp.xlsx</relative_path>
 <file_name>WA_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:1b2c3af42d92cc6aed998d69ac10bac424f739913061167cb68dff0e6020c86e</source_hash>
 </source>
 <table_name>Determine_WA_Filing_Requirement</table_name>
 <xls_file>WA_corp.xlsx</xls_file>
@@ -75,6 +76,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "WA" st
 <relative_path>WA_corp.xlsx</relative_path>
 <file_name>WA_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:1b2c3af42d92cc6aed998d69ac10bac424f739913061167cb68dff0e6020c86e</source_hash>
 </source>
 <table_name>Calculate_WA_Gross_Receipts</table_name>
 <xls_file>WA_corp.xlsx</xls_file>
@@ -143,6 +145,7 @@ revenue.total_revenue cvd /wa_result.gross_receipts xdef "No apportionment perce
 <relative_path>WA_corp.xlsx</relative_path>
 <file_name>WA_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:1b2c3af42d92cc6aed998d69ac10bac424f739913061167cb68dff0e6020c86e</source_hash>
 </source>
 <table_name>Determine_WA_Business_Classification</table_name>
 <xls_file>WA_corp.xlsx</xls_file>
@@ -229,6 +232,7 @@ wa_result.service_rate cvd /wa_result.bo_tax_rate xdef "Washington B&amp;O tax -
 <relative_path>WA_corp.xlsx</relative_path>
 <file_name>WA_corp.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:1b2c3af42d92cc6aed998d69ac10bac424f739913061167cb68dff0e6020c86e</source_hash>
 </source>
 <table_name>Calculate_WA_Small_Business_Credit</table_name>
 <xls_file>WA_corp.xlsx</xls_file>
@@ -297,6 +301,7 @@ false cvb /wa_result.qualifies_for_small_business_credit xdef 0.0 cvd /wa_result
 <relative_path>WA_corp.xlsx</relative_path>
 <file_name>WA_corp.xlsx</file_name>
 <sheet_number>5</sheet_number>
+<source_hash>sha256:1b2c3af42d92cc6aed998d69ac10bac424f739913061167cb68dff0e6020c86e</source_hash>
 </source>
 <table_name>Calculate_WA_BO_Tax</table_name>
 <xls_file>WA_corp.xlsx</xls_file>
@@ -365,6 +370,7 @@ wa_result.gross_receipts wa_result.bo_tax_rate fmul cvd /wa_result.bo_tax xdef w
 <relative_path>WA_corp.xlsx</relative_path>
 <file_name>WA_corp.xlsx</file_name>
 <sheet_number>6</sheet_number>
+<source_hash>sha256:1b2c3af42d92cc6aed998d69ac10bac424f739913061167cb68dff0e6020c86e</source_hash>
 </source>
 <table_name>Calculate_WA_Income_Adjustments</table_name>
 <xls_file>WA_corp.xlsx</xls_file>
@@ -415,6 +421,7 @@ apportionment.state_code "WA" streq
 <relative_path>WA_corp.xlsx</relative_path>
 <file_name>WA_corp.xlsx</file_name>
 <sheet_number>7</sheet_number>
+<source_hash>sha256:1b2c3af42d92cc6aed998d69ac10bac424f739913061167cb68dff0e6020c86e</source_hash>
 </source>
 <table_name>Calculate_WA_State_Tax</table_name>
 <xls_file>WA_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/WI_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/WI_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>WI_corp.xlsx</relative_path>
 <file_name>WI_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:bff98460500dbe2de899cc2eff303962aa61c9a659b4bb5bd28864ef49afa886</source_hash>
 </source>
 <table_name>Determine_WI_Filing_Requirement</table_name>
 <xls_file>WI_corp.xlsx</xls_file>
@@ -80,6 +81,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "WI" st
 <relative_path>WI_corp.xlsx</relative_path>
 <file_name>WI_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:bff98460500dbe2de899cc2eff303962aa61c9a659b4bb5bd28864ef49afa886</source_hash>
 </source>
 <table_name>Calculate_WI_Income_Adjustments</table_name>
 <xls_file>WI_corp.xlsx</xls_file>
@@ -135,6 +137,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>WI_corp.xlsx</relative_path>
 <file_name>WI_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:bff98460500dbe2de899cc2eff303962aa61c9a659b4bb5bd28864ef49afa886</source_hash>
 </source>
 <table_name>Calculate_WI_State_Tax</table_name>
 <xls_file>WI_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/WV_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/WV_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>WV_corp.xlsx</relative_path>
 <file_name>WV_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:8b3e7e5496d130db9f04f4430b7687fa3d8ada2e34fa6afe12384db85bc0fd80</source_hash>
 </source>
 <table_name>Determine_WV_Filing_Requirement</table_name>
 <xls_file>WV_corp.xlsx</xls_file>
@@ -75,6 +76,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.state_code "WV" st
 <relative_path>WV_corp.xlsx</relative_path>
 <file_name>WV_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:8b3e7e5496d130db9f04f4430b7687fa3d8ada2e34fa6afe12384db85bc0fd80</source_hash>
 </source>
 <table_name>Calculate_WV_Income_Adjustments</table_name>
 <xls_file>WV_corp.xlsx</xls_file>
@@ -125,6 +127,7 @@ apportionment.has_economic_nexus true beq { pop apportionment.has_physical_prese
 <relative_path>WV_corp.xlsx</relative_path>
 <file_name>WV_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:8b3e7e5496d130db9f04f4430b7687fa3d8ada2e34fa6afe12384db85bc0fd80</source_hash>
 </source>
 <table_name>Calculate_WV_State_Tax</table_name>
 <xls_file>WV_corp.xlsx</xls_file>

--- a/sampleprojects/CorporateTax/xml/states/WY_corp_dt.xml
+++ b/sampleprojects/CorporateTax/xml/states/WY_corp_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>WY_corp.xlsx</relative_path>
 <file_name>WY_corp.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:6f9531d405c90129da75db0aeee1ac30f1fe16b7d3169ba891aad652c38e0bb6</source_hash>
 </source>
 <table_name>Determine_WY_Filing_Requirement</table_name>
 <xls_file>WY_corp.xlsx</xls_file>
@@ -75,6 +76,7 @@ wy_result.annual_report_fee_foreign cvd /wy_result.annual_report_fee xdef 0.0 cv
 <relative_path>WY_corp.xlsx</relative_path>
 <file_name>WY_corp.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:6f9531d405c90129da75db0aeee1ac30f1fe16b7d3169ba891aad652c38e0bb6</source_hash>
 </source>
 <table_name>Calculate_WY_Income_Adjustments</table_name>
 <xls_file>WY_corp.xlsx</xls_file>
@@ -125,6 +127,7 @@ apportionment.has_physical_presence true beq { pop apportionment.state_code "WY"
 <relative_path>WY_corp.xlsx</relative_path>
 <file_name>WY_corp.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:6f9531d405c90129da75db0aeee1ac30f1fe16b7d3169ba891aad652c38e0bb6</source_hash>
 </source>
 <table_name>Calculate_WY_State_Tax</table_name>
 <xls_file>WY_corp.xlsx</xls_file>

--- a/sampleprojects/Cribbage/xml/Cribbage_dt.xml
+++ b/sampleprojects/Cribbage/xml/Cribbage_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>Cribbage.xlsx</relative_path>
 <file_name>Cribbage.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:3ed38101473acbfc31151c55c9555188406e62dbe6b9c3c1f89f0ce17e8de4f6</source_hash>
 </source>
 <table_name>Score_Hand</table_name>
 <xls_file>Cribbage.xlsx</xls_file>
@@ -124,6 +125,7 @@ hand.fifteen_points hand.pair_points + hand.run_points + hand.flush_points + han
 <relative_path>Cribbage.xlsx</relative_path>
 <file_name>Cribbage.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:3ed38101473acbfc31151c55c9555188406e62dbe6b9c3c1f89f0ce17e8de4f6</source_hash>
 </source>
 <table_name>Score_Runs</table_name>
 <xls_file>Cribbage.xlsx</xls_file>
@@ -179,6 +181,7 @@ hand.run_points seq.span seq.multiplicity * + cvi /hand.run_points xdef
 <relative_path>Cribbage.xlsx</relative_path>
 <file_name>Cribbage.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:3ed38101473acbfc31151c55c9555188406e62dbe6b9c3c1f89f0ce17e8de4f6</source_hash>
 </source>
 <table_name>Score_Fifteens</table_name>
 <xls_file>Cribbage.xlsx</xls_file>
@@ -234,6 +237,7 @@ combo.sum 15 ==
 <relative_path>Cribbage.xlsx</relative_path>
 <file_name>Cribbage.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:3ed38101473acbfc31151c55c9555188406e62dbe6b9c3c1f89f0ce17e8de4f6</source_hash>
 </source>
 <table_name>Score_Pairs</table_name>
 <xls_file>Cribbage.xlsx</xls_file>
@@ -333,6 +337,7 @@ grp.count 4 ==
 <relative_path>Cribbage.xlsx</relative_path>
 <file_name>Cribbage.xlsx</file_name>
 <sheet_number>5</sheet_number>
+<source_hash>sha256:3ed38101473acbfc31151c55c9555188406e62dbe6b9c3c1f89f0ce17e8de4f6</source_hash>
 </source>
 <table_name>Score_Flush</table_name>
 <xls_file>Cribbage.xlsx</xls_file>
@@ -419,6 +424,7 @@ hand.is_crib
 <relative_path>Cribbage.xlsx</relative_path>
 <file_name>Cribbage.xlsx</file_name>
 <sheet_number>6</sheet_number>
+<source_hash>sha256:3ed38101473acbfc31151c55c9555188406e62dbe6b9c3c1f89f0ce17e8de4f6</source_hash>
 </source>
 <table_name>Score_Nobs</table_name>
 <xls_file>Cribbage.xlsx</xls_file>
@@ -483,6 +489,7 @@ card.suit hand.starter_suit ==
 <relative_path>Cribbage.xlsx</relative_path>
 <file_name>Cribbage.xlsx</file_name>
 <sheet_number>7</sheet_number>
+<source_hash>sha256:3ed38101473acbfc31151c55c9555188406e62dbe6b9c3c1f89f0ce17e8de4f6</source_hash>
 </source>
 <table_name>Score_Play</table_name>
 <xls_file>Cribbage.xlsx</xls_file>
@@ -573,6 +580,7 @@ play.count_points play.pair_points + play.run_points + play.go_points + cvi /pla
 <relative_path>Cribbage.xlsx</relative_path>
 <file_name>Cribbage.xlsx</file_name>
 <sheet_number>8</sheet_number>
+<source_hash>sha256:3ed38101473acbfc31151c55c9555188406e62dbe6b9c3c1f89f0ce17e8de4f6</source_hash>
 </source>
 <table_name>Score_Play_Count</table_name>
 <xls_file>Cribbage.xlsx</xls_file>
@@ -641,6 +649,7 @@ play.count 31 ==
 <relative_path>Cribbage.xlsx</relative_path>
 <file_name>Cribbage.xlsx</file_name>
 <sheet_number>9</sheet_number>
+<source_hash>sha256:3ed38101473acbfc31151c55c9555188406e62dbe6b9c3c1f89f0ce17e8de4f6</source_hash>
 </source>
 <table_name>Score_Play_Pairs</table_name>
 <xls_file>Cribbage.xlsx</xls_file>
@@ -758,6 +767,7 @@ combo.count 2 ==
 <relative_path>Cribbage.xlsx</relative_path>
 <file_name>Cribbage.xlsx</file_name>
 <sheet_number>10</sheet_number>
+<source_hash>sha256:3ed38101473acbfc31151c55c9555188406e62dbe6b9c3c1f89f0ce17e8de4f6</source_hash>
 </source>
 <table_name>Score_Play_Runs</table_name>
 <xls_file>Cribbage.xlsx</xls_file>
@@ -840,6 +850,7 @@ combo.count cvi /play.run_points xdef
 <relative_path>Cribbage.xlsx</relative_path>
 <file_name>Cribbage.xlsx</file_name>
 <sheet_number>11</sheet_number>
+<source_hash>sha256:3ed38101473acbfc31151c55c9555188406e62dbe6b9c3c1f89f0ce17e8de4f6</source_hash>
 </source>
 <table_name>Score_Play_Go</table_name>
 <xls_file>Cribbage.xlsx</xls_file>

--- a/sampleprojects/KidAid/xml/kidaid_dt.xml
+++ b/sampleprojects/KidAid/xml/kidaid_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>kidaid.xlsx</relative_path>
 <file_name>kidaid.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:74edf8476e29cbb5cbdea2c895d724ce970e5768a03e6ce0e41bd996dc6d21c2</source_hash>
 </source>
 <table_name>Compute_Eligibility</table_name>
 <xls_file>kidaid.xlsx</xls_file>
@@ -137,6 +138,7 @@ true
 <relative_path>kidaid.xlsx</relative_path>
 <file_name>kidaid.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:74edf8476e29cbb5cbdea2c895d724ce970e5768a03e6ce0e41bd996dc6d21c2</source_hash>
 </source>
 <table_name>Calculate_Individual_Income</table_name>
 <xls_file>kidaid.xlsx</xls_file>
@@ -213,6 +215,7 @@ income.amount client.totalIncome + /client.totalIncome xdef
 <relative_path>kidaid.xlsx</relative_path>
 <file_name>kidaid.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:74edf8476e29cbb5cbdea2c895d724ce970e5768a03e6ce0e41bd996dc6d21c2</source_hash>
 </source>
 <table_name>Calculate_Group_Size</table_name>
 <xls_file>kidaid.xlsx</xls_file>
@@ -387,6 +390,7 @@ client.totalIncome 0 local@ entitypush totalGroupIncome + /totalGroupIncome xdef
 <relative_path>kidaid.xlsx</relative_path>
 <file_name>kidaid.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:74edf8476e29cbb5cbdea2c895d724ce970e5768a03e6ce0e41bd996dc6d21c2</source_hash>
 </source>
 <table_name>Evaluate_KidAid_Eligibility</table_name>
 <xls_file>kidaid.xlsx</xls_file>
@@ -691,6 +695,7 @@ false cvb /client.eligible xdef
 <relative_path>kidaid.xlsx</relative_path>
 <file_name>kidaid.xlsx</file_name>
 <sheet_number>5</sheet_number>
+<source_hash>sha256:74edf8476e29cbb5cbdea2c895d724ce970e5768a03e6ce0e41bd996dc6d21c2</source_hash>
 </source>
 <table_name>Evaluate_MEDICAID_Eligibility</table_name>
 <xls_file>kidaid.xlsx</xls_file>
@@ -750,6 +755,7 @@ false cvb /client.eligible xdef
 <relative_path>kidaid.xlsx</relative_path>
 <file_name>kidaid.xlsx</file_name>
 <sheet_number>6</sheet_number>
+<source_hash>sha256:74edf8476e29cbb5cbdea2c895d724ce970e5768a03e6ce0e41bd996dc6d21c2</source_hash>
 </source>
 <table_name>Evaluate_FOODSTAMPS_Eligibility</table_name>
 <xls_file>kidaid.xlsx</xls_file>
@@ -809,6 +815,7 @@ false cvb /client.eligible xdef
 <relative_path>kidaid.xlsx</relative_path>
 <file_name>kidaid.xlsx</file_name>
 <sheet_number>7</sheet_number>
+<source_hash>sha256:74edf8476e29cbb5cbdea2c895d724ce970e5768a03e6ce0e41bd996dc6d21c2</source_hash>
 </source>
 <table_name>Evaluate_Results</table_name>
 <xls_file>kidaid.xlsx</xls_file>

--- a/sampleprojects/Poker/xml/Poker_dt.xml
+++ b/sampleprojects/Poker/xml/Poker_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>Poker.xlsx</relative_path>
 <file_name>Poker.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:b9a1c347f42f53c0a822b970d82dd86b4e068aaae16f2c9b3c25558d0a14cbf9</source_hash>
 </source>
 <table_name>Poker_Decision</table_name>
 <xls_file>Poker.xlsx</xls_file>
@@ -135,6 +136,7 @@ decision game.decisions swap addto
 <relative_path>Poker.xlsx</relative_path>
 <file_name>Poker.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:b9a1c347f42f53c0a822b970d82dd86b4e068aaae16f2c9b3c25558d0a14cbf9</source_hash>
 </source>
 <table_name>TAG_Decision</table_name>
 <xls_file>Poker.xlsx</xls_file>
@@ -201,6 +203,7 @@ endif</action_dsl>
 <relative_path>Poker.xlsx</relative_path>
 <file_name>Poker.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:b9a1c347f42f53c0a822b970d82dd86b4e068aaae16f2c9b3c25558d0a14cbf9</source_hash>
 </source>
 <table_name>LAG_Decision</table_name>
 <xls_file>Poker.xlsx</xls_file>
@@ -317,6 +320,7 @@ player.can_check true beq
 <relative_path>Poker.xlsx</relative_path>
 <file_name>Poker.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:b9a1c347f42f53c0a822b970d82dd86b4e068aaae16f2c9b3c25558d0a14cbf9</source_hash>
 </source>
 <table_name>Rock_Decision</table_name>
 <xls_file>Poker.xlsx</xls_file>
@@ -420,6 +424,7 @@ player.can_check true beq
 <relative_path>Poker.xlsx</relative_path>
 <file_name>Poker.xlsx</file_name>
 <sheet_number>5</sheet_number>
+<source_hash>sha256:b9a1c347f42f53c0a822b970d82dd86b4e068aaae16f2c9b3c25558d0a14cbf9</source_hash>
 </source>
 <table_name>CallingStation_Decision</table_name>
 <xls_file>Poker.xlsx</xls_file>
@@ -523,6 +528,7 @@ player.can_check true beq
 <relative_path>Poker.xlsx</relative_path>
 <file_name>Poker.xlsx</file_name>
 <sheet_number>6</sheet_number>
+<source_hash>sha256:b9a1c347f42f53c0a822b970d82dd86b4e068aaae16f2c9b3c25558d0a14cbf9</source_hash>
 </source>
 <table_name>Evaluate_All_Players</table_name>
 <xls_file>Poker.xlsx</xls_file>

--- a/sampleprojects/Scopa/xml/Scopa_dt.xml
+++ b/sampleprojects/Scopa/xml/Scopa_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>Scopa.xlsx</relative_path>
 <file_name>Scopa.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:0566150b073ffa2dce2359aa5259fc6b96c5933c48e1ebb9659cdade0e3f1dd1</source_hash>
 </source>
 <table_name>Resolve_Capture</table_name>
 <xls_file>Scopa.xlsx</xls_file>
@@ -79,6 +80,7 @@ true
 <relative_path>Scopa.xlsx</relative_path>
 <file_name>Scopa.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:0566150b073ffa2dce2359aa5259fc6b96c5933c48e1ebb9659cdade0e3f1dd1</source_hash>
 </source>
 <table_name>Capture_Single</table_name>
 <xls_file>Scopa.xlsx</xls_file>
@@ -152,6 +154,7 @@ move.capture_found 0 ==
 <relative_path>Scopa.xlsx</relative_path>
 <file_name>Scopa.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:0566150b073ffa2dce2359aa5259fc6b96c5933c48e1ebb9659cdade0e3f1dd1</source_hash>
 </source>
 <table_name>Capture_Sum</table_name>
 <xls_file>Scopa.xlsx</xls_file>
@@ -216,6 +219,7 @@ combo.sum move.played_rank ==
 <relative_path>Scopa.xlsx</relative_path>
 <file_name>Scopa.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:0566150b073ffa2dce2359aa5259fc6b96c5933c48e1ebb9659cdade0e3f1dd1</source_hash>
 </source>
 <table_name>Score_Scopa</table_name>
 <xls_file>Scopa.xlsx</xls_file>
@@ -271,6 +275,7 @@ true cvb /move.is_scopa xdef
 <relative_path>Scopa.xlsx</relative_path>
 <file_name>Scopa.xlsx</file_name>
 <sheet_number>5</sheet_number>
+<source_hash>sha256:0566150b073ffa2dce2359aa5259fc6b96c5933c48e1ebb9659cdade0e3f1dd1</source_hash>
 </source>
 <table_name>Primiera_Value</table_name>
 <xls_file>Scopa.xlsx</xls_file>
@@ -438,6 +443,7 @@ card.rank 2 ==
 <relative_path>Scopa.xlsx</relative_path>
 <file_name>Scopa.xlsx</file_name>
 <sheet_number>6</sheet_number>
+<source_hash>sha256:0566150b073ffa2dce2359aa5259fc6b96c5933c48e1ebb9659cdade0e3f1dd1</source_hash>
 </source>
 <table_name>Suit_Best</table_name>
 <xls_file>Scopa.xlsx</xls_file>
@@ -488,6 +494,7 @@ true
 <relative_path>Scopa.xlsx</relative_path>
 <file_name>Scopa.xlsx</file_name>
 <sheet_number>7</sheet_number>
+<source_hash>sha256:0566150b073ffa2dce2359aa5259fc6b96c5933c48e1ebb9659cdade0e3f1dd1</source_hash>
 </source>
 <table_name>Suit_Best_Inner</table_name>
 <xls_file>Scopa.xlsx</xls_file>
@@ -538,6 +545,7 @@ card.primiera cvi /grp.best xdef
 <relative_path>Scopa.xlsx</relative_path>
 <file_name>Scopa.xlsx</file_name>
 <sheet_number>8</sheet_number>
+<source_hash>sha256:0566150b073ffa2dce2359aa5259fc6b96c5933c48e1ebb9659cdade0e3f1dd1</source_hash>
 </source>
 <table_name>Score_Primiera</table_name>
 <xls_file>Scopa.xlsx</xls_file>
@@ -619,6 +627,7 @@ true
 <relative_path>Scopa.xlsx</relative_path>
 <file_name>Scopa.xlsx</file_name>
 <sheet_number>9</sheet_number>
+<source_hash>sha256:0566150b073ffa2dce2359aa5259fc6b96c5933c48e1ebb9659cdade0e3f1dd1</source_hash>
 </source>
 <table_name>Score_Settebello</table_name>
 <xls_file>Scopa.xlsx</xls_file>

--- a/sampleprojects/SinusitisTherapy/xml/service1_medication_dt.xml
+++ b/sampleprojects/SinusitisTherapy/xml/service1_medication_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>service1_medication.xlsx</relative_path>
 <file_name>service1_medication.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:36078765476394bac61d22d0137cb74d0ebdc20f19f92c49be8ff198393bce25</source_hash>
 </source>
 <table_name>Determine_Medication_And_Dosing</table_name>
 <xls_file>service1_medication.xlsx</xls_file>
@@ -57,6 +58,7 @@ true
 <relative_path>service1_medication.xlsx</relative_path>
 <file_name>service1_medication.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:36078765476394bac61d22d0137cb74d0ebdc20f19f92c49be8ff198393bce25</source_hash>
 </source>
 <table_name>Select_Medication</table_name>
 <xls_file>service1_medication.xlsx</xls_file>
@@ -152,6 +154,7 @@ patient.age constants.adult_age &gt;=
 <relative_path>service1_medication.xlsx</relative_path>
 <file_name>service1_medication.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:36078765476394bac61d22d0137cb74d0ebdc20f19f92c49be8ff198393bce25</source_hash>
 </source>
 <table_name>Determine_Dose</table_name>
 <xls_file>service1_medication.xlsx</xls_file>

--- a/sampleprojects/SinusitisTherapy/xml/service2_creatinine_dt.xml
+++ b/sampleprojects/SinusitisTherapy/xml/service2_creatinine_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>service2_creatinine.xlsx</relative_path>
 <file_name>service2_creatinine.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:a418769770baee0f21ad335cc43684dc7eeb8c99dad57218bf024833f033f1c6</source_hash>
 </source>
 <table_name>Determine_Creatinine_Clearance</table_name>
 <xls_file>service2_creatinine.xlsx</xls_file>

--- a/sampleprojects/SinusitisTherapy/xml/service3_interactions_dt.xml
+++ b/sampleprojects/SinusitisTherapy/xml/service3_interactions_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>service3_interactions.xlsx</relative_path>
 <file_name>service3_interactions.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:94722d7b0bfad1eebc2828435ac191304cdb2248d6073898e487fa4d2deabf92</source_hash>
 </source>
 <table_name>Check_Drug_Interactions</table_name>
 <xls_file>service3_interactions.xlsx</xls_file>

--- a/sampleprojects/SinusitisTherapy/xml/sinusitis_map.xml
+++ b/sampleprojects/SinusitisTherapy/xml/sinusitis_map.xml
@@ -1,38 +1,33 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <mapping>
 	<XMLtoEDD>
 		<map>
 			<!-- Patient fields (resolved against the patient singleton on the context stack) -->
-			<setattribute tag='age'                 RAttribute='age'                 enclosure='patient'    type='integer'></setattribute>
-			<setattribute tag='lean_body_weight'    RAttribute='lean_body_weight'    enclosure='patient'    type='double'></setattribute>
-			<setattribute tag='pcr'                 RAttribute='pcr'                 enclosure='patient'    type='double'></setattribute>
-			<setattribute tag='penicillin_allergic' RAttribute='penicillin_allergic' enclosure='patient'    type='boolean'></setattribute>
-			<setattribute tag='diagnosis'           RAttribute='diagnosis'           enclosure='patient'    type='string'></setattribute>
-
+			<setattribute tag='age' RAttribute='age' enclosure='patient' type='integer'></setattribute>
+			<setattribute tag='lean_body_weight' RAttribute='lean_body_weight' enclosure='patient' type='double'></setattribute>
+			<setattribute tag='pcr' RAttribute='pcr' enclosure='patient' type='double'></setattribute>
+			<setattribute tag='penicillin_allergic' RAttribute='penicillin_allergic' enclosure='patient' type='boolean'></setattribute>
+			<setattribute tag='diagnosis' RAttribute='diagnosis' enclosure='patient' type='string'></setattribute>
 			<!-- Active medication fields -->
-			<setattribute tag='name'                RAttribute='name'                enclosure='medication' type='string'></setattribute>
-
+			<setattribute tag='name' RAttribute='name' enclosure='medication' type='string'></setattribute>
 			<!-- The patient root element becomes the patient singleton. Without
 			     this, a run that loads input data before pushing singletons
 			     leaves the patient fields with no entity to attach to, and the
 			     singleton is pushed empty. -->
-			<createentity entity='patient' tag='patient' id='id'></createentity>
-
 			<!-- Each <medication> element becomes a medication entity on patient.active_medications -->
+			<createentity entity='patient' tag='patient' id='id'></createentity>
 			<createentity entity='medication' tag='medication' id='name' list='active_medications'></createentity>
 		</map>
-
 		<entities>
-			<entity name='patient'    number='1'></entity>
+			<entity name='patient' number='1'></entity>
 			<entity name='medication' number='*'></entity>
-			<entity name='result'     number='1'></entity>
-			<entity name='constants'  number='1'></entity>
+			<entity name='result' number='1'></entity>
+			<entity name='constants' number='1'></entity>
 		</entities>
-
 		<initialization>
 			<initialentity entity='constants' epush='true'></initialentity>
-			<initialentity entity='result'    epush='true'></initialentity>
-			<initialentity entity='patient'   epush='true'></initialentity>
+			<initialentity entity='result' epush='true'></initialentity>
+			<initialentity entity='patient' epush='true'></initialentity>
 		</initialization>
 	</XMLtoEDD>
 </mapping>

--- a/sampleprojects/SinusitisTherapy/xml/therapy_dt.xml
+++ b/sampleprojects/SinusitisTherapy/xml/therapy_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>therapy.xlsx</relative_path>
 <file_name>therapy.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:5f328470ed25042b5cf35042e01970e4da1562a3652815a569f7b36ddd73e874</source_hash>
 </source>
 <table_name>Determine_Therapy</table_name>
 <xls_file>therapy.xlsx</xls_file>

--- a/sampleprojects/StateTax/xml/StateTax_dt.xml
+++ b/sampleprojects/StateTax/xml/StateTax_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>StateTax.xlsx</relative_path>
 <file_name>StateTax.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:c5ebd677971d8c5c3855b3796ca1c45ddcc85ce2fdc8409ce64a5e707527a8bb</source_hash>
 </source>
 <table_name>Compute_Tax</table_name>
 <xls_file>StateTax.xlsx</xls_file>
@@ -155,6 +156,7 @@ taxpayer.grossIncome cvi /taxpayer.agi xdef
 <relative_path>StateTax.xlsx</relative_path>
 <file_name>StateTax.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:c5ebd677971d8c5c3855b3796ca1c45ddcc85ce2fdc8409ce64a5e707527a8bb</source_hash>
 </source>
 <table_name>Calculate_Gross_Income</table_name>
 <xls_file>StateTax.xlsx</xls_file>
@@ -210,6 +212,7 @@ income.amount taxpayer.grossIncome + /taxpayer.grossIncome xdef
 <relative_path>StateTax.xlsx</relative_path>
 <file_name>StateTax.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:c5ebd677971d8c5c3855b3796ca1c45ddcc85ce2fdc8409ce64a5e707527a8bb</source_hash>
 </source>
 <table_name>Apply_Adjustments</table_name>
 <xls_file>StateTax.xlsx</xls_file>
@@ -265,6 +268,7 @@ adjustment.amount taxpayer.agi swap - /taxpayer.agi xdef
 <relative_path>StateTax.xlsx</relative_path>
 <file_name>StateTax.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:c5ebd677971d8c5c3855b3796ca1c45ddcc85ce2fdc8409ce64a5e707527a8bb</source_hash>
 </source>
 <table_name>Determine_Filing_Details</table_name>
 <xls_file>StateTax.xlsx</xls_file>
@@ -386,6 +390,7 @@ taxpayer.num_dependents 2 + cvi /taxpayer.exemptions xdef
 <relative_path>StateTax.xlsx</relative_path>
 <file_name>StateTax.xlsx</file_name>
 <sheet_number>5</sheet_number>
+<source_hash>sha256:c5ebd677971d8c5c3855b3796ca1c45ddcc85ce2fdc8409ce64a5e707527a8bb</source_hash>
 </source>
 <table_name>Calculate_Taxable_Income</table_name>
 <xls_file>StateTax.xlsx</xls_file>
@@ -445,6 +450,7 @@ taxpayer.agi taxpayer.deduction - taxpayer.exemptions state_config.exemption_amo
 <relative_path>StateTax.xlsx</relative_path>
 <file_name>StateTax.xlsx</file_name>
 <sheet_number>6</sheet_number>
+<source_hash>sha256:c5ebd677971d8c5c3855b3796ca1c45ddcc85ce2fdc8409ce64a5e707527a8bb</source_hash>
 </source>
 <table_name>Apply_Flat_Tax</table_name>
 <xls_file>StateTax.xlsx</xls_file>
@@ -486,6 +492,7 @@ taxpayer.taxableIncome state_config.flat_rate_bps 10000.0 fdiv fmul cvi /taxpaye
 <relative_path>StateTax.xlsx</relative_path>
 <file_name>StateTax.xlsx</file_name>
 <sheet_number>7</sheet_number>
+<source_hash>sha256:c5ebd677971d8c5c3855b3796ca1c45ddcc85ce2fdc8409ce64a5e707527a8bb</source_hash>
 </source>
 <table_name>Select_And_Apply_Brackets</table_name>
 <xls_file>StateTax.xlsx</xls_file>
@@ -581,6 +588,7 @@ state_config.brackets_hoh /taxpayer.active_brackets xdef false cvb /taxpayer.bra
 <relative_path>StateTax.xlsx</relative_path>
 <file_name>StateTax.xlsx</file_name>
 <sheet_number>8</sheet_number>
+<source_hash>sha256:c5ebd677971d8c5c3855b3796ca1c45ddcc85ce2fdc8409ce64a5e707527a8bb</source_hash>
 </source>
 <table_name>Apply_Bracket_Iteration</table_name>
 <xls_file>StateTax.xlsx</xls_file>
@@ -654,6 +662,7 @@ true cvb /bracket_applied xdef
 <relative_path>StateTax.xlsx</relative_path>
 <file_name>StateTax.xlsx</file_name>
 <sheet_number>9</sheet_number>
+<source_hash>sha256:c5ebd677971d8c5c3855b3796ca1c45ddcc85ce2fdc8409ce64a5e707527a8bb</source_hash>
 </source>
 <table_name>Evaluate_Results</table_name>
 <xls_file>StateTax.xlsx</xls_file>

--- a/sampleprojects/SyntaxTests/xml/syntaxexample_dt.xml
+++ b/sampleprojects/SyntaxTests/xml/syntaxexample_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Syntax_Examples</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -281,6 +282,7 @@ else
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Syntax_Examples_2</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -940,6 +942,7 @@ effectiveDate endofmonth cvdate /currentDate xdef
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Syntax_Examples_3</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -1405,6 +1408,7 @@ totalIncome 2 .4 roundto cvd /totalIncome xdef
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Syntax_Examples_4</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -2082,6 +2086,7 @@ clients client_ID memberof not cvb /eligible xdef
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>5</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Error_Handling_Table</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -2103,6 +2108,7 @@ clients client_ID memberof not cvb /eligible xdef
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>6</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -2353,6 +2359,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>7</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_2</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -2547,6 +2554,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>8</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_3</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -2751,6 +2759,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>9</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_4</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -2957,6 +2966,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>10</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_5</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -3163,6 +3173,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>11</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_6</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -3369,6 +3380,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>12</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_7</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -3568,6 +3580,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>13</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_8</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -3743,6 +3756,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>14</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_9</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -3916,6 +3930,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>15</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_10</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -4095,6 +4110,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>16</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_11</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -4283,6 +4299,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>17</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_12</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -4469,6 +4486,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>18</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_13</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -4648,6 +4666,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>19</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_14</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -4821,6 +4840,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>20</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_15</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -5104,6 +5124,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>21</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_16</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -5403,6 +5424,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>22</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Test_17</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -5645,6 +5667,7 @@ policystatements results true addarray
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>23</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Syntax_Examples_5</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>
@@ -6088,6 +6111,7 @@ results 1 getat
 <relative_path>syntaxexample.xlsx</relative_path>
 <file_name>syntaxexample.xlsx</file_name>
 <sheet_number>24</sheet_number>
+<source_hash>sha256:5a10760b1301fef09689a970f1f834be2f7018d4791049ed0cf84490bc6d4358</source_hash>
 </source>
 <table_name>Run_Syntax_Examples</table_name>
 <xls_file>syntaxexample.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/TaxReturn_dt.xml
+++ b/sampleprojects/TaxReturn/xml/TaxReturn_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Compute_Tax_Return</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -234,6 +235,7 @@ otherwise
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Gross_Income</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -471,6 +473,7 @@ result.gross_income result.total_adjustments f- cvd /result.agi xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_W2_Income</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -574,6 +577,7 @@ taxpayer.tip_income cvd result.total_tip_income f+ /result.total_tip_income xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Self_Employment</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -660,6 +664,7 @@ taxpayer.se_gross_income taxpayer.se_expenses f- cvd /taxpayer.se_net_profit xde
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>5</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_SE_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -719,6 +724,7 @@ taxpayer.se_net_profit constants.se_income_multiplier fmul cvd /result.se_base x
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>6</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Vehicle_Deduction</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -809,6 +815,7 @@ vehicle.actual_expenses vehicle.vehicle_depreciation f+ vehicle.business_use_per
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>7</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Rental_Income</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -926,6 +933,7 @@ property.rental_net_income cvd result.total_rental_income f+ /result.total_renta
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>8</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Other_Income</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -990,6 +998,7 @@ income.tax_withheld cvd result.total_payments f+ /result.total_payments xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>9</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_AGI_Adjustments</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -1049,6 +1058,7 @@ taxpayer.se_tax_deduction cvd result.total_adjustments f+ /result.total_adjustme
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>10</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Deductions</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -1115,6 +1125,7 @@ result.standard_deduction cvd /result.total_deduction xdef "standard" cvs /resul
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>11</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Standard_Deduction</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -1242,6 +1253,7 @@ constants.additional_std_deduction_single result.senior_std_count fmul cvd resul
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>12</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Itemized_Deductions</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -1344,6 +1356,7 @@ perform when called
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>13</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Sum_Taxpayer_Medical_Expenses</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -1394,6 +1407,7 @@ taxpayer.medical_expenses cvd result.total_medical_expenses f+ /result.total_med
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>14</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_SALT_Deduction</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -1456,6 +1470,7 @@ result.total_salt_collected cvd /result.salt_deduction xdef result.total_itemize
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>15</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Effective_SALT_Cap</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -1524,6 +1539,7 @@ salt_cap result.agi salt_phaseout_start f- salt_phaseout_rate fmul f- salt_reduc
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>16</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Sum_Primary_Residence_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -1581,6 +1597,7 @@ property.property_taxes cvd result.total_salt_collected f+ /result.total_salt_co
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>17</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Sum_SALT_Deduction</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -1638,6 +1655,7 @@ deduction.amount cvd result.total_salt_collected f+ /result.total_salt_collected
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>18</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Mortgage_Interest</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -1719,6 +1737,7 @@ property.mortgage_interest mortgage_limit_post_tcja property.mortgage_balance fd
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>19</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Filter_Primary_Residence</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -1767,6 +1786,7 @@ property.type "primary_residence" streq
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>20</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Charitable_Deduction</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -1822,6 +1842,7 @@ deduction.amount cvd result.total_itemized f+ /result.total_itemized xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>21</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Filter_Charity_Deduction</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -1870,6 +1891,7 @@ deduction.allowed_amount cvd result.total_itemized f+ /result.total_itemized xde
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>22</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Noncash_Charitable</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -1934,6 +1956,7 @@ result.total_noncash_charitable cvd result.total_itemized f+ /result.total_itemi
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>23</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Noncash_Contribution</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -2028,6 +2051,7 @@ noncash_contribution.fair_market_value cvd /noncash_contribution.deduction_amoun
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>24</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Taxable_Income</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -2083,6 +2107,7 @@ result.agi result.total_deduction f- result.qbi_deduction f- 0 fmax cvd /result.
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>25</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_QBI_Deduction</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -2142,6 +2167,7 @@ result.total_se_income qbi_rate fmul cvd /result.qbi_deduction xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>26</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Tax_Liability</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -2253,6 +2279,7 @@ result.regular_tax result.capital_gains_tax f+ result.se_tax f+ result.niit_tax 
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>27</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Apply_Tax_Brackets</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -2321,6 +2348,7 @@ otherwise
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>28</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Apply_Tax_Brackets_MFJ</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -2461,6 +2489,7 @@ bracket_1_mfj bracket_1_rate fmul bracket_2_mfj bracket_1_mfj f- bracket_2_rate 
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>29</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Apply_Tax_Brackets_Single</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -2601,6 +2630,7 @@ bracket_1_single bracket_1_rate fmul bracket_2_single bracket_1_single f- bracke
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>30</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_CDCC</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -2700,6 +2730,7 @@ result.total_care_expenses result.cdcc_expense_limit fmin cvd /result.cdcc_allow
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>31</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Count_CDCC_Qualifying_Person</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -2777,6 +2808,7 @@ false cvb /dependent.qualifies_for_cdcc xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>32</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Savers_Credit</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -3024,6 +3056,7 @@ result.total_savers_contribution constants.savers_max_contribution_single fmin r
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>33</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Sum_Savers_Contribution</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -3070,6 +3103,7 @@ result.total_savers_contribution taxpayer.traditional_ira_contribution taxpayer.
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>34</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Energy_Credits</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -3141,6 +3175,7 @@ result.total_credits 0 f&gt;
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>35</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Energy_Credit_Per_Improvement</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -3200,6 +3235,7 @@ improvement.cost 0.30 fmul cvd result.energy_efficiency_credit f+ /result.energy
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>36</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Passive_Activity_Loss</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -3271,6 +3307,7 @@ result.total_rental_loss 0 f&gt;
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>37</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Sum_Rental_Loss</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -3333,6 +3370,7 @@ rental.net_loss fnegate result.total_rental_losses swap addto
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>38</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_AMT</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -3421,6 +3459,7 @@ result.amti amt_phaseout_single f- 0.25 fmul 0 fmax cvd /result.amt_exemption_re
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>39</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Credits</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -3613,6 +3652,7 @@ result.total_ctc result.total_odc f+ result.education_credit f+ result.total_aot
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>40</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_CTC_Phase_Out</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -3751,6 +3791,7 @@ result.ctc_before_phaseout cvd /result.ctc_after_phaseout xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>41</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Child_Tax_Credit</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -3850,6 +3891,7 @@ constants.odc_amount cvd result.total_odc f+ /result.total_odc xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>42</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Premium_Tax_Credit</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -3965,6 +4007,7 @@ job.advance_ptc_received cvd /result.ptc_repayment xdef 0 cvd /result.premium_ta
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>43</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_EITC</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -4157,6 +4200,7 @@ eitc_max_0_children result.agi eitc_threshold_mfj_0 f- 0.0765 fmul f- 0 fmax cvd
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>44</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Education_Credits</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -4205,6 +4249,7 @@ perform when called
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>45</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Education_Credit_Per_Dependent</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -4337,6 +4382,7 @@ dependent.qualified_expenses 0.20 fmul llc_max fmin cvd /dependent.education_cre
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>46</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Final_Balance</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -4434,6 +4480,7 @@ result.total_tax result.total_payments f- cvd /result.refund_or_owed xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>47</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Validate_Results</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -4491,6 +4538,7 @@ job.expected_agi isnull not
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>48</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Validate_AGI</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -4550,6 +4598,7 @@ result.agi job.expected_agi f- fabs 1.0 f&lt;=
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>49</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Validate_Total_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -4609,6 +4658,7 @@ result.total_tax job.expected_total_tax f- fabs 1.0 f&lt;=
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>50</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Validate_Summary</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -4659,6 +4709,7 @@ result.validation_passed true beq
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>51</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Kiddie_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -4707,6 +4758,7 @@ otherwise
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>52</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Kiddie_Tax_For_Dependent</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -4811,6 +4863,7 @@ false cvb /dependent.subject_to_kiddie_tax xdef 0.0 cvd /dependent.kiddie_tax_am
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>53</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Validate_Taxable_Income</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -4870,6 +4923,7 @@ result.taxable_income job.expected_taxable_income f- fabs 1.0 f&lt;=
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>54</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_DC_Homebuyer_Credit</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -4932,6 +4986,7 @@ job.dc_home_purchase_price 0 f&gt;
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>55</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Energy_Appliance_Credit</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -4989,6 +5044,7 @@ taxpayer.energy_efficient_appliances_produced 0 &gt;
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>56</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Schedule_H</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -5046,6 +5102,7 @@ job.household_employees length 0 &gt;
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>57</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Schedule_H_Per_Employee</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -5123,6 +5180,7 @@ household_employee.cash_wages constants.futa_rate fmul result.schedule_h_tax swa
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>58</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_General_Business_Credit</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -5180,6 +5238,7 @@ result.general_business_credit_total result.gbc_available_limit fmin cvd /result
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>59</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Filter_Self_Employed_Taxpayer</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -5228,6 +5287,7 @@ taxpayer.is_self_employed true beq
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>60</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Filter_Taxpayer_Vehicle</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -5276,6 +5336,7 @@ vehicle.taxpayer_id taxpayer.id ==
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>61</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Filter_Rental_Property</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -5324,6 +5385,7 @@ property.type "rental" streq
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>62</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Count_EITC_Qualifying_Child</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -5399,6 +5461,7 @@ dependent.months_lived_with 6 &gt;
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>63</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Mortgage_Interest_For_Property</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -5449,6 +5512,7 @@ property.mortgage_interest cvd result.total_itemized f+ /result.total_itemized x
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>64</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_OBBBA_Deductions</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -5524,6 +5588,7 @@ result.tips_deduction result.overtime_deduction f+ result.senior_deduction f+ cv
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>65</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Tips_Deduction</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -5631,6 +5696,7 @@ result.total_tip_income constants.tips_deduction_max fmin cvd /result.tips_deduc
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>66</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Overtime_Deduction</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -5747,6 +5813,7 @@ result.total_overtime_income constants.overtime_deduction_max_single fmin cvd /r
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>67</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Senior_Deduction</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -5854,6 +5921,7 @@ result.senior_count constants.senior_deduction_amount fmul cvd /result.senior_de
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>68</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_SS_Taxability</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -6012,6 +6080,7 @@ result.total_social_security 0.85 fmul cvd /result.taxable_social_security xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>69</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Capital_Gains</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -6107,6 +6176,7 @@ income.gross_amount cvd result.total_qualified_dividends f+ /result.total_qualif
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>70</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Capital_Gains_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -6209,6 +6279,7 @@ job.filing_status "HOH" streq
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>71</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Capital_Gains_Tax_MFJ</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -6299,6 +6370,7 @@ perform when called
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>72</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Capital_Gains_Tax_HOH</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -6389,6 +6461,7 @@ perform when called
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>73</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Capital_Gains_Tax_Single</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -6479,6 +6552,7 @@ perform when called
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>74</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Apply_CG_Brackets_MFJ</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -6547,6 +6621,7 @@ result.cg_0_percent_mfj result.cg_rate_0_percent fmul result.cg_15_percent_mfj r
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>75</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Apply_CG_Brackets_HOH</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -6615,6 +6690,7 @@ result.cg_0_percent_hoh result.cg_rate_0_percent fmul result.cg_15_percent_hoh r
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>76</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Apply_CG_Brackets_Single</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -6683,6 +6759,7 @@ result.cg_0_percent_single result.cg_rate_0_percent fmul result.cg_15_percent_si
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>77</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_NIIT</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -6841,6 +6918,7 @@ result.magi_for_niit constants.niit_threshold_single f- 0.0 fmax cvd /result.nii
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>78</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Additional_Medicare_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -6977,6 +7055,7 @@ result.wages_for_additional_medicare constants.additional_medicare_threshold_sin
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>79</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_IRA_Deduction</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -7135,6 +7214,7 @@ taxpayer.traditional_ira_contribution constants.ira_contribution_limit fmin cvd 
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>80</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_HSA_Deduction</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -7258,6 +7338,7 @@ taxpayer.hsa_contribution constants.hsa_limit_self fmin cvd /taxpayer.hsa_deduct
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>81</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Student_Loan_Deduction</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -7383,6 +7464,7 @@ constants.student_loan_max_deduction constants.student_loan_phaseout_end_mfj res
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>82</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_K1_Income</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -7440,6 +7522,7 @@ k1_income.ordinary_income cvd result.total_k1_ordinary_income f+ /result.total_k
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>83</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_K1_SE_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -7497,6 +7580,7 @@ result.total_k1_se_earnings se_tax_rate fmul cvi /taxpayer.k1_se_tax xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>84</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_IRA_Accounts</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -7563,6 +7647,7 @@ ira_account.contribution_amount result.total_ira_contributions swap addto
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>85</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Roth_Conversion_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -7629,6 +7714,7 @@ result.total_ira_basis 0 f&gt;
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>86</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Farm_Income</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -7686,6 +7772,7 @@ farm_income.gross_income result.total_farm_income swap addto
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>87</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Farm_SE_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -7743,6 +7830,7 @@ result.net_farm_profit se_tax_rate fmul cvd /taxpayer.farm_se_tax xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>88</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Property_Sales</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -7854,6 +7942,7 @@ property_sale.total_gain_loss result.total_collectibles_gain swap addto
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>89</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Section_1231</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -7929,6 +8018,7 @@ result.net_section_1231 result.ordinary_loss swap addto
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>90</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Foreign_Income</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -7986,6 +8076,7 @@ taxpayer.foreign_earned_income cvd result.total_foreign_earned_income f+ /result
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>91</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Foreign_Tax_Credit</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8052,6 +8143,7 @@ result.regular_tax result.foreign_source_taxable result.taxable_income fdiv fmul
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>92</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Foreign_Earned_Income</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8111,6 +8203,7 @@ taxpayer.foreign_earned_income constants.feie_cap min cvd /result.foreign_earned
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>93</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Installment_Sales</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8161,6 +8254,7 @@ payments_received gross_profit_ratio fmul cvd /result.installment_gain xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>94</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Like_Kind_Exchanges</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8211,6 +8305,7 @@ like_kind_exchange.realized_gain 0 f&gt;
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>95</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Early_Distributions</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8270,6 +8365,7 @@ early_distribution.distribution_amount 0 f&gt;
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>96</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Kiddie_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8329,6 +8425,7 @@ dependent.unearned_income constants.kiddie_tax_threshold f&gt;
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>97</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Elderly_Disabled_Credit</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8388,6 +8485,7 @@ constants.elderly_credit_single cvd /result.elderly_base_amount xdef constants.e
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>98</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Estimated_Tax_Penalty</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8438,6 +8536,7 @@ estimated_payment.payment_amount cvd result.total_estimated_payments f+ /result.
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>99</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Casualty_Losses</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8497,6 +8596,7 @@ casualty_loss.disaster_designation "" streq not
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>100</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Clean_Vehicle_Credit</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8556,6 +8656,7 @@ clean_vehicle.vehicle_type "new" streq { pop clean_vehicle.final_assembly_us tru
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>101</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Adoption_Credit</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8606,6 +8707,7 @@ adoption.qualified_expenses 0 f&gt;
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>102</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Combat_Zone_Pay_Exclusion</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8696,6 +8798,7 @@ taxpayer.combat_zone_pay constants.officer_combat_zone_cap fmin cvi /result.comb
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>103</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Military_Moving_Expenses</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8773,6 +8876,7 @@ taxpayer.moving_expense cvi /result.moving_expense_deduction xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>104</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_Household_Employment</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8832,6 +8936,7 @@ household_employee.cash_wages constants.fica_combined_rate fmul cvi /result.hous
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>105</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Process_NOL_Carryover</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8882,6 +8987,7 @@ result.nol_amount_available 0 &gt;
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>106</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Coordinate_Military_And_Foreign_Income</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -8948,6 +9054,7 @@ result.total_combat_zone_exclusion 0 f&gt; { pop job.foreign_earned_incomes leng
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>107</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Mortgage_Interest_Credit</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -9007,6 +9114,7 @@ credit cvd /result.credit_amount xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>108</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Prior_Year_AMT_Credit</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -9066,6 +9174,7 @@ prior_year_amt.credit_available regular_tax tentative_minimum_tax f- fmin cvi /r
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>109</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Partnership_Audit_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -9116,6 +9225,7 @@ result.total_partnership_audit_adjustment constants.partnership_audit_rate * cvd
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>110</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Unreported_Tips_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -9175,6 +9285,7 @@ unreported_tips.unreported_tips_amount constants.fica_employee_rate fmul cvd /re
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>111</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_LIHTC_Recapture</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -9234,6 +9345,7 @@ recapture_amount interest f+ cvi /result.recapture_tax xdef
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>112</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Part_Year_Allocation</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -9298,6 +9410,7 @@ state_tax_result.state_tax_before_credits state_tax_result.state_credits f- 0.0 
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>113</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Dispatch_MO_HI_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -9357,6 +9470,7 @@ job.state "HI" streq
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>114</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Synthesize_State_Tax_Result_If_Empty</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -9398,6 +9512,7 @@ job.state_tax_results length 0 ==
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>115</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Log_State_Tax_Start</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -9448,6 +9563,7 @@ job.state_periods length 0 ==
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>116</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Apply_Part_Year_Allocations</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -9498,6 +9614,7 @@ perform when called
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>117</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Dispatch_State_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -10335,6 +10452,7 @@ job.state "MO" streq
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>118</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Dispatch_Territory_Tax</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -10498,6 +10616,7 @@ job.territory "MP" streq
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>119</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_State_Source_Income</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -10551,6 +10670,7 @@ perform when called
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>120</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Build_State_Tax_Result_For_Period</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -10610,6 +10730,7 @@ state_period.state_code job.state streq
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>121</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Allocate_Income_By_State</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -10690,6 +10811,7 @@ state_period.start_date state_period.end_date daysbetween cvi /state_period.days
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>122</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Allocate_Income_To_State_Period</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -10756,6 +10878,7 @@ income.gross_amount state_period.allocation_percentage fmul cvd state_period.all
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>123</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Other_State_Tax_Credit</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -10831,6 +10954,7 @@ total_other_state_taxes_paid result.state_tax_liability fmin cvi /result.other_s
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>124</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Educator_Expenses</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>
@@ -10886,6 +11010,7 @@ result.educator_expense_deduction taxpayer.educator_expenses constants.educator_
 <relative_path>TaxReturn.xlsx</relative_path>
 <file_name>TaxReturn.xlsx</file_name>
 <sheet_number>125</sheet_number>
+<source_hash>sha256:ef111043590db90088e957d5b1363fb7cf56be23d6338df5e557e985a248c523</source_hash>
 </source>
 <table_name>Calculate_Medical_Expense_Deduction</table_name>
 <xls_file>TaxReturn.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/AK_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/AK_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>AK.xlsx</relative_path>
 <file_name>AK.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:b8251a7ed705153b3e88a513289a91f59e3a79470e70d514548bdfc815ebd424</source_hash>
 </source>
 <table_name>AK_Tax</table_name>
 <xls_file>AK.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/AL_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/AL_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>AL.xlsx</relative_path>
 <file_name>AL.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:c141ebe063d4e3b27517563caeac800367d48bda95cf882c2c8c2fd82d9ba0ce</source_hash>
 </source>
 <table_name>AL_Tax</table_name>
 <xls_file>AL.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/AR_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/AR_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>AR.xlsx</relative_path>
 <file_name>AR.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:2d15c919c355524262923241251447201595d9eb1f02b5ab85ea732fe06b4a29</source_hash>
 </source>
 <table_name>AR_Tax</table_name>
 <xls_file>AR.xlsx</xls_file>
@@ -84,6 +85,7 @@ result.agi ar_standard_deduction_mfs f- 0.0 fmax cvi /result.ar_taxable_income x
 <relative_path>AR.xlsx</relative_path>
 <file_name>AR.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:2d15c919c355524262923241251447201595d9eb1f02b5ab85ea732fe06b4a29</source_hash>
 </source>
 <table_name>AR_Military_Retirement_Exclusion</table_name>
 <xls_file>AR.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/AS_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/AS_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>AS.xlsx</relative_path>
 <file_name>AS.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:4ffa4108fd375192e3a76a9e5b165d89d0c972466dcd0c5f40d075dc5de7bdc9</source_hash>
 </source>
 <table_name>AS_Tax</table_name>
 <xls_file>AS.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/AZ_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/AZ_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>AZ.xlsx</relative_path>
 <file_name>AZ.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:ae2ebaa52c97bf651015a77c71fa26a7ad80382a9f7bcdf475bff6aed852fbc6</source_hash>
 </source>
 <table_name>AZ_Tax</table_name>
 <xls_file>AZ.xlsx</xls_file>
@@ -104,6 +105,7 @@ result.az_taxable_income cvd /result.computed_state_taxable_income xdef result.a
 <relative_path>AZ.xlsx</relative_path>
 <file_name>AZ.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:ae2ebaa52c97bf651015a77c71fa26a7ad80382a9f7bcdf475bff6aed852fbc6</source_hash>
 </source>
 <table_name>AZ_Military_Retirement_Exclusion</table_name>
 <xls_file>AZ.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/CA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/CA_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>CA.xlsx</relative_path>
 <file_name>CA.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:61705958848bdd8f3ccef5f9b82d5938e197e86db1fcb9cb7822266b402369f2</source_hash>
 </source>
 <table_name>CA_Tax</table_name>
 <xls_file>CA.xlsx</xls_file>
@@ -82,6 +83,7 @@ result.ca_taxable_income cvd /result.computed_state_taxable_income xdef result.c
 <relative_path>CA.xlsx</relative_path>
 <file_name>CA.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:61705958848bdd8f3ccef5f9b82d5938e197e86db1fcb9cb7822266b402369f2</source_hash>
 </source>
 <table_name>ca_renter_credit</table_name>
 <xls_file>CA.xlsx</xls_file>
@@ -103,6 +105,7 @@ result.ca_taxable_income cvd /result.computed_state_taxable_income xdef result.c
 <relative_path>CA.xlsx</relative_path>
 <file_name>CA.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:61705958848bdd8f3ccef5f9b82d5938e197e86db1fcb9cb7822266b402369f2</source_hash>
 </source>
 <table_name>ca_military_retirement_exemption</table_name>
 <xls_file>CA.xlsx</xls_file>
@@ -124,6 +127,7 @@ result.ca_taxable_income cvd /result.computed_state_taxable_income xdef result.c
 <relative_path>CA.xlsx</relative_path>
 <file_name>CA.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:61705958848bdd8f3ccef5f9b82d5938e197e86db1fcb9cb7822266b402369f2</source_hash>
 </source>
 <table_name>CA_AGI</table_name>
 <xls_file>CA.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/CO_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/CO_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>CO.xlsx</relative_path>
 <file_name>CO.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:cd1c660e15ce792cd841ab1970f11b963991a16864f8b73de4eb31865f3502b3</source_hash>
 </source>
 <table_name>co_military_retirement_exemption</table_name>
 <xls_file>CO.xlsx</xls_file>
@@ -47,6 +48,7 @@ taxpayer.age 65 &gt;=
 <relative_path>CO.xlsx</relative_path>
 <file_name>CO.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:cd1c660e15ce792cd841ab1970f11b963991a16864f8b73de4eb31865f3502b3</source_hash>
 </source>
 <table_name>co_pension_subtraction</table_name>
 <xls_file>CO.xlsx</xls_file>
@@ -78,6 +80,7 @@ taxpayer.age 65 &gt;=
 <relative_path>CO.xlsx</relative_path>
 <file_name>CO.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:cd1c660e15ce792cd841ab1970f11b963991a16864f8b73de4eb31865f3502b3</source_hash>
 </source>
 <table_name>CO_Tax</table_name>
 <xls_file>CO.xlsx</xls_file>
@@ -140,6 +143,7 @@ result.co_taxable_income cvd /result.computed_state_taxable_income xdef result.c
 <relative_path>CO.xlsx</relative_path>
 <file_name>CO.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:cd1c660e15ce792cd841ab1970f11b963991a16864f8b73de4eb31865f3502b3</source_hash>
 </source>
 <table_name>CO_EITC</table_name>
 <xls_file>CO.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/CT_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/CT_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>CT.xlsx</relative_path>
 <file_name>CT.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:888eb3dcd6c0823fb369e9ab36cbcec971817bf8d3ade666bdc68cd5b50cab4e</source_hash>
 </source>
 <table_name>CT_Tax</table_name>
 <xls_file>CT.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/DC_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/DC_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>DC.xlsx</relative_path>
 <file_name>DC.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:c4037f062773c4b50615a861009aab770958718655e150dea9cd9165f355b35e</source_hash>
 </source>
 <table_name>DC_Tax</table_name>
 <xls_file>DC.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/DE_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/DE_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>DE.xlsx</relative_path>
 <file_name>DE.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:c5d574d5f547eb6c3e8f4cd5f22a4f5fb62df8c72441a18e1e2fa4b8dc012838</source_hash>
 </source>
 <table_name>DE_Tax</table_name>
 <xls_file>DE.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/FL_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/FL_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>FL.xlsx</relative_path>
 <file_name>FL.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:eb969ee596b0a8e7ed1566b7bb7749dd067bc96eb77fbd11db869f7ab04a942d</source_hash>
 </source>
 <table_name>FL_Tax</table_name>
 <xls_file>FL.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/GA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/GA_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>GA.xlsx</relative_path>
 <file_name>GA.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:1ce3cf5ae90a1975def3117d40e3ab9fd6c92f47a4a29276901150737bb98317</source_hash>
 </source>
 <table_name>GA_Tax</table_name>
 <xls_file>GA.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/GU_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/GU_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>GU.xlsx</relative_path>
 <file_name>GU.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:a92eeec05f1f49f88ff98613caff53316852f36fe59901ce0727834c8ef63cdc</source_hash>
 </source>
 <table_name>GU_Tax</table_name>
 <xls_file>GU.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/HI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/HI_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>HI.xlsx</relative_path>
 <file_name>HI.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:174c6bc0bb73d24c15cd3b9166d6dbbaf47d2aa9f0d4462a58b0080194439f31</source_hash>
 </source>
 <table_name>HI_Tax</table_name>
 <xls_file>HI.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/IA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/IA_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>IA.xlsx</relative_path>
 <file_name>IA.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:cf0a99e0a4485629004d9a68ef5a0ccac30ecb7481443bc7600b7e94d6e92955</source_hash>
 </source>
 <table_name>IA_Tax</table_name>
 <xls_file>IA.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/ID_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/ID_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>ID.xlsx</relative_path>
 <file_name>ID.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:4de4e13e2ecd5407973339b0481a3a8e86da5a8b44498f68cb26bc4d803c2022</source_hash>
 </source>
 <table_name>ID_Tax</table_name>
 <xls_file>ID.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/IL_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/IL_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>IL.xlsx</relative_path>
 <file_name>IL.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:5b574a055a8dbd89eb45a9d2a57378b91bd497a6da12ba322051658d065050e4</source_hash>
 </source>
 <table_name>il_tax</table_name>
 <xls_file>IL.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/IN_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/IN_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>IN.xlsx</relative_path>
 <file_name>IN.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:a91a983b9651c26f81989188feae17928b6ebf5e64c684d5fc9914cd91e8620f</source_hash>
 </source>
 <table_name>IN_Tax</table_name>
 <xls_file>IN.xlsx</xls_file>
@@ -69,6 +70,7 @@ result.in_taxable_income cvd /result.computed_state_taxable_income xdef result.i
 <relative_path>IN.xlsx</relative_path>
 <file_name>IN.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:a91a983b9651c26f81989188feae17928b6ebf5e64c684d5fc9914cd91e8620f</source_hash>
 </source>
 <table_name>in_military_retirement_exclusion</table_name>
 <xls_file>IN.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/KS_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/KS_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>KS.xlsx</relative_path>
 <file_name>KS.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:421ee1ffb4f25aabb3f2faddff9800b517ed27a0741d07a8c5f7e2bb56dde4f2</source_hash>
 </source>
 <table_name>KS_Tax</table_name>
 <xls_file>KS.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/KY_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/KY_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>KY.xlsx</relative_path>
 <file_name>KY.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:767ff959d19891d8e08915bc321d2396c0c7310f0e15ca6b3151cf4bdfcc5b33</source_hash>
 </source>
 <table_name>ky_military_retirement_exemption</table_name>
 <xls_file>KY.xlsx</xls_file>
@@ -36,6 +37,7 @@
 <relative_path>KY.xlsx</relative_path>
 <file_name>KY.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:767ff959d19891d8e08915bc321d2396c0c7310f0e15ca6b3151cf4bdfcc5b33</source_hash>
 </source>
 <table_name>KY_Tax</table_name>
 <xls_file>KY.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/LA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/LA_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>LA.xlsx</relative_path>
 <file_name>LA.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:b111f8fc33436015c537e9eba81189df7479219319232695a79498d1b8692ab3</source_hash>
 </source>
 <table_name>LA_Tax</table_name>
 <xls_file>LA.xlsx</xls_file>
@@ -48,6 +49,7 @@ la_standard_deduction_joint cvi /result.la_standard_deduction xdef result.agi re
 <relative_path>LA.xlsx</relative_path>
 <file_name>LA.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:b111f8fc33436015c537e9eba81189df7479219319232695a79498d1b8692ab3</source_hash>
 </source>
 <table_name>LA_Military_Retirement_Exclusion</table_name>
 <xls_file>LA.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/MA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MA_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MA.xlsx</relative_path>
 <file_name>MA.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:e8f871ff6ae5204953f70c412a2c7b975bd17c28d6b76183d9800c17e47def0d</source_hash>
 </source>
 <table_name>MA_Tax</table_name>
 <xls_file>MA.xlsx</xls_file>
@@ -104,6 +105,7 @@ result.ma_taxable_income cvd /result.computed_state_taxable_income xdef result.m
 <relative_path>MA.xlsx</relative_path>
 <file_name>MA.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:e8f871ff6ae5204953f70c412a2c7b975bd17c28d6b76183d9800c17e47def0d</source_hash>
 </source>
 <table_name>MA_Military_Retirement_Exclusion</table_name>
 <xls_file>MA.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/MD_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MD_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MD.xlsx</relative_path>
 <file_name>MD.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:7026a044412beaacc63457bab89c57e48548354781e6daf33da90fa87acd54ca</source_hash>
 </source>
 <table_name>MD_Tax</table_name>
 <xls_file>MD.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/ME_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/ME_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>ME.xlsx</relative_path>
 <file_name>ME.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:218121fb23e1f0163c0ed10b522ce926c2cb72ccb26b4bef42dfb703ad199fd1</source_hash>
 </source>
 <table_name>ME_Tax</table_name>
 <xls_file>ME.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/MI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MI_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MI.xlsx</relative_path>
 <file_name>MI.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:8bde37678436ea709fad3397439c5c4dbeaa7e982e288526ebe3b5a9ac8ecd39</source_hash>
 </source>
 <table_name>MI_Tax</table_name>
 <xls_file>MI.xlsx</xls_file>
@@ -69,6 +70,7 @@ result.mi_taxable_income cvd /result.computed_state_taxable_income xdef result.m
 <relative_path>MI.xlsx</relative_path>
 <file_name>MI.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:8bde37678436ea709fad3397439c5c4dbeaa7e982e288526ebe3b5a9ac8ecd39</source_hash>
 </source>
 <table_name>mi_military_retirement_exclusion</table_name>
 <xls_file>MI.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/MN_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MN_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MN.xlsx</relative_path>
 <file_name>MN.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:f606dbfab73593cd0765f35e7d8a05892e6d17d5fb89eef3a8440aa574de26ed</source_hash>
 </source>
 <table_name>MN_Tax</table_name>
 <xls_file>MN.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/MO_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MO_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MO.xlsx</relative_path>
 <file_name>MO.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:4980a25c6e878bb07f7b1807e01db741357681799b6d2432f9a6111d68b0dd3e</source_hash>
 </source>
 <table_name>MO_Tax</table_name>
 <xls_file>MO.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/MP_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MP_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MP.xlsx</relative_path>
 <file_name>MP.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:4bfeb01a6072bd517b9b85cfe72d157b617f9090bd22331b07308370a9828e43</source_hash>
 </source>
 <table_name>MP_Tax</table_name>
 <xls_file>MP.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/MS_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MS_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MS.xlsx</relative_path>
 <file_name>MS.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:d84bc87c13fe6fecdab4f2d78cf383adda162826b9085facd915700f7e5f89be</source_hash>
 </source>
 <table_name>MS_Tax</table_name>
 <xls_file>MS.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/MT_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/MT_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>MT.xlsx</relative_path>
 <file_name>MT.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:c10ba96af78bdd33a55ade01f359cc7840d88b9dc4e7451de8aa79e8b975e967</source_hash>
 </source>
 <table_name>MT_Tax</table_name>
 <xls_file>MT.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/NC_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NC_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>NC.xlsx</relative_path>
 <file_name>NC.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:b50362b17fb91915281d99ef21d4948a110baed762dd97b29e0b7096af98b8a1</source_hash>
 </source>
 <table_name>NC_Tax</table_name>
 <xls_file>NC.xlsx</xls_file>
@@ -104,6 +105,7 @@ result.nc_taxable_income cvd /result.computed_state_taxable_income xdef result.n
 <relative_path>NC.xlsx</relative_path>
 <file_name>NC.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:b50362b17fb91915281d99ef21d4948a110baed762dd97b29e0b7096af98b8a1</source_hash>
 </source>
 <table_name>nc_military_retirement_exclusion</table_name>
 <xls_file>NC.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/ND_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/ND_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>ND.xlsx</relative_path>
 <file_name>ND.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:cc7b040b5be55b40f955edcaf4eb3a43b3977311fd2443c0234d920c49d90008</source_hash>
 </source>
 <table_name>ND_Tax</table_name>
 <xls_file>ND.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/NE_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NE_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>NE.xlsx</relative_path>
 <file_name>NE.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:5eaf9d7782f9b8cee1c3124c425b7432a2bb89a224c8da4c8c8883d00b0728ee</source_hash>
 </source>
 <table_name>NE_Tax</table_name>
 <xls_file>NE.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/NH_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NH_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>NH.xlsx</relative_path>
 <file_name>NH.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:07011e487a1047f1b67214592b889614c26886d5310f7fed63b57c2f4aadcc67</source_hash>
 </source>
 <table_name>NH_Tax</table_name>
 <xls_file>NH.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/NJ_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NJ_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>NJ.xlsx</relative_path>
 <file_name>NJ.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:bb5bff100732752dc680e8204606c1851f5049c09ce13a7f7174cef73c8318f6</source_hash>
 </source>
 <table_name>NJ_Military_Retirement_Exclusion</table_name>
 <xls_file>NJ.xlsx</xls_file>
@@ -28,6 +29,7 @@
 <relative_path>NJ.xlsx</relative_path>
 <file_name>NJ.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:bb5bff100732752dc680e8204606c1851f5049c09ce13a7f7174cef73c8318f6</source_hash>
 </source>
 <table_name>nj_tax</table_name>
 <xls_file>NJ.xlsx</xls_file>
@@ -103,6 +105,7 @@ result.nj_taxable_income cvd /result.computed_state_taxable_income xdef result.n
 <relative_path>NJ.xlsx</relative_path>
 <file_name>NJ.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:bb5bff100732752dc680e8204606c1851f5049c09ce13a7f7174cef73c8318f6</source_hash>
 </source>
 <table_name>NJ_Tax_MFJ_Brackets</table_name>
 <xls_file>NJ.xlsx</xls_file>
@@ -261,6 +264,7 @@ nj_bracket_1_limit_joint nj_bracket_1_rate fmul nj_bracket_2_limit_joint nj_brac
 <relative_path>NJ.xlsx</relative_path>
 <file_name>NJ.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:bb5bff100732752dc680e8204606c1851f5049c09ce13a7f7174cef73c8318f6</source_hash>
 </source>
 <table_name>NJ_Tax_Single_Brackets</table_name>
 <xls_file>NJ.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/NM_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NM_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>NM.xlsx</relative_path>
 <file_name>NM.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:6c85f1704f2a8d5eff928c5221fd58a91f1882765f5f2c1334595e76b7130459</source_hash>
 </source>
 <table_name>nm_tax</table_name>
 <xls_file>NM.xlsx</xls_file>
@@ -38,6 +39,7 @@ job.filing_status "HOH" streq
 <relative_path>NM.xlsx</relative_path>
 <file_name>NM.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:6c85f1704f2a8d5eff928c5221fd58a91f1882765f5f2c1334595e76b7130459</source_hash>
 </source>
 <table_name>NM_Military_Retirement_Exclusion</table_name>
 <xls_file>NM.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/NV_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NV_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>NV.xlsx</relative_path>
 <file_name>NV.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:92edb82bf26d38d606cd24216f73c9faae2112d0c16c589ca220428207de1a3e</source_hash>
 </source>
 <table_name>NV_Tax</table_name>
 <xls_file>NV.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/NY_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/NY_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>NY.xlsx</relative_path>
 <file_name>NY.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:39512cca152b36b6425500c5614d2b7a51ed01ee86b70e1c795bc1bab646e30d</source_hash>
 </source>
 <table_name>NY_Tax</table_name>
 <xls_file>NY.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/OH_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/OH_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>OH.xlsx</relative_path>
 <file_name>OH.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:3f394c5f72cd06f766a23de4a31cc415d5e02df11015100a0d9a7ea9ff6db071</source_hash>
 </source>
 <table_name>OH_Tax</table_name>
 <xls_file>OH.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/OK_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/OK_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>OK.xlsx</relative_path>
 <file_name>OK.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:b9e8d77c4dfccfc6ad8924c628098539a9fa9d5fbb765ff9aec085b605550206</source_hash>
 </source>
 <table_name>ok_tax</table_name>
 <xls_file>OK.xlsx</xls_file>
@@ -56,6 +57,7 @@ job.filing_status "MFS" streq
 <relative_path>OK.xlsx</relative_path>
 <file_name>OK.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:b9e8d77c4dfccfc6ad8924c628098539a9fa9d5fbb765ff9aec085b605550206</source_hash>
 </source>
 <table_name>OK_Military_Retirement_Exclusion</table_name>
 <xls_file>OK.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/OR_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/OR_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>OR.xlsx</relative_path>
 <file_name>OR.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:08a8ded688aba183636dad26f22083841478c28cd52f6f5d8ccc622d465fd0f1</source_hash>
 </source>
 <table_name>OR_Tax</table_name>
 <xls_file>OR.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/PA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/PA_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>PA.xlsx</relative_path>
 <file_name>PA.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:74f05d7b636eb5fb4e59a5e2c535017d9d61485a4c8e79c90842c36ed813968b</source_hash>
 </source>
 <table_name>pa_tax</table_name>
 <xls_file>PA.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/PR_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/PR_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>PR.xlsx</relative_path>
 <file_name>PR.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:df149a90d63dea197f800994a59943e88194c124a330868a3768a73da8769c59</source_hash>
 </source>
 <table_name>PR_Tax</table_name>
 <xls_file>PR.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/RI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/RI_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>RI.xlsx</relative_path>
 <file_name>RI.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:9a75f43f6517b1ecbf5e80395567a4274463ca5d8b93e02646c229b133ab3500</source_hash>
 </source>
 <table_name>RI_Tax</table_name>
 <xls_file>RI.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/SC_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/SC_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>SC.xlsx</relative_path>
 <file_name>SC.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:c2d092a0b61f5c2c08fad87e818355abec20a2ed13e50cc35971872150a58b45</source_hash>
 </source>
 <table_name>SC_Military_Retirement_Exclusion</table_name>
 <xls_file>SC.xlsx</xls_file>
@@ -36,6 +37,7 @@
 <relative_path>SC.xlsx</relative_path>
 <file_name>SC.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:c2d092a0b61f5c2c08fad87e818355abec20a2ed13e50cc35971872150a58b45</source_hash>
 </source>
 <table_name>SC_Tax</table_name>
 <xls_file>SC.xlsx</xls_file>
@@ -100,6 +102,7 @@ result.sc_taxable_income cvd /result.computed_state_taxable_income xdef result.s
 <relative_path>SC.xlsx</relative_path>
 <file_name>SC.xlsx</file_name>
 <sheet_number>3</sheet_number>
+<source_hash>sha256:c2d092a0b61f5c2c08fad87e818355abec20a2ed13e50cc35971872150a58b45</source_hash>
 </source>
 <table_name>SC_Compute_Taxable_Income</table_name>
 <xls_file>SC.xlsx</xls_file>
@@ -150,6 +153,7 @@ result.agi sc_standard_deduction_single f- 0 fmax cvd /result.sc_taxable_income 
 <relative_path>SC.xlsx</relative_path>
 <file_name>SC.xlsx</file_name>
 <sheet_number>4</sheet_number>
+<source_hash>sha256:c2d092a0b61f5c2c08fad87e818355abec20a2ed13e50cc35971872150a58b45</source_hash>
 </source>
 <table_name>SC_Tax_Brackets</table_name>
 <xls_file>SC.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/SD_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/SD_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>SD.xlsx</relative_path>
 <file_name>SD.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:44ab69bd50208d8a3e154ef43717bfa8290f07e67b22cebd3e41cfd967210dac</source_hash>
 </source>
 <table_name>SD_Tax</table_name>
 <xls_file>SD.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/TN_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/TN_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>TN.xlsx</relative_path>
 <file_name>TN.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:895746e0f8920229dd48fbe378567c41f62d02f24e077a33aa76d2ed016a7ffa</source_hash>
 </source>
 <table_name>TN_Tax</table_name>
 <xls_file>TN.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/TX_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/TX_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>TX.xlsx</relative_path>
 <file_name>TX.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:1c95d779e50a7d5dbba41ce88c651d92caa32e85bc9aaa9ce5d98797b47af75f</source_hash>
 </source>
 <table_name>TX_Tax</table_name>
 <xls_file>TX.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/UT_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/UT_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>UT.xlsx</relative_path>
 <file_name>UT.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:2c04c36119822ce8a295b5dc0bf524f1ddf6ab41e3747f58f6e0eea80f5df999</source_hash>
 </source>
 <table_name>ut_tax</table_name>
 <xls_file>UT.xlsx</xls_file>
@@ -60,6 +61,7 @@ result.agi job.dependents length ut_personal_exemption fmul f- 0.0 fmax cvd /res
 <relative_path>UT.xlsx</relative_path>
 <file_name>UT.xlsx</file_name>
 <sheet_number>2</sheet_number>
+<source_hash>sha256:2c04c36119822ce8a295b5dc0bf524f1ddf6ab41e3747f58f6e0eea80f5df999</source_hash>
 </source>
 <table_name>UT_Military_Retirement_Exclusion</table_name>
 <xls_file>UT.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/VA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/VA_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>VA.xlsx</relative_path>
 <file_name>VA.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:740d061be100309af4a9bcae3bec38c5ba924eb58afebf5bba56c1643c43d91b</source_hash>
 </source>
 <table_name>VA_Tax</table_name>
 <xls_file>VA.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/VI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/VI_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>VI.xlsx</relative_path>
 <file_name>VI.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:b53bd38a9dc4d3b64f7f523a0256fd602b05f1b9cd4bfd5699cc2c57092ae71d</source_hash>
 </source>
 <table_name>VI_Tax</table_name>
 <xls_file>VI.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/VT_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/VT_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>VT.xlsx</relative_path>
 <file_name>VT.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:3326fa1a11213c814342e1de8ab5de9126c466fd4eda0c8cffaa4d5aaddd18c6</source_hash>
 </source>
 <table_name>VT_Tax</table_name>
 <xls_file>VT.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/WA_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/WA_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>WA.xlsx</relative_path>
 <file_name>WA.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:9a3ac1f8f5a48d3685b44be388aded6db212b6ffbb07f7ac63eb633f22ea5a53</source_hash>
 </source>
 <table_name>WA_Tax</table_name>
 <xls_file>WA.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/WI_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/WI_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>WI.xlsx</relative_path>
 <file_name>WI.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:f5e90840811341f97d6ba5315696dbcf9cb77b7c283926a3c2c5ba858d1d5365</source_hash>
 </source>
 <table_name>WI_Tax</table_name>
 <xls_file>WI.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/WV_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/WV_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>WV.xlsx</relative_path>
 <file_name>WV.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:e82f4098206bdfd8084dda57194a30167b16b40ad21b386e8f0f581e7668274a</source_hash>
 </source>
 <table_name>WV_Tax</table_name>
 <xls_file>WV.xlsx</xls_file>

--- a/sampleprojects/TaxReturn/xml/states/WY_dt.xml
+++ b/sampleprojects/TaxReturn/xml/states/WY_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>WY.xlsx</relative_path>
 <file_name>WY.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:d1741245a6fb2a1bb8682b0e13c8770cae68f591e1dcc5171fcbe13fa008579e</source_hash>
 </source>
 <table_name>WY_Tax</table_name>
 <xls_file>WY.xlsx</xls_file>

--- a/sampleprojects/TestProject/xml/Test_dt.xml
+++ b/sampleprojects/TestProject/xml/Test_dt.xml
@@ -7,6 +7,7 @@
 <relative_path>Test.xlsx</relative_path>
 <file_name>Test.xlsx</file_name>
 <sheet_number>1</sheet_number>
+<source_hash>sha256:89d4fd4f4cf5ab3047faef8f4eabe315f49fda1dfc5fb3abf33df7c3b492f597</source_hash>
 </source>
 <table_name>Test_Entry_Point</table_name>
 <xls_file>Test.xlsx</xls_file>


### PR DESCRIPTION
Excel is the system of record, so the relationship is one-directional and **one
hash is enough**: only the derived artifact records where it came from. Every
table's `<source>` block gains `<source_hash>` — the hash of the workbook bytes
the XML was compiled from. The workbook records nothing, so there is no
circularity to break.

The check is two file reads:

```
hash(workbook on disk) == <source_hash> recorded in the XML ?
```

## Why

Timestamps answer "which file was touched last", a proxy for "which changed",
and the proxy is wrong constantly — checkout, `cp`, containers, CI, mtime
granularity:

- **#1057** — `build --from-excel` asked mtimes, got NoSync, imported nothing, exited 0
- **#1061** — the guard compared mtime to a recorded export time, and checkout stamps every file, so **every fresh clone started locked**

Provenance travels with the artifact through git, `cp` and CI, which
`.sync-manifest.json` never could — it's gitignored, so the baseline never left
the machine that made it.

## Demonstrated

```
$ dtrules build --from-excel .          # stamps the XML
$ touch xml/*.xml excel/*.xlsx          # what a checkout does
$ dtrules build --dry-run .
[dry-run] No changes detected; nothing would be written.

$ printf '\x00' >> excel/kidaid.xlsx    # a real change
$ dtrules build --dry-run .
[dry-run] Would run excel-authored build
```

## The guard too

The export guard's question was always "has this workbook changed since the XML
was generated, so writing XML over it would discard an edit". The recorded hash
answers exactly that.

This change was prompted by **its own test suite**: rebuilding the sample
workbooks made every `table put` test fail on the mtime guard — the failure
mode the issue is about, reproduced by accident.

## Scope

XML with no stamp falls back to timestamps, so nothing written before this
breaks. `.sync-manifest.json` remains the workbook-to-XML *index*; what it is
no longer asked for is the *time*. **Retiring it entirely, and inverting
`Project.Save` so the XML falls out of compiling the Excel, are the remaining
pieces of #1091** and are left for a follow-up.

## Verification

- All **twelve** samples stamped; every one verifies with zero findings
- `make check` and the archive lane pass
- Unit tests for the hash, for stamp agreement across tables, and for all three
  direction cases including the touched-everything clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)