### PR TITLE
feat(debug): type EL at the console, not postfix (#930)

### DIFF
--- a/pkg/dtrules/apiserver/debug.go
+++ b/pkg/dtrules/apiserver/debug.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 
 	"github.com/DTRules/DTRules/pkg/dtrules"
+	"github.com/DTRules/DTRules/pkg/dtrules/authoring"
+	"github.com/DTRules/DTRules/pkg/dtrules/compiler/el"
+	"github.com/DTRules/DTRules/pkg/dtrules/operators"
 	"github.com/DTRules/DTRules/pkg/dtrules/trace"
 )
 
@@ -126,6 +129,22 @@ var consoleBlocked = map[string]bool{
 	"newentity": true, "findcreateentity": true, "performtable": true,
 	"executetable": true, "clear": true,
 }
+
+// consoleBlockedAfterEL is consoleBlocked without the two scope operators.
+//
+// EL cannot express mutation in a condition, so this is a backstop rather than
+// the guard -- but it must not refuse what the compiler legitimately emits.
+// entitypush/entitypop come out in balanced pairs for `there is <x> in <array>
+// where ...`, which is a read.
+var consoleBlockedAfterEL = func() map[string]bool {
+	m := make(map[string]bool, len(consoleBlocked))
+	for k, v := range consoleBlocked {
+		m[k] = v
+	}
+	delete(m, "entitypush")
+	delete(m, "entitypop")
+	return m
+}()
 
 // handleDebugLoad loads a trace file and prepares a replay session.
 // POST /api/debug/load {"path": "..."} — path is validated against the
