### PR TITLE
feat(authoring): export Excel, then compile it to produce the XML (#1091)

### DIFF
--- a/pkg/dtrules/authoring/excel_sync.go
+++ b/pkg/dtrules/authoring/excel_sync.go
@@ -154,6 +154,7 @@ func RefreshExcelIn(xmlDir, excelDir string) error {
 		return fmt.Errorf("excel refresh: load ruleset: %w", err)
 	}
 	exporter := excel.NewExporter(rs)
+	var changed []string
 	for excelRel, entry := range m.Files {
 		excelPath := filepath.Join(manifestDir, excelRel)
 		// Refresh what exists; do not resurrect what does not.
@@ -181,6 +182,7 @@ func RefreshExcelIn(xmlDir, excelDir string) error {
 		//
 		// A workbook no table claims is left alone rather than emptied --
 		// see ExportDecisionTablesOwnedBy.
+		before := excel.WorkbookHash(excelPath)
 		n, err := exporter.ExportDecisionTablesOwnedBy(excelPath)
 		if err != nil {
 			return fmt.Errorf("excel refresh: export %s: %w", excelPath, err)
@@ -188,8 +190,46 @@ func RefreshExcelIn(xmlDir, excelDir string) error {
 		if n == 0 {
 			continue
 		}
+		if excel.WorkbookHash(excelPath) != before {
+			changed = append(changed, excelPath)
+		}
 		if err := m.RecordExport(excelPath, entry.XMLFiles); err != nil {
 			return fmt.Errorf("excel refresh: record manifest for %s: %w", excelPath, err)
+		}
+	}
+
+	// Excel first, then compile it — the order the contract states.
+	//
+	// The XML was written from the in-memory model a moment ago and the Excel
+	// was exported from that XML, which left two artifacts that agree because
+	// two code paths agreed, and `verify`'s [build] check existed to keep
+	// discovering when they did not. Recompiling the workbook makes the XML
+	// literally the output of compiling the Excel, so agreement is a property
+	// of how the file was produced rather than something to test for. It also
+	// stamps the provenance hash of the workbook that was just written, which
+	// nothing else is in a position to know (#1091).
+	//
+	// Only workbooks whose bytes actually changed: an edit to one table in a
+	// 58-workbook project recompiles one workbook, not 58. The hash makes that
+	// cheap to know.
+	return recompileWorkbooks(xmlDir, changed)
+}
+
+// recompileWorkbooks regenerates XML from the named workbooks.
+func recompileWorkbooks(xmlDir string, workbooks []string) error {
+	if len(workbooks) == 0 {
+		return nil
+	}
+	imp := excel.NewWorkbookImporter()
+	imp.SetELCompiler(newCheckedCompiler())
+	// The whole project's types, so a table reading an entity declared in
+	// another workbook is not compiled as an integer (#1106).
+	if syms := LoadEDDSymbols(xmlDir); len(syms) > 0 {
+		imp.SetSymbols(syms)
+	}
+	for _, wb := range workbooks {
+		if _, _, err := imp.ImportWorkbookToDir(wb, xmlDir); err != nil {
+			return fmt.Errorf("excel refresh: recompile %s: %w", wb, err)
 		}
 	}
 	return nil

--- a/pkg/dtrules/authoring/recompile_order_test.go
+++ b/pkg/dtrules/authoring/recompile_order_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import "testing"
+
+// The order the contract states: export Excel, then compile it to produce XML.
+//
+// Writing the XML from the model and then exporting Excel from that XML leaves
+// two artifacts that agree because two code paths agreed — and `verify`'s
+// [build] check existed to keep discovering when they did not. Recompiling the
+// workbook makes the XML literally the output of compiling the Excel, so
+// agreement is a property of how the file was produced rather than something
+// to test for (#1091).
+
+func TestRecompileIsSkippedWhenNothingChanged(t *testing.T) {
+	// No workbooks changed means no recompile: an edit to one table in a
+	// 58-workbook project must not regenerate 58 XML files.
+	if err := recompileWorkbooks(t.TempDir(), nil); err != nil {
+		t.Errorf("recompiling an empty set should be a no-op, got %v", err)
+	}
+}
+
+// A workbook that cannot be read is reported against its own name rather than
+// failing anonymously somewhere inside the importer.
+func TestRecompileNamesTheWorkbookItFailedOn(t *testing.T) {
+	err := recompileWorkbooks(t.TempDir(), []string{"/nonexistent/Missing.xlsx"})
+	if err == nil {
+		t.Fatal("recompiling a workbook that does not exist should fail")
+	}
+	if !contains(err.Error(), "Missing.xlsx") {
+		t.Errorf("error should name the workbook: %v", err)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (haystack == needle ||
+		len(needle) == 0 || indexOf(haystack, needle) >= 0)
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
The order the contract states, made true of the code.

An authoring write used to produce the XML from the in-memory model, then
export Excel *from that XML*. Two artifacts, written by two code paths,
agreeing because both were correct — and `verify`'s `[build]` check existed to
keep discovering when they were not. **#1079 was exactly that**: both sides in
sync by every available measure, and regenerating produced different bytes.

## Change

The refresh recompiles the workbook it just wrote, so the XML on disk is
literally the output of compiling the Excel:

```
authoring edits the model
  → writes Excel                     (system of record)
  → compiles Excel → XML             (derived)
  → stamps the XML with hash(Excel)  (provenance)
```

Agreement becomes a property of how the file was produced rather than something
to test for. It also stamps the provenance hash of the workbook just written,
which nothing else is in a position to know.

## Why this was affordable

**Only workbooks whose bytes actually changed are recompiled.** An edit to one
table in a 58-workbook project recompiles one workbook, not 58 — the hash from
#1124 makes that cheap to know. Without it, the honest implementation would
have been a rewrite of the exporter to emit workbooks from the model directly.

The recompile carries the project's whole symbol table, so a table reading an
entity declared in another workbook isn't compiled as an integer (#1106).

## Measured

Editing one condition comment through `table put` on SinusitisTherapy:

| | result |
|---|---|
| workbooks changed | **1 of 6** — no #1077-class spread |
| edit present in regenerated XML | yes |
| `verify` | clean, exit 0 |

On CHIP the provenance stamp is correct immediately after the write, with no
build in between.

`make check` and the archive lane pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)