### PR TITLE
feat(analysis): dynamic dispatch bounds derived from its own literals (#776)

### DIFF
--- a/pkg/dtrules/analysis/call_graph.go
+++ b/pkg/dtrules/analysis/call_graph.go
@@ -67,6 +67,19 @@ type TableCallGraph struct {
 	// DTFile maps each defined table name → the *_dt.xml file it was
 	// loaded from. Useful for advisory output.
 	DTFile map[string]string
+
+	// UnboundedDispatch lists dynamic-dispatch sites whose expression has no
+	// literal segments, so no bound can be derived and no target enumerated
+	// (#776). Caller and file identify the site; Expr is the text.
+	UnboundedDispatch []DynamicDispatchSite
+}
+
+// DynamicDispatchSite is one `perform table named (<expr>)` the analyzer
+// could not bound.
+type DynamicDispatchSite struct {
+	Caller string
+	Expr   string
+	DTFile string
 }
 
 // OrphanCall records a `perform <name>` reference whose callee isn't
@@ -120,11 +133,17 @@ var reservedAfterPerform = map[string]bool{
 // the table-call relationships, and returns the graph plus any
 // orphan-call findings.
 //
-// Dynamic-dispatch sites (`perform table named (<expr>)`) are NOT
-// recorded as edges — static analysis can't enumerate their possible
-// targets without an enumeration-bounded declaration (#776 phase B).
-// They're reported separately via DynamicDispatchSites in a follow-up
-// piece; for now they're simply ignored.
+// Dynamic-dispatch sites (`perform table named (<expr>)`) resolve through
+// the literal segments of their expression (#776). The literals ARE the
+// bound: `"Determine_" + apportionment.state_code + "_Filing_Requirement"`
+// derives the pattern ^determine_.*_filing_requirement$, which matches
+// exactly the 51 state tables and nothing else -- no author declaration,
+// nothing to keep in sync. Every match becomes a call edge, so the
+// dispatch's targets are reachable and their fields referenced. A `with
+// default X` fallback is an edge outright. An expression with no literal
+// parts derives no bound at all; those sites are collected in
+// UnboundedDispatch for the analysis passes to report -- the analyzer
+// cannot reason about a rule set it cannot bound.
 func AnalyzeTableCallGraph(xmlDir string) (*TableCallGraph, error) {
 	graph := &TableCallGraph{
 		Tables: make(map[string]bool),
@@ -199,9 +218,11 @@ func AnalyzeTableCallGraph(xmlDir string) (*TableCallGraph, error) {
 	for _, rt := range rawTables {
 		for _, dsl := range rt.InitialActions {
 			recordCalls(graph, rt, dsl)
+			recordDynamicCalls(graph, rt.Name, rt.File, dsl)
 		}
 		for _, dsl := range rt.Actions {
 			recordCalls(graph, rt, dsl)
+			recordDynamicCalls(graph, rt.Name, rt.File, dsl)
 		}
 	}
 
@@ -219,6 +240,73 @@ func AnalyzeTableCallGraph(xmlDir string) (*TableCallGraph, error) {
 // recordCalls extracts every `perform <Name>` reference from dsl and
 // records caller→callee edges in the graph. Self-edges and duplicate
 // calls are deduplicated by the underlying set.
+
+// dynamicPerformPattern matches `perform table named ( <expr> )`, capturing
+// the expression, and optionally `with default <Table>`.
+var dynamicPerformPattern = regexp.MustCompile(
+	`(?is)\bperform\s+table\s+named\s*\(([^()]*)\)(?:\s*with\s+default\s+([A-Za-z_][A-Za-z0-9_]*))?`)
+
+// literalSegPattern pulls the quoted literals out of a dispatch expression.
+var literalSegPattern = regexp.MustCompile(`"([^"]*)"`)
+
+// recordDynamicCalls resolves a DSL fragment's dynamic dispatches against the
+// defined-table set via their literal segments (#776).
+var lineCommentPattern = regexp.MustCompile(`//[^\n]*`)
+
+func recordDynamicCalls(graph *TableCallGraph, caller, file, dsl string) {
+	// Commented-out DSL is prose, not a dispatch site. SyntaxTests documents
+	// the syntax inside `//` comments, which is exactly what this would
+	// otherwise report as an unbounded dispatch.
+	dsl = lineCommentPattern.ReplaceAllString(dsl, "")
+	for _, m := range dynamicPerformPattern.FindAllStringSubmatch(dsl, -1) {
+		expr, deflt := m[1], m[2]
+		if deflt != "" {
+			addCall(graph, caller, deflt)
+		}
+		lits := literalSegPattern.FindAllStringSubmatch(expr, -1)
+		if len(lits) == 0 {
+			graph.UnboundedDispatch = append(graph.UnboundedDispatch,
+				DynamicDispatchSite{Caller: caller, Expr: strings.TrimSpace(expr), DTFile: file})
+			continue
+		}
+		// The literals in order, with .* where the computed parts sit. EL
+		// names are case-insensitive, so the pattern folds like everything
+		// else (#1040 -- one name, never a clash).
+		parts := make([]string, 0, len(lits))
+		for _, l := range lits {
+			parts = append(parts, regexp.QuoteMeta(strings.ToLower(l[1])))
+		}
+		bound, err := regexp.Compile("^" + strings.Join(parts, ".*") + "$")
+		if err != nil {
+			continue
+		}
+		matched := false
+		for folded, authored := range graph.byFold {
+			if bound.MatchString(folded) {
+				addCall(graph, caller, authored)
+				matched = true
+			}
+		}
+		if !matched {
+			// A bound that matches nothing is as unreachable as no bound.
+			graph.UnboundedDispatch = append(graph.UnboundedDispatch,
+				DynamicDispatchSite{Caller: caller, Expr: strings.TrimSpace(expr), DTFile: file})
+		}
+	}
+}
+
+// addCall records one edge without orphan bookkeeping -- dynamic targets are
+// resolved against the defined set by construction.
+func addCall(graph *TableCallGraph, caller, callee string) {
+	if authored, ok := graph.byFold[strings.ToLower(callee)]; ok {
+		callee = authored
+	}
+	if _, ok := graph.Calls[caller]; !ok {
+		graph.Calls[caller] = make(map[string]bool)
+	}
+	graph.Calls[caller][callee] = true
+}
+
 func recordCalls(graph *TableCallGraph, rt struct {
 	Name           string
 	File           string

--- a/pkg/dtrules/analysis/dynamic_dispatch_test.go
+++ b/pkg/dtrules/analysis/dynamic_dispatch_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import "testing"
+
+// Dynamic dispatch resolves through the literal segments of its expression:
+// the literals ARE the bound, with nothing declared and nothing to keep in
+// sync (#776). CorporateTax's orchestrator is the shape:
+//
+//	perform table named ("Determine_" + apportionment.state_code + "_Filing_Requirement")
+//
+// derives ^determine_.*_filing_requirement$ and matches exactly the 51 state
+// tables.
+
+func dispatchGraph() *TableCallGraph {
+	g := &TableCallGraph{
+		Tables: map[string]bool{}, byFold: map[string]string{},
+		Calls: map[string]map[string]bool{}, DTFile: map[string]string{},
+	}
+	for _, n := range []string{"Determine_CA_Filing_Requirement", "Determine_NV_Filing_Requirement",
+		"Calculate_CA_State_Tax", "Handle_Default", "Orchestrator"} {
+		g.Tables[n] = true
+		g.byFold[foldName(n)] = n
+	}
+	return g
+}
+
+func foldName(n string) string {
+	out := make([]rune, 0, len(n))
+	for _, r := range n {
+		if r >= 'A' && r <= 'Z' {
+			r += 'a' - 'A'
+		}
+		out = append(out, r)
+	}
+	return string(out)
+}
+
+func TestDispatchBoundFromLiterals(t *testing.T) {
+	g := dispatchGraph()
+	recordDynamicCalls(g, "Orchestrator", "orch_dt.xml",
+		`perform table named ("Determine_" + apportionment.state_code + "_Filing_Requirement")`)
+
+	calls := g.Calls["Orchestrator"]
+	for _, want := range []string{"Determine_CA_Filing_Requirement", "Determine_NV_Filing_Requirement"} {
+		if !calls[want] {
+			t.Errorf("bound should reach %s; calls=%v", want, calls)
+		}
+	}
+	if calls["Calculate_CA_State_Tax"] {
+		t.Error("the bound must not match tables of a different shape")
+	}
+	if len(g.UnboundedDispatch) != 0 {
+		t.Errorf("a bounded site was reported unbounded: %v", g.UnboundedDispatch)
+	}
+}
+
+func TestDispatchDefaultIsAnEdge(t *testing.T) {
+	g := dispatchGraph()
+	recordDynamicCalls(g, "Orchestrator", "orch_dt.xml",
+		`perform table named ("Determine_" + r.code + "_Filing_Requirement") with default Handle_Default`)
+	if !g.Calls["Orchestrator"]["Handle_Default"] {
+		t.Error("the with-default fallback is a reachable target and must be an edge")
+	}
+}
+
+// An expression with no literal parts derives no bound: the analyzer cannot
+// reason about it, and says so rather than staying silent.
+func TestUnboundedDispatchIsReported(t *testing.T) {
+	g := dispatchGraph()
+	recordDynamicCalls(g, "Orchestrator", "orch_dt.xml",
+		`perform table named (job.whatever)`)
+	if len(g.UnboundedDispatch) != 1 {
+		t.Fatalf("want 1 unbounded site, got %v", g.UnboundedDispatch)
+	}
+	if g.UnboundedDispatch[0].Caller != "Orchestrator" {
+		t.Errorf("site should name its caller: %+v", g.UnboundedDispatch[0])
+	}
+}
+
+// A bound that matches nothing is as unreachable as no bound.
+func TestBoundMatchingNothingIsReported(t *testing.T) {
+	g := dispatchGraph()
+	recordDynamicCalls(g, "Orchestrator", "orch_dt.xml",
+		`perform table named ("NoSuch_" + r.x + "_Table")`)
+	if len(g.UnboundedDispatch) != 1 {
+		t.Errorf("a bound matching no table must be reported: %v", g.UnboundedDispatch)
+	}
+}

--- a/pkg/dtrules/analysis/edd_unused_test.go
+++ b/pkg/dtrules/analysis/edd_unused_test.go
@@ -179,4 +179,3 @@ func TestAnalyzeEDDUsage_EmptyDir(t *testing.T) {
 		t.Errorf("expected no warnings for empty dir, got %v", warns)
 	}
 }
-

--- a/pkg/dtrules/analysis/edd_usage_static_test.go
+++ b/pkg/dtrules/analysis/edd_usage_static_test.go
@@ -247,8 +247,8 @@ func TestExtractBareReads_SkipsStringsAndKeywords(t *testing.T) {
 func TestInlinePushes(t *testing.T) {
 	schema := &eddSchema{
 		ArraySubtype: map[string]string{
-			"job.accounts":    "account",
-			"job.taxpayers":   "taxpayer",
+			"job.accounts":      "account",
+			"job.taxpayers":     "taxpayer",
 			"job.state_periods": "state_period",
 		},
 		FieldsByEntity: map[string]map[string]bool{

--- a/pkg/dtrules/analysis/external_refs.go
+++ b/pkg/dtrules/analysis/external_refs.go
@@ -35,6 +35,11 @@ const (
 	// ExternalRefTable — a `perform <Name>` whose callee table isn't
 	// defined anywhere in the project's *_dt.xml set.
 	ExternalRefTable ExternalRefKind = "undefined_table"
+	// ExternalRefUnboundedDispatch — a `perform table named (<expr>)` whose
+	// expression has no literal segments, so no bound can be derived and no
+	// target enumerated. The analyzer cannot reason about the rule set past
+	// this point and says so (#776).
+	ExternalRefUnboundedDispatch ExternalRefKind = "unbounded_dispatch"
 
 	// ExternalRefField — a dotted `entity.attr` reference where `entity`
 	// is a declared EDD entity but `attr` is not one of its declared
@@ -61,6 +66,9 @@ func (f ExternalRefFinding) String() string {
 	switch f.Kind {
 	case ExternalRefTable:
 		return fmt.Sprintf("%s performs undefined table %s (%s)", f.Table, f.Symbol, f.DTFile)
+	case ExternalRefUnboundedDispatch:
+		return fmt.Sprintf("%s dispatches on an expression with no literal parts (%s) — no bound can be derived; "+
+			"anchor the name with a literal prefix or suffix (%s)", f.Table, f.Symbol, f.DTFile)
 	case ExternalRefField:
 		return fmt.Sprintf("%s references undefined field %s (%s)", f.Table, f.Symbol, f.DTFile)
 	case ExternalRefOperator:
@@ -99,6 +107,14 @@ func AnalyzeExternalRefs(xmlDir string, isOperator OperatorChecker) ([]ExternalR
 			Table:  o.Caller,
 			Symbol: o.Callee,
 			DTFile: o.DTFile,
+		})
+	}
+	for _, d := range graph.UnboundedDispatch {
+		findings = append(findings, ExternalRefFinding{
+			Kind:   ExternalRefUnboundedDispatch,
+			Table:  d.Caller,
+			Symbol: d.Expr,
+			DTFile: d.DTFile,
 		})
 	}
 
@@ -252,8 +268,8 @@ func collectUndefinedSymbols(xmlDir string, symbols *projectSymbols) ([]External
 
 		var doc struct {
 			Tables []struct {
-				Name     string         `xml:"table_name"`
-				Contexts []contextEntry `xml:"contexts>context_details"`
+				Name           string         `xml:"table_name"`
+				Contexts       []contextEntry `xml:"contexts>context_details"`
 				InitialActions []struct {
 					DSL     string `xml:"initial_action_dsl"`
 					Postfix string `xml:"action_postfix"`


### PR DESCRIPTION
The issue proposed an enumeration declared on the EDD field. Paul's review
found the flaw — **the bound is a property of the call site, not the data**:
one field (`apportionment.state_code`) drives three differently-shaped names,
and a field-level prefix/suffix has nowhere to put that.

The literals already in the expression **are** the bound:

```
perform table named ("Determine_" + apportionment.state_code + "_Filing_Requirement")
  → ^determine_.*_filing_requirement$
```

Every defined table matching becomes a call edge (folded — EL names are
case-insensitive); a `with default X` fallback is an edge outright. Nothing is
declared, nothing can drift.

## Measured

CorporateTax's orchestrator: three dispatch sites → **exactly 153 edges**
(51 `Determine_`, 102 `Calculate_`). Zero unbounded sites in the corpus.

## The refusal the issue asked for

No literal parts → no bound; a bound matching no table → equally unreachable.
Both surface through `AnalyzeExternalRefs` as `unbounded_dispatch`:

```
[external] X dispatches on an expression with no literal parts (…) — no bound
can be derived; anchor the name with a literal prefix or suffix
```

Commented-out DSL is stripped first — SyntaxTests documents the syntax inside
`//` comments, which is prose, not a dispatch site.

Over-approximation is the safe direction: matches are treated reachable even if
the field could never name them, so usage analysis can only mark **more**
things used, never fewer.

Four unit tests; `make check` passes; all 12 samples verify clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)