@@ -417,6 +436,10 @@ func (s *Server) handleDebugConsole(w http.ResponseWriter, r *http.Request) {
 	}
 	var req struct {
 		Postfix string `json:"postfix"`
+		// Language pins the input: "el", "postfix", or "" to try EL first
+		// and fall back. Pinning is for callers that already know, and for
+		// asking why something did not compile as EL.
+		Language string `json:"language"`
 	}
 	if err := s.limitedDecode(w, r, &req); err != nil {
 		jsonError(w, "Invalid request body", http.StatusBadRequest)
@@ -430,15 +453,43 @@ func (s *Server) handleDebugConsole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Read-only enforcement: refuse mutating operators by name.
-	for _, tok := range strings.Fields(req.Postfix) {
-		if consoleBlocked[strings.ToLower(tok)] {
+	// Type EL at the console, not postfix. `taxpayer.age > 65` is what an
+	// author has in front of them; `taxpayer.age 65 i>` is a transcription
+	// they have to do in their head, at the moment they are trying to think
+	// about something else (#930).
+	//
+	// EL first, raw postfix if that does not parse. The fallback is what makes
+	// it safe to try: the console has always been postfix and stays so for
+	// anything EL cannot express, including bare stack manipulation.
+	source, language, elErr := s.consoleCompileSource(req.Postfix, req.Language)
+	if elErr != nil {
+		jsonError(w, elErr.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Read-only enforcement, against the right list for how the input was
+	// read. The blocklist exists because "raw postfix has no parse-time notion
+	// of mutation" -- EL does: a condition is an expression, and the grammar
+	// has no spelling for assignment.
+	//
+	// So compiled EL is checked against a shorter list. entitypush/entitypop
+	// are blocked in raw postfix because a hand-typed push can be left
+	// unbalanced; EL emits them in balanced pairs for scoping, and
+	// `there is person in household.members where person.age > 18` -- a pure
+	// read -- compiles to exactly that. Checking compiled EL against the raw
+	// list would refuse it.
+	blocked := consoleBlocked
+	if language == "el" {
+		blocked = consoleBlockedAfterEL
+	}
+	for _, tok := range strings.Fields(source) {
+		if blocked[strings.ToLower(tok)] {
 			jsonError(w, fmt.Sprintf("%s is a mutating operator — console is read-only", tok), http.StatusBadRequest)
 			return
 		}
 	}
 
-	compiled, err := s.debug.replaySess.Compile(req.Postfix)
+	compiled, err := s.debug.replaySess.Compile(source)
 	if err != nil {
 		jsonError(w, fmt.Sprintf("Compile error: %v", err), http.StatusBadRequest)
 		return
@@ -468,5 +519,74 @@ func (s *Server) handleDebugConsole(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, map[string]interface{}{
 		"success": true,
 		"results": results,
+		// Which way the input was read, and what actually ran. An EL
+		// expression that compiles to surprising postfix is exactly the thing
+		// a debugger user wants to see.
+		"language": language,
+		"postfix":  source,
 	})
+}
+
+// consoleCompileSource resolves console input to the postfix that will run,
+// and says which language it was read as.
+//
+// With no language pinned it tries EL and falls back to treating the input as
+// postfix, because that is what the console accepted before and still must:
+// EL has no spelling for bare stack manipulation, and a debugger is exactly
+// where someone reaches for it.
+//
+// A pinned language does not fall back — asking "why does this not compile as
+// EL" deserves the EL error, not a postfix error about the same text.
+func (s *Server) consoleCompileSource(input, language string) (source, used string, err error) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return "", "postfix", nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(language)) {
+	case "postfix":
+		return trimmed, "postfix", nil
+	case "el":
+		compiled, cerr := s.compileConsoleEL(trimmed)
+		if cerr != nil {
+			return "", "", fmt.Errorf("EL compile error: %v", cerr)
+		}
+		return compiled, "el", nil
+	}
+
+	if compiled, cerr := s.compileConsoleEL(trimmed); cerr == nil && strings.TrimSpace(compiled) != "" {
+		return compiled, "el", nil
+	}
+	return trimmed, "postfix", nil
+}
+
+// compileConsoleEL compiles one EL expression, typed against the project's own
+// EDD so `taxpayer.age` is an integer rather than defaulting to one.
+func (s *Server) compileConsoleEL(expr string) (string, error) {
+	c := el.NewCompiler()
+	c.SetOperatorChecker(func(name string) bool {
+		_, ok := operators.GetByString(name)
+		return ok
+	})
+	if syms := s.consoleSymbols(); len(syms) > 0 {
+		c.SetSymbols(syms)
+	}
+	// A console line is an expression to evaluate, which is the condition
+	// form: it leaves its value on the data stack, which is what the console
+	// then prints.
+	return c.CompileCondition(expr)
+}
+
+// consoleSymbols is the project's EDD, so a console expression is typed the
+// way the rules are. Without it every field defaults to integer and
+// `taxpayer.agi > 1000.5` compiles to an integer comparison.
+//
+// Loaded per call rather than cached: a console line is typed by a human, so
+// the read is free at this rate, and the debugger should not go stale against
+// an EDD edited in another tab.
+func (s *Server) consoleSymbols() map[string]string {
+	if s.projectPath == "" {
+		return nil
+	}
+	return authoring.LoadEDDSymbols(projectXMLDir(s.projectPath))
 }

--- a/pkg/dtrules/apiserver/debug_console_el_test.go
+++ b/pkg/dtrules/apiserver/debug_console_el_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"strings"
+	"testing"
+)
+
+// The console has always taken postfix. `taxpayer.age 65 i>` is a
+// transcription the author has to do in their head at the moment they are
+// trying to think about something else, so it now takes EL too and says which
+// way it read the input (#930).
+
+func TestConsoleAcceptsEL(t *testing.T) {
+	h := debugServer(t, true)
+
+	status, body := do(t, h, "POST", "/api/debug/console", `{"postfix":"2 > 1"}`)
+	if status != 200 {
+		t.Fatalf("status %d, body %v", status, body)
+	}
+	if body["language"] != "el" {
+		t.Errorf("language = %v, want el", body["language"])
+	}
+	if got, _ := body["postfix"].(string); strings.TrimSpace(got) != "2 1 >" {
+		t.Errorf("postfix = %q, want the compiled form %q", got, "2 1 >")
+	}
+	results, _ := body["results"].([]any)
+	if len(results) != 1 || results[0] != "true" {
+		t.Errorf("results = %v, want [true]", results)
+	}
+}
+
+// The construct that caught a bug in this change before it shipped.
+// `there is <x> in <array> where ...` is a pure read, and it compiles to
+// `... entitypush ... entitypop swap pop`. Both of those are on the raw-postfix
+// blocklist, because a hand-typed push can be left unbalanced -- so checking
+// compiled EL against that list refused a legitimate query.
+func TestConsoleAllowsAnExistentialQuery(t *testing.T) {
+	h := debugServer(t, true)
+
+	status, body := do(t, h, "POST", "/api/debug/console",
+		`{"postfix":"there is client in case.clients where client.age > 18"}`)
+	// The assertion is about the guard, not the fixture's data: what must not
+	// happen is a refusal for containing entitypush. An execution error over
+	// the trace's own contents is a different thing and is fine here.
+	msg, _ := body["error"].(string)
+	if strings.Contains(strings.ToLower(msg), "read-only") ||
+		strings.Contains(strings.ToLower(msg), "mutating") {
+		t.Fatalf("a read-only existential was refused as a mutation: %v", body)
+	}
+	if got, _ := body["postfix"].(string); status == 200 && !strings.Contains(got, "entitypush") {
+		t.Errorf("postfix = %q, expected the scope operators this test exists for", got)
+	}
+}
+
+// Postfix still runs. EL has no spelling for bare stack manipulation, and a
+// debugger is exactly where someone reaches for it — so the fallback is what
+// makes trying EL first safe.
+func TestConsoleStillAcceptsPostfix(t *testing.T) {
+	h := debugServer(t, true)
+
+	status, body := do(t, h, "POST", "/api/debug/console", `{"postfix":"2 3 +"}`)
+	if status != 200 {
+		t.Fatalf("status %d, body %v", status, body)
+	}
+	if body["language"] != "postfix" {
+		t.Errorf("language = %v, want postfix", body["language"])
+	}
+	results, _ := body["results"].([]any)
+	if len(results) != 1 || results[0] != "5" {
+		t.Errorf("results = %v, want [5]", results)
+	}
+}
+
+// Raw postfix mutation is still refused, unchanged. EL cannot reach these:
+// a condition is an expression and the grammar has no spelling for
+// assignment, which is why compiled EL is checked against a shorter list
+// rather than trusted outright.
+func TestConsoleStillRefusesPostfixMutation(t *testing.T) {
+	h := debugServer(t, true)
+
+	for _, expr := range []string{`1 /x xdef`, `client.age 1 addto`} {
+		t.Run(expr, func(t *testing.T) {
+			status, body := do(t, h, "POST", "/api/debug/console",
+				`{"postfix":`+quote(expr)+`}`)
+			if status == 200 {
+				t.Fatalf("mutation accepted: %v", body)
+			}
+			msg, _ := body["error"].(string)
+			if msg == "" {
+				msg, _ = body["message"].(string)
+			}
+			if !strings.Contains(strings.ToLower(msg), "read-only") &&
+				!strings.Contains(strings.ToLower(msg), "mutating") {
+				t.Errorf("refused, but not as a mutation: %v", body)
+			}
+		})
+	}
+}
+
+// Pinning the language stops the fallback, so "why will this not compile as
+// EL" gets the EL error rather than a postfix error about the same text.
+func TestConsoleLanguagePinReportsTheELError(t *testing.T) {
+	h := debugServer(t, true)
+
+	status, body := do(t, h, "POST", "/api/debug/console",
+		`{"postfix":"2 3 +","language":"el"}`)
+	if status == 200 {
+		t.Fatalf("postfix pinned as EL should not compile: %v", body)
+	}
+	msg, _ := body["error"].(string)
+	if msg == "" {
+		msg, _ = body["message"].(string)
+	}
+	if !strings.Contains(msg, "EL compile error") {
+		t.Errorf("error = %q, want it to name EL as the language that failed", msg)
+	}
+}
+
+func TestConsolePostfixPinSkipsEL(t *testing.T) {
+	h := debugServer(t, true)
+
+	status, body := do(t, h, "POST", "/api/debug/console",
+		`{"postfix":"2 3 +","language":"postfix"}`)
+	if status != 200 {
+		t.Fatalf("status %d, body %v", status, body)
+	}
+	if body["language"] != "postfix" {
+		t.Errorf("language = %v, want postfix", body["language"])
+	}
+}
+
+// quote is a minimal JSON string quoter for the table above.
+func quote(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `\"`) + `"`
+}


### PR DESCRIPTION
Second bullet of #930. The console took raw postfix only, so asking whether a taxpayer is over 65 meant writing `taxpayer.age 65 >` — a transcription the author does in their head at the moment they are trying to think about something else.

## What it does

Compiles the line as EL, falling back to raw postfix when that does not parse. The fallback is what makes trying EL first safe: **EL has no spelling for bare stack manipulation, and a debugger is exactly where someone reaches for it.**

The response now carries `language` and the `postfix` that actually ran — EL that compiles to surprising postfix is precisely what a debugger user wants to see. A caller can pin `language` to `el` or `postfix`; a pinned language does **not** fall back, so "why will this not compile as EL" gets the EL error rather than a postfix error about the same text.

Expressions are typed against the project's own EDD, so `taxpayer.agi > 1000.5` is a double comparison rather than defaulting to integer.

## The guard, and the bug I put in it

Checking the typed text was sound while the text was always the postfix. So I moved the check onto the compiled output — and it then refused:

```
there is client in case.clients where client.age > 18
```

That is a **pure read**. It compiles to `... entitypush ... entitypop swap pop`, and both are on the blocklist — correctly, for raw postfix, where a hand-typed push can be left unbalanced. Checking compiled EL against that list broke a legitimate query.

Compiled EL is now checked against a shorter list without the two scope operators. The rest stay as a **backstop rather than the guard**: a condition is an expression and the grammar has no assignment, so EL cannot reach them at all. Raw postfix enforcement is unchanged.

There is a test for exactly this, because it is the kind of thing that comes back.

## Honest limits

`2 + 3` and `client.age + 1` are not conditions; they fall through to postfix and fail there. Conditions and field references — what a console is actually for, and what the watch-breakpoint bullet will need — compile fine.

Remaining work on #930: watch breakpoints, cross-trace diff in the UI, and lazy tree loading remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMYhZQVsuYAtPFtFwMJoUR