### PR TITLE
perf(decisiontable): lazy encoding for FIRST tables and high condition counts (#1148)

### DIFF
--- a/pkg/dtrules/decisiontable/analysis_test.go
+++ b/pkg/dtrules/decisiontable/analysis_test.go
@@ -494,8 +494,8 @@ func TestAnalyze_AssignmentOnlyTable_MixedActions(t *testing.T) {
 	)
 	actions := makeActions(
 		[]string{
-			`set rate = 0.075`,                            // assignment
-			`add "CA processed" to job.audit_trail`,       // not assignment
+			`set rate = 0.075`,                      // assignment
+			`add "CA processed" to job.audit_trail`, // not assignment
 		},
 		[][]string{
 			{"X", ""},
@@ -599,9 +599,9 @@ func TestIsDSLNegation(t *testing.T) {
 		{`job.amount >= 50`, `job.amount < 50`, true},
 		{`not job.active`, `job.active`, true},
 		{`job.active`, `not job.active`, true},
-		{`job.a > 5`, `job.b <= 5`, false},  // different identifiers
-		{`job.a > 5`, `job.a > 5`, false},    // same, not negation
-		{`job.a > 5`, `job.a < 5`, false},    // not a pair in our table
+		{`job.a > 5`, `job.b <= 5`, false}, // different identifiers
+		{`job.a > 5`, `job.a > 5`, false},  // same, not negation
+		{`job.a > 5`, `job.a < 5`, false},  // not a pair in our table
 	}
 	for _, tt := range tests {
 		got := isNegationOf(tt.a, tt.b)

--- a/pkg/dtrules/decisiontable/lazy.go
+++ b/pkg/dtrules/decisiontable/lazy.go
@@ -23,6 +23,14 @@ import (
 // lazyLeafThreshold is the number of leaves above which ALL tables switch to lazy encoding.
 const lazyLeafThreshold = 64
 
+// lazyCondThreshold is the condition count above which FIRST and ALL tables
+// switch to lazy encoding. The unbalanced tree grows with conditions as well
+// as columns: TaxReturn's Dispatch_State_Tax -- FIRST policy, 43 conditions,
+// ~51 columns, under the column threshold -- built a tree that peaked at
+// 24.5GB and took 30 seconds, on every load until #1149 and on every first
+// execution after it (#1148).
+const lazyCondThreshold = 24
+
 // condReq encodes the requirement a column has for a condition.
 // 1 = requires Y, 0 = requires N, -1 = don't care.
 type condReq int8
@@ -48,6 +56,9 @@ type LazyTable struct {
 	numCols      int
 	numConds     int
 	star         bool
+	// first: execute only the first surviving column (FIRST policy). The
+	// elimination loop is unchanged; only the final sweep differs.
+	first bool
 }
 
 // buildLazyTable constructs a LazyTable from the decision table's raw data.
@@ -154,11 +165,15 @@ func (lt *LazyTable) Execute(state dtrules.State) error {
 		}
 	}
 
-	// Execute actions for every surviving column, in authored order.
+	// Execute actions for the surviving columns in authored order -- all of
+	// them, or only the first for a FIRST-policy table.
 	for col := 0; col < lt.numCols; col++ {
 		if alive[col] {
 			if err := lt.columnNodes[col].Execute(state); err != nil {
 				return err
+			}
+			if lt.first {
+				break
 			}
 		}
 	}

--- a/pkg/dtrules/decisiontable/lazy_test.go
+++ b/pkg/dtrules/decisiontable/lazy_test.go
@@ -616,3 +616,75 @@ func TestBalancedTableUnaffected(t *testing.T) {
 		t.Error("BALANCED table should not use LazyTable encoding")
 	}
 }
+
+// A FIRST-policy table past the condition threshold takes the lazy encoding,
+// and must execute only the first surviving column. The case is TaxReturn's
+// Dispatch_State_Tax: FIRST, 43 conditions, ~51 columns — under the column
+// threshold, so it built the binary tree, at 24.5GB (#1148).
+func TestLazyTable_FirstPolicyStopsAtFirstMatch(t *testing.T) {
+	numConds := lazyCondThreshold + 2 // past the threshold, so lazy is chosen
+	numCols := 4
+	executed := make([]int, 0)
+
+	conditions := make([]dtrules.Object, numConds)
+	for i := range conditions {
+		conditions[i] = &boolCondition{value: true}
+	}
+	actions := make([]dtrules.Object, numCols)
+	for i := range actions {
+		actions[i] = &testAction{num: i, executed: &executed}
+	}
+
+	// Every column requires condition 0 = Y; all conditions are true, so all
+	// columns survive. FIRST must run only column 0.
+	condTable := make([][]string, numConds)
+	for row := range condTable {
+		condTable[row] = make([]string, numCols)
+		for col := range condTable[row] {
+			condTable[row][col] = "-"
+		}
+	}
+	for col := 0; col < numCols; col++ {
+		condTable[0][col] = "Y"
+	}
+	actTable := make([][]string, numCols)
+	for row := range actTable {
+		actTable[row] = make([]string, numCols)
+		actTable[row][row] = "x"
+	}
+
+	dt, err := buildTestTable("FirstLazy", FIRST, conditions, actions, condTable, actTable, numCols)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if err := dt.ensureTree(newTestState()); err != nil {
+		t.Fatalf("ensureTree: %v", err)
+	}
+	lt, ok := dt.decisionTree.(*LazyTable)
+	if !ok {
+		t.Fatal("a FIRST table past the condition threshold should take the lazy encoding")
+	}
+	if !lt.first {
+		t.Fatal("the lazy table must know it is FIRST-policy")
+	}
+
+	if err := dt.ExecuteTable(newTestState()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(executed) != 1 || executed[0] != 0 {
+		t.Errorf("FIRST must run exactly the first surviving column; ran %v", executed)
+	}
+
+	// ALL behaviour unchanged for comparison: same shape, ALL policy.
+	executed = executed[:0]
+	dtAll, err := buildTestTable("AllLazy", ALL, conditions, actions, condTable, actTable, numCols)
+	if err != nil {
+		t.Fatalf("build ALL: %v", err)
+	}
+	if err := dtAll.ExecuteTable(newTestState()); err != nil {
+		t.Fatalf("execute ALL: %v", err)
+	}
+	if len(executed) != numCols {
+		t.Errorf("ALL must run every surviving column; ran %v", executed)
+	}
+}

--- a/pkg/dtrules/decisiontable/table.go
+++ b/pkg/dtrules/decisiontable/table.go
@@ -675,10 +675,14 @@ func (dt *RDecisionTable) buildUnbalanced(state dtrules.State, executeAll bool) 
 		return
 	}
 
-	// ALL tables with more columns than the threshold use lazy encoding without
-	// building the binary tree at all.
-	if executeAll && dt.maxCol > lazyLeafThreshold {
-		dt.decisionTree = buildLazyTable(dt)
+	// Wide tables use lazy encoding without building the binary tree at all.
+	// Two triggers: ALL tables past the column threshold (the original case),
+	// and any table past the condition threshold -- the tree grows with
+	// conditions too, and a FIRST dispatch with 43 of them cost 24.5GB (#1148).
+	if (executeAll && dt.maxCol > lazyLeafThreshold) || len(dt.conditions) > lazyCondThreshold {
+		lt := buildLazyTable(dt)
+		lt.first = !executeAll
+		dt.decisionTree = lt
 		return
 	}
 


### PR DESCRIPTION
Deferring the tree build (#1149) moved the 24.5 GB to first execution. This
removes it.

The tree grows with **conditions** as well as columns, and the lazy threshold
only looked at columns, only for ALL tables. `Dispatch_State_Tax` — FIRST
policy, **43 conditions**, ~51 columns — sat under the column threshold and
built the binary tree on every execution.

## Change

`LazyTable` serves FIRST as well: the elimination loop is unchanged, and the
final sweep stops at the first surviving column. A second trigger selects lazy
encoding for any table past 24 conditions, either policy.

## Measured

| | before | after |
|---|---|---|
| scenario ratchet | 24.9 GB / 31 s | **272 MB / 3.5 s** |
| archive lane | ~400 s, OOM-killed under load | **3.8 s / 273 MB** |

The archive lane was thirteen 30-second tree builds wearing a test suite.

## Semantics

The lazy encoding evaluates only the conditions an alive column still needs;
the binary tree evaluates every row on its path. That difference was accepted
when LazyTable shipped for ALL tables — FIRST inherits it. A test pins
first-match-only execution against the identical shape run as ALL.

Postfix untouched — runtime representation only. `make check`, the **full
archive lane** (previously deferred), and the scenario floors all pass; clean
count unchanged at 185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)