### PR TITLE
feat(debug): watch breakpoints — run until a predicate becomes true (#930)

### DIFF
--- a/pkg/dtrules/apiserver/debug.go
+++ b/pkg/dtrules/apiserver/debug.go
@@ -222,6 +222,10 @@ func debugSessionPayload(ds *debugSession) map[string]interface{} {
 		"fingerprintMatch": ds.fingerprintMatch,
 		"verifyMismatches": ds.verifyMismatches,
 		"speculative":      ds.speculative,
+		// Where the replay currently sits. A client that steps, runs to a
+		// node, or runs until a predicate fires needs to be able to ask; it
+		// was the one piece of session state the payload did not carry.
+		"position": ds.position,
 	}
 }
 
@@ -589,4 +593,180 @@ func (s *Server) consoleSymbols() map[string]string {
 		return nil
 	}
 	return authoring.LoadEDDSymbols(projectXMLDir(s.projectPath))
+}
+
+// watchDefaultLimit bounds how many nodes a single watch request will replay.
+//
+// Each step re-establishes the entity stack for that node, so the cost is
+// linear in nodes examined and the traces are large -- 398k nodes in the
+// synthetic fixture. An unbounded "run until" would be a request that never
+// returns, so the search is bounded and reports where it stopped; the caller
+// resumes from there. That keeps a long hunt interruptible instead of opaque.
+const watchDefaultLimit = 2000
+
+// handleDebugWatch runs forward from the current position until a predicate
+// becomes true, and stops there.
+// POST /api/debug/watch {"expression":"...", "language":"el"|"postfix",
+//
+//	"from":<node>, "limit":<n>}
+//
+// Edge-triggered: it stops where the predicate first becomes true having been
+// false at the node before. "Run until drift_anomaly is true" means the moment
+// it *became* true, not every node it stays true for -- otherwise the first
+// step of the next search stops immediately on the same condition and the
+// debugger cannot be walked forward through a run of them (#930).
+func (s *Server) handleDebugWatch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		jsonError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Expression string `json:"expression"`
+		Language   string `json:"language"`
+		From       int    `json:"from"`
+		Limit      int    `json:"limit"`
+	}
+	if err := s.limitedDecode(w, r, &req); err != nil {
+		jsonError(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Expression) == "" {
+		jsonError(w, "expression is required", http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.debug == nil || s.debug.trace == nil {
+		jsonError(w, "No trace loaded", http.StatusBadRequest)
+		return
+	}
+
+	source, language, err := s.consoleCompileSource(req.Expression, req.Language)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	blocked := consoleBlocked
+	if language == "el" {
+		blocked = consoleBlockedAfterEL
+	}
+	for _, tok := range strings.Fields(source) {
+		if blocked[strings.ToLower(tok)] {
+			jsonError(w, fmt.Sprintf("%s is a mutating operator — a watch expression is read-only", tok),
+				http.StatusBadRequest)
+			return
+		}
+	}
+
+	from := req.From
+	if from <= 0 {
+		from = s.debug.position
+	}
+	limit := req.Limit
+	if limit <= 0 || limit > watchDefaultLimit {
+		limit = watchDefaultLimit
+	}
+
+	// The value at the starting node is the baseline the edge is measured
+	// against. Without it, a predicate already true where the search begins
+	// would report a transition that did not happen.
+	prev, _ := s.evalAt(from, source)
+
+	examined := 0
+	for node := from + 1; node <= s.debug.nodeCount && examined < limit; node++ {
+		examined++
+		cur, evalErr := s.evalAt(node, source)
+		if evalErr != nil {
+			// A node where the expression cannot be evaluated -- a name not on
+			// that entity stack, say -- is not a match and not a failure. The
+			// stack changes shape as the run descends, and refusing to
+			// continue would make a watch unusable on anything but the
+			// shallowest expression.
+			prev = false
+			continue
+		}
+		if cur && !prev {
+			target := s.debug.trace.Find(node)
+			if target == nil {
+				break
+			}
+			sess, serr := s.debug.trace.SetState(s.ruleSet, target)
+			if serr != nil {
+				jsonError(w, fmt.Sprintf("Replay failed: %v", serr), http.StatusInternalServerError)
+				return
+			}
+			s.debug.replaySess = sess
+			s.debug.position = node
+			jsonResponse(w, map[string]interface{}{
+				"success":  true,
+				"hit":      true,
+				"position": node,
+				"examined": examined,
+				"nodes":    s.debug.nodeCount,
+				"language": language,
+				"postfix":  source,
+				"context":  debugContext(target),
+				"node": map[string]interface{}{
+					"name": target.Name, "attrs": target.Attributes, "body": target.Body},
+				"stack": debugStack(sess.GetState()),
+			})
+			return
+		}
+		prev = cur
+	}
+
+	// No transition inside the bound. Reported as a result, not an error: the
+	// caller needs to know where the search reached so it can resume, and
+	// "not yet" is a legitimate answer to "run until".
+	jsonResponse(w, map[string]interface{}{
+		"success":  true,
+		"hit":      false,
+		"position": s.debug.position,
+		"examined": examined,
+		"searched_to": func() int {
+			end := from + examined
+			if end > s.debug.nodeCount {
+				return s.debug.nodeCount
+			}
+			return end
+		}(),
+		"nodes":    s.debug.nodeCount,
+		"language": language,
+		"postfix":  source,
+	})
+}
+
+// evalAt replays to one node and evaluates a read-only postfix there,
+// reporting its truth. The replay session is left where it was: a search that
+// examined two thousand nodes should not move the debugger to the last one it
+// looked at.
+func (s *Server) evalAt(node int, postfix string) (bool, error) {
+	target := s.debug.trace.Find(node)
+	if target == nil {
+		return false, fmt.Errorf("node %d not found", node)
+	}
+	sess, err := s.debug.trace.SetState(s.ruleSet, target)
+	if err != nil {
+		return false, err
+	}
+	compiled, err := sess.Compile(postfix)
+	if err != nil {
+		return false, err
+	}
+	state := sess.GetState()
+	if err := compiled.Execute(state); err != nil {
+		return false, err
+	}
+	if state.DataStackDepth() == 0 {
+		return false, fmt.Errorf("expression left nothing on the stack")
+	}
+	v, err := state.DataPop()
+	if err != nil {
+		return false, err
+	}
+	if b, berr := v.BooleanValue(); berr == nil {
+		return b, nil
+	}
+	return strings.EqualFold(strings.TrimSpace(v.StringValue()), "true"), nil
 }

--- a/pkg/dtrules/apiserver/debug_watch_test.go
+++ b/pkg/dtrules/apiserver/debug_watch_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Paul Snow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"strings"
+	"testing"
+)
+
+// "Run until X is true" — the predicate is re-evaluated as the replay walks
+// forward, and the run stops where it first becomes true (#930).
+
+func TestWatchStopsWhereThePredicateBecomesTrue(t *testing.T) {
+	h := debugServer(t, true)
+
+	// client.age is only on the entity stack once the run descends into a
+	// client, so the predicate is genuinely false-then-true across the trace
+	// rather than constant.
+	status, body := do(t, h, "POST", "/api/debug/watch",
+		`{"expression":"client.age > 0","from":1,"limit":140}`)
+	if status != 200 {
+		t.Fatalf("status %d, body %v", status, body)
+	}
+	if body["hit"] != true {
+		t.Fatalf("the predicate never fired anywhere in the trace: %v", body)
+	}
+	pos, _ := body["position"].(float64)
+	if pos < 2 {
+		t.Errorf("position = %v, want a node after the one it started from", body["position"])
+	}
+	if body["language"] != "el" {
+		t.Errorf("language = %v, want el — the watch takes EL like the console", body["language"])
+	}
+	// The debugger is left where the predicate fired, which is the point of
+	// "run until".
+	_, st := do(t, h, "GET", "/api/debug/status", "")
+	if got, _ := st["position"].(float64); got != pos {
+		t.Errorf("after a hit the session sits at %v, want the node that fired (%v)", got, pos)
+	}
+}
+
+// A predicate that is already true where the search starts has not *become*
+// true. Constant-true is the sharpest case: it must never fire, because
+// otherwise every step through a run of satisfying nodes stops on the spot and
+// the debugger cannot be walked forward.
+func TestWatchDoesNotFireOnAPredicateAlreadyTrue(t *testing.T) {
+	h := debugServer(t, true)
+
+	status, body := do(t, h, "POST", "/api/debug/watch",
+		`{"expression":"1 > 0","from":1,"limit":60}`)
+	if status != 200 {
+		t.Fatalf("status %d, body %v", status, body)
+	}
+	if body["hit"] != false {
+		t.Errorf("a predicate true at every node reported a transition at %v — "+
+			"the watch is level-triggered", body["position"])
+	}
+}
+
+// Edge-triggered, not level-triggered. A predicate that is already true where
+// the search starts has not just become true, so the search must walk past it
+// rather than stopping on the spot -- otherwise stepping through a run of
+// nodes that all satisfy it is impossible, because every step stops at once.
+func TestWatchIsEdgeTriggered(t *testing.T) {
+	h := debugServer(t, true)
+
+	first, body := do(t, h, "POST", "/api/debug/watch",
+		`{"expression":"client.age > 0","from":1,"limit":140}`)
+	if first != 200 || body["hit"] != true {
+		t.Fatalf("setup: %v", body)
+	}
+	at, _ := body["position"].(float64)
+
+	// Resuming from where it stopped must not return the same node: at that
+	// node the predicate is true, so it has not just become true.
+	status, body2 := do(t, h, "POST", "/api/debug/watch",
+		`{"expression":"client.age > 0","from":`+itoa(int(at))+`,"limit":140}`)
+	if status != 200 {
+		t.Fatalf("status %d, body %v", status, body2)
+	}
+	if body2["hit"] == true {
+		if again, _ := body2["position"].(float64); again == at {
+			t.Errorf("stopped again at node %v — the watch is level-triggered, so a run "+
+				"of nodes satisfying the predicate cannot be walked through", at)
+		}
+	}
+}
+
+// "Not yet" is an answer, not an error: the caller needs to know how far the
+// search reached so it can resume, and an unbounded run-until would be a
+// request that never returns.
+func TestWatchReportsNoHitWithWhereItReached(t *testing.T) {
+	h := debugServer(t, true)
+
+	status, body := do(t, h, "POST", "/api/debug/watch",
+		`{"expression":"1 > 2","from":1,"limit":25}`)
+	if status != 200 {
+		t.Fatalf("a search that found nothing should not be an error: %d %v", status, body)
+	}
+	if body["hit"] != false {
+		t.Fatalf("hit = %v, want false", body["hit"])
+	}
+	ex, _ := body["examined"].(float64)
+	if ex <= 0 || ex > 25 {
+		t.Errorf("examined = %v, want it bounded by the limit", body["examined"])
+	}
+	if _, ok := body["searched_to"]; !ok {
+		t.Error("no searched_to — the caller cannot resume without knowing where it got to")
+	}
+}
+
+// A watch expression is read-only, on the same terms as the console.
+func TestWatchRefusesAMutatingExpression(t *testing.T) {
+	h := debugServer(t, true)
+
+	status, body := do(t, h, "POST", "/api/debug/watch",
+		`{"expression":"1 /x xdef","language":"postfix","from":1}`)
+	if status == 200 {
+		t.Fatalf("a mutating watch was accepted: %v", body)
+	}
+	msg, _ := body["error"].(string)
+	if !strings.Contains(strings.ToLower(msg), "read-only") {
+		t.Errorf("refused, but not as read-only: %v", body)
+	}
+}
+
+func TestWatchRequiresAnExpression(t *testing.T) {
+	h := debugServer(t, true)
+	status, _ := do(t, h, "POST", "/api/debug/watch", `{"from":1}`)
+	if status == 200 {
+		t.Error("an empty watch expression should be refused")
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/pkg/dtrules/apiserver/server.go
+++ b/pkg/dtrules/apiserver/server.go
@@ -443,6 +443,7 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("/api/debug/tree", s.handleDebugTree)
 	mux.HandleFunc("/api/debug/position", s.handleDebugPosition)
 	mux.HandleFunc("/api/debug/console", s.handleDebugConsole)
+	mux.HandleFunc("/api/debug/watch", s.handleDebugWatch)
 
 	origin := s.cfg.CORSOrigin
 	if origin == "" {
@@ -468,6 +469,10 @@ func readOnlyGuard(next http.Handler) http.Handler {
 		"/api/debug/load":     true,
 		"/api/debug/position": true,
 		"/api/debug/console":  true,
+		// A watch replays and evaluates; it blocks mutating operators on the
+		// same terms as the console and leaves the session where it found it
+		// unless the predicate fires.
+		"/api/debug/watch": true,
 		// Reports read replayed state; spec SAVES are guarded inside the
 		// handler itself (403 when read-only).
 		"/api/debug/report": true,


### PR DESCRIPTION
Third bullet of #930, on the EL console from #1187.

`POST /api/debug/watch` takes an expression, walks the replay forward, and stops where the predicate first becomes true. The expression gets the same reading the console does — EL, falling back to raw postfix, checked read-only against the list matching how it was read.

## Edge-triggered, and that is the design

"Run until `drift_anomaly` is true" means the moment it *became* true, not every node it stays true for. Level-triggering would stop instantly on the first step of the next search, so a run of satisfying nodes could never be walked through. The value at the starting node is the baseline the edge is measured against — without it, a predicate already true where the search begins reports a transition that never happened.

Both halves are tested: a varying predicate (`client.age > 0`, which only resolves once the run descends into a client) fires at node 21, and a constant-true predicate never fires at all.

## Bounded on purpose

Each step re-establishes the entity stack for its node, and the traces are large — 398k nodes in the synthetic fixture. An unbounded run-until is a request that never returns. The search is bounded, reports how far it reached, and returns "not yet" as a **result rather than an error**, because that is a legitimate answer to the question and the caller needs the resume point.

## One judgement call

A node where the expression cannot be evaluated is treated as *not a match* rather than a failure. The entity stack changes shape as the run descends, so a name that resolves deep in the tree does not resolve at the root; erroring out would make a watch usable on nothing but the shallowest expression.

## Also

`position` is added to the debug session payload — the one piece of session state it did not carry, and a client that steps or runs-until has to be able to ask where it ended up. Found because a test asserted on it and got zero.

Remaining work on #930: cross-trace diff in the UI, and lazy tree loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMYhZQVsuYAtPFtFwMJoUR