### PR TITLE
fix(authoring): pair workbooks with XML from the artifacts, not the manifest (#1091)

### DIFF
--- a/pkg/dtrules/authoring/excel_sync.go
+++ b/pkg/dtrules/authoring/excel_sync.go
@@ -61,6 +61,42 @@ func GuardExcelInDir(xmlDir string, overwrite bool) error {
 // exactly that shape: excel/ is declared and used by build and verify, while a
 // stale pkg/dtrules/excel/ sits next to the rules and won the search (#1049).
 func GuardExcelIn(xmlDir, excelDir string, overwrite bool) error {
+	// The artifacts know their own pairing, so a clone works. The manifest is
+	// gitignored: it never left the machine that built it, and both this and
+	// the refresh were documented as no-ops without one -- which described
+	// every clone anyone had ever made (#1091).
+	if pairing := discoverWorkbookPairing(xmlDir, resolveExcelDir(xmlDir, excelDir)); len(pairing) > 0 {
+		for excelPath, xmlFiles := range pairing {
+			if err := excelLockError(excelPath); err != nil {
+				return err
+			}
+			if overwrite {
+				continue
+			}
+			recorded := recordedHashForPaths(xmlFiles)
+			if recorded == "" {
+				continue // unstamped: nothing to compare, and no clock to ask
+			}
+			// A workbook that is not there cannot have changed, and there are
+			// no user edits in it to lose. `verify` reports tables whose
+			// declared workbook is absent, which is where that belongs; the
+			// guard's only job is to refuse to overwrite something.
+			current := excel.WorkbookHash(excelPath)
+			if current == "" {
+				continue
+			}
+			if recorded != current {
+				return &sync.ExcelModifiedError{
+					ExcelPath: excelPath,
+					Message: fmt.Sprintf("Excel file %q has changed since the XML was compiled "+
+						"from it; user changes would be lost. Import Excel to XML first, then "+
+						"re-apply your changes.", excelPath),
+				}
+			}
+		}
+		return nil
+	}
+
 	m, manifestDir := loadSyncManifest(xmlDir, excelDir)
 	if m == nil {
 		return nil
@@ -145,8 +181,9 @@ func RefreshExcelInDir(xmlDir string) error {
 // RefreshExcelIn is RefreshExcelInDir with the project's declared Excel
 // directory. Pass "" to search the conventional layouts (#1049).
 func RefreshExcelIn(xmlDir, excelDir string) error {
+	pairing := discoverWorkbookPairing(xmlDir, resolveExcelDir(xmlDir, excelDir))
 	m, manifestDir := loadSyncManifest(xmlDir, excelDir)
-	if m == nil {
+	if m == nil && len(pairing) == 0 {
 		return nil
 	}
 	rs, err := loadRuleSetForExportInDir(xmlDir)
@@ -155,8 +192,24 @@ func RefreshExcelIn(xmlDir, excelDir string) error {
 	}
 	exporter := excel.NewExporter(rs)
 	var changed []string
-	for excelRel, entry := range m.Files {
-		excelPath := filepath.Join(manifestDir, excelRel)
+
+	// The workbooks to refresh, and the XML each is paired with. Discovery
+	// reads that out of the artifacts' own `<source>` blocks; the manifest is
+	// the fallback for projects whose XML records no source at all.
+	targets := pairing
+	if len(targets) == 0 {
+		targets = make(map[string][]string, len(m.Files))
+		for excelRel, entry := range m.Files {
+			abs := filepath.Join(manifestDir, excelRel)
+			paired := make([]string, 0, len(entry.XMLFiles))
+			for _, rel := range entry.XMLFiles {
+				paired = append(paired, filepath.Join(manifestDir, rel))
+			}
+			targets[abs] = paired
+		}
+	}
+
+	for excelPath, xmlFiles := range targets {
 		// Refresh what exists; do not resurrect what does not.
 		//
 		// The manifest outlives the files it names. TaxReturn's committed
@@ -193,8 +246,19 @@ func RefreshExcelIn(xmlDir, excelDir string) error {
 		if excel.WorkbookHash(excelPath) != before {
 			changed = append(changed, excelPath)
 		}
-		if err := m.RecordExport(excelPath, entry.XMLFiles); err != nil {
-			return fmt.Errorf("excel refresh: record manifest for %s: %w", excelPath, err)
+		// Keep the manifest current where one exists, so a project that still
+		// has it does not start disagreeing with itself. Nothing reads its
+		// timestamps any more (#1091).
+		if m != nil {
+			rel := make([]string, 0, len(xmlFiles))
+			for _, x := range xmlFiles {
+				if r, rerr := filepath.Rel(manifestDir, x); rerr == nil {
+					rel = append(rel, r)
+				}
+			}
+			if err := m.RecordExport(excelPath, rel); err != nil {
+				return fmt.Errorf("excel refresh: record manifest for %s: %w", excelPath, err)
+			}
 		}
 	}
 
@@ -233,6 +297,37 @@ func recompileWorkbooks(xmlDir string, workbooks []string) error {
 		}
 	}
 	return nil
+}
+
+// recordedHashForPaths reads the provenance stamp out of already-resolved XML
+// paths. Returns "" when none carry one.
+func recordedHashForPaths(xmlPaths []string) string {
+	for _, p := range xmlPaths {
+		if !strings.HasSuffix(p, "_dt.xml") {
+			continue
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		var doc excel.DecisionTablesXML
+		if err := xml.Unmarshal(data, &doc); err != nil {
+			continue
+		}
+		if h := excel.RecordedWorkbookHash(doc.Tables); h != "" {
+			return h
+		}
+	}
+	return ""
+}
+
+// resolveExcelDir falls back to the conventional sibling layout when a project
+// declares no Excel directory.
+func resolveExcelDir(xmlDir, excelDir string) string {
+	if excelDir != "" {
+		return excelDir
+	}
+	return filepath.Join(filepath.Dir(xmlDir), "excel")
 }
 
 // LoadSyncManifestForXMLDir searches the conventional layouts for the

--- a/pkg/dtrules/authoring/workbook_pairing.go
+++ b/pkg/dtrules/authoring/workbook_pairing.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/excel"
+	"github.com/DTRules/DTRules/pkg/dtrules/loader"
+)
+
+// discoverWorkbookPairing answers "which workbook does each XML file belong
+// to" by reading the artifacts instead of a side file.
+//
+// Every table and every entity already records its workbook in a `<source>`
+// block. That is the same pairing `.sync-manifest.json` held, except it
+// travels: the manifest is gitignored, so the pairing never left the machine
+// that built it. A fresh clone had no manifest, so the guard and the refresh
+// silently did nothing at all -- both are documented as no-ops on projects
+// without one, which described every clone anyone had ever made (#1091).
+//
+// Keyed by absolute workbook path, valued by the XML files that named it.
+// Workbooks are resolved against excelDir, falling back to the recorded
+// relative path when that does not exist, because a project's workbooks are
+// not always flat.
+func discoverWorkbookPairing(xmlDir, excelDir string) map[string][]string {
+	pairing := make(map[string][]string)
+
+	add := func(workbook, xmlPath string) {
+		name := strings.TrimSpace(workbook)
+		if name == "" {
+			return
+		}
+		abs := filepath.Join(excelDir, name)
+		if _, err := os.Stat(abs); err != nil {
+			// Recorded as a path rather than a base name, or nested.
+			if alt := filepath.Join(excelDir, filepath.Base(name)); alt != abs {
+				if _, err2 := os.Stat(alt); err2 == nil {
+					abs = alt
+				}
+			}
+		}
+		for _, seen := range pairing[abs] {
+			if seen == xmlPath {
+				return
+			}
+		}
+		pairing[abs] = append(pairing[abs], xmlPath)
+	}
+
+	_ = filepath.WalkDir(xmlDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if filepath.Ext(name) != ".xml" || loader.SkipRuleFile(p) {
+			return nil
+		}
+		data, rerr := os.ReadFile(p)
+		if rerr != nil {
+			return nil
+		}
+		switch {
+		case strings.HasSuffix(name, "_dt.xml"):
+			var doc excel.DecisionTablesXML
+			if xml.Unmarshal(data, &doc) != nil {
+				return nil
+			}
+			for i := range doc.Tables {
+				if src := doc.Tables[i].Source; src != nil {
+					add(sourceWorkbook(src), p)
+				}
+			}
+		case strings.HasSuffix(name, "_edd.xml"):
+			var doc excel.EDDXML
+			if xml.Unmarshal(data, &doc) != nil {
+				return nil
+			}
+			for _, ent := range doc.Entities {
+				if ent == nil {
+					continue
+				}
+				if ent.Source != nil {
+					add(sourceWorkbook(ent.Source), p)
+				} else if ent.XlsFile != "" {
+					add(ent.XlsFile, p)
+				}
+			}
+		}
+		return nil
+	})
+
+	for k := range pairing {
+		sort.Strings(pairing[k])
+	}
+	return pairing
+}
+
+// sourceWorkbook prefers the file name a source block records, falling back to
+// its relative path. Both spellings appear in the corpus.
+func sourceWorkbook(src *excel.SourceXML) string {
+	if n := strings.TrimSpace(src.FileName); n != "" {
+		return n
+	}
+	return strings.TrimSpace(src.RelativePath)
+}

--- a/pkg/dtrules/authoring/workbook_pairing_test.go
+++ b/pkg/dtrules/authoring/workbook_pairing_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authoring
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The pairing has to come from the artifacts, because `.sync-manifest.json` is
+// gitignored and never leaves the machine that built it. Both the guard and
+// the refresh were documented as no-ops without one — which described every
+// clone anyone had ever made. Measured on a manifest-free copy of
+// SinusitisTherapy before this landed: an authoring edit updated 0 of 6
+// workbooks and left the project failing verify (#1091).
+
+func writePairingFixture(t *testing.T) (xmlDir, excelDir string) {
+	t.Helper()
+	root := t.TempDir()
+	xmlDir = filepath.Join(root, "xml")
+	excelDir = filepath.Join(root, "excel")
+	for _, d := range []string{xmlDir, excelDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(excelDir, "Book.xlsx"), []byte("wb"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dt := `<decision_tables><decision_table><table_name>T</table_name>` +
+		`<source><relative_path>Book.xlsx</relative_path><file_name>Book.xlsx</file_name>` +
+		`<sheet_number>1</sheet_number></source></decision_table></decision_tables>`
+	if err := os.WriteFile(filepath.Join(xmlDir, "Book_dt.xml"), []byte(dt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return xmlDir, excelDir
+}
+
+func TestPairingComesFromTheArtifacts(t *testing.T) {
+	xmlDir, excelDir := writePairingFixture(t)
+
+	pairing := discoverWorkbookPairing(xmlDir, excelDir)
+
+	want := filepath.Join(excelDir, "Book.xlsx")
+	paired, ok := pairing[want]
+	if !ok {
+		t.Fatalf("the workbook the XML names was not discovered; got %v", pairing)
+	}
+	if len(paired) != 1 || filepath.Base(paired[0]) != "Book_dt.xml" {
+		t.Errorf("paired with %v, want the DT file that named it", paired)
+	}
+}
+
+// Templates are scaffolding to copy, not rules, and must not pull a workbook
+// into the refresh — the same predicate the loader and verify use.
+func TestTemplatesAreNotPaired(t *testing.T) {
+	xmlDir, excelDir := writePairingFixture(t)
+	tpl := `<decision_tables><decision_table><table_name>X</table_name>` +
+		`<source><file_name>Template.xlsx</file_name><sheet_number>1</sheet_number></source>` +
+		`</decision_table></decision_tables>`
+	if err := os.WriteFile(filepath.Join(xmlDir, "TEMPLATE_dt.xml"), []byte(tpl), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for wb := range discoverWorkbookPairing(xmlDir, excelDir) {
+		if filepath.Base(wb) == "Template.xlsx" {
+			t.Error("a template's workbook was pulled into the pairing")
+		}
+	}
+}
+
+// A project whose XML records no source at all falls back to the manifest,
+// so nothing written before source blocks existed breaks.
+func TestNoSourceBlocksDiscoversNothing(t *testing.T) {
+	root := t.TempDir()
+	xmlDir := filepath.Join(root, "xml")
+	if err := os.MkdirAll(xmlDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `<decision_tables><decision_table><table_name>T</table_name></decision_table></decision_tables>`
+	if err := os.WriteFile(filepath.Join(xmlDir, "a_dt.xml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := discoverWorkbookPairing(xmlDir, filepath.Join(root, "excel")); len(got) != 0 {
+		t.Errorf("discovered %v from XML that records no source", got)
+	}
+}


### PR DESCRIPTION
`.sync-manifest.json` is **gitignored**, so the pairing it holds never leaves
the machine that built it. Both the export guard and the Excel refresh are
documented as no-ops on projects without one — which describes **every clone
anyone has ever made**.

## Measured, not inferred

Same `table put` on a manifest-free copy of SinusitisTherapy (produced with
`git archive HEAD`, i.e. exactly what a clone gives):

| | main | this change |
|---|---|---|
| workbooks updated by the edit | **0 of 6** | 1 of 6 |
| edit reached the XML | yes | yes |
| `verify` afterwards | **1 finding — drift** | clean, exit 0 |

The XML changed and the Excel did not, silently, on a fresh clone. The
system-of-record contract inverted by a missing side file.

## Change

Every table and every entity already records its workbook in a `<source>`
block — the same pairing the manifest held, except it travels through git,
`cp` and CI. Discovery reads it.

The manifest stays as the fallback for XML that records no source at all, and
is still kept current where one exists, so a project doesn't start disagreeing
with itself.

Templates are excluded through the same predicate the loader and `verify` use,
so scaffolding can't pull a workbook into the refresh.

## One behaviour correction found by the tests

The guard now **skips a workbook that isn't on disk**. It can't have changed
and holds no user edits to lose — `verify` reports tables whose declared
workbook is absent, which is where that belongs. `TestSave_TaxReturnIdempotent`
caught this: it copies only `xml/` to a temp dir, so every recorded workbook is
missing, and the guard refused the save. The refresh already worked this way.

`make check`, the archive lane, and all 12 samples pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)