### PR TITLE
fix(authoring): a patch that does not match the schema is refused, not half-applied (#1144)

### DIFF
--- a/cmd/dtrules/table_cmd.go
+++ b/cmd/dtrules/table_cmd.go
@@ -20,6 +20,7 @@ package main
 // error record to stderr with the shape defined by jsonError.
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -508,8 +509,15 @@ func (ctx *tableCmdCtx) tablePatch(rest []string) int {
 		return emitErr(ctx.stderr, 1, "io_error", "", "", err.Error())
 	}
 	var patch tablePatch
-	if err := json.Unmarshal(data, &patch); err != nil {
-		return emitErr(ctx.stderr, 1, "parse_error", "", "patch input must be a JSON object", err.Error())
+	// Unknown fields are rejected, not ignored. A payload with its fields
+	// nested one level deep decoded to all-zero values and half-applied an
+	// empty row while reporting `patched` (#1144). The error names the field,
+	// which is what points at the mis-shape.
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&patch); err != nil {
+		return emitErr(ctx.stderr, 1, "parse_error", "",
+			"patch input must be a flat JSON object matching `table schema --patch`", err.Error())
 	}
 	if err := patch.apply(p, t); err != nil {
 		return emitErr(ctx.stderr, 1, "invalid_patch", "", patch.hint(), err.Error())

--- a/cmd/dtrules/table_patch.go
+++ b/cmd/dtrules/table_patch.go
@@ -40,12 +40,18 @@ type tablePatch struct {
 	Name            string `json:"name,omitempty"`
 	Number          int    `json:"number,omitempty"`
 	Policy          string `json:"policy,omitempty"`
-	DSL             string `json:"dsl,omitempty"`
-	Comment         string `json:"comment,omitempty"`
-	Description     string `json:"description,omitempty"`
-	File            string `json:"file,omitempty"`
-	Range           string `json:"range,omitempty"`
-	Reason          string `json:"reason,omitempty"`
+	// DSL and Comment are pointers so a patch can tell "omitted" from
+	// "explicitly empty". update-* ops keep the existing value when the field
+	// is omitted -- that is what patch means -- and blank it only when the
+	// caller writes "dsl": "" in so many words. A mis-shaped payload used to
+	// decode every top-level field as its zero value and half-apply an empty
+	// row while reporting `patched` (#1144).
+	DSL         *string `json:"dsl,omitempty"`
+	Comment     *string `json:"comment,omitempty"`
+	Description string  `json:"description,omitempty"`
+	File        string  `json:"file,omitempty"`
+	Range       string  `json:"range,omitempty"`
+	Reason      string  `json:"reason,omitempty"`
 
 	// column ops
 	Conditions map[string]string `json:"conditions,omitempty"`
@@ -55,6 +61,22 @@ type tablePatch struct {
 	Columns map[string]string `json:"columns,omitempty"` // for condition
 	// add/update-action whole-row
 	ActionColumns map[string]bool `json:"action_columns,omitempty"`
+}
+
+// strOr returns the patch field when present, otherwise the existing value.
+func strOr(p *string, existing string) string {
+	if p != nil {
+		return *p
+	}
+	return existing
+}
+
+// reqStr returns the field or an error naming the op that requires it.
+func reqStr(p *string, op string) (string, error) {
+	if p == nil {
+		return "", fmt.Errorf("%s requires \"dsl\"", op)
+	}
+	return *p, nil
 }
 
 func (p *tablePatch) hint() string {
@@ -145,10 +167,14 @@ func (p *tablePatch) apply(proj *authoring.Project, t *authoring.Table) error {
 		if err != nil {
 			return err
 		}
+		dsl, err := reqStr(p.DSL, "add-condition")
+		if err != nil {
+			return err
+		}
 		return t.AddCondition(authoring.Condition{
 			Number:  p.ConditionNumber,
-			Comment: p.Comment,
-			DSL:     p.DSL,
+			Comment: strOr(p.Comment, ""),
+			DSL:     dsl,
 			Columns: cols,
 		})
 
@@ -156,13 +182,21 @@ func (p *tablePatch) apply(proj *authoring.Project, t *authoring.Table) error {
 		if p.ConditionNumber == 0 {
 			return fmt.Errorf("update-condition requires condition_number")
 		}
-		cols, err := stringMapToIntString(p.Columns)
+		existing, err := findCondition(t, p.ConditionNumber)
 		if err != nil {
 			return err
 		}
+		// Patch semantics: omitted fields keep their values. A mis-shaped
+		// payload used to zero every field and report `patched` (#1144).
+		cols := existing.Columns
+		if p.Columns != nil {
+			if cols, err = stringMapToIntString(p.Columns); err != nil {
+				return err
+			}
+		}
 		return t.UpdateCondition(p.ConditionNumber, authoring.Condition{
-			Comment: p.Comment,
-			DSL:     p.DSL,
+			Comment: strOr(p.Comment, existing.Comment),
+			DSL:     strOr(p.DSL, existing.DSL),
 			Columns: cols,
 		})
 
@@ -174,9 +208,13 @@ func (p *tablePatch) apply(proj *authoring.Project, t *authoring.Table) error {
 		if err != nil {
 			return err
 		}
+		dsl, err := reqStr(p.DSL, "update-condition-dsl")
+		if err != nil {
+			return err
+		}
 		return t.UpdateCondition(p.ConditionNumber, authoring.Condition{
 			Comment: existing.Comment,
-			DSL:     p.DSL,
+			DSL:     dsl,
 			Columns: existing.Columns,
 		})
 
@@ -191,10 +229,14 @@ func (p *tablePatch) apply(proj *authoring.Project, t *authoring.Table) error {
 		if err != nil {
 			return err
 		}
+		dsl, err := reqStr(p.DSL, "add-action")
+		if err != nil {
+			return err
+		}
 		return t.AddAction(authoring.Action{
 			Number:  p.ActionNumber,
-			Comment: p.Comment,
-			DSL:     p.DSL,
+			Comment: strOr(p.Comment, ""),
+			DSL:     dsl,
 			Columns: cols,
 		})
 
@@ -202,13 +244,20 @@ func (p *tablePatch) apply(proj *authoring.Project, t *authoring.Table) error {
 		if p.ActionNumber == 0 {
 			return fmt.Errorf("update-action requires action_number")
 		}
-		cols, err := stringMapToIntBool(p.ActionColumns)
+		existing, err := findAction(t, p.ActionNumber)
 		if err != nil {
 			return err
 		}
+		// Patch semantics: omitted fields keep their values (#1144).
+		cols := existing.Columns
+		if p.ActionColumns != nil {
+			if cols, err = stringMapToIntBool(p.ActionColumns); err != nil {
+				return err
+			}
+		}
 		return t.UpdateAction(p.ActionNumber, authoring.Action{
-			Comment: p.Comment,
-			DSL:     p.DSL,
+			Comment: strOr(p.Comment, existing.Comment),
+			DSL:     strOr(p.DSL, existing.DSL),
 			Columns: cols,
 		})
 
@@ -220,9 +269,13 @@ func (p *tablePatch) apply(proj *authoring.Project, t *authoring.Table) error {
 		if err != nil {
 			return err
 		}
+		dsl, err := reqStr(p.DSL, "update-action-dsl")
+		if err != nil {
+			return err
+		}
 		return t.UpdateAction(p.ActionNumber, authoring.Action{
 			Comment: existing.Comment,
-			DSL:     p.DSL,
+			DSL:     dsl,
 			Columns: existing.Columns,
 		})
 
@@ -233,19 +286,35 @@ func (p *tablePatch) apply(proj *authoring.Project, t *authoring.Table) error {
 		return t.DeleteAction(p.ActionNumber)
 
 	case "add-initial-action":
-		return t.AddInitialAction(authoring.InitialAction{DSL: p.DSL})
+		dsl, err := reqStr(p.DSL, "add-initial-action")
+		if err != nil {
+			return err
+		}
+		return t.AddInitialAction(authoring.InitialAction{DSL: dsl})
 
 	case "update-initial-action":
-		return t.UpdateInitialAction(p.Index, authoring.InitialAction{DSL: p.DSL})
+		dsl, err := reqStr(p.DSL, "update-initial-action")
+		if err != nil {
+			return err
+		}
+		return t.UpdateInitialAction(p.Index, authoring.InitialAction{DSL: dsl})
 
 	case "delete-initial-action":
 		return t.DeleteInitialAction(p.Index)
 
 	case "add-context":
-		return t.AddContext(authoring.Context{DSL: p.DSL})
+		dsl, err := reqStr(p.DSL, "add-context")
+		if err != nil {
+			return err
+		}
+		return t.AddContext(authoring.Context{DSL: dsl})
 
 	case "update-context":
-		return t.UpdateContext(p.Index, authoring.Context{DSL: p.DSL})
+		dsl, err := reqStr(p.DSL, "update-context")
+		if err != nil {
+			return err
+		}
+		return t.UpdateContext(p.Index, authoring.Context{DSL: dsl})
 
 	case "delete-context":
 		return t.DeleteContext(p.Index)

--- a/cmd/dtrules/table_patch_1144_test.go
+++ b/cmd/dtrules/table_patch_1144_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// A payload with its fields nested one level deep decoded to all-zero values
+// and half-applied an empty row while reporting `patched` -- Scopa's primiera
+// totals went to 0 two steps from the cause (#1144).
+
+func TestPatchRejectsUnknownFields(t *testing.T) {
+	payload := []byte(`{"op":"update-action","action_number":1,` +
+		`"action":{"number":1,"dsl":"x"}}`)
+	var patch tablePatch
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	dec.DisallowUnknownFields()
+	err := dec.Decode(&patch)
+	if err == nil {
+		t.Fatal("a nested \"action\" object must be rejected, not silently dropped")
+	}
+}
+
+// Omitted fields keep their values -- that is what patch means. Only pointers
+// can tell "omitted" from "explicitly empty", which is why DSL and Comment
+// are *string on the patch struct.
+func TestPatchDistinguishesOmittedFromEmpty(t *testing.T) {
+	var omitted, explicit tablePatch
+	if err := json.Unmarshal([]byte(`{"op":"update-action","action_number":1,"comment":"c"}`), &omitted); err != nil {
+		t.Fatal(err)
+	}
+	if omitted.DSL != nil {
+		t.Error("an omitted dsl must decode to nil, so the existing DSL survives")
+	}
+	if err := json.Unmarshal([]byte(`{"op":"update-action","action_number":1,"dsl":""}`), &explicit); err != nil {
+		t.Fatal(err)
+	}
+	if explicit.DSL == nil || *explicit.DSL != "" {
+		t.Error("an explicit \"dsl\": \"\" is a stated request to blank, and must decode as present")
+	}
+}


### PR DESCRIPTION
A payload with its fields nested one level deep decoded every top-level field
to its zero value and **half-applied an empty row while reporting `patched`**.
Scopa's primiera totals went to 0 two steps from the cause, with verify green
the whole way — the build round-trips an empty action consistently.

## Two changes, each sufficient alone

**Unknown fields are rejected, not ignored.**

```
$ echo '{"op":"update-action","action_number":1,"action":{…}}' | dtrules table patch …
parse_error | json: unknown field "action"
```

**update-condition / update-action are patches now**: omitted fields keep
their values. `DSL` and `Comment` become `*string`, because only presence can
tell "omitted" from "explicitly empty" — and an explicit `"dsl": ""` still
blanks, stated in so many words, per the issue's wording. The `add-*` and
`*-dsl` ops require `dsl` outright and name the op that wanted it.

## Verified against the issue's exact sequence

| | before | after |
|---|---|---|
| mis-shaped payload | `patched`, DSL destroyed | rejected naming the field, DSL intact |
| comment-only update | blanked the DSL | keeps DSL, updates comment |
| explicit `"dsl": ""` | — | blanks, as an explicit request should |

All sibling ops audited per the issue: add/update-condition, -action,
-initial-action, -context. `make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)