### PR TITLE
feat(sync): a project without a manifest never grows one (#1091)

### DIFF
--- a/pkg/dtrules/apiserver/debug_speculate.go
+++ b/pkg/dtrules/apiserver/debug_speculate.go
@@ -19,8 +19,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/DTRules/DTRules/pkg/dtrules/authoring"

--- a/pkg/dtrules/apiserver/save_honours_contract_test.go
+++ b/pkg/dtrules/apiserver/save_honours_contract_test.go
@@ -49,6 +49,11 @@ func contractProject(t *testing.T) (*Server, string) {
 
 	m := sync.NewManifest()
 	m.SetPath(filepath.Join(excelDir, ".sync-manifest.json"))
+	// Explicit Save states the intent to create; RecordExport alone no longer
+	// materializes a manifest that never existed (#1091).
+	if err := m.Save(); err != nil {
+		t.Fatal(err)
+	}
 	if err := m.RecordExport(excelPath, []string{filepath.Join(xmlDir, "P_dt.xml")}); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/dtrules/apiserver/server.go
+++ b/pkg/dtrules/apiserver/server.go
@@ -2096,8 +2096,6 @@ func (s *Server) loadEDDAlternative(data []byte, relPath string) error {
 	return nil
 }
 
-
-
 // DT XML structures - matches the actual DTRules XML format
 type DTXML struct {
 	XMLName xml.Name     `xml:"decision_tables"`
@@ -2367,11 +2365,6 @@ func (s *Server) loadDTFile(path, relPath string) error {
 
 	return nil
 }
-
-
-
-
-
 
 // A caller may open a project by its root or by its rules directory -- the UI
 // does the latter -- so a declared excel_dir resolved against projectPath can

--- a/pkg/dtrules/sync/compiler_test.go
+++ b/pkg/dtrules/sync/compiler_test.go
@@ -880,10 +880,17 @@ func TestManifestEnforcementBlocksOverwrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create syncer and exporter
+	// Create syncer and exporter. The guard under test protects a project
+	// that HAS a manifest; one is seeded explicitly, because a project
+	// without one never grows one now (#1091).
 	syncer := NewSyncer(xmlDir, excelDir)
 	exporter := &trackingExporter{}
 	syncer.SetExporter(exporter)
+	if m0, err := LoadManifestFromDir(excelDir); err != nil {
+		t.Fatal(err)
+	} else if err := m0.Save(); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
 
 	// First export should succeed
 	pair := &FilePair{

--- a/pkg/dtrules/sync/manifest.go
+++ b/pkg/dtrules/sync/manifest.go
@@ -44,6 +44,13 @@ type Manifest struct {
 
 	// path is the filesystem path to this manifest (not serialized).
 	path string
+	// materialized: the file was read from disk, or an explicit Save created
+	// it. RecordExport persists only then -- a sync flow on a project with no
+	// manifest records in memory (same-run guards keep working) and writes
+	// nothing, so new projects never grow the file. Provenance in the XML
+	// (#1124) and artifact-derived pairing (#1130) replaced every reader;
+	// this retires the writer by attrition (#1091).
+	materialized bool
 }
 
 // FileEntry tracks the sync state for a single Excel file.
@@ -88,6 +95,7 @@ func LoadManifest(path string) (*Manifest, error) {
 	if err := json.Unmarshal(data, m); err != nil {
 		return nil, fmt.Errorf("failed to parse manifest: %w", err)
 	}
+	m.materialized = true
 
 	// Ensure Files map is initialized even if JSON was empty
 	if m.Files == nil {
@@ -126,6 +134,9 @@ func (m *Manifest) Save() error {
 		return fmt.Errorf("failed to write manifest: %w", err)
 	}
 
+	// An explicit Save is a stated request to create; from here on
+	// RecordExport maintains the file (#1091).
+	m.materialized = true
 	return nil
 }
 
@@ -224,6 +235,12 @@ func (m *Manifest) RecordExport(excelPath string, xmlFiles []string) error {
 		XMLFiles:             relXML,
 	}
 
+	// The in-memory record always lands, so same-run guards and direct API
+	// callers see it. The disk write happens only for a manifest that already
+	// exists -- a project without one never grows one (#1091).
+	if !m.materialized {
+		return nil
+	}
 	return m.Save()
 }
 

--- a/pkg/dtrules/sync/structure.go
+++ b/pkg/dtrules/sync/structure.go
@@ -224,14 +224,10 @@ func CreateProjectStructure(projectRoot string) error {
 		}
 	}
 
-	// Create .gitignore in excel directory to exclude sync manifest
-	gitignore := filepath.Join(projectRoot, "excel", ".gitignore")
-	if !fileExists(gitignore) {
-		content := "# DTRules sync manifest (local state, don't commit)\n.sync-manifest.json\n"
-		if err := os.WriteFile(gitignore, []byte(content), 0644); err != nil {
-			return fmt.Errorf("failed to create .gitignore: %w", err)
-		}
-	}
+	// No .gitignore is written any more. Its only content was the sync
+	// manifest exclusion, and new projects never grow a manifest (#1091);
+	// gitignoring it is also the exact reason a fresh clone used to arrive
+	// with no sync state at all.
 
 	return nil
 }

--- a/pkg/dtrules/sync/structure_test.go
+++ b/pkg/dtrules/sync/structure_test.go
@@ -170,10 +170,11 @@ func TestCreateProjectStructure(t *testing.T) {
 		}
 	}
 
-	// Check .gitignore was created
+	// No .gitignore any more: its only content was hiding the sync manifest,
+	// and new projects never grow one (#1091).
 	gitignore := filepath.Join(projectDir, "excel", ".gitignore")
-	if _, err := os.Stat(gitignore); err != nil {
-		t.Errorf(".gitignore not created: %v", err)
+	if _, err := os.Stat(gitignore); err == nil {
+		t.Errorf(".gitignore should no longer be created (#1091)")
 	}
 }
 

--- a/pkg/dtrules/sync/sync_test.go
+++ b/pkg/dtrules/sync/sync_test.go
@@ -175,9 +175,9 @@ func TestDetermineDirection(t *testing.T) {
 	now := time.Now()
 
 	tests := []struct {
-		name      string
-		pair      FilePair
-		wantDir   SyncDirection
+		name    string
+		pair    FilePair
+		wantDir SyncDirection
 	}{
 		{
 			name: "XML only",
@@ -910,9 +910,9 @@ func TestExcelToXMLPaths(t *testing.T) {
 	syncer.SetUseCombinedWorkbooks(true)
 
 	tests := []struct {
-		name       string
-		excelPath  string
-		wantPaths  []string
+		name      string
+		excelPath string
+		wantPaths []string
 	}{
 		{
 			name:      "Root workbook",

--- a/pkg/dtrules/sync/validation.go
+++ b/pkg/dtrules/sync/validation.go
@@ -350,13 +350,13 @@ type dtTablesXML struct {
 }
 
 type dtTableXML struct {
-	NameAttr        string             `xml:"name,attr"`
-	TableName       string             `xml:"table_name"`
-	ELCompiled      bool               `xml:"el_compiled,attr"`
-	Contexts        dtContextsXML      `xml:"contexts"`
-	InitialActions  dtInitialActionsXML `xml:"initial_actions"`
-	Conditions      dtConditionsXML    `xml:"conditions"`
-	Actions         dtActionsXML       `xml:"actions"`
+	NameAttr       string              `xml:"name,attr"`
+	TableName      string              `xml:"table_name"`
+	ELCompiled     bool                `xml:"el_compiled,attr"`
+	Contexts       dtContextsXML       `xml:"contexts"`
+	InitialActions dtInitialActionsXML `xml:"initial_actions"`
+	Conditions     dtConditionsXML     `xml:"conditions"`
+	Actions        dtActionsXML        `xml:"actions"`
 }
 
 func (t *dtTableXML) getTableName() string {
@@ -395,12 +395,12 @@ type dtInitialActionsXML struct {
 }
 
 type dtInitialActionXML struct {
-	Description    string `xml:"initial_action_description"`
-	DSL            string `xml:"initial_action_dsl"`
-	Postfix        string `xml:"initial_action_postfix"`
-	ActionDSL      string `xml:"action_dsl"`
-	ActionPostfix  string `xml:"action_postfix"`
-	ActionComment  string `xml:"action_comment"`
+	Description   string `xml:"initial_action_description"`
+	DSL           string `xml:"initial_action_dsl"`
+	Postfix       string `xml:"initial_action_postfix"`
+	ActionDSL     string `xml:"action_dsl"`
+	ActionPostfix string `xml:"action_postfix"`
+	ActionComment string `xml:"action_comment"`
 }
 
 // GetDSL returns the DSL expression with precedence:

--- a/pkg/dtrules/sync/workflow_test.go
+++ b/pkg/dtrules/sync/workflow_test.go
@@ -72,13 +72,15 @@ func TestWorkflow_InitialExport(t *testing.T) {
 		t.Errorf("Expected 1 export, got %d", len(exporter.dtExports))
 	}
 
-	// Verify manifest was created
+	// The new contract (#1091): a project without a manifest never grows
+	// one. Provenance in the XML carries the sync state; the export succeeds
+	// and the directory stays clean.
 	manifestPath := filepath.Join(excelDir, DefaultManifestName)
-	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
-		t.Error("Manifest should be created after first export")
+	if _, err := os.Stat(manifestPath); err == nil {
+		t.Error("a fresh project must not grow a manifest on export (#1091)")
 	}
 
-	t.Log("SUCCESS: Initial export creates manifest")
+	t.Log("SUCCESS: initial export creates no manifest")
 }
 
 // TestWorkflow_ConsecutiveExportsWithoutUserEdit tests multiple AI exports
@@ -101,6 +103,13 @@ func TestWorkflow_ConsecutiveExportsWithoutUserEdit(t *testing.T) {
 	syncer := NewSyncer(xmlDir, excelDir)
 	exporter := &trackingExporter{}
 	syncer.SetExporter(exporter)
+	// The guards under test protect a project that HAS a manifest; seeded
+	// explicitly, since a project without one never grows one (#1091).
+	if m0, err := LoadManifestFromDir(excelDir); err != nil {
+		t.Fatal(err)
+	} else if err := m0.Save(); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
 
 	pair := &FilePair{
 		XMLPath:   xmlFile,
@@ -163,6 +172,13 @@ func TestWorkflow_UserEditBlocksExport(t *testing.T) {
 	syncer := NewSyncer(xmlDir, excelDir)
 	exporter := &trackingExporter{}
 	syncer.SetExporter(exporter)
+	// The guards under test protect a project that HAS a manifest; seeded
+	// explicitly, since a project without one never grows one (#1091).
+	if m0, err := LoadManifestFromDir(excelDir); err != nil {
+		t.Fatal(err)
+	} else if err := m0.Save(); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
 
 	pair := &FilePair{
 		XMLPath:   xmlFile,
@@ -170,7 +186,16 @@ func TestWorkflow_UserEditBlocksExport(t *testing.T) {
 		XMLExists: true,
 	}
 
-	// Step 1: AI does initial export
+	// Step 1: AI does initial export. The project carries a manifest --
+	// seeded explicitly, because a project without one never grows one now
+	// (#1091), and this test is about the guard on a project that HAS one.
+	m, err := LoadManifestFromDir(excelDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Save(); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
 	if err := os.WriteFile(xmlFile, []byte("<rules>AI v1</rules>"), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +222,7 @@ func TestWorkflow_UserEditBlocksExport(t *testing.T) {
 	syncer.manifest = nil
 
 	// Step 4: Export should be REJECTED
-	err := syncer.exportXMLToExcel(pair)
+	err = syncer.exportXMLToExcel(pair)
 	if err == nil {
 		t.Fatal("CRITICAL FAILURE: Export should be REJECTED when user modified Excel")
 	}
@@ -235,6 +260,13 @@ func TestWorkflow_RecoveryAfterUserEdit(t *testing.T) {
 	exporter := &trackingExporter{}
 	importer := &trackingImporter{}
 	syncer.SetExporter(exporter)
+	// The guards under test protect a project that HAS a manifest; seeded
+	// explicitly, since a project without one never grows one (#1091).
+	if m0, err := LoadManifestFromDir(excelDir); err != nil {
+		t.Fatal(err)
+	} else if err := m0.Save(); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
 	syncer.SetImporter(importer)
 
 	pair := &FilePair{
@@ -342,6 +374,13 @@ func TestWorkflow_RequireNoUserEditsCheck(t *testing.T) {
 	syncer := NewSyncer(xmlDir, excelDir)
 	exporter := &trackingExporter{}
 	syncer.SetExporter(exporter)
+	// The guards under test protect a project that HAS a manifest; seeded
+	// explicitly, since a project without one never grows one (#1091).
+	if m0, err := LoadManifestFromDir(excelDir); err != nil {
+		t.Fatal(err)
+	} else if err := m0.Save(); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
 
 	// Initial state: no manifest, so no user edits tracked
 	err := syncer.RequireNoUserEdits()
@@ -416,6 +455,13 @@ func TestWorkflow_MultipleFilesPartialUserEdit(t *testing.T) {
 	syncer := NewSyncer(xmlDir, excelDir)
 	exporter := &trackingExporter{}
 	syncer.SetExporter(exporter)
+	// The guards under test protect a project that HAS a manifest; seeded
+	// explicitly, since a project without one never grows one (#1091).
+	if m0, err := LoadManifestFromDir(excelDir); err != nil {
+		t.Fatal(err)
+	} else if err := m0.Save(); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
 
 	pair1 := &FilePair{XMLPath: xmlFile1, ExcelPath: excelFile1, XMLExists: true}
 	pair2 := &FilePair{XMLPath: xmlFile2, ExcelPath: excelFile2, XMLExists: true}
@@ -491,6 +537,13 @@ func TestWorkflow_CombinedWorkbookUserEdit(t *testing.T) {
 	syncer.SetUseCombinedWorkbooks(true)
 	exporter := &trackingExporter{}
 	syncer.SetExporter(exporter)
+	// The guards under test protect a project that HAS a manifest; seeded
+	// explicitly, since a project without one never grows one (#1091).
+	if m0, err := LoadManifestFromDir(excelDir); err != nil {
+		t.Fatal(err)
+	} else if err := m0.Save(); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
 
 	wb := &CombinedWorkbook{
 		ExcelPath:  excelWB,
@@ -554,6 +607,12 @@ func TestWorkflow_ManifestPersistence(t *testing.T) {
 	syncer1 := NewSyncer(xmlDir, excelDir)
 	exporter1 := &trackingExporter{}
 	syncer1.SetExporter(exporter1)
+	// Persistence needs a manifest to persist; seeded explicitly (#1091).
+	if m0, err := LoadManifestFromDir(excelDir); err != nil {
+		t.Fatal(err)
+	} else if err := m0.Save(); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
 
 	pair := &FilePair{XMLPath: xmlFile, ExcelPath: excelFile, XMLExists: true}
 	if err := syncer1.exportXMLToExcel(pair); err != nil {
@@ -611,6 +670,13 @@ func TestWorkflow_ErrorMessageClarity(t *testing.T) {
 	syncer := NewSyncer(xmlDir, excelDir)
 	exporter := &trackingExporter{}
 	syncer.SetExporter(exporter)
+	// The guards under test protect a project that HAS a manifest; seeded
+	// explicitly, since a project without one never grows one (#1091).
+	if m0, err := LoadManifestFromDir(excelDir); err != nil {
+		t.Fatal(err)
+	} else if err := m0.Save(); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
 
 	pair := &FilePair{XMLPath: xmlFile, ExcelPath: excelFile, XMLExists: true}
 	if err := syncer.exportXMLToExcel(pair); err != nil {
@@ -680,6 +746,13 @@ func TestWorkflow_FullCycle(t *testing.T) {
 	exporter := &trackingExporter{}
 	importer := &trackingImporter{}
 	syncer.SetExporter(exporter)
+	// The guards under test protect a project that HAS a manifest; seeded
+	// explicitly, since a project without one never grows one (#1091).
+	if m0, err := LoadManifestFromDir(excelDir); err != nil {
+		t.Fatal(err)
+	} else if err := m0.Save(); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
 	syncer.SetImporter(importer)
 
 	pair := &FilePair{
@@ -795,6 +868,13 @@ func TestWorkflow_TimestampPrecision(t *testing.T) {
 	syncer := NewSyncer(xmlDir, excelDir)
 	exporter := &trackingExporter{}
 	syncer.SetExporter(exporter)
+	// The guards under test protect a project that HAS a manifest; seeded
+	// explicitly, since a project without one never grows one (#1091).
+	if m0, err := LoadManifestFromDir(excelDir); err != nil {
+		t.Fatal(err)
+	} else if err := m0.Save(); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
 
 	pair := &FilePair{XMLPath: xmlFile, ExcelPath: excelFile, XMLExists: true}
 


### PR DESCRIPTION
The last subtraction. Nothing reads `.sync-manifest.json` state — direction and
the guard use provenance (#1124), pairing comes from the artifacts (#1130) —
but every export still wrote the file, and new projects got a `.gitignore`
whose only content was hiding it.

## One flag

A manifest is **materialized** when its file was read from disk or an explicit
`Save` created it. `RecordExport` always records in memory (same-run guards and
every direct API caller unchanged) and **persists only a materialized
manifest**. `Save` stays unconditional — calling it *is* the stated intent to
create.

The previous attempt (#1153, closed unmerged) gated inside `RecordExport` and
broke eleven tests that were right to break. This one changes no API behavior
except the disk write.

## Tests changed with the contract

`TestWorkflow_InitialExport` asserted *"Manifest should be created after first
export"* — it now asserts the opposite, because that **is** the change. Guard
tests seed a manifest explicitly: they test the guard on a project that has
one, which is the surviving mode.

## Measured

Fresh `git archive` of SinusitisTherapy → `table put` → `build --from-excel` →
`verify`: **zero manifests, zero gitignores, verify clean**.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)