### PR TITLE
fix(analysis): read the pushed entity stack that was never being read (#776)

### DIFF
--- a/pkg/dtrules/analysis/initial_entities.go
+++ b/pkg/dtrules/analysis/initial_entities.go
@@ -15,6 +15,7 @@
 package analysis
 
 import (
+	"bytes"
 	"encoding/xml"
 	"os"
 	"path/filepath"
@@ -43,13 +44,6 @@ import (
 // This is precise rather than an over-approximation: these entities really are
 // on the stack for every table, so a bare name really can resolve to them.
 func initialEntities(xmlDir string) []string {
-	var doc struct {
-		Initial []struct {
-			Entity string `xml:"entity,attr"`
-			EPush  string `xml:"epush,attr"`
-		} `xml:"initialization>initialentity"`
-	}
-
 	seen := make(map[string]bool)
 	_ = filepath.WalkDir(xmlDir, func(p string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), "_map.xml") {
@@ -59,17 +53,44 @@ func initialEntities(xmlDir string) []string {
 		if rerr != nil {
 			return nil
 		}
-		doc.Initial = nil
-		if xml.Unmarshal(data, &doc) != nil {
-			return nil
-		}
-		for _, e := range doc.Initial {
-			// epush='false' declares the entity without putting it on the
-			// stack, so a bare name cannot resolve to it.
-			if !strings.EqualFold(strings.TrimSpace(e.EPush), "true") {
+		// Scanned as tokens rather than unmarshalled into a path, because the
+		// path is what broke it. The struct tag read
+		// `initialization>initialentity`, which anchors at the document
+		// element -- and every mapping in the corpus nests the block one
+		// level deeper, under <XMLtoEDD>. So the decode matched nothing, for
+		// every project, and this function had always returned an empty
+		// stack. The bare-name resolution it exists to feed was therefore
+		// inert since it shipped: the very example in the comment above,
+		// CHIP's job.currentdate, was still being reported as unused.
+		//
+		// Depth is not information here -- an <initialentity> means the same
+		// thing wherever the file puts it -- so nothing is gained by pinning
+		// the path and a whole class of silent breakage is avoided.
+		dec := xml.NewDecoder(bytes.NewReader(data))
+		for {
+			tok, terr := dec.Token()
+			if terr != nil {
+				break
+			}
+			se, ok := tok.(xml.StartElement)
+			if !ok || !strings.EqualFold(se.Name.Local, "initialentity") {
 				continue
 			}
-			if name := strings.ToLower(strings.TrimSpace(e.Entity)); name != "" {
+			var entity, epush string
+			for _, a := range se.Attr {
+				switch strings.ToLower(a.Name.Local) {
+				case "entity":
+					entity = a.Value
+				case "epush":
+					epush = a.Value
+				}
+			}
+			// epush='false' declares the entity without putting it on the
+			// stack, so a bare name cannot resolve to it.
+			if !strings.EqualFold(strings.TrimSpace(epush), "true") {
+				continue
+			}
+			if name := strings.ToLower(strings.TrimSpace(entity)); name != "" {
 				seen[name] = true
 			}
 		}

--- a/pkg/dtrules/analysis/initial_entities_test.go
+++ b/pkg/dtrules/analysis/initial_entities_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The entities a mapping pushes before any table runs are what a bare name in
+// a table with no context of its own resolves against. Reading them is the
+// whole basis of that resolution, so when it silently returns nothing the
+// resolution is not wrong -- it simply never happens, and every such field is
+// reported unused.
+//
+// That is what it did. The decode was anchored at the document element
+// (`initialization>initialentity`) while every mapping in the corpus nests the
+// block under <XMLtoEDD>, so it matched nothing, in every project, since it
+// shipped. The example its own comment cited as fixed -- CHIP's
+// job.currentdate, read on every run -- was still being reported (#776).
+func TestInitialEntitiesAreFoundWhereverTheyAreNested(t *testing.T) {
+	dir := t.TempDir()
+
+	// The shape every mapping in the corpus actually has: the block is a
+	// grandchild of the document element, not a child.
+	nested := `<?xml version="1.0" encoding="UTF-8"?>
+<mapping>
+	<XMLtoEDD>
+		<map></map>
+		<initialization>
+			<initialentity entity='result' epush='true'></initialentity>
+			<initialentity entity='job' epush='true'></initialentity>
+			<initialentity entity='ignored' epush='false'></initialentity>
+		</initialization>
+	</XMLtoEDD>
+</mapping>`
+	if err := os.WriteFile(filepath.Join(dir, "X_map.xml"), []byte(nested), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := initialEntities(dir)
+
+	want := map[string]bool{"job": true, "result": true}
+	if len(got) != len(want) {
+		t.Fatalf("initialEntities = %v, want job and result — a stack read as empty means "+
+			"every bare name in a context-free table is reported unused", got)
+	}
+	for _, g := range got {
+		if !want[g] {
+			t.Errorf("unexpected entity %q", g)
+		}
+	}
+}
+
+// epush='false' declares the entity without putting it on the stack, so a bare
+// name cannot resolve to it and the analyzer must not pretend otherwise.
+func TestInitialEntitiesRespectEPush(t *testing.T) {
+	dir := t.TempDir()
+	doc := `<mapping><XMLtoEDD><initialization>
+		<initialentity entity='pushed' epush='true'></initialentity>
+		<initialentity entity='declared_only' epush='false'></initialentity>
+		<initialentity entity='no_attr'></initialentity>
+	</initialization></XMLtoEDD></mapping>`
+	if err := os.WriteFile(filepath.Join(dir, "Y_map.xml"), []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := initialEntities(dir)
+	if len(got) != 1 || got[0] != "pushed" {
+		t.Errorf("initialEntities = %v, want only the epush='true' entity", got)
+	}
+}
+
+// A flat mapping, were one ever written, must work too — depth carries no
+// meaning here, and pinning the path is what broke it.
+func TestInitialEntitiesToleratesAFlatMapping(t *testing.T) {
+	dir := t.TempDir()
+	doc := `<mapping><initialization>
+		<initialentity entity='job' epush='true'></initialentity>
+	</initialization></mapping>`
+	if err := os.WriteFile(filepath.Join(dir, "Z_map.xml"), []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := initialEntities(dir)
+	if len(got) != 1 || got[0] != "job" {
+		t.Errorf("initialEntities = %v, want [job]", got)
+	}
+}
+
+// The end-to-end shape of the bug: a field read only as a bare name, in a
+// table with no context of its own, against an entity the mapping pushed.
+func TestBareNameResolvesAgainstThePushedStack(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("P_map.xml", `<mapping><XMLtoEDD><initialization>
+		<initialentity entity='job' epush='true'></initialentity>
+	</initialization></XMLtoEDD></mapping>`)
+	write("P_edd.xml", `<entity_data_dictionary>
+		<entity name="job">
+			<field name="threshold" type="double"></field>
+			<field name="never_read" type="double"></field>
+		</entity>
+	</entity_data_dictionary>`)
+	write("P_dt.xml", `<decision_tables><decision_table>
+		<table_name>T</table_name>
+		<conditions><condition_details>
+			<condition_dsl>threshold &gt; 0</condition_dsl>
+		</condition_details></conditions>
+	</decision_table></decision_tables>`)
+
+	warns, err := AnalyzeEDDUsage(dir)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	reported := map[string]bool{}
+	for _, w := range warns {
+		reported[w.Field] = true
+	}
+	if reported["job.threshold"] {
+		t.Error("job.threshold is read as a bare name against the pushed job entity, " +
+			"but was reported unused")
+	}
+	if !reported["job.never_read"] {
+		t.Error("job.never_read is read nowhere and should still be reported — " +
+			"the fix must not silence real findings")
+	}
+}


### PR DESCRIPTION
Advances #776. The phase-1 machinery for resolving bare names was in place; the function feeding it returned nothing.

## The bug

`initialEntities` decodes with the struct tag `initialization>initialentity`, which anchors at the **document element**. Every mapping in the corpus nests that block one level deeper:

```
mapping > XMLtoEDD > initialization > initialentity
```

So it matched nothing, in every project, since it shipped — `baseStack` was always `[]`, and the bare-name resolution it exists to feed never ran for any table without a `for all` context of its own.

**The example its own comment cites as fixed was still broken.** CHIP's `job.currentdate` — read on every run — was still reported unused. I confirmed by reverting the fix and watching it come back.

## The fix

Scanned as tokens rather than unmarshalled into a path. Depth carries no meaning here: an `<initialentity>` means the same thing wherever the file puts it, so pinning the path bought nothing and cost a whole class of silent breakage.

## Measured, not asserted

| | before | after |
|---|---|---|
| all sample projects, `unused` | 2687 | **2581** |
| TaxReturn | 1217 | **1123** |
| CHIP | 10 | 9 |
| SyntaxTests | 53 | 44 |

`result.il_tax_rate` and `result.pa_tax_rate` — read bare as `result.il_taxable_income * il_tax_rate` — are no longer flagged.

**The remainder is largely genuine**, which matters as much as the reduction: 1038 of TaxReturn's remaining 1123 appear in **no DSL fragment anywhere**, which is what a project carrying bracket constants for unimplemented states looks like. I spot-checked survivors rather than assuming — `result.farm_se_tax` (only `taxpayer.farm_se_tax` is read), `child_unearned_income.kiddie_tax` (only `result.kiddie_tax`), `taxpayer.estimated_payments` (the bare occurrence is `for all estimated_payments`, an iteration, not a read). All correct findings.

## Tests

Four, including the end-to-end shape: a field read **only** as a bare name in a context-free table against a pushed entity — plus a second field beside it that nothing reads, so the fix is checked for silencing false positives rather than findings.

Remaining work on #776: the enumeration-bounded dynamic-string work and the cross-table phases remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMYhZQVsuYAtPFtFwMJoUR