### PR TITLE
perf(authoring): stop building decision trees a save never executes (#1132)

### DIFF
--- a/pkg/dtrules/authoring/excel_sync.go
+++ b/pkg/dtrules/authoring/excel_sync.go
@@ -404,6 +404,12 @@ func loadRuleSetForExportInDir(xmlDir string) (*session.RuleSet, error) {
 	if rs == nil {
 		return nil, fmt.Errorf("failed to create ruleset")
 	}
+	// This rule set is written out, never run. Building each table's
+	// executable decision tree is the single largest allocation in an
+	// authoring save -- 46GB across two saves of TaxReturn, all of it
+	// NewCNode and NewANodeForColumn, for trees nothing here executes
+	// (#1132).
+	rs.SkipDecisionTrees(true)
 	// EDD files are loaded recursively, for the same reason the DT files
 	// below are: a nested layout puts them under states/ and the runtime
 	// loader finds them there.

--- a/pkg/dtrules/decisiontable/builder.go
+++ b/pkg/dtrules/decisiontable/builder.go
@@ -26,6 +26,13 @@ type Builder struct {
 	dt *RDecisionTable
 }
 
+// SetSkipDecisionTree suppresses construction of the executable decision tree
+// for loads that never execute anything (#1132).
+func (b *Builder) SetSkipDecisionTree(skip bool) *Builder {
+	b.dt.SkipDecisionTree = skip
+	return b
+}
+
 // NewBuilder creates a new decision table builder.
 // Returns nil if name has invalid syntax.
 func NewBuilder(name string, session dtrules.Session) *Builder {

--- a/pkg/dtrules/decisiontable/skip_tree_test.go
+++ b/pkg/dtrules/decisiontable/skip_tree_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package decisiontable
+
+import "testing"
+
+// The executable decision tree is a runtime artifact, and it is not small: it
+// grows with the columns a table can take. An authoring save of TaxReturn --
+// which executes nothing — allocated 46GB, 99.8% of it NewCNode and
+// NewANodeForColumn, because the loader builds a tree for every table on every
+// load (#1132).
+
+func TestSkipDecisionTreeLeavesNoTree(t *testing.T) {
+	dt := &RDecisionTable{}
+	dt.SkipDecisionTree = true
+
+	if dt.decisionTree != nil {
+		t.Fatal("fixture starts with a tree")
+	}
+	if dt.SkipDecisionTree != true {
+		t.Error("the flag did not take")
+	}
+}
+
+// The builder must carry the flag onto the table, since that is how the loader
+// passes it down.
+func TestBuilderCarriesTheFlag(t *testing.T) {
+	b := NewBuilder("T", nil)
+	if b == nil {
+		t.Fatal("NewBuilder returned nil")
+	}
+	b.SetSkipDecisionTree(true)
+	if !b.dt.SkipDecisionTree {
+		t.Error("SetSkipDecisionTree did not reach the table being built")
+	}
+
+	// The default must build the tree: every runtime consumer needs it.
+	if other := NewBuilder("U", nil); other != nil && other.dt.SkipDecisionTree {
+		t.Error("skipping the tree became the default")
+	}
+}

--- a/pkg/dtrules/decisiontable/table.go
+++ b/pkg/dtrules/decisiontable/table.go
@@ -58,6 +58,11 @@ func (t TableType) String() string {
 type RDecisionTable struct {
 	dtrules.BaseObject
 
+	// SkipDecisionTree suppresses construction of the executable decision
+	// tree. Set by loads that never execute anything -- the Excel export
+	// needs a table's rows, not a way to run it (#1132).
+	SkipDecisionTree bool
+
 	name *dtrules.RName // The decision table's name
 	// authoredName is the name exactly as written in the source.
 	//
@@ -467,14 +472,28 @@ func (dt *RDecisionTable) Build(state dtrules.State) error {
 		return err
 	}
 
-	// Build the decision tree based on type
-	switch dt.tableType {
-	case BALANCED:
-		dt.buildBalanced()
-	case FIRST:
-		dt.buildUnbalanced(state, false)
-	case ALL:
-		dt.buildUnbalanced(state, true)
+	// Build the decision tree based on type.
+	//
+	// SkipDecisionTree is for loads that never execute anything. The tree is
+	// a runtime artifact and it is not small: it grows with the columns a
+	// table can take, and `TestSave_TaxReturnIdempotent` -- which loads
+	// TaxReturn and saves it twice, executing nothing -- allocated 46GB, all
+	// of it NewCNode and NewANodeForColumn under the export's rule-set load.
+	// TaxReturn's Dispatch_State_Tax alone declares 43 conditions (#1132).
+	//
+	// Only the tree is skipped. Validation and expression compilation still
+	// run, so an export still refuses a table it cannot compile, and the
+	// unreachable-column analysis below is skipped with it because it reads
+	// the tree.
+	if !dt.SkipDecisionTree {
+		switch dt.tableType {
+		case BALANCED:
+			dt.buildBalanced()
+		case FIRST:
+			dt.buildUnbalanced(state, false)
+		case ALL:
+			dt.buildUnbalanced(state, true)
+		}
 	}
 
 	// Check for errors
@@ -484,7 +503,9 @@ func (dt *RDecisionTable) Build(state dtrules.State) error {
 
 	// Mark what's used
 	dt.whatsUsed()
-	dt.setUnreachable()
+	if !dt.SkipDecisionTree {
+		dt.setUnreachable()
+	}
 
 	dt.compiled = true
 	return nil

--- a/pkg/dtrules/loader/dt.go
+++ b/pkg/dtrules/loader/dt.go
@@ -59,6 +59,11 @@ type DTLoader struct {
 	// → re-import pipeline). Default false; runtime consumers stay
 	// strict.
 	Tolerant bool
+
+	// SkipDecisionTree suppresses the executable decision tree on every table
+	// this loader builds. For loads that never execute anything -- the Excel
+	// export wants a table's rows, not a way to run it (#1132).
+	SkipDecisionTree bool
 }
 
 // NewDTLoader creates a new Decision Table loader in the default strict mode.
@@ -598,8 +603,10 @@ func (l *DTLoader) processTable(table *DTTable) error {
 		builder.SetRInitialActions(rinitialActions)
 	}
 
-	// Build the decision table (constructs the decision tree)
+	// Build the decision table. SkipDecisionTree suppresses the executable
+	// tree for loads that never run anything (#1132).
 	state := l.session.GetState()
+	builder.SetSkipDecisionTree(l.SkipDecisionTree)
 	dt, err := builder.Build(state)
 	if err != nil {
 		return fmt.Errorf("failed to build decision table %s: %w", name.StringValue(), err)

--- a/pkg/dtrules/session/ruleset.go
+++ b/pkg/dtrules/session/ruleset.go
@@ -31,6 +31,10 @@ import (
 // This includes the EDD (Entity Data Dictionary), decision tables,
 // and mappings.
 type RuleSet struct {
+	// skipDecisionTrees suppresses the executable decision tree on tables
+	// loaded into this rule set (#1132).
+	skipDecisionTrees bool
+
 	name          *dtrules.RName
 	entityFactory *entity.Factory
 	eddNames      []string
@@ -113,6 +117,14 @@ func (rs *RuleSet) LoadDecisionTablesTolerant(r io.Reader) error {
 	return rs.loadDecisionTables(r, true)
 }
 
+// SkipDecisionTrees suppresses the executable decision tree on tables loaded
+// after it is set. For rule sets built to be written out rather than run: the
+// Excel export needs a table's rows, not a way to execute it, and the tree is
+// where the memory goes (#1132).
+func (rs *RuleSet) SkipDecisionTrees(skip bool) {
+	rs.skipDecisionTrees = skip
+}
+
 func (rs *RuleSet) loadDecisionTables(r io.Reader, tolerant bool) error {
 	tempSession := &loadSession{
 		factory:    rs.entityFactory,
@@ -121,6 +133,7 @@ func (rs *RuleSet) loadDecisionTables(r io.Reader, tolerant bool) error {
 
 	dtLoader := loader.NewDTLoader(tempSession, rs.entityFactory)
 	dtLoader.Tolerant = tolerant
+	dtLoader.SkipDecisionTree = rs.skipDecisionTrees
 	return dtLoader.Load(r)
 }
 
@@ -190,14 +203,15 @@ func (rs *RuleSet) LoadDecisionTablesTolerantFile(filePath string) error {
 // If eddPath and dtPath are both provided, they are loaded as individual files.
 //
 // Examples:
-//   // Load from directory
-//   rs.LoadFromPath("./sampleprojects/TaxReturn/xml", "", "")
 //
-//   // Load from individual files
-//   rs.LoadFromPath("", "./xml/TaxReturn_edd.xml", "./xml/TaxReturn_dt.xml")
+//	// Load from directory
+//	rs.LoadFromPath("./sampleprojects/TaxReturn/xml", "", "")
 //
-//   // Auto-detect from directory
-//   rs.LoadFromPath("./xml", "", "")
+//	// Load from individual files
+//	rs.LoadFromPath("", "./xml/TaxReturn_edd.xml", "./xml/TaxReturn_dt.xml")
+//
+//	// Auto-detect from directory
+//	rs.LoadFromPath("./xml", "", "")
 func (rs *RuleSet) LoadFromPath(path, eddPath, dtPath string) error {
 	// If individual files are specified, load them
 	if eddPath != "" && dtPath != "" {
@@ -268,9 +282,10 @@ func LoadRulesFromDirectory(name, dirPath string) (*RuleSet, error) {
 // rules from EDD and DT files into a new RuleSet.
 //
 // Example:
-//   rs, err := session.LoadRulesFromFiles("TaxReturn",
-//       "./xml/TaxReturn_edd.xml",
-//       "./xml/TaxReturn_dt.xml")
+//
+//	rs, err := session.LoadRulesFromFiles("TaxReturn",
+//	    "./xml/TaxReturn_edd.xml",
+//	    "./xml/TaxReturn_dt.xml")
 func LoadRulesFromFiles(name, eddPath, dtPath string) (*RuleSet, error) {
 	rs := NewRuleSet(name)
 	if rs == nil {


### PR DESCRIPTION
`TestSave_TaxReturnIdempotent` loads TaxReturn and saves it twice, executing
nothing. It peaked at **29.3 GB resident** and allocated **45.9 GB** — and on a
machine with anything else running, the package was OOM-killed, which surfaces
as `signal: killed` rather than a test failure. That is what has been making
`make check` fail intermittently with nothing to look at.

## The profile is unambiguous

```
Showing nodes accounting for 45.82GB, 99.78% of 45.92GB total
   24.81GB 54.03%  decisiontable.NewCNode
   21.01GB 45.75%  decisiontable.NewANodeForColumn
         0     0%  authoring.(*Project).Save
         0     0%  authoring.RefreshExcelIn
         0     0%  authoring.loadRuleSetForExportInDir
```

99.8% is the **executable decision tree**, built eagerly by the loader for
every table. The load in question exists to write Excel; it never runs a rule.
The tree grows with the columns a table can take, and TaxReturn's
`Dispatch_State_Tax` declares **43 conditions**.

## Fix

A rule set can be told it will be written out rather than run. Validation and
expression compilation still happen — an export still refuses a table it cannot
compile — and only the tree, plus the unreachable-column analysis that reads
it, are skipped.

| | before | after |
|---|---|---|
| `TestSave_TaxReturnIdempotent` peak RSS | 29.3 GB | **329 MB** |
| wall clock | 70 s | **0.24 s** |
| whole `authoring` package | OOM-killed | 3 s, 330 MB |

## Verification

- `make check` passes
- All 12 samples verify with zero findings
- An authoring write still produces correct Excel and XML (checked on a
  manifest-free SinusitisTherapy: edit lands in the XML, verify clean)

## Not fixed here

The eager build remains for every other consumer — `verify`, `review` and the
analysis passes all load rule sets they never execute. Making the tree lazy
would fix the class rather than one call site, but it moves `setUnreachable`
off the load path, so the advisory output needs checking first. Recorded on
#1132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)