### PR TITLE
refactor(apiserver): the editor's save is authoring.Project's save (#1084)

### DIFF
--- a/pkg/dtrules/apiserver/debug_speculate.go
+++ b/pkg/dtrules/apiserver/debug_speculate.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sort"
 	"strings"
 
 	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
@@ -363,3 +364,72 @@ type compileError struct {
 
 func (e *compileError) Error() string { return e.Table + ": " + e.Err.Error() }
 func (e *compileError) Unwrap() error { return e.Err }
+
+// The merge helpers below serve ONLY speculation: they overlay the editor's
+// unsaved rows onto a copy of the canonical table so "Run speculation" sees
+// what the author sees. The save path stopped using them when it collapsed
+// onto authoring.Project (#1084) — a real save reconciles through the
+// authoring mutations instead.
+
+// applyTableEdits overwrites the fields the editor can edit — type, comments,
+// table number, and the condition/action rows — on a speculation copy.
+func applyTableEdits(x *excel.DecisionTableXML, t *DecisionTableData) {
+	if t == nil {
+		return
+	}
+	x.AttributeFields.Type = t.Type
+	x.AttributeFields.Comments = t.Comments
+	x.AttributeFields.TableNumber = t.TableNumber
+
+	x.Conditions = mergeConditionRows(x.Conditions, t.Conditions)
+	x.Actions = mergeActionRows(x.Actions, t.Actions)
+}
+
+func mergeConditionRows(existing []excel.ConditionXML, rows []ConditionData) []excel.ConditionXML {
+	out := make([]excel.ConditionXML, len(rows))
+	for i, r := range rows {
+		if i < len(existing) {
+			out[i] = existing[i] // preserve postfix and any legacy fields
+		}
+		out[i].Number = strconv.Itoa(r.Number)
+		out[i].Comment = r.Comment
+		out[i].DSL = r.Description
+		out[i].Columns = columnValues(r.Columns)
+	}
+	return out
+}
+
+func mergeActionRows(existing []excel.ActionXML, rows []ActionData) []excel.ActionXML {
+	out := make([]excel.ActionXML, len(rows))
+	for i, r := range rows {
+		if i < len(existing) {
+			out[i] = existing[i] // preserve postfix and any legacy fields
+		}
+		out[i].Number = strconv.Itoa(r.Number)
+		out[i].Comment = r.Comment
+		out[i].DSL = r.Description
+		out[i].Columns = columnValues(r.Columns)
+	}
+	return out
+}
+
+// columnValues converts the editor's cell map to the XML column list, sorted
+// by column number so output is deterministic.
+func columnValues(cols map[string]string) []excel.ColumnValueXML {
+	nums := make([]int, 0, len(cols))
+	for k := range cols {
+		if n, err := strconv.Atoi(strings.TrimSpace(k)); err == nil {
+			nums = append(nums, n)
+		}
+	}
+	sort.Ints(nums)
+	out := make([]excel.ColumnValueXML, 0, len(nums))
+	for _, n := range nums {
+		v := strings.TrimSpace(cols[strconv.Itoa(n)])
+		if v == "" {
+			continue
+		}
+		out = append(out, excel.ColumnValueXML{Number: n, Value: v})
+	}
+	return out
+}

--- a/pkg/dtrules/apiserver/project_save.go
+++ b/pkg/dtrules/apiserver/project_save.go
@@ -1,0 +1,311 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+)
+
+// saveViaProject is the editor's save, collapsed onto authoring.Project
+// (#1084). The apiserver used to carry its own model→XML serializers
+// (saveEDDFile / saveDTFile); two implementations of "turn an edited rule
+// set into XML" drift, and #928/#804 were both that drift. Now the editor's
+// in-memory model is reconciled onto a freshly-loaded Project and saved
+// through the same funnel `dtrules table put` uses — guard, DSL recompile,
+// XML write, Excel refresh, and the authoring-notes journal, learned once.
+//
+// Reconcile order is what makes a failed save atomic: every table mutation
+// validates and compiles in memory first (authoring's mutations refuse DSL
+// that does not compile), so a compile error aborts before anything touches
+// disk — strictly better than the old per-file sequential writes.
+func (s *Server) saveViaProject() (saved []string, err error) {
+	modifiedEDD := []string{}
+	modifiedDT := []string{}
+	for _, f := range s.eddFiles {
+		if s.modified[f] {
+			modifiedEDD = append(modifiedEDD, f)
+		}
+	}
+	for _, f := range s.dtFiles {
+		if s.modified[f] {
+			modifiedDT = append(modifiedDT, f)
+		}
+	}
+	if len(modifiedEDD)+len(modifiedDT) == 0 {
+		return nil, nil
+	}
+
+	p, err := authoring.OpenProject(s.projectPath)
+	if err != nil {
+		return nil, fmt.Errorf("open project: %w", err)
+	}
+
+	// Tables first: their mutations compile DSL and can refuse, and nothing
+	// has been written yet when they do.
+	if err := s.reconcileTables(p); err != nil {
+		return nil, err
+	}
+
+	// EDD files. Project holds one EDD at a time; multi-EDD projects select
+	// each in turn. All but the last are written through SaveEDD (guarded,
+	// Excel-refreshing); the last stays loaded so Project.Save covers it
+	// together with the tables in one operation.
+	for i, rel := range modifiedEDD {
+		if err := p.UseEDDFile(rel); err != nil {
+			return nil, fmt.Errorf("select EDD %s: %w", rel, err)
+		}
+		if err := s.reconcileEDD(p, rel); err != nil {
+			return nil, err
+		}
+		if i < len(modifiedEDD)-1 {
+			if err := p.SaveEDD(); err != nil {
+				return nil, fmt.Errorf("save %s: %w", rel, err)
+			}
+		}
+	}
+
+	if err := p.Save(); err != nil {
+		return nil, err
+	}
+	return append(modifiedEDD, modifiedDT...), nil
+}
+
+// reconcileTables applies the editor model's table state onto the Project:
+// tables the editor deleted go, tables it created come, and every kept
+// table's editable fields — policy, comments, number, and the condition and
+// action rows — are written through the authoring mutations, which compile
+// the DSL as they go. Contexts, initial actions, and policy statements are
+// read-only in the editor and left exactly as loaded.
+func (s *Server) reconcileTables(p *authoring.Project) error {
+	keep := make(map[string]*DecisionTableData, len(s.tables))
+	for _, t := range s.tables {
+		keep[t.TableName] = t
+	}
+	for _, name := range p.Tables() {
+		if keep[name] == nil {
+			if err := p.DeleteTable(name, "deleted in the browser editor"); err != nil {
+				return fmt.Errorf("delete table %s: %w", name, err)
+			}
+		}
+	}
+
+	for _, td := range s.tables {
+		t := p.Table(td.TableName)
+		if t == nil {
+			file := filepath.Base(td.Source)
+			created, err := p.AddTable(td.TableName, file, "created in the browser editor")
+			if err != nil {
+				return fmt.Errorf("create table %s: %w", td.TableName, err)
+			}
+			t = created
+		}
+		if err := applyTableData(t, td); err != nil {
+			return &compileError{Table: td.TableName, Err: err}
+		}
+	}
+	return nil
+}
+
+// applyTableData writes one editor table onto its authoring view.
+func applyTableData(t *authoring.Table, td *DecisionTableData) error {
+	t.Policy = td.Type
+	t.Comments = td.Comments
+	if n, err := strconv.Atoi(strings.TrimSpace(td.TableNumber)); err == nil && n > 0 && n != t.Number {
+		if err := t.SetNumber(n); err != nil {
+			return fmt.Errorf("table number: %w", err)
+		}
+	}
+
+	// Conditions, keyed by row number.
+	haveCond := map[int]bool{}
+	for _, c := range t.Conditions {
+		haveCond[c.Number] = true
+	}
+	wantCond := map[int]bool{}
+	for _, r := range td.Conditions {
+		wantCond[r.Number] = true
+		c := authoring.Condition{
+			Number:  r.Number,
+			Comment: r.Comment,
+			DSL:     r.Description,
+			Columns: condColumns(r.Columns),
+		}
+		var err error
+		if haveCond[r.Number] {
+			err = t.UpdateCondition(r.Number, c)
+		} else {
+			err = t.AddCondition(c)
+		}
+		if err != nil {
+			return fmt.Errorf("condition %d: %w", r.Number, err)
+		}
+	}
+	for _, c := range append([]authoring.Condition(nil), t.Conditions...) {
+		if !wantCond[c.Number] {
+			if err := t.DeleteCondition(c.Number); err != nil {
+				return fmt.Errorf("delete condition %d: %w", c.Number, err)
+			}
+		}
+	}
+
+	// Actions, keyed by row number.
+	haveAct := map[int]bool{}
+	for _, a := range t.Actions {
+		haveAct[a.Number] = true
+	}
+	wantAct := map[int]bool{}
+	for _, r := range td.Actions {
+		wantAct[r.Number] = true
+		a := authoring.Action{
+			Number:  r.Number,
+			Comment: r.Comment,
+			DSL:     r.Description,
+			Columns: actColumns(r.Columns),
+		}
+		var err error
+		if haveAct[r.Number] {
+			err = t.UpdateAction(r.Number, a)
+		} else {
+			err = t.AddAction(a)
+		}
+		if err != nil {
+			return fmt.Errorf("action %d: %w", r.Number, err)
+		}
+	}
+	for _, a := range append([]authoring.Action(nil), t.Actions...) {
+		if !wantAct[a.Number] {
+			if err := t.DeleteAction(a.Number); err != nil {
+				return fmt.Errorf("delete action %d: %w", a.Number, err)
+			}
+		}
+	}
+	return nil
+}
+
+// condColumns converts the editor's string-keyed cell map to the authoring
+// form. Empty and don't-care cells are simply absent in both.
+func condColumns(cols map[string]string) map[int]string {
+	out := make(map[int]string, len(cols))
+	for k, v := range cols {
+		n, err := strconv.Atoi(strings.TrimSpace(k))
+		if err != nil || n <= 0 {
+			continue
+		}
+		v = strings.TrimSpace(v)
+		if v == "" || v == "-" {
+			continue
+		}
+		out[n] = v
+	}
+	return out
+}
+
+// actColumns: any marked cell (canonically "X") means the action fires on
+// that column.
+func actColumns(cols map[string]string) map[int]bool {
+	out := make(map[int]bool, len(cols))
+	for k, v := range cols {
+		n, err := strconv.Atoi(strings.TrimSpace(k))
+		if err != nil || n <= 0 {
+			continue
+		}
+		v = strings.TrimSpace(v)
+		if v == "" || v == "-" {
+			continue
+		}
+		out[n] = true
+	}
+	return out
+}
+
+// reconcileEDD applies the editor model's entities for one EDD file onto
+// the Project's loaded EDD. Attribute metadata the editor does not carry
+// (collect flags, question definitions) survives because UpdateAttribute
+// merges by name with keep-existing semantics — an improvement on the old
+// serializer, which matched that metadata by row index.
+func (s *Server) reconcileEDD(p *authoring.Project, relPath string) error {
+	keep := make(map[string]*EntityData)
+	for _, e := range s.entities {
+		if e.Source == relPath {
+			keep[e.Name] = e
+		}
+	}
+
+	edd := p.EDD()
+	for _, ent := range edd.Entities() {
+		if keep[ent.Name] == nil {
+			if err := edd.DeleteEntity(ent.Name); err != nil {
+				return fmt.Errorf("delete entity %s: %w", ent.Name, err)
+			}
+		}
+	}
+
+	for _, e := range s.entities {
+		if e.Source != relPath {
+			continue
+		}
+		ent := edd.Entity(e.Name)
+		if ent == nil {
+			created, err := edd.AddEntity(e.Name)
+			if err != nil {
+				return fmt.Errorf("create entity %s: %w", e.Name, err)
+			}
+			ent = created
+		}
+		ent.SetNumber(e.Number)
+		ent.SetAccess(e.Access)
+		ent.SetComment(e.Comment)
+
+		haveAttr := map[string]bool{}
+		for _, a := range ent.Attributes {
+			haveAttr[a.Name] = true
+		}
+		wantAttr := map[string]bool{}
+		for _, f := range e.Fields {
+			wantAttr[f.Name] = true
+			a := authoring.Attribute{
+				Name:    f.Name,
+				Type:    f.Type,
+				Subtype: f.Subtype,
+				Access:  f.Access,
+				Input:   f.Input,
+				Default: f.DefaultValue,
+				Comment: f.Comment,
+			}
+			var err error
+			if haveAttr[f.Name] {
+				err = ent.UpdateAttribute(f.Name, a)
+			} else {
+				err = ent.AddAttribute(a)
+			}
+			if err != nil {
+				return fmt.Errorf("entity %s field %s: %w", e.Name, f.Name, err)
+			}
+		}
+		for _, a := range append([]authoring.Attribute(nil), ent.Attributes...) {
+			if !wantAttr[a.Name] {
+				if err := ent.DeleteAttribute(a.Name); err != nil {
+					return fmt.Errorf("entity %s delete field %s: %w", e.Name, a.Name, err)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/dtrules/apiserver/save_preserves_test.go
+++ b/pkg/dtrules/apiserver/save_preserves_test.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules/excel"
+)
+
+// A project carrying everything the editor's model does NOT edit: a context,
+// a policy statement, and collect/question metadata on an EDD field. The
+// collapse onto authoring.Project (#1084) must round-trip all of it.
+const preserveEDD = `<entity_data_dictionary version="2">
+  <entity name="person" number="100" access="rw">
+    <field name="income" type="integer" access="rw" collect="true"><question text="Annual income?" type="number"></question></field>
+    <field name="qualified" type="boolean" access="rw"></field>
+  </entity>
+  <entity name="job" number="200" access="rw">
+    <field name="salary" type="integer" access="rw"></field>
+  </entity>
+</entity_data_dictionary>`
+
+const preserveDT = `<decision_tables>
+<decision_table>
+  <table_name>Qualify</table_name>
+  <attribute_fields><Type>FIRST</Type><TABLE_NUMBER>100</TABLE_NUMBER></attribute_fields>
+  <contexts><context_details>
+    <context_number>1</context_number>
+    <context_dsl>for all person.jobs</context_dsl>
+    <context_postfix>dup person.jobs forall pop</context_postfix>
+  </context_details></contexts>
+  <conditions><condition_details>
+    <condition_number>1</condition_number>
+    <condition_dsl>person.income &gt; 1000</condition_dsl>
+    <condition_postfix>person.income 1000 i&gt;</condition_postfix>
+    <condition_column column_number="1" column_value="Y" />
+  </condition_details></conditions>
+  <actions><action_details>
+    <action_number>1</action_number>
+    <action_dsl>set person.qualified = true</action_dsl>
+    <action_postfix>true person.qualified bset</action_postfix>
+    <action_column column_number="1" column_value="X" />
+  </action_details></actions>
+  <policy_statements><policy_statement column="1">
+    <policy_description>Qualified on income</policy_description>
+    <policy_statement_postfix>"Qualified on income"</policy_statement_postfix>
+  </policy_statement></policy_statements>
+</decision_table>
+</decision_tables>`
+
+// TestSavePreservesWhatTheEditorCannotEdit pins the round-trip half of
+// #1084: contexts, policy statements, and collect/question metadata are
+// read-only in the editor's model, and a save that reconciles through
+// authoring.Project must carry them through untouched — the old serializer
+// preserved them by merging, the new path by mutating only what the editor
+// can express.
+func TestSavePreservesWhatTheEditorCannotEdit(t *testing.T) {
+	dir := t.TempDir()
+	xmlDir := filepath.Join(dir, "xml")
+	if err := os.MkdirAll(xmlDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(xmlDir, "p_edd.xml"), []byte(preserveEDD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dtPath := filepath.Join(xmlDir, "p_dt.xml")
+	if err := os.WriteFile(dtPath, []byte(preserveDT), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{modified: map[string]bool{}}
+	if err := s.LoadProject(dir); err != nil {
+		t.Fatalf("LoadProject: %v", err)
+	}
+
+	// The editor touches one condition comment and one entity comment — the
+	// smallest possible edits — and marks both files dirty.
+	for _, td := range s.tables {
+		if td.TableName == "Qualify" {
+			td.Conditions[0].Comment = "edited in the browser"
+		}
+	}
+	for _, e := range s.entities {
+		if e.Name == "person" {
+			e.Comment = "edited entity comment"
+		}
+	}
+	for f := range map[string]bool{"xml/p_edd.xml": true, "xml/p_dt.xml": true} {
+		s.modified[f] = true
+	}
+	s.mu.Lock()
+	saved, err := s.saveViaProject()
+	s.mu.Unlock()
+	if err != nil {
+		t.Fatalf("saveViaProject: %v", err)
+	}
+	if len(saved) != 2 {
+		t.Fatalf("saved %v, want both files", saved)
+	}
+
+	// The table's untouchables survived.
+	got := tableFromFile(t, dtPath)
+	if len(got.Contexts.Details) != 1 || !strings.Contains(got.Contexts.Details[0].DSL, "for all person.jobs") {
+		t.Errorf("context did not survive the save: %+v", got.Contexts.Details)
+	}
+	if len(got.PolicyStatements) != 1 || got.PolicyStatements[0].Description != "Qualified on income" {
+		t.Errorf("policy statement did not survive the save: %+v", got.PolicyStatements)
+	}
+	if got.Conditions[0].Comment != "edited in the browser" {
+		t.Errorf("the edit itself did not land: %q", got.Conditions[0].Comment)
+	}
+	if !strings.Contains(got.Conditions[0].Postfix, "1000") {
+		t.Errorf("condition postfix lost: %q", got.Conditions[0].Postfix)
+	}
+
+	// The EDD's collect metadata survived, keyed by name not by index.
+	eddData, err := os.ReadFile(filepath.Join(xmlDir, "p_edd.xml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var edd excel.EDDXML
+	if err := xml.Unmarshal(eddData, &edd); err != nil {
+		t.Fatalf("saved EDD does not parse: %v", err)
+	}
+	var person *excel.EDDXMLEntity
+	for _, e := range edd.Entities {
+		if e.Name == "person" {
+			person = e
+		}
+	}
+	if person == nil {
+		t.Fatal("person entity missing after save")
+	}
+	if person.Comment != "edited entity comment" {
+		t.Errorf("entity comment edit did not land: %q", person.Comment)
+	}
+	foundCollect := false
+	for _, f := range person.Fields {
+		if f.Name == "income" && f.Collect == "true" &&
+			f.Question != nil && f.Question.Text == "Annual income?" {
+			foundCollect = true
+		}
+	}
+	if !foundCollect {
+		t.Error("collect/question metadata did not survive the save")
+	}
+}

--- a/pkg/dtrules/apiserver/save_recompiles_test.go
+++ b/pkg/dtrules/apiserver/save_recompiles_test.go
@@ -94,7 +94,7 @@ func tableFromFile(t *testing.T, path string) excel.DecisionTableXML {
 
 // TestSaveRecompilesDSL pins #928.
 //
-// saveDTFile merged edited DSL into the XML and wrote it without recompiling,
+// The old saveDTFile merged edited DSL into the XML and wrote it without recompiling,
 // so a saved table carried the new DSL against the postfix from before the
 // edit. That is worse than writing none: the file stays well-formed and loads,
 // so the rule goes on executing the old logic while displaying the new. The
@@ -110,8 +110,10 @@ func TestSaveRecompilesDSL(t *testing.T) {
 		Actions:    []ActionData{{Number: 1, Description: "set client.eligible = true", Columns: map[string]string{"1": "X"}}},
 	}}
 
-	if err := s.saveDTFile(dtPath, "xml/p_dt.xml"); err != nil {
-		t.Fatalf("saveDTFile: %v", err)
+	s.dtFiles = []string{"xml/p_dt.xml"}
+	s.modified = map[string]bool{"xml/p_dt.xml": true}
+	if _, err := s.saveViaProject(); err != nil {
+		t.Fatalf("saveViaProject: %v", err)
 	}
 
 	got := tableFromFile(t, dtPath)
@@ -149,7 +151,9 @@ func TestSaveRejectsUncompilableDSL(t *testing.T) {
 		Conditions: []ConditionData{{Number: 1, Description: "client.age >= >= and and", Columns: map[string]string{"1": "Y"}}},
 	}}
 
-	err = s.saveDTFile(dtPath, "xml/p_dt.xml")
+	s.dtFiles = []string{"xml/p_dt.xml"}
+	s.modified = map[string]bool{"xml/p_dt.xml": true}
+	_, err = s.saveViaProject()
 	if err == nil {
 		t.Fatal("save accepted DSL that does not compile")
 	}

--- a/pkg/dtrules/apiserver/server.go
+++ b/pkg/dtrules/apiserver/server.go
@@ -43,7 +43,6 @@ import (
 	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
 	"github.com/DTRules/DTRules/pkg/dtrules/compiler"
 	"github.com/DTRules/DTRules/pkg/dtrules/entity"
-	"github.com/DTRules/DTRules/pkg/dtrules/excel"
 	"github.com/DTRules/DTRules/pkg/dtrules/interpreter"
 	"github.com/DTRules/DTRules/pkg/dtrules/project"
 	"github.com/DTRules/DTRules/pkg/dtrules/session"
@@ -916,71 +915,43 @@ func (s *Server) handleProjectSave(w http.ResponseWriter, r *http.Request) {
 	defer s.mu.Unlock()
 
 	// Excel is the system of record, so the HTTP surface obeys the same
-	// contract as `dtrules table put` and the MCP write tools: refuse to write
-	// over a workbook someone has edited, and refresh Excel from the XML in
-	// the same operation.
-	//
-	// It did neither. A PUT followed by a save changed the XML and left the
-	// workbook byte-identical, reported success, and put the project straight
-	// into `content differs from build output` at the next verify. That is not
-	// a side-door API — `dtrules edit` embeds this server, so it was the
-	// browser editor breaking the contract on every save (#804).
+	// contract as `dtrules table put` and the MCP write tools: refuse to
+	// write over a workbook someone has edited (#804). The guard runs here
+	// as well as inside Project.Save so the refusal maps to 409 before any
+	// reconciliation work happens.
 	xmlDir, excelDir := s.authoringDirs()
 	if err := authoring.GuardExcelIn(xmlDir, excelDir, false); err != nil {
 		jsonError(w, fmt.Sprintf("Refusing to save: %v", err), http.StatusConflict)
 		return
 	}
 
-	savedFiles := []string{}
-
-	// Save modified EDD files
-	for _, eddFile := range s.eddFiles {
-		if s.modified[eddFile] {
-			path := filepath.Join(s.projectPath, eddFile)
-			if err := s.saveEDDFile(path, eddFile); err != nil {
-				jsonError(w, fmt.Sprintf("Failed to save %s: %v", eddFile, err), http.StatusInternalServerError)
-				return
-			}
-			savedFiles = append(savedFiles, eddFile)
-			s.modified[eddFile] = false
+	// The save itself is authoring.Project's — the same funnel as
+	// `dtrules table put`: DSL recompile, guarded XML write, Excel refresh,
+	// and the authoring-notes journal, in one code path (#1084). The old
+	// per-file serializers this replaces are gone; what the editor learns
+	// about writing rules safely is now learned once.
+	saved, err := s.saveViaProject()
+	if err != nil {
+		// A compile error is the author's DSL, not a server fault, so it
+		// comes back 400. The editor can tell "fix your rule" from "the
+		// server broke" only if we make that distinction here.
+		status := http.StatusInternalServerError
+		var ce *compileError
+		if errors.As(err, &ce) {
+			status = http.StatusBadRequest
 		}
+		jsonError(w, fmt.Sprintf("Failed to save: %v", err), status)
+		return
 	}
 
-	// Save modified DT files
-	for _, dtFile := range s.dtFiles {
-		if s.modified[dtFile] {
-			path := filepath.Join(s.projectPath, dtFile)
-			if err := s.saveDTFile(path, dtFile); err != nil {
-				// A compile error is the author's DSL, not a server fault, so
-				// it comes back 400. The editor can tell "fix your rule" from
-				// "the server broke" only if we make that distinction here.
-				status := http.StatusInternalServerError
-				var ce *compileError
-				if errors.As(err, &ce) {
-					status = http.StatusBadRequest
-				}
-				jsonError(w, fmt.Sprintf("Failed to save %s: %v", dtFile, err), status)
-				return
-			}
-			savedFiles = append(savedFiles, dtFile)
-			s.modified[dtFile] = false
-		}
-	}
-
-	// Excel catches up in the same operation. Reported rather than fatal: the
-	// XML is already on disk, so failing the request would tell the caller the
-	// save did not happen when half of it did.
-	var excelErr string
-	if len(savedFiles) > 0 {
-		if err := authoring.RefreshExcelIn(xmlDir, excelDir); err != nil {
-			excelErr = err.Error()
-		}
+	for _, f := range saved {
+		s.modified[f] = false
 	}
 
 	jsonResponse(w, map[string]interface{}{
 		"success":    true,
-		"savedFiles": savedFiles,
-		"excelError": excelErr,
+		"savedFiles": saved,
+		"excelError": "",
 	})
 }
 
@@ -2125,84 +2096,7 @@ func (s *Server) loadEDDAlternative(data []byte, relPath string) error {
 	return nil
 }
 
-// saveEDDFile persists the entities belonging to relPath by merging the
-// API's editable fields into the canonical on-disk model and emitting through
-// the excel package's WriteXML — which backfills missing entity numbers.
-// Elements the API model doesn't carry (sources, collect/question metadata)
-// survive the round-trip.
-func (s *Server) saveEDDFile(path, relPath string) error {
-	doc := &excel.EDDXML{}
-	if data, err := os.ReadFile(path); err == nil {
-		if perr := xml.Unmarshal(data, doc); perr != nil {
-			return fmt.Errorf("parse %s: %w", path, perr)
-		}
-	}
 
-	// Entities that should be in this file now, by name.
-	keep := make(map[string]*EntityData)
-	for _, e := range s.entities {
-		if e.Source == relPath {
-			keep[e.Name] = e
-		}
-	}
-
-	// Drop entities deleted through the API, keep everything else.
-	filtered := doc.Entities[:0]
-	for _, x := range doc.Entities {
-		if keep[x.Name] != nil {
-			filtered = append(filtered, x)
-		}
-	}
-	doc.Entities = filtered
-
-	// Append entities created through the API, in document order.
-	inFile := make(map[string]bool, len(doc.Entities))
-	for _, x := range doc.Entities {
-		inFile[x.Name] = true
-	}
-	for _, e := range s.entities {
-		if e.Source == relPath && !inFile[e.Name] {
-			doc.Entities = append(doc.Entities, &excel.EDDXMLEntity{Name: e.Name})
-		}
-	}
-
-	// Apply the API-editable fields onto the canonical model.
-	for _, x := range doc.Entities {
-		applyEntityEdits(x, keep[x.Name])
-	}
-
-	importer := excel.NewEDDImporter()
-	return importer.WriteXML(doc, path)
-}
-
-// applyEntityEdits overwrites the fields the API can edit — number, access,
-// comment, and the field rows — while preserving per-field metadata the API
-// model doesn't carry (collect flags, question definitions) by index.
-func applyEntityEdits(x *excel.EDDXMLEntity, e *EntityData) {
-	if e == nil {
-		return
-	}
-	x.Number = e.Number
-	x.Access = e.Access
-	x.Comment = e.Comment
-
-	fields := make([]*excel.EDDXMLField, len(e.Fields))
-	for i, f := range e.Fields {
-		var xf excel.EDDXMLField
-		if i < len(x.Fields) && x.Fields[i] != nil {
-			xf = *x.Fields[i] // preserve collect/question metadata
-		}
-		xf.Name = f.Name
-		xf.Type = f.Type
-		xf.SubType = f.Subtype
-		xf.Access = f.Access
-		xf.Input = f.Input
-		xf.DefaultValue = f.DefaultValue
-		xf.Comment = f.Comment
-		fields[i] = &xf
-	}
-	x.Fields = fields
-}
 
 // DT XML structures - matches the actual DTRules XML format
 type DTXML struct {
@@ -2474,140 +2368,10 @@ func (s *Server) loadDTFile(path, relPath string) error {
 	return nil
 }
 
-// saveDTFile persists the tables belonging to relPath. It merges the API's
-// editable fields into the canonical on-disk model and emits through the
-// excel package's WriteXML — the single DT-XML emission funnel — so workbook
-// provenance (<xls_file>/<source>) is normalized and every element the API
-// model doesn't carry (DSL/postfix pairs it didn't touch, structured initial
-// actions, legacy tag forms, table descriptions) survives the round-trip.
-func (s *Server) saveDTFile(path, relPath string) error {
-	doc := &excel.DecisionTablesXML{}
-	if data, err := os.ReadFile(path); err == nil {
-		parsed, perr := excel.UnmarshalDecisionTablesXML(data)
-		if perr != nil {
-			return fmt.Errorf("parse %s: %w", path, perr)
-		}
-		doc = parsed
-	}
 
-	// Tables that should be in this file now, by name.
-	keep := make(map[string]*DecisionTableData)
-	for _, t := range s.tables {
-		if t.Source == relPath {
-			keep[t.TableName] = t
-		}
-	}
 
-	// Drop tables deleted through the API, keep everything else.
-	filtered := doc.Tables[:0]
-	for _, x := range doc.Tables {
-		if _, ok := keep[x.TableName]; ok {
-			filtered = append(filtered, x)
-		}
-	}
-	doc.Tables = filtered
 
-	// Append tables created through the API that aren't in the file yet.
-	inFile := make(map[string]bool, len(doc.Tables))
-	for i := range doc.Tables {
-		inFile[doc.Tables[i].TableName] = true
-	}
-	for _, t := range keep {
-		if !inFile[t.TableName] {
-			doc.Tables = append(doc.Tables, excel.DecisionTableXML{TableName: t.TableName})
-		}
-	}
 
-	// Apply the API-editable fields onto the canonical model, then recompile
-	// each table's DSL to postfix.
-	//
-	// Without the recompile a save wrote the edited DSL against the postfix
-	// from before the edit (#928). That is worse than writing none: the file
-	// stays well-formed and loads, so the table goes on executing the old
-	// logic while displaying the new — and the editor's own "Run speculation"
-	// disagreed with it, because that path has always compiled.
-	//
-	// A compile error fails the save rather than being written past. Refusing
-	// to save is a visible problem the author can fix; a save that silently
-	// keeps stale postfix is not.
-	xmlDir := projectXMLDir(s.projectPath)
-	for i := range doc.Tables {
-		applyTableEdits(&doc.Tables[i], keep[doc.Tables[i].TableName])
-		if err := compileTableDSL(xmlDir, &doc.Tables[i]); err != nil {
-			return &compileError{Table: doc.Tables[i].TableName, Err: err}
-		}
-		doc.Tables[i].ELCompiled = true
-	}
-
-	importer := excel.NewDTImporter()
-	return importer.WriteXML(doc, path)
-}
-
-// applyTableEdits overwrites the fields the API can edit — type, comments,
-// table number, and the condition/action rows (comment, DSL, rule cells) —
-// while preserving everything else the file carries. Contexts, initial
-// actions, and policy statements are read-only in the API and left untouched
-// when present.
-func applyTableEdits(x *excel.DecisionTableXML, t *DecisionTableData) {
-	if t == nil {
-		return
-	}
-	x.AttributeFields.Type = t.Type
-	x.AttributeFields.Comments = t.Comments
-	x.AttributeFields.TableNumber = t.TableNumber
-
-	x.Conditions = mergeConditionRows(x.Conditions, t.Conditions)
-	x.Actions = mergeActionRows(x.Actions, t.Actions)
-}
-
-func mergeConditionRows(existing []excel.ConditionXML, rows []ConditionData) []excel.ConditionXML {
-	out := make([]excel.ConditionXML, len(rows))
-	for i, r := range rows {
-		if i < len(existing) {
-			out[i] = existing[i] // preserve postfix and any legacy fields
-		}
-		out[i].Number = strconv.Itoa(r.Number)
-		out[i].Comment = r.Comment
-		out[i].DSL = r.Description
-		out[i].Columns = columnValues(r.Columns)
-	}
-	return out
-}
-
-func mergeActionRows(existing []excel.ActionXML, rows []ActionData) []excel.ActionXML {
-	out := make([]excel.ActionXML, len(rows))
-	for i, r := range rows {
-		if i < len(existing) {
-			out[i] = existing[i] // preserve postfix and any legacy fields
-		}
-		out[i].Number = strconv.Itoa(r.Number)
-		out[i].Comment = r.Comment
-		out[i].DSL = r.Description
-		out[i].Columns = columnValues(r.Columns)
-	}
-	return out
-}
-
-// columnValues converts the API's cell map to the XML column list, sorted by
-// column number so output is deterministic.
-func columnValues(cols map[string]string) []excel.ColumnValueXML {
-	nums := make([]int, 0, len(cols))
-	for k := range cols {
-		if n, err := strconv.Atoi(strings.TrimSpace(k)); err == nil {
-			nums = append(nums, n)
-		}
-	}
-	sort.Ints(nums)
-	out := make([]excel.ColumnValueXML, 0, len(nums))
-	for _, n := range nums {
-		v := strings.TrimSpace(cols[strconv.Itoa(n)])
-		if v == "" {
-			continue
-		}
-		out = append(out, excel.ColumnValueXML{Number: n, Value: v})
-	}
-	return out
-}
 
 // A caller may open a project by its root or by its rules directory -- the UI
 // does the latter -- so a declared excel_dir resolved against projectPath can

--- a/pkg/dtrules/authoring/edd.go
+++ b/pkg/dtrules/authoring/edd.go
@@ -271,6 +271,25 @@ func attributeFromXML(f *excel.EDDXMLField) Attribute {
 	return a
 }
 
+// SetNumber, SetAccess and SetComment write the entity-level scalars the
+// browser editor can change (#1084). They write through to the canonical
+// XML immediately, the same discipline as the attribute mutations below.
+
+// SetNumber sets the entity's number attribute (a string in the EDD schema).
+func (e *Entity) SetNumber(n string) {
+	e.xmlEntity.Number = n
+}
+
+// SetAccess sets the entity's access mode.
+func (e *Entity) SetAccess(a string) {
+	e.xmlEntity.Access = a
+}
+
+// SetComment sets the entity-level comment.
+func (e *Entity) SetComment(c string) {
+	e.xmlEntity.Comment = c
+}
+
 // AddAttribute appends an attribute to this entity after validation.
 func (e *Entity) AddAttribute(a Attribute) error {
 	if err := validateAttribute(a); err != nil {

--- a/pkg/dtrules/authoring/table.go
+++ b/pkg/dtrules/authoring/table.go
@@ -29,6 +29,10 @@ type Table struct {
 	Name   string
 	Number int // TABLE_NUMBER — load/sheet ordering; 0 means unset
 	Policy string
+	// Comments is the table-level COMMENTS attribute field. A plain field
+	// like Policy: loaded by syncFromXML, written back by syncToXML, so a
+	// caller that never touches it round-trips the stored value (#1084).
+	Comments string
 	// Workbook is the Excel file this table belongs in (`xls_file`), which
 	// decides which workbook an export writes it to.
 	//
@@ -164,6 +168,7 @@ func newTableWithProject(x *excel.DecisionTableXML, symbols map[string]string, p
 func (t *Table) syncFromXML() {
 	t.Name = t.xml.TableName
 	t.Policy = t.xml.AttributeFields.EffectiveType()
+	t.Comments = t.xml.AttributeFields.Comments
 	t.Number, _ = strconv.Atoi(strings.TrimSpace(t.xml.AttributeFields.TableNumber))
 
 	t.Contexts = nil
@@ -255,6 +260,7 @@ func (t *Table) syncToXML() {
 	// Write the canonical spelling and clear the legacy ones, so a table
 	// cannot end up carrying two different types.
 	t.xml.AttributeFields.Type = t.Policy
+	t.xml.AttributeFields.Comments = t.Comments
 	t.xml.AttributeFields.TypeUppercase = ""
 	t.xml.AttributeFields.TypeLowercase = ""
 	// Only write a number when one is set, so an unspecified number keeps the


### PR DESCRIPTION
Closes #1084.

`saveEDDFile` / `saveDTFile` and their merge helpers are deleted from the save path; `POST /api/project/save` reconciles the editor's model onto a freshly-loaded `authoring.Project` and saves through the same funnel as `dtrules table put` — guard, DSL recompile, XML write, Excel refresh, authoring-notes. The speculation overlay keeps private copies of the merge helpers: it previews *unsaved* state, which is exactly what a Project cannot hold, and the issue predicted as much.

Beyond deduplication, the collapse upgrades three behaviors:

1. **Atomic failure** — authoring mutations validate and compile in memory before any write, so a bad rule aborts the whole save. The old path wrote files sequentially until it hit the error.
2. **Name-keyed metadata preservation** — collect/question metadata now survives by attribute *name* (UpdateAttribute's merge), not by row *index* as the old serializer matched it.
3. **Real validation** — the funnel refuses what the old writer emitted blind (collected field without question text, colliding table numbers, deleting an entity tables still reference).

Authoring gains the two small surfaces the editor edits that it lacked: `Table.Comments` and `Entity.SetNumber/SetAccess/SetComment`. Multi-EDD projects reconcile per-file via `UseEDDFile`.

All pinned save tests (#928 recompile, 400-vs-500 compile errors, #804 guard→409, dirty-flag semantics) pass against the new path unmodified in what they assert; a new `TestSavePreservesWhatTheEditorCannotEdit` pins the round-trip of contexts, policy statements, and collect metadata through an editor save.

`make check` green in both modes. 🤖 Generated with [Claude Code](https://claude.com/claude-code)