### PR TITLE
fix(analysis): three ways a field read on every run was reported unused (#776)

### DIFF
--- a/pkg/dtrules/analysis/edd_unused.go
+++ b/pkg/dtrules/analysis/edd_unused.go
@@ -225,6 +225,9 @@ var createEntityPattern = regexp.MustCompile(`(?i)new\s+([a-z_][a-z0-9_]*)\s+ent
 // field of the iterated entity are recorded as `entitytype.field`
 // references. This is the entity-stack-aware pass from #776 phase 1.
 func collectDTReferences(xmlDir string, schema *eddSchema) (readRefs map[string]bool, writeRefs map[string]bool, err error) {
+	// What the mapping puts on the entity stack before any table runs. Every
+	// table's own context extends this rather than starting empty (#776).
+	baseStack := initialEntities(xmlDir)
 	readRefs = make(map[string]bool)
 	writeRefs = make(map[string]bool)
 
@@ -244,7 +247,7 @@ func collectDTReferences(xmlDir string, schema *eddSchema) (readRefs map[string]
 
 		var tables struct {
 			Tables []struct {
-				Contexts []contextEntry `xml:"contexts>context_details"`
+				Contexts       []contextEntry `xml:"contexts>context_details"`
 				InitialActions []struct {
 					DSL     string `xml:"initial_action_dsl"`
 					Postfix string `xml:"action_postfix"`
@@ -272,7 +275,10 @@ func collectDTReferences(xmlDir string, schema *eddSchema) (readRefs map[string]
 			// iteration clause is present — the analyzer then
 			// falls back to the dotted-only regex pass, identical
 			// to the pre-#776 behaviour.
-			entityStack := stackFromContexts(schema, table.Contexts)
+			// Seeded with what the mapping pushes before any table runs, so
+			// a bare name in a table with no context of its own still
+			// resolves (#776).
+			entityStack := append(append([]string{}, baseStack...), stackFromContexts(schema, table.Contexts)...)
 
 			// The iterated field itself is being read by every
 			// iteration clause (context or inline). Record it so
@@ -301,6 +307,7 @@ func collectDTReferences(xmlDir string, schema *eddSchema) (readRefs map[string]
 				if schema != nil {
 					local := append(append([]string{}, entityStack...), inlinePushes(c.DSL, schema)...)
 					extractBareReads(c.DSL, local, schema, readRefs)
+					extractBarePostfixReads(c.Postfix, local, schema, readRefs)
 				}
 			}
 			// Actions: extract writes explicitly, then reads for non-write positions.
@@ -310,6 +317,7 @@ func collectDTReferences(xmlDir string, schema *eddSchema) (readRefs map[string]
 				if schema != nil {
 					local := append(append([]string{}, entityStack...), inlinePushes(a.DSL, schema)...)
 					extractBareWritesAndReads(a.DSL, local, schema, writeRefs, readRefs)
+					extractBarePostfixReads(a.Postfix, local, schema, readRefs)
 				}
 			}
 			for _, a := range table.Actions {
@@ -318,6 +326,7 @@ func collectDTReferences(xmlDir string, schema *eddSchema) (readRefs map[string]
 				if schema != nil {
 					local := append(append([]string{}, entityStack...), inlinePushes(a.DSL, schema)...)
 					extractBareWritesAndReads(a.DSL, local, schema, writeRefs, readRefs)
+					extractBarePostfixReads(a.Postfix, local, schema, readRefs)
 				}
 			}
 		}
@@ -356,6 +365,18 @@ var iterationPattern = regexp.MustCompile(
 		`|for\s+first\s+(?:of|in)` + // forfirstOf, forfirstIn
 		`|for\s+each\s+[a-z_][a-z0-9_]*\s+in` + // foreach <var> in
 		`)\s+([a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)?)`)
+
+// existentialPattern matches `there is <entity> in <array> where <pred>` and
+// its `is there` / `there is no` spellings.
+//
+// It captures the element name rather than the array, because that name is the
+// entity: `there is person in household.members where person.is_adult`. The
+// array cannot be relied on to say — CHIP declares `relationships` as
+// `type="array" subtype=""`, so nothing recovers the element type from it, and
+// relationship.type, .source and .target were reported as unused while three
+// tables read them through exactly this construct (#776).
+var existentialPattern = regexp.MustCompile(
+	`(?i)\b(?:there\s+is|is\s+there)(?:\s+no)?\s+([a-z_][a-z0-9_]*)\s+in\b`)
 
 // usingPattern matches the statement-level `using <Entity> { ... }` form
 // that pushes one or more named typedEntities onto the entity stack
@@ -443,6 +464,14 @@ func inlinePushes(dsl string, schema *eddSchema) []string {
 	for _, m := range iterationPattern.FindAllStringSubmatch(dsl, -1) {
 		if entity := resolveIteratedEntity(strings.ToLower(m[1]), schema); entity != "" {
 			pushed = append(pushed, entity)
+		}
+	}
+
+	// Existential quantifiers, which name their element directly.
+	for _, m := range existentialPattern.FindAllStringSubmatch(dsl, -1) {
+		name := strings.ToLower(m[1])
+		if _, ok := schema.FieldsByEntity[name]; ok {
+			pushed = append(pushed, name)
 		}
 	}
 
@@ -602,6 +631,44 @@ func stripStringsAndDotted(text string) string {
 // stringLiteralPattern matches "..." with no escape handling — adequate
 // for the DSL the analyzer sees, where strings are simple display text.
 var stringLiteralPattern = regexp.MustCompile(`"[^"]*"`)
