### PR TITLE
fix(mapping): push the initialization stack before reading the document (#1168)

### DIFF
--- a/cmd/dtrules/run_cmd.go
+++ b/cmd/dtrules/run_cmd.go
@@ -287,9 +287,17 @@ func initMapping(sess dtrules.Session, xmlDir, input, mapPath string) error {
 		return err
 	}
 	if input != "" {
-		// Load the data first, then push singletons so the stack holds the
-		// LOADED instances — Initialize+LoadData would push default-valued
-		// entities disconnected from the input.
+		// Pushes the initialization stack, reads the document, then pushes any
+		// further cardinality-1 entities the document itself created — so the
+		// stack holds the LOADED instances.
+		//
+		// The comment here used to say the data had to be read first, or
+		// Initialize would push default-valued entities disconnected from the
+		// input. That stopped being true once newDataLoader learned to adopt
+		// the entities Initialize created, and reading first had by then
+		// become the bug: an entity that is only an <initialentity> was not on
+		// the stack while the document was read, so every attribute enclosed
+		// by it was dropped (#1168).
 		f, err := os.Open(input)
 		if err != nil {
 			return err

--- a/pkg/dtrules/mapping/mapping.go
+++ b/pkg/dtrules/mapping/mapping.go
@@ -286,28 +286,36 @@ func (m *Mapping) SingletonEntityNames() []string {
 //  2. Remaining cardinality-1 entities found in the data that were not already
 //     pushed via entitystack are also pushed.
 func (m *Mapping) LoadDataAndPushSingletons(r io.Reader) error {
+	// The initialization stack is pushed BEFORE the document is read, not
+	// after.
+	//
+	// A setattribute resolves its enclosure against the entity stack while the
+	// document is being read (see dataLoader.handleStartElement). An entity
+	// that is only an <initialentity> -- nothing names it in a createentity --
+	// is not on that stack yet if the push happens afterwards, so the lookup
+	// for (tag, enclosure) misses and every attribute it encloses is dropped
+	// without error. Then a freshly created, default-valued instance was
+	// pushed on top, and that is what executed: TaxReturn's job.state came
+	// back as the EDD default "TX" on a scenario that says "OH", filing status
+	// empty, and the whole return computed to zero (#1168).
+	//
+	// Pushing first no longer costs what this order was written to avoid.
+	// newDataLoader adopts whatever Initialize created, so a cardinality-1
+	// entity that also has a createentity binds to the instance already on the
+	// stack rather than building a second one nobody holds.
+	if len(m.initialized) == 0 {
+		if err := m.Initialize(); err != nil {
+			return err
+		}
+	}
+
 	loader := newDataLoader(m)
 	if err := loader.Load(r); err != nil {
 		return err
 	}
 
-	pushed := make(map[string]bool)
-
-	// Push entities from the initialization stack in declared order.
+	pushed := make(map[string]bool, len(m.entitystack))
 	for _, name := range m.entitystack {
-		if entity, ok := loader.entities[name]; ok {
-			m.state.EntityPush(entity)
-		} else {
-			rname := dtrules.GetRName(name)
-			if rname == nil {
-				return fmt.Errorf("invalid entity name in initialization: %s", name)
-			}
-			entity, err := m.session.CreateEntity(rname)
-			if err != nil {
-				return fmt.Errorf("create initialization entity %s: %w", name, err)
-			}
-			m.state.EntityPush(entity)
-		}
 		pushed[name] = true
 	}
 

--- a/pkg/dtrules/singleton_load_test.go
+++ b/pkg/dtrules/singleton_load_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtrules_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/mapping"
+	"github.com/DTRules/DTRules/pkg/dtrules/session"
+)
+
+// A setattribute resolves its enclosure against the entity stack while the
+// document is being read. An entity that is only an <initialentity> -- nothing
+// names it in a createentity -- was pushed only after the read, so the lookup
+// missed and every attribute it enclosed was dropped in silence. A
+// default-valued instance was then pushed on top and that is what executed.
+//
+// TaxReturn is the shape that exposes it: `job` is an initialentity carrying
+// 20-odd mapped attributes and no createentity. `dtrules run --input` reported
+// job.state as the EDD default "TX" on a scenario that says "OH", with an
+// empty filing status and a return that computed to zero -- looking like a
+// plausible answer the whole way (#1168).
+//
+// The two load paths must agree: Initialize + LoadData is what the scenario
+// corpus uses, LoadDataAndPushSingletons is what `dtrules run` and the trace
+// tooling use, and a project cannot mean two different things depending on
+// which one read it.
+func TestBothLoadPathsSeeTheSameSingletonData(t *testing.T) {
+	cwd, _ := os.Getwd()
+	sampleDir := filepath.Join(cwd, "..", "..", "sampleprojects", "TaxReturn")
+	xmlDir := filepath.Join(sampleDir, "xml")
+	if _, err := os.Stat(xmlDir); err != nil {
+		t.Skip("TaxReturn sample not present")
+	}
+	scenario := filepath.Join(sampleDir, "testfiles", "TestScenarios",
+		"Integration", "TestCase_Integration_01_Family_All_Credits.xml")
+
+	rs := session.NewRuleSet("TaxReturn")
+	if err := rs.LoadFromDirectory(xmlDir); err != nil {
+		t.Fatalf("load rules: %v", err)
+	}
+
+	// load reads the scenario through one of the two paths and reports the
+	// job attributes that arrive only as enclosure='job' setattributes.
+	load := func(pushSingletons bool) (state, filing, expectedAGI string) {
+		sess, err := rs.NewSession()
+		if err != nil {
+			t.Fatalf("session: %v", err)
+		}
+		m := mapping.NewMapping(sess)
+		mf, err := os.Open(filepath.Join(xmlDir, "TaxReturn_map.xml"))
+		if err != nil {
+			t.Fatalf("open mapping: %v", err)
+		}
+		defer mf.Close()
+		if err := m.LoadMapping(mf); err != nil {
+			t.Fatalf("load mapping: %v", err)
+		}
+		f, err := os.Open(scenario)
+		if err != nil {
+			t.Fatalf("open scenario: %v", err)
+		}
+		defer f.Close()
+
+		if pushSingletons {
+			if err := m.LoadDataAndPushSingletons(f); err != nil {
+				t.Fatalf("LoadDataAndPushSingletons: %v", err)
+			}
+		} else {
+			if err := m.Initialize(); err != nil {
+				t.Fatalf("initialize: %v", err)
+			}
+			if err := m.LoadData(f); err != nil {
+				t.Fatalf("LoadData: %v", err)
+			}
+		}
+
+		st := sess.GetState()
+		get := func(attr string) string {
+			for i := 0; i < st.EntityDepth(); i++ {
+				e, _ := st.EntityFetch(i)
+				if e == nil || e.GetName().StringValue() != "job" {
+					continue
+				}
+				if v, _ := e.Get(dtrules.GetRName(attr)); v != nil {
+					return v.StringValue()
+				}
+			}
+			return ""
+		}
+		return get("state"), get("filing_status"), get("expected_agi")
+	}
+
+	wantState, wantFiling, wantAGI := "OH", "MFJ", "73200"
+
+	for _, tc := range []struct {
+		name           string
+		pushSingletons bool
+	}{
+		{"Initialize+LoadData", false},
+		{"LoadDataAndPushSingletons", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotState, gotFiling, gotAGI := load(tc.pushSingletons)
+			if gotState != wantState {
+				t.Errorf("job.state = %q, want %q — the scenario's value was dropped and "+
+					"the EDD default is what executed", gotState, wantState)
+			}
+			if gotFiling != wantFiling {
+				t.Errorf("job.filing_status = %q, want %q", gotFiling, wantFiling)
+			}
+			if gotAGI != wantAGI {
+				t.Errorf("job.expected_agi = %q, want %q — an expectation that does not load "+
+					"asserts nothing", gotAGI, wantAGI)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1168.

`dtrules run --input` returned EDD defaults instead of the scenario's own data, and said nothing about it. On TaxReturn it reported `job.state` as `"TX"` — the declared default — for a scenario that says `"OH"`, with an empty filing status, no expectations loaded, and a return that computed to **zero**. The output looked like an answer the whole way down.

## Cause

A setattribute resolves its enclosure against the entity stack *while the document is being read* (`dataLoader.handleStartElement`). `LoadDataAndPushSingletons` read first and pushed afterwards, so an entity that is only an `<initialentity>` — nothing names it in a `createentity` — was not on that stack yet. The lookup for `(tag, enclosure)` missed, the attribute was recorded empty, and a freshly created default-valued instance was then pushed on top and executed.

TaxReturn is the shape that exposes it: `job` carries 20-odd mapped attributes and no `createentity`. CHIP, Cribbage and Scopa were unaffected because their data arrives through `createentity` lists — which is why this survived.

## Fix

Initialize, then read. That no longer costs what the original order was written to avoid: `newDataLoader` already adopts the entities `Initialize` created, so a cardinality-1 entity that *also* has a `createentity` binds to the instance already on the stack rather than building a second one nobody holds. The comment at the call site had outlived that fix and was still citing the hazard as a reason to read first — updated.

## Verification

Same scenario, before and after:

| | before | after |
|---|---|---|
| `job.state` | `TX` (EDD default) | `OH` |
| `job.filing_status` | *(empty)* | `MFJ` |
| `job.expected_agi` | *(empty)* | `73200` |
| computed AGI / taxable | 0 / 0 | 76,000 / 44,500 |

Those figures now match what the Go harness produces for the same file, so the CLI and the library finally agree.

The regression test pins **both load paths against each other** rather than hardcoding one — `Initialize + LoadData` is what the scenario corpus uses, `LoadDataAndPushSingletons` is what `dtrules run` and the trace tooling use, and a project cannot mean two different things depending on which one read it. Confirmed to fail without the fix (`job.state = "TX", want "OH"`) and pass with it.

`make check` green — this function has ten-odd callers across CHIP, Cribbage, Scopa, CorporateTax, the trace round-trip and `authoring/execute`, and all of them still pass. CHIP re-checked by hand through the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMYhZQVsuYAtPFtFwMJoUR