### PR TITLE
feat(sync): the manifest is retired by attrition (#1091)

### DIFF
--- a/pkg/dtrules/sync/manifest.go
+++ b/pkg/dtrules/sync/manifest.go
@@ -197,8 +197,16 @@ func (m *Manifest) CheckExcelModified(excelPath string) (modified bool, entry *F
 }
 
 // RecordExport records that XML was exported to an Excel file.
+//
+// Since #1124/#1130 the artifacts carry their own provenance and pairing, so
+// nothing reads this state any more. A project that already has a manifest
+// keeps it current so it never disagrees with itself; a project without one
+// never grows one -- the file is retired by attrition (#1091).
 // Call this AFTER a successful export to update the manifest.
 func (m *Manifest) RecordExport(excelPath string, xmlFiles []string) error {
+	if _, err := os.Stat(m.path); err != nil {
+		return nil // no manifest on disk: do not create one (#1091)
+	}
 	relPath := m.normalizePath(excelPath)
 
 	// Get Excel file's current modTime (after export)

--- a/pkg/dtrules/sync/structure.go
+++ b/pkg/dtrules/sync/structure.go
@@ -224,14 +224,11 @@ func CreateProjectStructure(projectRoot string) error {
 		}
 	}
 
-	// Create .gitignore in excel directory to exclude sync manifest
-	gitignore := filepath.Join(projectRoot, "excel", ".gitignore")
-	if !fileExists(gitignore) {
-		content := "# DTRules sync manifest (local state, don't commit)\n.sync-manifest.json\n"
-		if err := os.WriteFile(gitignore, []byte(content), 0644); err != nil {
-			return fmt.Errorf("failed to create .gitignore: %w", err)
-		}
-	}
+	// No .gitignore is written any more. Its only content was the sync
+	// manifest exclusion, and new projects never grow a manifest: provenance
+	// travels in the XML (#1124) and the workbook pairing comes from the
+	// artifacts (#1130). Gitignoring the manifest is also the exact reason a
+	// fresh clone used to arrive with no sync state at all (#1091).
 
 	return nil
 }

--- a/pkg/dtrules/sync/sync_test.go
+++ b/pkg/dtrules/sync/sync_test.go
@@ -175,9 +175,9 @@ func TestDetermineDirection(t *testing.T) {
 	now := time.Now()
 
 	tests := []struct {
-		name      string
-		pair      FilePair
-		wantDir   SyncDirection
+		name    string
+		pair    FilePair
+		wantDir SyncDirection
 	}{
 		{
 			name: "XML only",
@@ -910,9 +910,9 @@ func TestExcelToXMLPaths(t *testing.T) {
 	syncer.SetUseCombinedWorkbooks(true)
 
 	tests := []struct {
-		name       string
-		excelPath  string
-		wantPaths  []string
+		name      string
+		excelPath string
+		wantPaths []string
 	}{
 		{
 			name:      "Root workbook",

--- a/pkg/dtrules/sync/validation.go
+++ b/pkg/dtrules/sync/validation.go
@@ -350,13 +350,13 @@ type dtTablesXML struct {
 }
 
 type dtTableXML struct {
-	NameAttr        string             `xml:"name,attr"`
-	TableName       string             `xml:"table_name"`
-	ELCompiled      bool               `xml:"el_compiled,attr"`
-	Contexts        dtContextsXML      `xml:"contexts"`
-	InitialActions  dtInitialActionsXML `xml:"initial_actions"`
-	Conditions      dtConditionsXML    `xml:"conditions"`
-	Actions         dtActionsXML       `xml:"actions"`
+	NameAttr       string              `xml:"name,attr"`
+	TableName      string              `xml:"table_name"`
+	ELCompiled     bool                `xml:"el_compiled,attr"`
+	Contexts       dtContextsXML       `xml:"contexts"`
+	InitialActions dtInitialActionsXML `xml:"initial_actions"`
+	Conditions     dtConditionsXML     `xml:"conditions"`
+	Actions        dtActionsXML        `xml:"actions"`
 }
 
 func (t *dtTableXML) getTableName() string {
@@ -395,12 +395,12 @@ type dtInitialActionsXML struct {
 }
 
 type dtInitialActionXML struct {
-	Description    string `xml:"initial_action_description"`
-	DSL            string `xml:"initial_action_dsl"`
-	Postfix        string `xml:"initial_action_postfix"`
-	ActionDSL      string `xml:"action_dsl"`
-	ActionPostfix  string `xml:"action_postfix"`
-	ActionComment  string `xml:"action_comment"`
+	Description   string `xml:"initial_action_description"`
+	DSL           string `xml:"initial_action_dsl"`
+	Postfix       string `xml:"initial_action_postfix"`
+	ActionDSL     string `xml:"action_dsl"`
+	ActionPostfix string `xml:"action_postfix"`
+	ActionComment string `xml:"action_comment"`
 }
 
 // GetDSL returns the DSL expression with precedence:


### PR DESCRIPTION
Nothing reads `.sync-manifest.json` state any more — direction and the export
guard ask the provenance hash in the XML (#1124), and workbook pairing comes
from the artifacts' own source blocks (#1130). What remained: every export
still wrote the file, and every new project got a `.gitignore` whose only
content was hiding it.

## Change

`RecordExport` refreshes a manifest **only where one already exists**: a
project that has one never disagrees with itself; a project without one never
grows one. The `.gitignore` write is deleted — gitignoring the manifest is the
exact reason a fresh clone used to arrive with no sync state at all, which was
this issue's founding complaint.

## Measured

Fresh `git archive` of SinusitisTherapy → `table put` → `build --from-excel` →
`verify`: **zero manifests created**, verify clean, zero findings.

Reading stays (`LoadManifest`, the fallback pairing) for XML predating source
blocks; deleting the reader is for after the last committed manifest leaves the
samples.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)