+
+// extractBarePostfixReads resolves bare tokens in compiled postfix against the
+// entity stack.
+//
+// The DSL pass has to skip EL keywords, because a word like `type` is
+// syntax there as often as it is a field. Postfix has no syntax left: the
+// compiler has already decided what every word meant, so a bare token is an
+// operator, a literal, a block delimiter, or a reference resolved against the
+// entity stack at run time. A token naming a declared field of an in-scope
+// entity is therefore a read, keyword or not.
+//
+// CHIP is the case. `is there relationship in case.relationships where (type
+// == "parent" ...)` compiles to `false { type "parent" streq ... } forall`,
+// and relationship.type was reported as unused across 22 references because
+// `type` is on the keyword list the DSL pass must honour (#776).
+func extractBarePostfixReads(postfix string, entityStack []string, schema *eddSchema, into map[string]bool) {
+	if len(entityStack) == 0 || schema == nil || postfix == "" {
+		return
+	}
+	for _, tok := range strings.Fields(strings.ToLower(postfix)) {
+		// Literals, block delimiters and slash-quoted names are not reads.
+		if tok == "" || strings.ContainsAny(tok[:1], `"/{}[]0123456789`) {
+			continue
+		}
+		if strings.Contains(tok, ".") {
+			continue // dotted: the regex pass already has it
+		}
+		if !barePostfixToken.MatchString(tok) {
+			continue
+		}
+		if key := attribute(tok, entityStack, schema); key != "" {
+			into[key] = true
+		}
+	}
+}
+
+// barePostfixToken is a plain identifier: no punctuation, no operator symbols.
+var barePostfixToken = regexp.MustCompile(`^[a-z_][a-z0-9_]*$`)
 
 // extractBareReads attributes every bare identifier in `text` that
 // matches a field of the topmost entity on the stack as a read of

--- a/pkg/dtrules/analysis/existential_scope_test.go
+++ b/pkg/dtrules/analysis/existential_scope_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import "testing"
+
+// Two ways a field that is read on every run was reported as unused, both from
+// CHIP's `is there relationship in case.relationships where (type == "parent"
+// and source == client and target == ApplyingClient)` (#776).
+
+func relSchema() *eddSchema {
+	return &eddSchema{
+		FieldsByEntity: map[string]map[string]bool{
+			"relationship": {"type": true, "source": true, "target": true},
+			"case":         {"relationships": true},
+		},
+	}
+}
+
+// The existential quantifier binds its element exactly as `for all` does. It
+// names the entity directly, which matters because the array it iterates
+// cannot be relied on to say: CHIP declares `relationships` as
+// `type="array" subtype=""`, so nothing recovers the element type from it.
+func TestExistentialBindsItsElement(t *testing.T) {
+	got := inlinePushes(`is there relationship in case.relationships where (type == "parent")`, relSchema())
+
+	var found bool
+	for _, e := range got {
+		if e == "relationship" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("pushed %v, want relationship — its `where` clause reads the element's fields", got)
+	}
+}
+
+func TestThereIsNoAlsoBinds(t *testing.T) {
+	if got := inlinePushes(`there is no relationship in case.relationships where source == client`, relSchema()); len(got) == 0 {
+		t.Error("the negated spelling binds its element too")
+	}
+}
+
+// The DSL pass must skip EL keywords, because a word like `type` is syntax
+// there as often as it is a field. Postfix has no syntax left — the compiler
+// already decided what every word meant — so a bare token naming a declared
+// field is a read, keyword or not.
+func TestKeywordNamedFieldIsSeenInPostfix(t *testing.T) {
+	reads := map[string]bool{}
+	extractBarePostfixReads(`false { type "parent" streq { pop source client req } over if } case.relationships forall`,
+		[]string{"relationship"}, relSchema(), reads)
+
+	for _, want := range []string{"relationship.type", "relationship.source"} {
+		if !reads[want] {
+			t.Errorf("%s was not counted as read; reads=%v", want, reads)
+		}
+	}
+}
+
+// Literals and block delimiters are not field reads.
+func TestPostfixLiteralsAreNotReads(t *testing.T) {
+	reads := map[string]bool{}
+	extractBarePostfixReads(`{ } "type" 42 3.14`, []string{"relationship"}, relSchema(), reads)
+	if len(reads) != 0 {
+		t.Errorf("literals and delimiters were read as fields: %v", reads)
+	}
+}

--- a/pkg/dtrules/analysis/initial_entities.go
+++ b/pkg/dtrules/analysis/initial_entities.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// initialEntities are the entities a project's mapping pushes onto the entity
+// stack before any table runs.
+//
+// The analyzer resolved bare identifiers only against entities a table's own
+// `for all` / `using` context pushed, and gave up entirely when that context
+// was empty — which is most tables. But a bare name in such a table is not
+// unresolvable: it resolves against whatever the mapping pushed at
+// initialization, and the mapping says exactly what that is:
+//
+//	<initialization>
+//	  <initialentity entity='job' epush='true'></initialentity>
+//	</initialization>
+//
+// Without this, CHIP's `lostInsuranceDate + 90 days is greater than the
+// currentdate` — which compiles to `currentdate d>` and reads job.currentdate
+// — was reported as "unused EDD field: job.currentdate". The field is read on
+// every run (#776).
+//
+// This is precise rather than an over-approximation: these entities really are
+// on the stack for every table, so a bare name really can resolve to them.
+func initialEntities(xmlDir string) []string {
+	var doc struct {
+		Initial []struct {
+			Entity string `xml:"entity,attr"`
+			EPush  string `xml:"epush,attr"`
+		} `xml:"initialization>initialentity"`
+	}
+
+	seen := make(map[string]bool)
+	_ = filepath.WalkDir(xmlDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), "_map.xml") {
+			return nil
+		}
+		data, rerr := os.ReadFile(p)
+		if rerr != nil {
+			return nil
+		}
+		doc.Initial = nil
+		if xml.Unmarshal(data, &doc) != nil {
+			return nil
+		}
+		for _, e := range doc.Initial {
+			// epush='false' declares the entity without putting it on the
+			// stack, so a bare name cannot resolve to it.
+			if !strings.EqualFold(strings.TrimSpace(e.EPush), "true") {
+				continue
+			}
+			if name := strings.ToLower(strings.TrimSpace(e.Entity)); name != "" {
+				seen[name] = true
+			}
+		}
+		return nil
+	})
+
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}


### PR DESCRIPTION
The EDD-usage pass resolves bare identifiers against the entity stack. Three
things were missing from its picture of that stack — all found by taking CHIP's
21 warnings and checking each against the actual DSL.

## 1. Existential quantifiers bind their element

```
is there relationship in case.relationships where (type == "parent" and source == client and target == ApplyingClient)
```

scopes those bare names to `relationship` exactly as `for all` does, and the
pass didn't recognise the construct.

It names its element **directly**, which is what makes this recoverable — the
array can't be relied on to say, because CHIP declares `relationships` as
`type="array" subtype=""` and nothing recovers an element type from that.

## 2. Postfix has no keywords left

The DSL pass must skip EL keywords: a word like `type` is syntax there as often
as it is a field. But in compiled postfix the compiler has *already decided*
what every word meant, so a bare token naming a declared field of an in-scope
entity is a read, keyword or not.

`relationship.type` was reported unused across **22 references** for this
reason alone.

## 3. The mapping's initial entities are always on the stack

A table with no `for all` context of its own was analysed with an empty stack,
so bare names in it resolved to nothing. The mapping states exactly which
entities are pushed before any table runs — that's the base stack now.

## Result

| project | unused before | after |
|---|---|---|
| CHIP | 21 | **10** |
| Cribbage | 6 | 4 |
| Scopa | 7 | 4 |
| CorporateTax | 1366 | 1366 |
| TaxReturn | 1238 | 1237 |

CHIP's remaining ten were checked individually — every one has zero references
in DSL or postfix. The big two barely move, which is the **right** answer: eight
findings sampled at random from CorporateTax's 1366 have no references either.
Those projects have genuinely large unused surfaces and the report was not
wrong about them.

## Still open on #776

The enumeration-bounded `perform table named (<expr>)` design, and cross-table
stack propagation beyond what's already there. This closes the false-positive
classes that were making the report untrustworthy, not the whole issue.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)